### PR TITLE
CRIMAP-80 update client nino page

### DIFF
--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -6,17 +6,11 @@ module Steps
       # taken from Civil Apply
       NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\Z/
 
-      attribute :has_nino, :yes_no
       attribute :nino, :string
 
       has_one_association :applicant
 
-      validates_inclusion_of :has_nino, in: :choices
-      validates :nino, format: { with: NINO_REGEXP }, if: -> { has_nino&.yes? }
-
-      def choices
-        YesNoAnswer.values
-      end
+      validates :nino, format: { with: NINO_REGEXP }
 
       private
 

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -8,7 +8,7 @@ module Decisions
       when :details
         edit(:has_nino)
       when :has_nino
-        after_has_nino
+        edit('/steps/contact/home_address')
       when :contact_details
         show('/home', action: :index)
       else
@@ -24,14 +24,6 @@ module Decisions
         show(:partner_exit)
       else
         edit(:details)
-      end
-    end
-
-    def after_has_nino
-      if form_object.has_nino.yes?
-        start_address_journey(HomeAddress, form_object.applicant)
-      else
-        show(:nino_exit)
       end
     end
 

--- a/app/views/steps/client/has_nino/edit.html.erb
+++ b/app/views/steps/client/has_nino/edit.html.erb
@@ -5,16 +5,18 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :has_nino do %>
-        <%= f.govuk_radio_button :has_nino, YesNoAnswer::YES, link_errors: true do %>
-          <%= f.govuk_text_field :nino, width: 'three-quarters' %>
-        <% end %>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-        <%= f.govuk_radio_button :has_nino, YesNoAnswer::NO %>
-      <% end %>
+    <%= step_form @form_object do |f| %>
+
+      <%= f.govuk_text_field :nino, width: 'three-quarters' %>
+
+      <div class='govuk-body' >
+        <%= link_to t('.eforms_link'), steps_client_nino_exit_path %>
+      </div>
 
       <%= f.continue_button %>
+
     <% end %>
   </div>
 </div>

--- a/app/views/steps/client/has_nino/edit.html.erb
+++ b/app/views/steps/client/has_nino/edit.html.erb
@@ -9,7 +9,7 @@
 
     <%= step_form @form_object do |f| %>
 
-      <%= f.govuk_text_field :nino, width: 'three-quarters' %>
+      <%= f.govuk_text_field :nino, width: 'three-quarters', label: nil %>
 
       <div class='govuk-body' >
         <%= link_to t('.eforms_link'), steps_client_nino_exit_path %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -38,9 +38,6 @@ en:
         first_name: First name
         last_name: Last name
         other_names: Other names (optional)
-      steps_client_has_nino_form:
-        nino: Enter their National Insurance number
-
       steps_address_lookup_form:
         postcode: Postcode
       steps_address_details_form:
@@ -49,3 +46,9 @@ en:
         city: Town or city
         country: Country
         postcode: Postcode
+      steps_contact_home_address_form:
+        home_address_line_one: Address line 1
+        home_address_line_two: Address line 2 (optional)
+        home_city: Town or city
+        home_county: County (optional)
+        home_postcode: Postcode

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -18,8 +18,6 @@ en:
         client_has_partner: Does your client have a partner?
       steps_client_details_form:
         date_of_birth: Date of birth
-      steps_client_has_nino_form:
-        has_nino: Do you have your client's National Insurance number?
 
     hint:
       steps_client_has_partner_form:
@@ -31,6 +29,7 @@ en:
         has_nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
       steps_address_lookup_form:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
+        nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
 
     label:
       steps_client_has_partner_form:
@@ -40,7 +39,6 @@ en:
         last_name: Last name
         other_names: Other names (optional)
       steps_client_has_nino_form:
-        has_nino_options: *YESNO
         nino: Enter their National Insurance number
 
       steps_address_lookup_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -13,7 +13,7 @@ en:
       has_nino:
         edit:
           page_title: Enter your client’s NINO
-          heading: Do you have your client's National Insurance number?
+          heading: Enter your client's National Insurance number
           eforms_link: My client does not have a National Insurance number or can't find it
       nino_exit:
         show:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -13,6 +13,8 @@ en:
       has_nino:
         edit:
           page_title: Enter your client’s NINO
+          heading: Do you have your client's National Insurance number?
+          eforms_link: My client does not have a National Insurance number or can't find it
       nino_exit:
         show:
           page_title: Use eForms for this application

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Steps::Client::HasNinoForm do
 
   let(:arguments) { {
     crime_application: crime_application,
-    has_nino: has_nino,
     nino: nino
   } }
 
@@ -14,46 +13,13 @@ RSpec.describe Steps::Client::HasNinoForm do
     instance_double(CrimeApplication)
   }
 
-  let(:has_nino) { nil }
   let(:nino) { nil }
 
   subject { described_class.new(arguments) }
 
-  describe '#choices' do
-    it 'returns the possible choices' do
-      expect(
-        subject.choices
-      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
-    end
-  end
-
   describe '#save' do
-    context 'when `has_nino` is not provided' do
-      it 'returns false' do
-        expect(subject.save).to be(false)
-      end
-
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:has_nino, :inclusion)).to eq(true)
-      end
-    end
-
-    context 'when `has_nino` is not valid' do
-      let(:has_nino) { 'maybe' }
-
-      it 'returns false' do
-        expect(subject.save).to be(false)
-      end
-
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:has_nino, :inclusion)).to eq(true)
-      end
-    end
 
     context 'when `nino` is blank' do
-      let(:has_nino) { 'yes' }
       let(:nino) { '' }
 
       it 'has a validation error on the field' do
@@ -63,7 +29,6 @@ RSpec.describe Steps::Client::HasNinoForm do
     end
 
     context 'when `nino` is invalid' do
-      let(:has_nino) { 'yes' }
       let(:nino) { 'not a NINO' }
 
       it 'has a validation error on the field' do
@@ -73,12 +38,10 @@ RSpec.describe Steps::Client::HasNinoForm do
     end
 
     context 'when validations pass' do
-      let(:has_nino) { 'yes' }
       let(:nino) { 'AB123456C' }
       it_behaves_like 'a has-one-association form',
                       association_name: :applicant,
                       expected_attributes: {
-                        'has_nino' => YesNoAnswer::YES,
                         'nino' => "AB123456C"
                       }
     end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -28,25 +28,10 @@ RSpec.describe Decisions::ClientDecisionTree do
   end
 
   context 'when the step is `has_nino`' do
-    let(:form_object) { double('FormObject', applicant: 'applicant', has_nino: has_nino) }
+    let(:form_object) { double('FormObject', applicant: 'applicant') }
     let(:step_name) { :has_nino }
 
-    context 'and answer is `no`' do
-      let(:has_nino) { YesNoAnswer::NO }
-      it { is_expected.to have_destination(:nino_exit, :show) }
-    end
-
-    context 'and answer is `yes`' do
-      let(:has_nino) { YesNoAnswer::YES }
-
-      before do
-        allow(
-          HomeAddress
-        ).to receive(:find_or_create_by).with(person: 'applicant').and_return('address')
-      end
-
-      it { expect(subject.destination).to eq(controller: '/steps/address/lookup', action: :edit, id: 'address') }
-    end
+    it { is_expected.to have_destination('/steps/contact/home_address', :edit) }
   end
 
   context 'when the step is `contact_details`' do


### PR DESCRIPTION
## Description of change
Slight rework of nino page as per updated design

## Link to relevant ticket
[CRIMAP-80](https://dsdmoj.atlassian.net/browse/CRIMAP-80)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="829" alt="Screenshot 2022-08-08 at 11 44 33" src="https://user-images.githubusercontent.com/13377553/183400745-23506cfd-54a8-4f45-9955-7ec55bd362af.png">

### After changes:
<img width="894" alt="Screenshot 2022-08-08 at 11 44 03" src="https://user-images.githubusercontent.com/13377553/183400674-fcea52fc-90c0-4195-bb93-517d399e70de.png">


## How to manually test the feature
Check that NINO validation works the same as before.

Check that link to eForms redirect works. 


