### PR TITLE
CRIMAP-16 Update to new ingress controller

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -14,6 +14,7 @@ metadata:
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
@@ -22,7 +23,7 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: service-staging


### PR DESCRIPTION
Ticket https://dsdmoj.atlassian.net/browse/CRIMAP-16

To improve security of the Cloud Platform they have introduced new v1 Ingress Controllers.

Tweaked the existing ingress manifest as per documentation here:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Switch-ingress-to-v1-ingress-controller.html#switch-ingress-to-the-new-nginx-ingress-controller-v1-2

And slack convo here:
https://mojdt.slack.com/archives/CH6D099DF/p1657794137979789

This would have incur a minor downtime but because this service is not live/production we can do this all in one go.

To not incur downtime there are specific instructions to do it in 2-steps creating a separate ingress controller.