### PR TITLE
CRIMAP-60 Add home address manual entry

### DIFF
--- a/app/controllers/steps/contact/home_address_controller.rb
+++ b/app/controllers/steps/contact/home_address_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Contact
+    class HomeAddressController < Steps::ContactStepController
+      def edit
+        @form_object = HomeAddressForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(HomeAddressForm, as: :home_address)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/contact_step_controller.rb
+++ b/app/controllers/steps/contact_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class ContactStepController < BaseStepController
+    private
+
+    def decision_tree_class
+      Decisions::ContactDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/contact/home_address_form.rb
+++ b/app/forms/steps/contact/home_address_form.rb
@@ -1,0 +1,27 @@
+module Steps
+  module Contact
+    class HomeAddressForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      has_one_association :applicant_contact_details
+
+      attribute :home_address_line_one, :string
+      attribute :home_address_line_two, :string
+      attribute :home_city, :string
+      attribute :home_county, :string
+      attribute :home_postcode, :string
+
+      validates_presence_of :home_address_line_one,
+                            :home_city,
+                            :home_postcode
+
+      private
+
+      def persist!
+        applicant_contact_details.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -25,7 +25,7 @@ module Decisions
 
     def after_has_nino
       if form_object.has_nino.yes?
-        show('/home', action: :nino_yes)
+        edit('/steps/contact/home_address')
       else
         show('/home', action: :nino_no)
       end

--- a/app/services/decisions/contact_decision_tree.rb
+++ b/app/services/decisions/contact_decision_tree.rb
@@ -1,0 +1,12 @@
+module Decisions
+  class ContactDecisionTree < BaseDecisionTree
+    def destination
+      case step_name
+      when :home_address
+        show('/home', action: :index)
+      else
+        raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+  end
+end

--- a/app/views/steps/contact/home_address/edit.html.erb
+++ b/app/views/steps/contact/home_address/edit.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :home_address_line_one, autocomplete: 'off' %>
+      <%= f.govuk_text_field :home_address_line_two, autocomplete: 'off' %>
+      <%= f.govuk_text_field :home_city, autocomplete: 'off', width: 'one-half' %>
+      <%= f.govuk_text_field :home_county, autocomplete: 'off', width: 'one-half' %>
+      <%= f.govuk_text_field :home_postcode, autocomplete: 'off', width: 'one-third' %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -52,3 +52,11 @@ en:
               inclusion: Select whether you have a National Insurance Number or not
             nino: 
               invalid: Please enter a valid National Insurance number
+        steps/contact/home_address_form:
+          attributes:
+            home_address_line_one:
+              blank: Enter first line of home address
+            home_city:
+              blank: Enter home address city
+            home_postcode:
+              blank: Enter home address postcode

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -39,3 +39,9 @@ en:
       steps_client_has_nino_form:
         has_nino_options: *YESNO
         nino: Enter their National Insurance number
+      steps_contact_home_address_form:
+        home_address_line_one: Address line 1
+        home_address_line_two: Address line 2 (optional)
+        home_city: Town or city
+        home_county: County (optional)
+        home_postcode: Postcode

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -13,3 +13,9 @@ en:
       has_nino:
         edit:
           page_title: Enter your client’s NINO
+
+    contact:
+      home_address:
+        edit:
+          page_title: Client’s home address
+          heading: Enter your client’s home address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do
       edit_step :details
       edit_step :has_nino
     end
+
+    namespace :contact do
+      edit_step :home_address
+    end
   end
 
   # catch-all route

--- a/spec/controllers/steps/contact/home_address_controller_spec.rb
+++ b/spec/controllers/steps/contact/home_address_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Contact::HomeAddressController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Contact::HomeAddressForm, Decisions::ContactDecisionTree
+end

--- a/spec/forms/steps/contact/home_address_form_spec.rb
+++ b/spec/forms/steps/contact/home_address_form_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Contact::HomeAddressForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    home_address_line_one: 'Address line 1',
+    home_address_line_two: 'Address line 2',
+    home_city: 'City',
+    home_county: 'County',
+    home_postcode: 'Postcode',
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:home_address_line_one) }
+      it { should validate_presence_of(:home_city) }
+      it { should validate_presence_of(:home_postcode) }
+
+      it { should_not validate_presence_of(:home_address_line_two) }
+      it { should_not validate_presence_of(:home_county) }
+    end
+
+    context 'when validations pass' do
+      it_behaves_like 'a has-one-association form',
+                      association_name: :applicant_contact_details,
+                      expected_attributes: {
+                        'home_address_line_one' => 'Address line 1',
+                        'home_address_line_two' => 'Address line 2',
+                        'home_city' => 'City',
+                        'home_county' => 'County',
+                        'home_postcode' => 'Postcode'
+                      }
+    end
+  end
+end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Decisions::ClientDecisionTree do
 
     context 'and answer is `yes`' do
       let(:has_nino) { YesNoAnswer::YES }
-      it { is_expected.to have_destination('/home', :nino_yes) }
+      it { is_expected.to have_destination('/steps/contact/home_address', :edit) }
     end
   end
 end

--- a/spec/services/decisions/contact_decision_tree_spec.rb
+++ b/spec/services/decisions/contact_decision_tree_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Decisions::ContactDecisionTree do
+  subject { described_class.new(form_object, as: step_name) }
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `home_address`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :home_address }
+
+    it { is_expected.to have_destination('/home', :index) }
+  end
+end

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -3,7 +3,21 @@ RSpec.shared_examples 'a has-one-association form' do |options|
   let(:expected_attributes) { options[:expected_attributes] }
   let(:build_method_name) { "build_#{association_name}".to_sym }
 
-  let(:association_double) { instance_double(association_name.to_s.camelize.constantize) }
+  let(:association_double) { instance_double(associated_class_name.camelize.constantize) }
+
+  def associated_class_name
+    reflection = CrimeApplication.reflect_on_association(association_name)
+
+    if reflection.is_a?(ActiveRecord::Reflection::HasOneReflection)
+      # For an `association_name` of `:applicant` it will return `applicant`
+      reflection.name.to_s
+    elsif reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+      # For an `association_name` of `:applicant_contact_details` it will return `contact_details`
+      reflection.source_reflection_name.to_s
+    else
+      raise 'Unknown reflection. Shared examples may need adjustments.'
+    end
+  end
 
   context 'for valid details' do
     context 'when record does not exist' do

--- a/spec/support/shared_examples/step_controller_shared_examples.rb
+++ b/spec/support/shared_examples/step_controller_shared_examples.rb
@@ -15,8 +15,12 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
       end
     end
 
+    # NOTE: for now it is ok to assume we just have the applicant, but when we
+    # integrate the partner steps, this will have to either be passed as configuration
+    # to the shared examples, or to also create the partner associated record.
+    #
     context 'when a case exists in the session' do
-      let!(:existing_case) { CrimeApplication.create }
+      let!(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
 
       it 'responds with HTTP success' do
         get :edit, session: { crime_application_id: existing_case.id }


### PR DESCRIPTION
## Description of change
First part of the journey to enter the home address of the applicant (client's home address).

For now just the manual entry. Postcode lookup will be added later on as a separate one or more PRs.

The code is somehow coupled for now to the applicant as we don't have `partner` yet for the MVP, but in the future I anticipate we could make these controllers / form objects somehow work for partner too with not too much effort.

The database models already supports as of PR #36 to have different contact details for applicant and for partner.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-60

## Notes for reviewer
Manual entry only. After entering details it goes back to home (as we don't have yet following step).

## Screenshots of changes (if applicable)
<img width="758" alt="Screenshot 2022-08-03 at 10 40 51" src="https://user-images.githubusercontent.com/687910/182577444-9ed30167-746a-4e70-9d08-c4cd8eb7f4e9.png">

<img width="409" alt="Screenshot 2022-08-03 at 10 41 15" src="https://user-images.githubusercontent.com/687910/182577510-441d7998-b96b-4df2-8825-480ec5a610ed.png">


## How to manually test the feature
