### PR TITLE
CRIMAP-11 Add yes-no value object

### DIFF
--- a/app/attributes/yes_no_type.rb
+++ b/app/attributes/yes_no_type.rb
@@ -1,0 +1,10 @@
+class YesNoType < ActiveModel::Type::String
+  def cast(value)
+    case value
+    when String, Symbol
+      YesNoAnswer.new(value)
+    when YesNoAnswer
+      value
+    end
+  end
+end

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -1,0 +1,22 @@
+class ValueObject
+  attr_reader :value
+
+  delegate :to_s, :to_sym, to: :value
+
+  def initialize(raw_value)
+    raise ArgumentError, 'Raw value must be symbol or implicitly convertible' unless raw_value.respond_to?(:to_sym)
+
+    @value = raw_value.to_sym
+    freeze
+  end
+
+  def ==(other)
+    other.is_a?(self.class) && other.value == value
+  end
+  alias === ==
+  alias eql? ==
+
+  def hash
+    [ValueObject, self.class, value].hash
+  end
+end

--- a/app/value_objects/yes_no_answer.rb
+++ b/app/value_objects/yes_no_answer.rb
@@ -1,0 +1,18 @@
+class YesNoAnswer < ValueObject
+  VALUES = [
+    YES = new(:yes),
+    NO  = new(:no)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+
+  def yes?
+    value == :yes
+  end
+
+  def no?
+    value == :no
+  end
+end

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -1,0 +1,3 @@
+require 'yes_no_type'
+
+ActiveModel::Type.register(:yes_no, YesNoType)

--- a/spec/attributes/yes_no_type_spec.rb
+++ b/spec/attributes/yes_no_type_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe YesNoType do
+  subject { described_class.new }
+
+  let(:coerced_value) { subject.cast(value) }
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is a symbol' do
+    let(:value) { :yes }
+    it { expect(coerced_value).to eq(YesNoAnswer::YES) }
+  end
+
+  describe 'when value is a string' do
+    let(:value) { 'yes' }
+    it { expect(coerced_value).to eq(YesNoAnswer::YES) }
+  end
+
+  describe 'when value is already a value-object' do
+    let(:value) { YesNoAnswer::YES }
+    it { expect(coerced_value).to eq(YesNoAnswer::YES) }
+  end
+end

--- a/spec/value_objects/value_object_spec.rb
+++ b/spec/value_objects/value_object_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ValueObject do
+  before do
+    stub_const('FooValue', Class.new(ValueObject))
+    stub_const('BarValue', Class.new(ValueObject))
+  end
+
+  let(:value) { 'Hello!' }
+  subject     { described_class.new(value) }
+
+  let(:foo_one)      { FooValue.new('one') }
+  let(:also_foo_one) { FooValue.new('one') }
+  let(:foo_two)      { FooValue.new('two') }
+  let(:bar_one)      { BarValue.new('one') }
+
+  it 'is immutable' do
+    expect(subject).to be_frozen
+  end
+
+  describe '#==' do
+    it 'considers same class/same value equal' do
+      expect(foo_one).to eq(also_foo_one)
+    end
+
+    it 'considers same class/different value not equal' do
+      expect(foo_one).to_not eq(foo_two)
+    end
+
+    it 'considers different class/same value not equal' do
+      expect(foo_one).to_not eq(bar_one)
+    end
+
+    it 'considers different class/different value not equal' do
+      expect(foo_two).to_not eq(bar_one)
+    end
+  end
+
+  describe '#hash' do
+    it 'considers same class/same value equal' do
+      expect(foo_one.hash).to eq(also_foo_one.hash)
+    end
+
+    it 'considers same class/different value not equal' do
+      expect(foo_one.hash).to_not eq(foo_two.hash)
+    end
+
+    it 'considers different class/same value not equal' do
+      expect(foo_one.hash).to_not eq(bar_one.hash)
+    end
+
+    it 'considers different class/different value not equal' do
+      expect(foo_two.hash).to_not eq(bar_one.hash)
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the value as a string' do
+      expect(foo_one.to_s).to eq('one')
+    end
+  end
+
+  describe '#to_sym' do
+    it 'returns the value (which is already a symbol)' do
+      expect(foo_one.to_sym).to eq(:one)
+    end
+  end
+end

--- a/spec/value_objects/yes_no_answer_spec.rb
+++ b/spec/value_objects/yes_no_answer_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe YesNoAnswer do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(yes no))
+    end
+  end
+
+  describe '#yes?' do
+    context 'when value is `yes`' do
+      let(:value) { :yes }
+      it { expect(subject.yes?).to eq(true) }
+    end
+
+    context 'when value is not `yes`' do
+      let(:value) { :no }
+      it { expect(subject.yes?).to eq(false) }
+    end
+  end
+
+  describe '#no?' do
+    context 'when value is `no`' do
+      let(:value) { :no }
+      it { expect(subject.no?).to eq(true) }
+    end
+
+    context 'when value is not `no`' do
+      let(:value) { :yes }
+      it { expect(subject.no?).to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
This value object along with its custom Type can be used for basic yes-no step questions.

It will be used for the first time in a follow-up PR to implement the `client has a partner` question.