### PR TITLE
CRIMAP-80 Implement Nino form redesign

### DIFF
--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -6,17 +6,11 @@ module Steps
       # taken from Civil Apply
       NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\Z/
 
-      attribute :has_nino, :yes_no
       attribute :nino, :string
 
       has_one_association :applicant
 
-      validates_inclusion_of :has_nino, in: :choices
-      validates :nino, format: { with: NINO_REGEXP }, if: -> { has_nino&.yes? }
-
-      def choices
-        YesNoAnswer.values
-      end
+      validates :nino, format: { with: NINO_REGEXP }
 
       private
 

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -7,7 +7,7 @@ module Decisions
       when :details
         edit(:has_nino)
       when :has_nino
-        after_has_nino
+        start_address_journey(HomeAddress, form_object.applicant)
       when :contact_details
         show('/home', action: :index)
       else
@@ -22,14 +22,6 @@ module Decisions
         show(:partner_exit)
       else
         edit(:details)
-      end
-    end
-
-    def after_has_nino
-      if form_object.has_nino.yes?
-        start_address_journey(HomeAddress, form_object.applicant)
-      else
-        show(:nino_exit)
       end
     end
 

--- a/app/views/steps/client/has_nino/edit.html.erb
+++ b/app/views/steps/client/has_nino/edit.html.erb
@@ -5,14 +5,14 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :has_nino do %>
-        <%= f.govuk_radio_button :has_nino, YesNoAnswer::YES, link_errors: true do %>
-          <%= f.govuk_text_field :nino, width: 'three-quarters' %>
-        <% end %>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-        <%= f.govuk_radio_button :has_nino, YesNoAnswer::NO %>
-      <% end %>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :nino, width: 'two-thirds', label: { hidden: true } %>
+
+      <div class='govuk-body' >
+        <%= link_to t('.eforms_link'), steps_client_nino_exit_path %>
+      </div>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -18,8 +18,6 @@ en:
         client_has_partner: Does your client have a partner?
       steps_client_details_form:
         date_of_birth: Date of birth
-      steps_client_has_nino_form:
-        has_nino: Do you have your client's National Insurance number?
 
     hint:
       steps_client_has_partner_form:
@@ -28,7 +26,7 @@ en:
         other_names: This includes aliases, nicknames or other names your client may be known as.
         date_of_birth: For example, 27 3 2007
       steps_client_has_nino_form:
-        has_nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
+        nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
       steps_address_lookup_form:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
 
@@ -40,9 +38,7 @@ en:
         last_name: Last name
         other_names: Other names (optional)
       steps_client_has_nino_form:
-        has_nino_options: *YESNO
         nino: Enter their National Insurance number
-
       steps_address_lookup_form:
         postcode: Postcode
       steps_address_details_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -12,7 +12,9 @@ en:
           full_name_legend: Full name
       has_nino:
         edit:
+          heading: Enter your client's National Insurance number 
           page_title: Enter your client’s NINO
+          eforms_link: My client does not have a National Insurance number or can't find it
       nino_exit:
         show:
           page_title: Use eForms for this application

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Steps::Client::HasNinoForm do
 
   let(:arguments) { {
     crime_application: crime_application,
-    has_nino: has_nino,
     nino: nino
   } }
 
@@ -14,46 +13,12 @@ RSpec.describe Steps::Client::HasNinoForm do
     instance_double(CrimeApplication)
   }
 
-  let(:has_nino) { nil }
   let(:nino) { nil }
 
   subject { described_class.new(arguments) }
 
-  describe '#choices' do
-    it 'returns the possible choices' do
-      expect(
-        subject.choices
-      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
-    end
-  end
-
   describe '#save' do
-    context 'when `has_nino` is not provided' do
-      it 'returns false' do
-        expect(subject.save).to be(false)
-      end
-
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:has_nino, :inclusion)).to eq(true)
-      end
-    end
-
-    context 'when `has_nino` is not valid' do
-      let(:has_nino) { 'maybe' }
-
-      it 'returns false' do
-        expect(subject.save).to be(false)
-      end
-
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:has_nino, :inclusion)).to eq(true)
-      end
-    end
-
     context 'when `nino` is blank' do
-      let(:has_nino) { 'yes' }
       let(:nino) { '' }
 
       it 'has a validation error on the field' do
@@ -63,7 +28,6 @@ RSpec.describe Steps::Client::HasNinoForm do
     end
 
     context 'when `nino` is invalid' do
-      let(:has_nino) { 'yes' }
       let(:nino) { 'not a NINO' }
 
       it 'has a validation error on the field' do
@@ -73,12 +37,10 @@ RSpec.describe Steps::Client::HasNinoForm do
     end
 
     context 'when validations pass' do
-      let(:has_nino) { 'yes' }
       let(:nino) { 'AB123456C' }
       it_behaves_like 'a has-one-association form',
                       association_name: :applicant,
                       expected_attributes: {
-                        'has_nino' => YesNoAnswer::YES,
                         'nino' => "AB123456C"
                       }
     end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -28,16 +28,11 @@ RSpec.describe Decisions::ClientDecisionTree do
   end
 
   context 'when the step is `has_nino`' do
-    let(:form_object) { double('FormObject', applicant: 'applicant', has_nino: has_nino) }
+    let(:form_object) { double('FormObject', applicant: 'applicant') }
     let(:step_name) { :has_nino }
 
-    context 'and answer is `no`' do
-      let(:has_nino) { YesNoAnswer::NO }
-      it { is_expected.to have_destination(:nino_exit, :show) }
-    end
-
-    context 'and answer is `yes`' do
-      let(:has_nino) { YesNoAnswer::YES }
+    context 'has correct next step' do
+      let(:nino) { 'AA123245A' }
 
       before do
         allow(


### PR DESCRIPTION
## Description of change
Slight rework of nino page as per updated design

## Link to relevant ticket
[CRIMAP-80](https://dsdmoj.atlassian.net/browse/CRIMAP-80)

## Screenshots of changes (if applicable)

### Before changes:
<img width="829" alt="Screenshot 2022-08-08 at 11 44 33" src="https://user-images.githubusercontent.com/13377553/183400745-23506cfd-54a8-4f45-9955-7ec55bd362af.png">

### After changes:
<img width="997" alt="Screenshot 2022-08-08 at 12 44 34" src="https://user-images.githubusercontent.com/13377553/183410679-c50f031e-a375-4474-a3c5-e1fa283516a8.png">


## How to manually test the feature
Check that NINO validation works the same as before.

Check that link to eForms redirect works. 


