### PR TITLE
CRIMAP-6 Add basic error handling and error pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include ErrorHandling
   include StepsHelper
 
   def current_crime_application

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -1,0 +1,28 @@
+module ErrorHandling
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from Exception do |exception|
+      case exception
+      when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
+        redirect_to invalid_session_errors_path
+      when Errors::ApplicationNotFound
+        redirect_to application_not_found_errors_path
+      # NOTE: Add more custom errors as they are needed, for instance:
+      # when Errors::ApplicationSubmitted
+      #   redirect_to application_submitted_errors_path
+      else
+        raise if Rails.application.config.consider_all_requests_local
+
+        Sentry.capture_exception(exception)
+        redirect_to unhandled_errors_path
+      end
+    end
+  end
+
+  private
+
+  def check_crime_application_presence
+    raise Errors::InvalidSession unless current_crime_application
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,28 @@
+class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def invalid_session
+    respond_with_status(:ok)
+  end
+
+  def application_not_found
+    respond_with_status(:not_found)
+  end
+
+  def not_found
+    respond_with_status(:not_found)
+  end
+
+  def unhandled
+    respond_with_status(:internal_server_error)
+  end
+
+  private
+
+  def respond_with_status(status)
+    respond_to do |format|
+      format.html { render status: status }
+      format.all  { head status }
+    end
+  end
+end

--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -1,5 +1,7 @@
 module Steps
   class BaseStepController < ApplicationController
+    before_action :check_crime_application_presence
+
     # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :update_navigation_stack, only: [:show, :edit]
     # rubocop:enable  Rails/LexicallyScopedActionFilter

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -39,4 +39,20 @@ module StepsHelper
       f.govuk_error_summary t('errors.error_summary.heading')
     end
   end
+
+  def link_button(name, href, options = {})
+    html_options = {
+      class: 'govuk-button', role: 'button', draggable: false, data: { module: 'govuk-button' },
+    }.merge(options) do |_key, old_value, new_value|
+      if new_value.is_a?(String) || new_value.is_a?(Array)
+        # For strings or array attributes, merge (union) both values
+        Array(old_value) | Array(new_value)
+      else
+        # For other attributes do not merge, override (i.e. draggable and data)
+        new_value
+      end
+    end
+
+    link_to name, href, html_options
+  end
 end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,0 +1,4 @@
+module Errors
+  class InvalidSession < StandardError; end
+  class ApplicationNotFound < StandardError; end
+end

--- a/app/views/errors/application_not_found.html.erb
+++ b/app/views/errors/application_not_found.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+
+    <%= link_button t('helpers.start_again'), root_path, class: 'govuk-!-margin-top-2' %>
+  </div>
+</div>

--- a/app/views/errors/invalid_session.html.erb
+++ b/app/views/errors/invalid_session.html.erb
@@ -1,0 +1,12 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+    <p class="govuk-body"><%=t '.more_text' %></p>
+
+    <%= link_button t('helpers.start_again'), root_path, class: 'govuk-!-margin-top-2' %>
+  </div>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+
+    <%= link_button t('helpers.start_again'), root_path, class: 'govuk-!-margin-top-2' %>
+  </div>
+</div>

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+
+    <%= link_button t('helpers.start_again'), root_path, class: 'govuk-!-margin-top-2' %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -5,6 +5,23 @@ en:
     page_title_prefix: "Error: "
     error_summary:
       heading: There is a problem on this page
+    invalid_session:
+      page_title: Sorry, you’ll have to start again
+      heading: Sorry, you’ll have to start again
+      lead_text: Your session automatically ends if you don’t use the service for XX minutes.
+      more_text: We do this for your security. Any unsaved details will be deleted.
+    application_not_found:
+      page_title: Application not found
+      heading: Sorry, this application no longer exists
+      lead_text: If you copied a web address, please check it’s correct.
+    not_found:
+      page_title: Page not found
+      heading: Page not found
+      lead_text: If you copied a web address, please check it’s correct.
+    unhandled:
+      page_title: Unexpected error
+      heading: Sorry, something went wrong with our service
+      lead_text: You can go back and retry, or start again.
 
   activemodel:
     errors:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -7,6 +7,7 @@ en:
 
   helpers:
     back_link: Back
+    start_again: Start again
     submit:
       save_and_continue: Save and continue
       save_and_come_back_later: Save and come back later

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,13 @@ Rails.application.routes.draw do
 
   root 'home#index'
 
+  resource :errors, only: [] do
+    get :application_not_found
+    get :invalid_session
+    get :unhandled
+    get :not_found
+  end
+
   # Just for demo purposes, to be removed
   get 'home/selected_yes'
   get 'home/selected_no'
@@ -25,4 +32,10 @@ Rails.application.routes.draw do
       edit_step :has_partner
     end
   end
+
+  # catch-all route
+  # :nocov:
+  match '*path', to: 'errors#not_found', via: :all, constraints:
+    lambda { |_request| !Rails.application.config.consider_all_requests_local }
+  # :nocov:
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController do
+  controller do
+    def invalid_session; raise Errors::InvalidSession; end
+    def application_not_found; raise Errors::ApplicationNotFound; end
+    def another_exception; raise Exception; end
+  end
+
+  context 'Exceptions handling' do
+    context 'Errors::InvalidSession' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'invalid_session' => 'anonymous#invalid_session' }
+
+        expect(Sentry).not_to receive(:capture_exception)
+
+        get :invalid_session
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'Errors::ApplicationNotFound' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'application_not_found' => 'anonymous#application_not_found' }
+
+        expect(Sentry).not_to receive(:capture_exception)
+
+        get :application_not_found
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'Other exceptions' do
+      before do
+        allow(Rails.application.config).to receive(:consider_all_requests_local).and_return(false)
+      end
+
+      it 'should report the exception, and redirect to the error page' do
+        routes.draw { get 'another_exception' => 'anonymous#another_exception' }
+
+        expect(Sentry).to receive(:capture_exception)
+
+        get :another_exception
+        expect(response).to redirect_to(unhandled_errors_path)
+      end
+    end
+  end
+end

--- a/spec/helpers/steps_helper_spec.rb
+++ b/spec/helpers/steps_helper_spec.rb
@@ -116,4 +116,18 @@ RSpec.describe StepsHelper, type: :helper do
       end
     end
   end
+
+  describe '#link_button' do
+    it 'builds the link markup styled as a button' do
+      expect(
+        helper.link_button('Continue', root_path)
+      ).to eq('<a class="govuk-button" role="button" draggable="false" data-module="govuk-button" href="/">Continue</a>')
+    end
+
+    it 'appends to the default attributes where possible, otherwise overwrite them' do
+      expect(
+        helper.link_button('Continue', root_path, class: 'ga-pageLink', draggable: true, data: { module: 'govuk-button', ga_category: 'category', ga_label: 'label' })
+      ).to eq('<a class="govuk-button ga-pageLink" role="button" draggable="true" data-module="govuk-button" data-ga-category="category" data-ga-label="label" href="/">Continue</a>')
+    end
+  end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Error pages' do
+  context 'invalid session' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/invalid_session'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'application not found' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/application_not_found'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'not found' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/not_found'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'unhandled' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/unhandled'
+      expect(response).to have_http_status(:internal_server_error)
+    end
+  end
+end

--- a/spec/support/shared_examples/step_controller_shared_examples.rb
+++ b/spec/support/shared_examples/step_controller_shared_examples.rb
@@ -9,8 +9,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
         allow(controller).to receive(:current_crime_application).and_return(nil)
       end
 
-      # TODO: implement error handling
-      xit 'redirects to the invalid session error page' do
+      it 'redirects to the invalid session error page' do
         get :edit
         expect(response).to redirect_to(invalid_session_errors_path)
       end
@@ -38,8 +37,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
         allow(controller).to receive(:current_crime_application).and_return(nil)
       end
 
-      # TODO: implement error handling
-      xit 'redirects to the invalid session error page' do
+      it 'redirects to the invalid session error page' do
         put :update, params: expected_params
         expect(response).to redirect_to(invalid_session_errors_path)
       end
@@ -142,8 +140,7 @@ RSpec.shared_examples 'a step that can be drafted' do |form_class|
         allow(controller).to receive(:current_crime_application).and_return(nil)
       end
 
-      # TODO: implement error handling
-      xit 'redirects to the invalid session error page' do
+      it 'redirects to the invalid session error page' do
         put :update, params: expected_params
         expect(response).to redirect_to(invalid_session_errors_path)
       end


### PR DESCRIPTION
## Description of change
Handling of a few common errors, like invalid session or `ApplicationNotFound` (this one still not really in use until we have the applications dashboard functionality). No doubt there will be more.

The error pages copy is kind of placeholder, generic copy. This will have to revised at some point in the future.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-6

## Notes for reviewer

## Screenshots of changes (if applicable)

Example of an error, all are very similar just changing the copy:
<img width="652" alt="Screenshot 2022-07-21 at 11 56 18" src="https://user-images.githubusercontent.com/687910/180197876-b479c4b9-e3db-42dd-a132-dd8002ebce08.png">


## How to manually test the feature
You can access each of the error pages by using their URL, for example:

http://localhost:3000/errors/not_found
http://localhost:3000/errors/application_not_found
http://localhost:3000/errors/invalid_session

In production, any URL that doesn't exist will trigger the not found error page. In non-production the exception is shown in the browser on purpose for debug purposes.