### PR TITLE
Ensure env is correct for rspec and rubocop tasks

### DIFF
--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-# Clear the original definition as we are going to redefine it
-Rake::Task['spec'].clear
+if Gem.loaded_specs.key?('rspec-rails')
+  # Clear the original definition as we are going to redefine it
+  Rake::Task['spec'].clear
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec)
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-require 'rubocop/rake_task'
+if Gem.loaded_specs.key?('rubocop')
+  require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do
-  # Rubocop spawns multiple processes and the debugger is quite verbose
-  # in the default `warn` level, so raising to `error` here.
-  DEBUGGER__::CONFIG[:log_level] = :ERROR
+  RuboCop::RakeTask.new do
+    # Rubocop spawns multiple processes and the debugger is quite verbose
+    # in the default `warn` level, so raising to `error` here.
+    DEBUGGER__::CONFIG[:log_level] = :ERROR
+  end
 end


### PR DESCRIPTION
Follow-up to PR #14.

Some tasks rely on gems only included in specific Gemfile groups (like `development` and/or `test`).

On building the docker image, we exclude those groups from the Gemfile (as we run on `production`).

We need to guard these tasks against trying to require unavailable gems, or the build will fail.