### PR TITLE
CRIMAP-61 Add postcode lookup step (no API yet)

### DIFF
--- a/app/controllers/steps/contact/postcode_lookup_controller.rb
+++ b/app/controllers/steps/contact/postcode_lookup_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Contact
+    class PostcodeLookupController < Steps::ContactStepController
+      def edit
+        @form_object = PostcodeLookupForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(PostcodeLookupForm, as: :postcode_lookup)
+      end
+    end
+  end
+end

--- a/app/forms/steps/contact/postcode_lookup_form.rb
+++ b/app/forms/steps/contact/postcode_lookup_form.rb
@@ -1,0 +1,20 @@
+module Steps
+  module Contact
+    class PostcodeLookupForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      has_one_association :applicant_contact_details
+
+      attribute :home_postcode, :string
+      validates :home_postcode, presence: true
+
+      private
+
+      def persist!
+        applicant_contact_details.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -25,7 +25,7 @@ module Decisions
 
     def after_has_nino
       if form_object.has_nino.yes?
-        edit('/steps/contact/home_address')
+        edit('/steps/contact/postcode_lookup')
       else
         show('/home', action: :nino_no)
       end

--- a/app/services/decisions/contact_decision_tree.rb
+++ b/app/services/decisions/contact_decision_tree.rb
@@ -2,6 +2,8 @@ module Decisions
   class ContactDecisionTree < BaseDecisionTree
     def destination
       case step_name
+      when :postcode_lookup
+        edit(:home_address)
       when :home_address
         show('/home', action: :index)
       else

--- a/app/views/steps/contact/postcode_lookup/edit.html.erb
+++ b/app/views/steps/contact/postcode_lookup/edit.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :home_postcode, autocomplete: 'off', width: 'one-third' %>
+
+      <p class="govuk-body govuk-!-margin-bottom-8">
+        <%= link_to t('.manual_entry'), edit_steps_contact_home_address_path %>
+      </p>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -52,6 +52,11 @@ en:
               inclusion: Select whether you have a National Insurance Number or not
             nino: 
               invalid: Please enter a valid National Insurance number
+        steps/contact/postcode_lookup_form:
+          attributes:
+            home_postcode:
+              blank: Enter postcode
+
         steps/contact/home_address_form:
           attributes:
             home_address_line_one:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -28,6 +28,8 @@ en:
         date_of_birth: For example, 27 3 2007
       steps_client_has_nino_form:
         has_nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
+      steps_contact_postcode_lookup_form:
+        home_postcode: This must be a valid UK postcode.
 
     label:
       steps_client_has_partner_form:
@@ -39,6 +41,8 @@ en:
       steps_client_has_nino_form:
         has_nino_options: *YESNO
         nino: Enter their National Insurance number
+      steps_contact_postcode_lookup_form:
+        home_postcode: Postcode
       steps_contact_home_address_form:
         home_address_line_one: Address line 1
         home_address_line_two: Address line 2 (optional)

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -15,6 +15,11 @@ en:
           page_title: Enter your client’s NINO
 
     contact:
+      postcode_lookup:
+        edit:
+          page_title: Client’s postcode
+          heading: Enter your client’s postcode
+          manual_entry: Enter address manually
       home_address:
         edit:
           page_title: Client’s home address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     end
 
     namespace :contact do
+      edit_step :postcode_lookup
       edit_step :home_address
     end
   end

--- a/spec/controllers/steps/contact/postcode_lookup_controller_spec.rb
+++ b/spec/controllers/steps/contact/postcode_lookup_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Contact::PostcodeLookupController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Contact::PostcodeLookupForm, Decisions::ContactDecisionTree
+end

--- a/spec/forms/steps/contact/postcode_lookup_form_spec.rb
+++ b/spec/forms/steps/contact/postcode_lookup_form_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Contact::PostcodeLookupForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    home_postcode: 'Postcode',
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:home_postcode) }
+    end
+
+    context 'when validations pass' do
+      it_behaves_like 'a has-one-association form',
+                      association_name: :applicant_contact_details,
+                      expected_attributes: {
+                        'home_postcode' => 'Postcode'
+                      }
+    end
+  end
+end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Decisions::ClientDecisionTree do
 
     context 'and answer is `yes`' do
       let(:has_nino) { YesNoAnswer::YES }
-      it { is_expected.to have_destination('/steps/contact/home_address', :edit) }
+      it { is_expected.to have_destination('/steps/contact/postcode_lookup', :edit) }
     end
   end
 end

--- a/spec/services/decisions/contact_decision_tree_spec.rb
+++ b/spec/services/decisions/contact_decision_tree_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Decisions::ContactDecisionTree do
 
   it_behaves_like 'a decision tree'
 
+  context 'when the step is `postcode_lookup`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :postcode_lookup }
+
+    it { is_expected.to have_destination(:home_address, :edit) }
+  end
+
   context 'when the step is `home_address`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :home_address }


### PR DESCRIPTION
## Description of change
This just prepares the step to, in a follow-up PR integrate with the Ordnance API.

However before that it made sense to do this step as a normal one, because I think we have to plan to make it generic to work for correspondence addresses too, and in the future even with partners.

I will have a think about how best to do that because if we make it work for this view it will also work for the results of the postcode lookup.

Note: no "postcode" validation yet, we can add that later, for now only presence.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-61
https://dsdmoj.atlassian.net/browse/CRIMAP-60

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="743" alt="Screenshot 2022-08-03 at 12 14 37" src="https://user-images.githubusercontent.com/687910/182594981-c137679b-f61a-4d88-901a-ffdcbb016143.png">

<img width="812" alt="Screenshot 2022-08-03 at 12 15 56" src="https://user-images.githubusercontent.com/687910/182595054-5385e8a4-446c-4bc0-b5c9-c2537c4a0d4f.png">


## How to manually test the feature
