### PR TITLE
Add govuk-frontend javascript as import-map

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -5,3 +5,4 @@
 # https://thoughtbot.com/blog/brewfile-a-gemfile-but-for-homebrew
 
 brew 'adr-tools'
+brew 'yarn'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,41 @@
 
 A service to apply for criminal legal aid
 
+## Getting Started
+
+Clone the repository, and follow these steps in order.  
+The instructions assume you have [Homebrew](https://brew.sh) installed in your machine, as well as use some ruby version manager, usually [rbenv](https://github.com/rbenv/rbenv). If not, please install all this first.
+
+**1. Pre-requirements**
+
+* `brew bundle`
+* `gem install bundler`
+* `bundle install`
+
+**2. Configuration**
+
+* Copy `.env.development` to `.env.development.local` and modify with suitable values for your local machine
+* Copy `.env.test` to `.env.test.local` and modify with suitable values for your local machine
+
+After you've defined your DB configuration in the above files, run the following:
+
+* `bin/rails db:prepare` (for the development database)
+* `RAILS_ENV=test bin/rails db:prepare` (for the test database)
+
+**3. GOV.UK Frontend (styles, javascript and other assets)**
+
+* `yarn`
+
+**4. Run the app locally**
+
+Once all the above is done, you should be able to run the application as follow:
+
+a) `bin/dev` - will run foreman, spawning a rails server and `dartsass:watch` to process SCSS files and watch for any changes.
+b) `rails server` - will only run the rails server, usually fine if you are not making changes to the CSS.
+
+You can also compile assets manually with `rails dartsass:build` at any time, and just run the rails server, without foreman.
+
+If you ever feel something is not right with the CSS or JS, run `rails assets:clobber` to purge the local cache.
 
 ## Docker
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,1 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+
+// https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
+import { initAll } from 'govuk-frontend'
+initAll()

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,3 +1,4 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application", preload: true
+pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.2.0/govuk-esm/all.mjs", preload: true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "laa-apply-for-criminal-legal-aid",
   "private": "true",
   "dependencies": {
-    "govuk-frontend": "^4.2.0"
+    "govuk-frontend": "4.2.0"
+  },
+  "scripts": {
+    "postinstall": "bin/importmap pin govuk-frontend@4.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@^4.2.0:
+govuk-frontend@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.2.0.tgz#1248eb8025c5f8aa6a80282e92da4c81263caf0c"
   integrity sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==


### PR DESCRIPTION
We are pinning the `govuk-frontend` JS to the `importmap.rb` and
also ensuring same version is pinned as a postinstall yarn script.

Added instructions on how to build and run the app to the README.