### PR TITLE
Add eForms redirect when there is a partner

### DIFF
--- a/app/controllers/steps/client/partner_exit_controller.rb
+++ b/app/controllers/steps/client/partner_exit_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Client
+    class PartnerExitController < Steps::ClientStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -17,7 +17,7 @@ module Decisions
 
     def after_has_partner
       if form_object.client_has_partner.yes?
-        show('/home', action: :selected_yes)
+        show(:partner_exit)
       else
         edit(:details)
       end

--- a/app/views/home/nino_no.html.erb
+++ b/app/views/home/nino_no.html.erb
@@ -1,9 +1,0 @@
-<% title '' %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Selected NO. Client does not have a NINO.
-    </h1>
-  </div>
-</div>

--- a/app/views/home/nino_yes.html.erb
+++ b/app/views/home/nino_yes.html.erb
@@ -1,9 +1,0 @@
-<% title '' %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Selected YES. Client has a NINO.
-    </h1>
-  </div>
-</div>

--- a/app/views/home/selected_no.html.erb
+++ b/app/views/home/selected_no.html.erb
@@ -1,9 +1,0 @@
-<% title '' %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Selected NO. Client has no partner.
-    </h1>
-  </div>
-</div>

--- a/app/views/home/selected_yes.html.erb
+++ b/app/views/home/selected_yes.html.erb
@@ -1,9 +1,0 @@
-<% title '' %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Selected YES. Client has a partner.
-    </h1>
-  </div>
-</div>

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -1,6 +1,3 @@
-<% title t('.page_title') %>
-<% step_header %>
-
 <div class="govuk-grid-row app-inverted--card app-inverted-text">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l app-inverted-text">Use eForms for this application</h1>

--- a/app/views/steps/client/nino_exit/show.html.erb
+++ b/app/views/steps/client/nino_exit/show.html.erb
@@ -1,0 +1,4 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<%= render partial: 'shared/eforms_redirect' %>

--- a/app/views/steps/client/partner_exit/show.html.erb
+++ b/app/views/steps/client/partner_exit/show.html.erb
@@ -1,0 +1,4 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<%= render partial: 'shared/eforms_redirect' %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -16,6 +16,9 @@ en:
       nino_exit:
         show:
           page_title: Use eForms for this application
+      partner_exit:
+        show:
+          page_title: Use eForms for this application
 
     contact:
       home_address:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       edit_step :has_nino
 
       show_step :nino_exit
+      show_step :partner_exit
     end
 
     namespace :contact do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,13 +29,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # Just for demo purposes, to be removed
-  get 'home/selected_yes'
-  get 'home/selected_no'
-
-  get 'home/nino_yes'
-  get 'home/nino_no'
-
   namespace :steps do
     namespace :client do
       edit_step :has_partner

--- a/spec/controllers/steps/client/partner_exit_controller_spec.rb
+++ b/spec/controllers/steps/client/partner_exit_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::PartnerExitController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -7,20 +7,4 @@ RSpec.describe 'Home' do
       expect(response).to have_http_status(:ok)
     end
   end
-
-  # Just for demo purposes. To be removed.
-  #
-  describe 'selected_yes' do
-    it 'renders the expected page' do
-      get '/home/selected_yes'
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
-  describe 'selected_no' do
-    it 'renders the expected page' do
-      get '/home/selected_no'
-      expect(response).to have_http_status(:ok)
-    end
-  end
 end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Decisions::ClientDecisionTree do
 
     context 'and answer is `yes`' do
       let(:client_has_partner) { YesNoAnswer::YES }
-      it { is_expected.to have_destination('/home', :selected_yes) }
+      it { is_expected.to have_destination(:partner_exit, :show) }
     end
   end
 


### PR DESCRIPTION
## Description of change
Adds eFroms redirect to `/has_partner` page if applicant has a partner (selects 'yes')
## Link to relevant ticket

## Notes for reviewer
- I haven't added to the request spec for the eforms redirect as I think it is covered by the nino_exit path.
- Also removed some the temp `selected_yes/no` routes views for has_partner and has_nino as these now have places to go as extra steps have been added.
## How to manually test the feature

- start application > at has partner? select 'Yes' > submit
- should go to eForms redirect page.
