### PR TITLE
CRIMAP-31 Add ping endpoint to expose build info

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -3,6 +3,10 @@ class HealthcheckController < BareApplicationController
     render json: { healthcheck: healthcheck_result }, status: http_status
   end
 
+  def ping
+    render json: build_args, status: :ok
+  end
+
   private
 
   def healthcheck_result
@@ -10,7 +14,7 @@ class HealthcheckController < BareApplicationController
   end
 
   def http_status
-    green? ? 200 : 503
+    green? ? :ok : :service_unavailable
   end
 
   def green?
@@ -23,5 +27,14 @@ class HealthcheckController < BareApplicationController
     ActiveRecord::Base.connection.active?
   rescue StandardError
     false
+  end
+
+  # Build information exposed in the Dockerfile
+  def build_args
+    {
+      build_date: ENV.fetch('APP_BUILD_DATE', nil),
+      build_tag:  ENV.fetch('APP_BUILD_TAG',  nil),
+      commit_id:  ENV.fetch('APP_GIT_COMMIT', nil),
+    }.freeze
   end
 end

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -35,18 +35,7 @@ spec:
             memory: 1Gi
         readinessProbe:
           httpGet:
-            path: /
-            port: 3000
-            httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-              - name: X-Forwarded-Ssl
-                value: "on"
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /
+            path: /health
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
@@ -54,6 +43,17 @@ spec:
               - name: X-Forwarded-Ssl
                 value: "on"
           initialDelaySeconds: 15
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+              - name: X-Forwarded-Ssl
+                value: "on"
+          initialDelaySeconds: 30
           periodSeconds: 10
         envFrom:
           - configMapRef:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
-  get '/health', to: 'healthcheck#show', as: :healthcheck
+  get :health, to: 'healthcheck#show'
+  get :ping,   to: 'healthcheck#ping'
 
   root 'home#index'
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -23,4 +23,24 @@ RSpec.describe "Healthcheck endpoint" do
       expect(response).to have_http_status(503)
     end
   end
+
+  describe 'Ping endpoint' do
+    before do
+      allow(ENV).to receive(:fetch).with('APP_BUILD_DATE', nil).and_return('date')
+      allow(ENV).to receive(:fetch).with('APP_BUILD_TAG',  nil).and_return('tag')
+      allow(ENV).to receive(:fetch).with('APP_GIT_COMMIT', nil).and_return('commit')
+    end
+
+    it 'has a 200 response code' do
+      get '/ping'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the expected payload' do
+      get '/ping'
+      expect(
+        response.body
+      ).to eq('{"build_date":"date","build_tag":"tag","commit_id":"commit"}')
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/CRIMAP-31

This endpoint `/ping` exposes currently deployed build details and also can be used as a lightweight probe.

The ENV variables are exposed in the Dockerfile, and passed as `build-arg` when building the image in the deploy pipeline.

I've also pointed the k8s probes to the new /health endpoint created in PR #19.