### PR TITLE
Add UK postcode validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'faraday', '~> 2.4'
 gem 'pg', '~> 1.4'
 gem 'puma'
 gem 'rails', '~> 7.0.3'
+gem 'uk_postcode'
 
 gem 'govuk_design_system_formbuilder', '~> 3.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    uk_postcode (2.1.8)
     unicode-display_width (2.2.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -311,6 +312,7 @@ DEPENDENCIES
   sentry-ruby
   simplecov
   sprockets-rails
+  uk_postcode
   web-console
   webdrivers
   webmock

--- a/app/forms/steps/address/lookup_form.rb
+++ b/app/forms/steps/address/lookup_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Address
     class LookupForm < Steps::BaseFormObject
       attribute :postcode, :string
-      validates :postcode, presence: true
+      validates :postcode, presence: true, uk_postcode: true
 
       private
 

--- a/app/forms/steps/address/results_form.rb
+++ b/app/forms/steps/address/results_form.rb
@@ -24,7 +24,7 @@ module Steps
 
       def address_count_item
         Struct.new(:results_size, :lookup_id) do
-          def address_lines
+          def compact_address
             I18n.translate!(:results_count, count: results_size, scope: 'steps.address.results.edit')
           end
         end.new(addresses.size)

--- a/app/services/ordnance_survey/address_lookup_results.rb
+++ b/app/services/ordnance_survey/address_lookup_results.rb
@@ -6,8 +6,8 @@ module OrdnanceSurvey
     OTHER_TERRITORIES = ['ISLE OF MAN', 'JERSEY', 'GUERNSEY'].freeze
 
     Address = Struct.new(:address_line_one, :address_line_two, :city, :country, :postcode, :lookup_id) do
-      def address_lines
-        [address_line_one, address_line_two].compact_blank.join(', ')
+      def compact_address
+        [address_line_one, address_line_two, city].compact_blank.join(', ')
       end
     end
 

--- a/app/validators/uk_postcode_validator.rb
+++ b/app/validators/uk_postcode_validator.rb
@@ -1,0 +1,11 @@
+class UkPostcodeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, :invalid) unless parsed_postcode(value).full_valid?
+  end
+
+  private
+
+  def parsed_postcode(postcode)
+    UKPostcode.parse(postcode)
+  end
+end

--- a/app/views/steps/address/results/edit.html.erb
+++ b/app/views/steps/address/results/edit.html.erb
@@ -21,7 +21,7 @@
     <% if @form_object.addresses.any? %>
 
       <%= step_form @form_object do |f| %>
-        <%= f.govuk_collection_select :lookup_id, @form_object.addresses, :lookup_id, :address_lines %>
+        <%= f.govuk_collection_select :lookup_id, @form_object.addresses, :lookup_id, :compact_address %>
 
         <p class="govuk-body govuk-!-margin-bottom-8">
           <%= link_to t('.address_not_listed'), edit_steps_address_details_path(record) %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -61,6 +61,7 @@ en:
           attributes:
             postcode:
               blank: Enter postcode
+              invalid: Enter a valid UK postcode
         steps/address/results_form:
           attributes:
             lookup_id:

--- a/spec/forms/steps/address/lookup_form_spec.rb
+++ b/spec/forms/steps/address/lookup_form_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe Steps::Address::LookupForm do
   let(:arguments) { {
     crime_application: crime_application,
     record: address_record,
-    postcode: 'SW1H 9AJ',
+    postcode: postcode,
   } }
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:address_record) { Address.new }
+  let(:postcode) { 'SW1H 9AJ' }
 
   subject { described_class.new(arguments) }
 
@@ -17,12 +18,23 @@ RSpec.describe Steps::Address::LookupForm do
   end
 
   describe '#save' do
-    context 'when the attribute is given but is not a valid postcode' do
-      let(:postcode) { 'SE1' }
+    context 'UK postcode validation' do
+      context 'when postcode is incomplete' do
+        let(:postcode) { 'SE1' }
 
-      xit 'adds an `invalid` error on the attribute' do
-        expect(subject).not_to be_valid
-        expect(subject.errors.added?(:postcode, :invalid)).to eq(true)
+        it 'adds an `invalid` error on the attribute' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.added?(:postcode, :invalid)).to eq(true)
+        end
+      end
+
+      context 'when postcode is not valid' do
+        let(:postcode) { 'SZ123A' }
+
+        it 'adds an `invalid` error on the attribute' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.added?(:postcode, :invalid)).to eq(true)
+        end
       end
     end
 

--- a/spec/forms/steps/address/results_form_spec.rb
+++ b/spec/forms/steps/address/results_form_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Steps::Address::ResultsForm do
 
       it 'contains an addresses count item' do
         expect(subject.addresses[0].lookup_id).to be_nil
-        expect(subject.addresses[0].address_lines).to eq('1 address found')
+        expect(subject.addresses[0].compact_address).to eq('1 address found')
       end
 
       it 'contains the addresses' do
         expect(subject.addresses[1].lookup_id).to eq('23749191')
-        expect(subject.addresses[1].address_lines).to eq('1, POST OFFICE, BROADWAY')
+        expect(subject.addresses[1].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
       end
     end
 
@@ -48,16 +48,16 @@ RSpec.describe Steps::Address::ResultsForm do
 
       it 'contains an addresses count item' do
         expect(subject.addresses[0].lookup_id).to be_nil
-        expect(subject.addresses[0].address_lines).to eq('2 addresses found')
+        expect(subject.addresses[0].compact_address).to eq('2 addresses found')
       end
 
       # They are dupes but this is ok for this test scenario
       it 'contains the addresses' do
         expect(subject.addresses[1].lookup_id).to eq('23749191')
-        expect(subject.addresses[1].address_lines).to eq('1, POST OFFICE, BROADWAY')
+        expect(subject.addresses[1].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
 
         expect(subject.addresses[2].lookup_id).to eq('23749191')
-        expect(subject.addresses[2].address_lines).to eq('1, POST OFFICE, BROADWAY')
+        expect(subject.addresses[2].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
       end
     end
 

--- a/spec/services/ordnance/address_lookup_results_spec.rb
+++ b/spec/services/ordnance/address_lookup_results_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe OrdnanceSurvey::AddressLookupResults do
       context '`Address` struct convenience methods' do
         let(:result) { subject[0] }
 
-        context '#address_lines' do
-          it 'returns only the address lines' do
-            expect(result.address_lines).to eq('1, POST OFFICE, BROADWAY')
+        context '#compact_address' do
+          it 'returns a shorter version of the full address' do
+            expect(result.compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
           end
         end
 


### PR DESCRIPTION
## Description of change
Improve the postcode lookup step by ensuring valid UK postcodes are used, as otherwise Ordnance Survey will fail or return no addresses anyways.

It validates against million of postcodes in England, Wales, Scotland, Northern Ireland, the Channel Islands, and the Isle of Man.

I've also checked and it pass for Guernsey and Jersey postcodes too.

Not really related to this validator but I've renamed the Struct method from `address_lines` to `compact_address` to better capture the meaning, and added the city to it because at first glance in the dropdown a provider might want to have the assurance they are looking at results from a city they might expect, particularly important if we are going to skip the address manual entry page after they select an address in the dropdown.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="750" alt="Screenshot 2022-08-10 at 10 38 06" src="https://user-images.githubusercontent.com/687910/183869292-c3fb48fc-6a68-42f9-bd30-6a864dd114ec.png">


## How to manually test the feature
