### PR TITLE
Minor styling tweak in the info card

### DIFF
--- a/app/assets/stylesheets/local/info_card.scss
+++ b/app/assets/stylesheets/local/info_card.scss
@@ -21,7 +21,6 @@
   background-color: govuk-colour("blue");
 }
 
-
 // Inverted button styles from
 // https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/components/_inverted-button.scss
 $button-shadow-size: $govuk-border-width-form-element;
@@ -29,6 +28,17 @@ $app-button-inverted-background-colour: govuk-colour("white");
 $app-button-inverted-foreground-colour: govuk-colour("blue");
 $app-button-inverted-shadow-colour: govuk-shade($app-button-inverted-foreground-colour, 30%);
 $app-button-inverted-hover-background-colour: govuk-tint($app-button-inverted-foreground-colour, 90%);
+
+.app-button--m {
+  // Below styles from govuk-button--start
+  @include govuk-typography-weight-bold;
+  @include govuk-typography-responsive($size: 19, $override-line-height: 1);
+
+  min-height: auto;
+  justify-content: center;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
 
 .app-button--inverted,
 .app-button--inverted:link,

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -4,7 +4,7 @@
 
     <p class="govuk-body app-inverted-text">You cannot use this service if your client:</p>
 
-    <ul class="govuk-list govuk-list--bullet app-inverted-text app-inverted-narrow-width">
+    <ul class="govuk-list govuk-list--bullet app-inverted-text">
       <li>has a partner</li>
       <li>does not have a National Insurance number </li>
       <li>does not receive a passporting benefit based on DWP records, including Universal Credits</li>
@@ -12,8 +12,9 @@
     </ul>
 
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <%= link_button 'Apply in eForms', 'https://portal.legalservices.gov.uk', class: 'govuk-button app-button--inverted' %>
+      <%= link_button 'Apply in eForms', 'https://portal.legalservices.gov.uk', class: 'app-button--m app-button--inverted' %>
     </div>
-    <%= link_to 'Back to your applications', '/todo_route_to_applications', class: 'app-link--inverted' %>
+
+    <%= link_to 'Back to all applications', '/todo_route_to_applications', class: 'app-link--inverted govuk-!-font-size-19' %>
   </div>
 </div>


### PR DESCRIPTION
## Description of change
Improving button contrast and slightly bigger font-size in the link.

Removing unused class `app-inverted-narrow-width`.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1049" alt="Screenshot 2022-08-04 at 15 41 13" src="https://user-images.githubusercontent.com/687910/182876250-7f714e30-882f-477e-b9e5-a1746727f714.png">

### After changes:
<img width="1041" alt="Screenshot 2022-08-04 at 15 40 02" src="https://user-images.githubusercontent.com/687910/182876285-8ca7e659-fe58-4489-8eb6-5bd8fae44dac.png">


## How to manually test the feature
