### PR TITLE
CRIMAP-44 Enter client's NINO step

### DIFF
--- a/app/controllers/steps/client/has_nino_controller.rb
+++ b/app/controllers/steps/client/has_nino_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(HasNinoForm, as: :has_nino)
       end
-
-      private
-
-      def decision_tree_class
-        Decisions::ClientDecisionTree
-      end
     end
   end
 end

--- a/app/controllers/steps/client/has_nino_controller.rb
+++ b/app/controllers/steps/client/has_nino_controller.rb
@@ -1,0 +1,21 @@
+module Steps
+  module Client
+    class HasNinoController < Steps::ClientStepController
+      def edit
+        @form_object = HasNinoForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(HasNinoForm, as: :has_nino)
+      end
+
+      private
+
+      def decision_tree_class
+        Decisions::ClientDecisionTree
+      end
+    end
+  end
+end

--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -1,0 +1,30 @@
+module Steps
+  module Client
+    class HasNinoForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      # taken from Civil Apply
+      NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\Z/
+
+      attribute :has_nino, :yes_no
+      attribute :nino, :string
+
+      has_one_association :applicant_details
+
+      validates_inclusion_of :has_nino, in: :choices
+      validates :nino, format: { with: NINO_REGEXP }, if: -> { has_nino&.yes? }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        applicant_details.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -5,7 +5,9 @@ module Decisions
       when :has_partner
         after_has_partner
       when :details
-        show('/home', action: :index)
+        edit(:has_nino)
+      when :has_nino
+        after_has_nino
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -18,6 +20,14 @@ module Decisions
         show('/home', action: :selected_yes)
       else
         edit(:details)
+      end
+    end
+
+    def after_has_nino
+      if form_object.has_nino.yes?
+        show('/home', action: :nino_yes)
+      else
+        show('/home', action: :nino_no)
       end
     end
   end

--- a/app/views/home/nino_no.html.erb
+++ b/app/views/home/nino_no.html.erb
@@ -1,0 +1,9 @@
+<% title '' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Selected NO. Client does not have a NINO.
+    </h1>
+  </div>
+</div>

--- a/app/views/home/nino_yes.html.erb
+++ b/app/views/home/nino_yes.html.erb
@@ -1,0 +1,9 @@
+<% title '' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Selected YES. Client has a NINO.
+    </h1>
+  </div>
+</div>

--- a/app/views/steps/client/has_nino/edit.html.erb
+++ b/app/views/steps/client/has_nino/edit.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :has_nino do %>
+        <%= f.govuk_radio_button :has_nino, YesNoAnswer::YES, link_errors: true do %>
+          <%= f.govuk_text_field :nino, width: 'three-quarters' %>
+        <% end %>
+
+        <%= f.govuk_radio_button :has_nino, YesNoAnswer::NO %>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -36,3 +36,9 @@ en:
               blank: First name can’t be blank
             last_name:
               blank: Last name can’t be blank
+        steps/client/has_nino_form:
+          attributes:
+            has_nino:
+              inclusion: Select whether you have a National Insurance Number or not
+            nino: 
+              invalid: Please enter a valid National Insurance number

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -15,12 +15,16 @@ en:
     legend:
       steps_client_has_partner_form:
         client_has_partner: Does your client have a partner?
+      steps_client_has_nino_form:
+        has_nino: Do you have your client's National Insurance number?
 
     hint:
       steps_client_has_partner_form:
         client_has_partner: By partner we mean someone they are married to, in a civil partnership with, cohabit with or otherwise share finances.
       steps_client_details_form:
         other_names: This includes aliases, nicknames or other names your client may be known as.
+      steps_client_has_nino_form:
+        has_nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
 
     label:
       steps_client_has_partner_form:
@@ -29,3 +33,6 @@ en:
         first_name: First name
         last_name: Last name
         other_names: Other names (optional)
+      steps_client_has_nino_form:
+        has_nino_options: *YESNO
+        nino: Enter their National Insurance number

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -10,3 +10,7 @@ en:
           page_title: Enter your client’s details
           heading: Enter your client’s details
           full_name_legend: Full name
+      has_nino:
+        edit:
+          page_title: Enter your client’s NINO
+          has_nino: Do you have your client's National Insurance number? 

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -13,4 +13,3 @@ en:
       has_nino:
         edit:
           page_title: Enter your client’s NINO
-          has_nino: Do you have your client's National Insurance number? 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,10 +27,14 @@ Rails.application.routes.draw do
   get 'home/selected_yes'
   get 'home/selected_no'
 
+  get 'home/nino_yes'
+  get 'home/nino_no'
+
   namespace :steps do
     namespace :client do
       edit_step :has_partner
       edit_step :details
+      edit_step :has_nino
     end
   end
 

--- a/spec/controllers/steps/client/has_nino_controller_spec.rb
+++ b/spec/controllers/steps/client/has_nino_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::HasNinoController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Client::HasNinoForm, Decisions::ClientDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::Client::HasNinoForm
+end

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -88,5 +88,16 @@ RSpec.describe Steps::Client::HasNinoForm do
         expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
       end
     end
+
+    context 'when validations pass' do
+      let(:has_nino) { 'yes' }
+      let(:nino) { 'AB123456C' }
+      it_behaves_like 'a has-one-association form',
+                      association_name: :applicant_details,
+                      expected_attributes: {
+                        'has_nino' => YesNoAnswer::YES,
+                        'nino' => "AB123456C"
+                      }
+    end
   end
 end

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::HasNinoForm do
+  # Note: not using shared examples for form objects yet, to be added
+  # once we have some more form objects and some patterns emerge
+
+  let(:arguments) { {
+    crime_application: crime_application,
+    has_nino: has_nino,
+    nino: nino
+  } }
+
+  let(:crime_application) { 
+    instance_double(CrimeApplication, 
+      applicant_details: applicant_details
+    )
+  }
+
+  let(:applicant_details) {instance_double(ApplicantDetails, :update)}
+  let(:has_nino) { nil }
+  let(:nino) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `has_nino` is not provided' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:has_nino, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when `has_nino` is not valid' do
+      let(:has_nino) { 'maybe' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:has_nino, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when `has_nino` is valid' do
+      let(:has_nino) { 'yes' }
+      let(:nino) { 'AB123456C' }
+
+      it 'saves the record' do
+        expect(crime_application.applicant_details).to receive(:update).with(
+          'has_nino' => YesNoAnswer::YES,
+          'nino' => 'AB123456C'
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when `nino` is blank' do
+      let(:has_nino) { 'yes' }
+      let(:nino) { '' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+      end
+    end
+
+    context 'when `nino` is invalid' do
+      let(:has_nino) { 'yes' }
+      let(:nino) { 'not a NINO' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -24,6 +24,21 @@ RSpec.describe Decisions::ClientDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :details }
 
-    it { is_expected.to have_destination('/home', :index) }
+    it { is_expected.to have_destination(:has_nino, :edit) }
+  end
+
+  context 'when the step is `has_nino`' do
+    let(:form_object) { double('FormObject', has_nino: has_nino) }
+    let(:step_name) { :has_nino}
+
+    context 'and answer is `no`' do
+      let(:has_nino) { YesNoAnswer::NO }
+      it { is_expected.to have_destination('/home', :nino_no) }
+    end
+
+    context 'and answer is `yes`' do
+      let(:has_nino) { YesNoAnswer::YES }
+      it { is_expected.to have_destination('/home', :nino_yes) }
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Add form to collect client Nino details + specs / validations

atm validations for NINO format are in the form, but these could be moved to a custom validator at some future point if needed.

Also added some holding pages for the progression of the form steps (`nino_yes.html.erb` and `nino_no.html.erb`) that can be removed as we build out more steps.

## Link to relevant ticket

[CRIMAP](https://dsdmoj.atlassian.net/browse/CRIMAP-44)

## Notes for reviewer
- please check that our 'conventions' are followed 👍  
  
## Screenshots of changes (if applicable)
<img width="989" alt="Screenshot 2022-07-27 at 17 35 33" src="https://user-images.githubusercontent.com/13377553/181301618-4f68b647-9615-4460-8d99-22374fedf727.png">

Format Error:
<img width="810" alt="Screenshot 2022-07-27 at 17 36 02" src="https://user-images.githubusercontent.com/13377553/181301727-e9e6130b-b498-4dbe-a901-ca553a767bca.png">

Blank error:
<img width="706" alt="Screenshot 2022-07-27 at 17 37 16" src="https://user-images.githubusercontent.com/13377553/181301974-f653e518-ae7e-4bf7-ac6e-0cdb6a372533.png">


## How to manually test the feature
Run through the stepped journey form  `/has_partner`:
- `/details` on completion now routes to `has_nino`
- check validations on `/has_nino`:
  - if radios are blank it errors saying choose one 
  - if yes selected and NINO is blank or incorrect then it will error saying that you need to enter a NINO in the right format (`AB123456C` is a valid NINO)