### PR TITLE
CRIMAP-60 Add DB fields to hold contact details

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,5 +3,4 @@ class HomeController < ApplicationController
 
   # Just for demo purposes, to be removed
   def selected_yes; end
-  def selected_no; end
 end

--- a/app/models/contact_details.rb
+++ b/app/models/contact_details.rb
@@ -1,0 +1,14 @@
+class ContactDetails < ApplicationRecord
+  belongs_to :crime_application
+
+  ADDRESS_FIELDS = %i[
+    address_line_one
+    address_line_two
+    city
+    county
+    postcode
+  ].freeze
+
+  store_accessor :home_address, ADDRESS_FIELDS, prefix: :home
+  store_accessor :correspondence_address, ADDRESS_FIELDS, prefix: :correspondence
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,3 +1,4 @@
 class CrimeApplication < ApplicationRecord
   has_one :applicant_details, class_name: 'ApplicantDetails', dependent: :destroy
+  has_one :contact_details, class_name: 'ContactDetails', dependent: :destroy
 end

--- a/app/views/home/selected_no.html.erb
+++ b/app/views/home/selected_no.html.erb
@@ -1,9 +1,0 @@
-<% title '' %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Selected NO. Client has no partner.
-    </h1>
-  </div>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,6 @@ Rails.application.routes.draw do
 
   # Just for demo purposes, to be removed
   get 'home/selected_yes'
-  get 'home/selected_no'
 
   get 'home/nino_yes'
   get 'home/nino_no'

--- a/db/migrate/20220729135824_create_contact_details_table.rb
+++ b/db/migrate/20220729135824_create_contact_details_table.rb
@@ -1,0 +1,12 @@
+class CreateContactDetailsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contact_details, id: :uuid do |t|
+      t.timestamps
+
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false, index: { unique: true }
+
+      t.json :home_address, default: {}
+      t.json :correspondence_address, default: {}
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_21_131958) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_29_135824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -28,6 +28,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_131958) do
     t.index ["crime_application_id"], name: "index_applicant_details_on_crime_application_id", unique: true
   end
 
+  create_table "contact_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "crime_application_id", null: false
+    t.json "home_address", default: {}
+    t.json "correspondence_address", default: {}
+    t.index ["crime_application_id"], name: "index_contact_details_on_crime_application_id", unique: true
+  end
+
   create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "navigation_stack", default: [], array: true
     t.datetime "created_at", null: false
@@ -36,4 +45,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_131958) do
   end
 
   add_foreign_key "applicant_details", "crime_applications"
+  add_foreign_key "contact_details", "crime_applications"
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -16,11 +16,4 @@ RSpec.describe 'Home' do
       expect(response).to have_http_status(:ok)
     end
   end
-
-  describe 'selected_no' do
-    it 'renders the expected page' do
-      get '/home/selected_no'
-      expect(response).to have_http_status(:ok)
-    end
-  end
 end


### PR DESCRIPTION
## Description of change
We are working on the next step of the journey, to ask for home address, phone number and correspondence address. These can all be considered as "contact details" for sake of simplicity, as eventually this also will include a phone number, and stored in a separate table.

This table for now only includes the home address and the correspondence address. These are JSON attributes in the database but exposed as individual attribute getter/setter with `store_accessor`.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-60
