### PR TITLE
CRIMAP-13 Add DfE Form Builder and configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ AllCops:
 ## Customization for this project ##
 ####################################
 
+# Disabled cops
+###############
+
 Style/Documentation:
   Enabled: false
 
@@ -37,3 +40,14 @@ Style/TrailingCommaInArrayLiteral:
 
 Layout/HashAlignment:
   Enabled: false
+
+# Enabled but tweaked cops
+##########################
+
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
+
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BlockForwarding
+Naming/BlockForwarding:
+  EnforcedStyle: explicit

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'pg', '~> 1.4'
 gem 'puma'
 gem 'rails', '~> 7.0.3'
 
+gem 'govuk_design_system_formbuilder', '~> 3.1.0'
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,9 +88,9 @@ GEM
     crass (1.0.6)
     dartsass-rails (0.4.0)
       railties (>= 6.0.0)
-    debug (1.5.0)
+    debug (1.6.1)
       irb (>= 1.3.6)
-      reline (>= 0.2.7)
+      reline (>= 0.3.1)
     diff-lcs (1.5.0)
     digest (3.1.0)
     docile (1.4.0)
@@ -101,6 +101,13 @@ GEM
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    govuk_design_system_formbuilder (3.1.0)
+      actionview (>= 6.1)
+      activemodel (>= 6.1)
+      activesupport (>= 6.1)
+      html-attributes-utils (~> 0.9, >= 0.9.2)
+    html-attributes-utils (0.9.2)
+      activesupport (>= 6.1.4.4)
     i18n (1.11.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.2)
@@ -276,6 +283,7 @@ DEPENDENCIES
   dartsass-rails (~> 0.4.0)
   debug
   dotenv-rails
+  govuk_design_system_formbuilder (~> 3.1.0)
   importmap-rails
   pg (~> 1.4)
   puma

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+  def service_name
+    t('service.name')
+  end
+
+  def title(page_title)
+    content_for(
+      :page_title, [page_title.presence, service_name, 'GOV.UK'].compact.join(' - ')
+    )
+  end
+
+  # In local/test we raise an exception, so we are aware a title has not been set
+  def fallback_title
+    exception = StandardError.new("page title missing: #{controller_name}##{action_name}")
+    raise exception if Rails.application.config.consider_all_requests_local
+
+    title ''
+  end
 end

--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -1,0 +1,25 @@
+# This module gets mixed in and extends the helpers already provided by
+# `GOVUKDesignSystemFormBuilder::FormBuilder`. These are app-specific
+# form helpers so can be coupled to application business and logic.
+#
+module FormBuilderHelper
+  def continue_button
+    submit_button(:save_and_continue) do
+      submit_button(:save_and_come_back_later, secondary: true, name: 'commit_draft') if show_secondary_button?
+    end
+  end
+
+  private
+
+  # The `save and come back later` might not always be needed,
+  # this method can have logic for show/hide.
+  # :nocov:
+  def show_secondary_button?
+    true
+  end
+  # :nocov:
+
+  def submit_button(i18n_key, opts = {}, &block)
+    govuk_submit I18n.t("helpers.submit.#{i18n_key}"), **opts, &block
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,5 @@
+<% title '' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,4 @@
-<% content_for?(:page_title) ? yield(:page_title) : 'Apply for criminal legal aid' %>
+<% content_for?(:page_title) ? yield(:page_title) : service_name %>
 
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
@@ -6,7 +6,7 @@
 <% end %>
 
 <% content_for(:service_name) do %>
-  <%= link_to 'Apply for criminal legal aid', root_path,
+  <%= link_to service_name, root_path,
               class: 'govuk-header__link govuk-header__service-name', id: 'header-service-name' %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,4 @@
-<% content_for?(:page_title) ? yield(:page_title) : service_name %>
+<% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
 
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -4,7 +4,7 @@
 
 <head>
   <meta charset="utf-8"/>
-  <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
+  <title><%= yield(:page_title) %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,0 +1,12 @@
+ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+GOVUKDesignSystemFormBuilder.configure do |config|
+  config.default_legend_tag   = 'h1'
+  config.default_legend_size  = 'xl'
+  config.default_caption_size = 'xl'
+end
+
+GOVUKDesignSystemFormBuilder::FormBuilder.class_eval do
+  require 'form_builder_helper'
+  include FormBuilderHelper
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  service:
+    name: Apply for criminal legal aid

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,0 +1,6 @@
+---
+en:
+  helpers:
+    submit:
+      save_and_continue: Save and continue
+      save_and_come_back_later: Save and come back later

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#title' do
+    let(:title) { helper.content_for(:page_title) }
+
+    before do
+      helper.title(value)
+    end
+
+    context 'for a blank value' do
+      let(:value) { '' }
+      it { expect(title).to eq('Apply for criminal legal aid - GOV.UK') }
+    end
+
+    context 'for a provided value' do
+      let(:value) { 'Test page' }
+      it { expect(title).to eq('Test page - Apply for criminal legal aid - GOV.UK') }
+    end
+  end
+
+  describe '#fallback_title' do
+    before do
+      allow(helper).to receive(:controller_name).and_return('my_controller')
+      allow(helper).to receive(:action_name).and_return('an_action')
+
+      # So we can simulate what would happen on production
+      allow(
+        Rails.application.config
+      ).to receive(:consider_all_requests_local).and_return(false)
+    end
+
+    it 'should call #title with a blank value' do
+      expect(helper).to receive(:title).with('')
+      helper.fallback_title
+    end
+  end
+end

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe FormBuilderHelper, type: :helper do
+  let(:form_object) { double('FormObject') }
+
+  let(:builder) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(
+      :object_name,
+      form_object,
+      self,
+      {}
+    )
+  end
+
+  describe '#continue_button' do
+    before do
+      allow(builder).to receive(:show_secondary_button?).and_return(draftable)
+    end
+
+    context 'for an application that cannot be drafted' do
+      let(:draftable) { false }
+      let(:expected_markup) {
+        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>'
+      }
+
+      it 'outputs only the continue button' do
+        expect(
+          builder.continue_button
+        ).to eq(expected_markup)
+      end
+    end
+
+    context 'for an application that can be drafted' do
+      let(:draftable) { true }
+      let(:expected_markup) {
+        '<div class="govuk-button-group"><button type="submit" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>' + \
+        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-prevent-double-click="true" name="commit_draft">Save and come back later</button></div>'
+      }
+
+      it 'outputs the continue button together with a save draft button' do
+        expect(
+          builder.continue_button
+        ).to eq(expected_markup)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In preparation for the step-by-step journey and the different form elements, first we add the Form Builder which is 100% compatible with GOV.UK Frontend.

https://govuk-form-builder.netlify.app

https://github.com/DFE-Digital/govuk-formbuilder

Some basic configuration to customise the default tags and size (these can be override on individual elements).

Also added some basic helpers to the `ApplicationHelper` to deal with the service name and the title of the pages.