### PR TITLE
Change PodDisruptionBudget apiVersion

### DIFF
--- a/config/kubernetes/staging/disruption.yml
+++ b/config/kubernetes/staging/disruption.yml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pdb-staging


### PR DESCRIPTION
This fixes a deprecation warning:

```Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget```