### PR TITLE
CRIMAP-32 Add client details step to journey

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,7 @@ Naming/BlockForwarding:
 Naming/MethodParameterName:
   AllowedNames:
     - as
+
+Naming/PredicateName:
+  AllowedMethods:
+    - has_one_association

--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -1,10 +1,21 @@
 module Steps
   class BaseStepController < ApplicationController
     before_action :check_crime_application_presence
-
-    # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :update_navigation_stack, only: [:show, :edit]
-    # rubocop:enable  Rails/LexicallyScopedActionFilter
+
+    # :nocov:
+    def show
+      raise 'implement this action, if needed, in subclasses'
+    end
+
+    def edit
+      raise 'implement this action, if needed, in subclasses'
+    end
+
+    def update
+      raise 'implement this action, if needed, in subclasses'
+    end
+    # :nocov:
 
     private
 

--- a/app/controllers/steps/client/details_controller.rb
+++ b/app/controllers/steps/client/details_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Client
+    class DetailsController < Steps::ClientStepController
+      def edit
+        @form_object = DetailsForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(DetailsForm, as: :details)
+      end
+    end
+  end
+end

--- a/app/forms/concerns/steps/has_one_association.rb
+++ b/app/forms/concerns/steps/has_one_association.rb
@@ -17,8 +17,6 @@ module Steps
         parent.public_send(association_name) || parent.public_send("build_#{association_name}")
       end
 
-      private
-
       def has_one_association(name)
         self.association_name = name
 

--- a/app/forms/concerns/steps/has_one_association.rb
+++ b/app/forms/concerns/steps/has_one_association.rb
@@ -1,0 +1,31 @@
+module Steps
+  module HasOneAssociation
+    extend ActiveSupport::Concern
+
+    class_methods do
+      attr_accessor :association_name
+
+      def build(crime_application)
+        super(
+          associated_record(crime_application),
+          crime_application: crime_application
+        )
+      end
+
+      # Return the record if already exists, or initialise a blank one
+      def associated_record(parent)
+        parent.public_send(association_name) || parent.public_send("build_#{association_name}")
+      end
+
+      private
+
+      def has_one_association(name)
+        self.association_name = name
+
+        define_method(name) do
+          @_assoc ||= self.class.associated_record(crime_application)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -1,0 +1,24 @@
+module Steps
+  module Client
+    class DetailsForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      has_one_association :applicant_detail
+
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :other_names, :string
+
+      validates_presence_of :first_name,
+                            :last_name
+
+      private
+
+      def persist!
+        applicant_detail.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -3,7 +3,7 @@ module Steps
     class DetailsForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
 
-      has_one_association :applicant_detail
+      has_one_association :applicant_details
 
       attribute :first_name, :string
       attribute :last_name, :string
@@ -15,7 +15,7 @@ module Steps
       private
 
       def persist!
-        applicant_detail.update(
+        applicant_details.update(
           attributes
         )
       end

--- a/app/models/applicant_detail.rb
+++ b/app/models/applicant_detail.rb
@@ -1,0 +1,3 @@
+class ApplicantDetail < ApplicationRecord
+  belongs_to :crime_application
+end

--- a/app/models/applicant_detail.rb
+++ b/app/models/applicant_detail.rb
@@ -1,3 +1,0 @@
-class ApplicantDetail < ApplicationRecord
-  belongs_to :crime_application
-end

--- a/app/models/applicant_details.rb
+++ b/app/models/applicant_details.rb
@@ -1,0 +1,3 @@
+class ApplicantDetails < ApplicationRecord
+  belongs_to :crime_application
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,3 +1,3 @@
 class CrimeApplication < ApplicationRecord
-  has_one :applicant_detail, dependent: :destroy
+  has_one :applicant_details, class_name: 'ApplicantDetails', dependent: :destroy
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,2 +1,3 @@
 class CrimeApplication < ApplicationRecord
+  has_one :applicant_detail, dependent: :destroy
 end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -4,6 +4,8 @@ module Decisions
       case step_name
       when :has_partner
         after_has_partner
+      when :details
+        show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -15,7 +17,7 @@ module Decisions
       if form_object.client_has_partner.yes?
         show('/home', action: :selected_yes)
       else
-        show('/home', action: :selected_no)
+        edit(:details)
       end
     end
   end

--- a/app/views/steps/client/details/edit.html.erb
+++ b/app/views/steps/client/details/edit.html.erb
@@ -1,0 +1,21 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_fieldset legend: { text: t('.full_name_legend'), tag: 'span', size: 'm' } do %>
+        <%= f.govuk_text_field :first_name, width: 'three-quarters' %>
+        <%= f.govuk_text_field :last_name, width: 'three-quarters' %>
+      <% end %>
+
+      <%= f.govuk_text_field :other_names, width: 'three-quarters', label: { size: 'm' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -30,3 +30,9 @@ en:
           attributes:
             client_has_partner:
               inclusion: Select whether you have a partner or not
+        steps/client/details_form:
+          attributes:
+            first_name:
+              blank: First name can’t be blank
+            last_name:
+              blank: Last name can’t be blank

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -19,7 +19,13 @@ en:
     hint:
       steps_client_has_partner_form:
         client_has_partner: By partner we mean someone they are married to, in a civil partnership with, cohabit with or otherwise share finances.
+      steps_client_details_form:
+        other_names: This includes aliases, nicknames or other names your client may be known as.
 
     label:
       steps_client_has_partner_form:
         client_has_partner_options: *YESNO
+      steps_client_details_form:
+        first_name: First name
+        last_name: Last name
+        other_names: Other names (optional)

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -5,3 +5,8 @@ en:
       has_partner:
         edit:
           page_title: Does your client have a partner?
+      details:
+        edit:
+          page_title: Enter your client’s details
+          heading: Enter your client’s details
+          full_name_legend: Full name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   namespace :steps do
     namespace :client do
       edit_step :has_partner
+      edit_step :details
     end
   end
 

--- a/db/migrate/20220721131958_create_applicant_details_table.rb
+++ b/db/migrate/20220721131958_create_applicant_details_table.rb
@@ -1,0 +1,16 @@
+class CreateApplicantDetailsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :applicant_details, id: :uuid do |t|
+      t.timestamps
+
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false, index: { unique: true }
+
+      t.string :first_name
+      t.string :last_name
+      t.string :other_names
+      t.date   :date_of_birth
+      t.string :has_nino
+      t.string :nino
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_12_144140) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_21_131958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "applicant_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "crime_application_id", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.string "other_names"
+    t.date "date_of_birth"
+    t.string "has_nino"
+    t.string "nino"
+    t.index ["crime_application_id"], name: "index_applicant_details_on_crime_application_id", unique: true
+  end
 
   create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "navigation_stack", default: [], array: true
@@ -22,4 +35,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_12_144140) do
     t.string "client_has_partner"
   end
 
+  add_foreign_key "applicant_details", "crime_applications"
 end

--- a/spec/controllers/steps/client/details_controller_spec.rb
+++ b/spec/controllers/steps/client/details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::DetailsController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Client::DetailsForm, Decisions::ClientDecisionTree
+end

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::DetailsForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    first_name: 'John',
+    last_name: 'Doe',
+    other_names: nil,
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:first_name) }
+      it { should validate_presence_of(:last_name) }
+      it { should_not validate_presence_of(:other_names) }
+    end
+
+    context 'when validations pass' do
+      it_behaves_like 'a has-one-association form',
+                      association_name: :applicant_detail,
+                      expected_attributes: {
+                        'first_name' => 'John',
+                        'last_name' => 'Doe',
+                        'other_names' => nil
+                      }
+    end
+  end
+end

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Steps::Client::DetailsForm do
 
     context 'when validations pass' do
       it_behaves_like 'a has-one-association form',
-                      association_name: :applicant_detail,
+                      association_name: :applicant_details,
                       expected_attributes: {
                         'first_name' => 'John',
                         'last_name' => 'Doe',

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -11,12 +11,19 @@ RSpec.describe Decisions::ClientDecisionTree do
 
     context 'and answer is `no`' do
       let(:client_has_partner) { YesNoAnswer::NO }
-      it { is_expected.to have_destination('/home', :selected_no) }
+      it { is_expected.to have_destination(:details, :edit) }
     end
 
     context 'and answer is `yes`' do
       let(:client_has_partner) { YesNoAnswer::YES }
       it { is_expected.to have_destination('/home', :selected_yes) }
     end
+  end
+
+  context 'when the step is `details`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :details }
+
+    it { is_expected.to have_destination('/home', :index) }
   end
 end

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples 'a has-one-association form' do |options|
   let(:expected_attributes) { options[:expected_attributes] }
   let(:build_method_name) { "build_#{association_name}".to_sym }
 
-  let(:association_double) { double(association_name) }
+  let(:association_double) { instance_double(association_name.to_s.camelize.constantize) }
 
   context 'for valid details' do
     context 'when record does not exist' do

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -1,0 +1,41 @@
+RSpec.shared_examples 'a has-one-association form' do |options|
+  let(:association_name) { options[:association_name] }
+  let(:expected_attributes) { options[:expected_attributes] }
+  let(:build_method_name) { "build_#{association_name}".to_sym }
+
+  let(:association_double) { double(association_name) }
+
+  context 'for valid details' do
+    context 'when record does not exist' do
+      before do
+        allow(crime_application).to receive(association_name).and_return(nil)
+      end
+
+      it 'creates the record if it does not exist' do
+        expect(crime_application).to receive(build_method_name).and_return(association_double)
+
+        expect(association_double).to receive(:update).with(
+          expected_attributes
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when record already exists' do
+      before do
+        allow(crime_application).to receive(association_name).and_return(association_double)
+      end
+
+      it 'updates the record if it already exists' do
+        expect(crime_application).not_to receive(build_method_name)
+
+        expect(association_double).to receive(:update).with(
+          expected_attributes
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This step is a bit more elaborated and we are going to need form objects to work with `has_one` records (a crime application has one applicant details).

This can be used as well as an example for similar steps.

For now, I'm leaving the date field (DOB) to simplify the form object.

Individual commits with more details.


## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-32

## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="717" alt="Screenshot 2022-07-22 at 10 08 21" src="https://user-images.githubusercontent.com/687910/180405596-d4208dc3-b7ee-4b35-ab72-b3613bf10459.png">


## How to manually test the feature
