### PR TITLE
Improve nino validation

### DIFF
--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -4,7 +4,7 @@ module Steps
       include Steps::HasOneAssociation
 
       # taken from Civil Apply
-      NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\Z/
+      NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\s*\d\s*){6}([A-DFM]|\s)\Z/
 
       attribute :nino, :string
 

--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -3,14 +3,17 @@ module Steps
     class HasNinoForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
 
-      # taken from Civil Apply
-      NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\s*\d\s*){6}([A-DFM]|\s)\Z/
+      NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z][0-9]{6}([A-DFM])\Z/
 
       attribute :nino, :string
 
       has_one_association :applicant
 
       validates :nino, format: { with: NINO_REGEXP }
+
+      def nino=(str)
+        super(str.upcase.delete(' ')) if str
+      end
 
       private
 

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -28,11 +28,39 @@ RSpec.describe Steps::Client::HasNinoForm do
     end
 
     context 'when `nino` is invalid' do
-      let(:nino) { 'not a NINO' }
+      context 'with a random string' do
+        let(:nino) { 'not a NINO' }
 
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+        end
+      end
+
+      context 'with an unused prefix' do
+        let(:nino) { 'BG123456C' }
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+        end
+      end
+    end
+
+    context 'when `nino` is valid' do
+      context 'with spaces between numbers' do
+        let(:nino) { 'AB 12 34 56 C' }
+        it 'passes validation' do
+          expect(subject).to be_valid
+          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(false)
+        end
+      end
+      context 'with trailing spaces' do
+        let(:nino) { ' AB 1234 56C ' }
+        it 'passed validation' do
+          expect(subject).to be_valid
+          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
## Description of change

Based on NINO allocation rules as per https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110 - improved validation to include raising validation errors for specific unused prefixes

Also strips spaces and upcases input prior to validation to allow for input variation (particularly for spaces which are shown as part of the hint text NINO example)