### PR TITLE
CAD-323 Add initial kubernetes manifest files

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+data:
+  RACK_ENV: production
+  RAILS_ENV: production

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-web-staging
+  template:
+    metadata:
+      labels:
+        app: apply-for-criminal-legal-aid-web-staging
+        tier: frontend
+    spec:
+      containers:
+      - name: webapp
+        image: ${ECR_URL}:${IMAGE_TAG}
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 9292
+        resources:
+          requests:
+            cpu: 125m
+            memory: 500Mi
+          limits:
+            cpu: 250m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9292
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+              - name: X-Forwarded-Ssl
+                value: "on"
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9292
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+              - name: X-Forwarded-Ssl
+                value: "on"
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        envFrom:
+          - configMapRef:
+              name: configmap-staging

--- a/config/kubernetes/staging/disruption.yml
+++ b/config/kubernetes/staging/disruption.yml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: pdb-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-web-staging

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-laa-apply-for-criminal-legal-aid-staging-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location = /.well-known/security.txt {
+        return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
+      }
+spec:
+  tls:
+  - hosts:
+    - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: service-staging
+            port:
+              number: 80

--- a/config/kubernetes/staging/service.yml
+++ b/config/kubernetes/staging/service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+  labels:
+    app: apply-for-criminal-legal-aid-web-staging
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 9292
+  selector:
+    app: apply-for-criminal-legal-aid-web-staging


### PR DESCRIPTION
This is the basic configuration to be able to deploy the Hello World app.

I'm not adding a secrets file just yet as that can be a bit more involved with git-crypt, but that will be next, and will also allow us to set the http basic-auth credentials.

Note: once we have a Rails app we need to replace the port `9292` with the standard `3000`, but other than that, and maybe adding the RDS endpoint, this should all continue to be valid.