### PR TITLE
CRIMAP-10 Add developer tools to footer

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,42 @@
+class SessionsController < ApplicationController
+  def destroy
+    reset_session
+    redirect_to root_path
+  end
+
+  # :nocov:
+  def bypass_to_client_details
+    raise 'For development use only' unless FeatureFlags.developer_tools.enabled?
+
+    find_or_create_applicant_details
+
+    crime_application.update(
+      navigation_stack: %w[/steps/client/has_partner /steps/client/details]
+    )
+
+    redirect_to edit_steps_client_details_path
+  end
+  # :nocov:
+
+  private
+
+  # :nocov:
+  def crime_application
+    current_crime_application || initialize_crime_application(
+      client_has_partner: YesNoAnswer::YES
+    )
+  end
+
+  def find_or_create_applicant_details
+    ApplicantDetails.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
+      unless record.persisted?
+        record.update(
+          first_name: 'John',
+          last_name: 'Test',
+          date_of_birth: 25.years.ago
+        )
+      end
+    end
+  end
+  # :nocov:
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,14 +7,3 @@
     </h1>
   </div>
 </div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if FeatureFlags.test_on.enabled? %>
-      <p>Features are enableable!</p>
-    <% end %>
-
-    <% if FeatureFlags.test_off.disabled? %>
-      <p>Features are disableable!</p>
-    <% end %>
-  </div>
-</div>

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -1,0 +1,35 @@
+<% content_for(:footer_top) do %>
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Developer Tools
+      </span>
+    </summary>
+    <div class="govuk-details__text app-util--inline-buttons">
+      <% if current_crime_application %>
+        <h4 class="govuk-heading-s">Current Application ID</h4>
+        <p><%= current_crime_application.id %></p>
+      <% end %>
+
+      <h4 class="govuk-heading-s">Destroy session</h4>
+      <p>Deletes all data entered in this session and lets you start a new application from scratch.</p>
+
+      <%= button_to session_path, method: :delete,
+                    class: 'govuk-button govuk-button--warning',
+                    data: { module: 'govuk-button' } do; 'Destroy session'; end %>
+
+      <h4 class="govuk-heading-s">Bypass steps</h4>
+      <p>Speed up some common test scenarios by pre-filling some information</p>
+
+      <div class="govuk-button-group">
+        <%= button_to edit_steps_client_has_partner_path, method: :get,
+                      class: 'govuk-button govuk-!-margin-right-1',
+                      data: { module: 'govuk-button' } do; 'Start application'; end %>
+
+        <%= button_to bypass_to_client_details_session_path,
+                      class: 'govuk-button',
+                      data: { module: 'govuk-button' } do; 'Bypass to client details'; end %>
+      </div>
+    </div>
+  </details>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% content_for(:phase_banner) do %>
-  <%= render partial: 'layouts/phase_banner' %>
+  <% render partial: 'layouts/phase_banner' %>
 <% end %>
 
 <% content_for(:content) do %>
@@ -21,5 +21,7 @@
 <% content_for(:footer_links) do %>
   <% render partial: 'layouts/footer_links' %>
 <% end %>
+
+<% render partial: 'layouts/developer_tools' if FeatureFlags.developer_tools.enabled? %>
 
 <%= render template: 'layouts/govuk_template', layout: false %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ Rails.application.routes.draw do
     get :not_found
   end
 
+  resource :session, only: [:destroy] do
+    member do
+      post :bypass_to_client_details
+    end
+  end
+
   # Just for demo purposes, to be removed
   get 'home/selected_yes'
   get 'home/selected_no'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,5 @@
 feature_flags:
-  test_on:
+  developer_tools:
     local: true
     staging: true
-  test_off:
-    local: false
-    staging: false
+    production: false

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+  describe '#destroy' do
+    it 'resets the session' do
+      expect(subject).to receive(:reset_session)
+      delete :destroy
+    end
+
+    it 'redirects to the home page' do
+      delete :destroy
+      expect(subject).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Just some basic operations for now. It is behind a feature flag, enabled in development/staging envs, disabled on production (although we don't have yet prod).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-10

## Notes for reviewer
As we develop more of the app, we might have to change some of the links/actions but that is OK, this is supposed to help us get quicker to some steps / pre-fill something etc. For now we don't have a lot anyways.

I tried to use a request spec, instead of controller spec, and couldn't make it work to check the `reset_session` was being called as apparently request specs don't have access to the session. So instead of having one test (the redirect) in the request spec, and another test (the reset session) in the controller spec, I opted for having all in the controller spec...

## Screenshots of changes (if applicable)
<img width="911" alt="Screenshot 2022-07-28 at 16 12 34" src="https://user-images.githubusercontent.com/687910/181573648-8508fea6-9bde-4c8e-859f-ee4c7db1097f.png">

