### PR TITLE
Add phone number attribute and input

### DIFF
--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -3,7 +3,18 @@ module Steps
     class ContactDetailsForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
 
+      # Very basic validation to prevent alphabetic input
+      TEL_REGEXP = /\A([^A-Za-z]*)\Z/
+
+      attribute :telephone_number, :string
+
       has_one_association :applicant
+
+      validates :telephone_number, format: { with: TEL_REGEXP }, presence: true
+
+      def telephone_number=(str)
+        super(str.delete(' ')) if str
+      end
 
       private
 

--- a/app/views/steps/client/contact_details/edit.html.erb
+++ b/app/views/steps/client/contact_details/edit.html.erb
@@ -7,5 +7,10 @@
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :telephone_number, autocomplete: 'off', width: 'one-third', label: { size: 'm' } %>
+
+      <%= f.continue_button %>
+    <% end %>
   </div>
 </div>

--- a/app/views/steps/client/contact_details/edit.html.erb
+++ b/app/views/steps/client/contact_details/edit.html.erb
@@ -8,7 +8,7 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :telephone_number, autocomplete: 'off', width: 'one-third', label: { size: 'm' } %>
+      <%= f.govuk_phone_field :telephone_number, autocomplete: 'off', width: 'one-third', label: { size: 'm' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -52,7 +52,10 @@ en:
               inclusion: Select whether you have a National Insurance Number or not
             nino: 
               invalid: Please enter a valid National Insurance number
-
+        steps/client/contact_details_form:
+          attributes:
+            telephone_number:
+              blank: Telephone number can’t be blank
         steps/address/lookup_form:
           attributes:
             postcode:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -56,6 +56,7 @@ en:
           attributes:
             telephone_number:
               blank: Telephone number can’t be blank
+              invalid: Please enter a valid UK telephone number
         steps/address/lookup_form:
           attributes:
             postcode:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -26,7 +26,9 @@ en:
         other_names: This includes aliases, nicknames or other names your client may be known as.
         date_of_birth: For example, 27 3 2007
       steps_client_has_nino_form:
-        nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. 
+        nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      steps_client_contact_details_form:
+        telephone_number: We'll use this to chase your client if they don't pay towards their legal aid.
       steps_address_lookup_form:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
 
@@ -39,6 +41,8 @@ en:
         other_names: Other names (optional)
       steps_client_has_nino_form:
         nino: Enter their National Insurance number
+      steps_client_contact_details_form:
+        telephone_number: UK telephone number
       steps_address_lookup_form:
         postcode: Postcode
       steps_address_details_form:

--- a/db/migrate/20220808161007_add_telephone_number_to_people.rb
+++ b/db/migrate/20220808161007_add_telephone_number_to_people.rb
@@ -1,0 +1,5 @@
+class AddTelephoneNumberToPeople < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :telephone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_05_103536) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_08_161007) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_103536) do
     t.date "date_of_birth"
     t.string "has_nino"
     t.string "nino"
+    t.string "telephone_number"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 

--- a/spec/forms/steps/client/contact_details_form_spec.rb
+++ b/spec/forms/steps/client/contact_details_form_spec.rb
@@ -2,18 +2,47 @@ require 'rails_helper'
 
 RSpec.describe Steps::Client::ContactDetailsForm do
   let(:arguments) { {
-    crime_application: crime_application
+    crime_application: crime_application,
+    telephone_number: telephone_number
   } }
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
+  let(:telephone_number) { nil }
+
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    context 'when validations pass' do
+    context 'when telephone_number is blank' do
+      let(:telephone_number) { '' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:telephone_number, :blank)).to eq(true)
+      end
+    end
+
+    context 'when telephone_number contains letters' do
+      let(:telephone_number) { 'not a telephone_number' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:telephone_number, :invalid)).to eq(true)
+      end
+    end
+
+    context 'when telephone_number is valid' do
+      let(:telephone_number) { '07000 000 000' }
+
+      it 'removes spaces from input' do
+        expect(subject.telephone_number).to eq('07000000000')
+      end
+
       it_behaves_like 'a has-one-association form',
                       association_name: :applicant,
-                      expected_attributes: {}
+                      expected_attributes: {
+                        'telephone_number' => "07000000000"
+                      }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Add phone number input to client/contact_details form view, add very basic validation and enforce presence. Strip spaces prior to validation and storage. 
Adds telephone_number column to people table. 
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-63
## Notes for reviewer
rails db:migrate to update people table
## Screenshots of changes 
### After changes:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/45827968/183517408-ccd7a272-9327-4640-add1-fac8f479a6e0.png">

## How to manually test the feature
Checkout, rails db:migrate, bin/dev - view at http://localhost:3000/steps/client/contact_details