### PR TITLE
deps: Bump to latest GOV.UK Frontend version

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,4 +1,4 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application", preload: true
-pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.2.0/govuk-esm/all.mjs"
+pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.3.0/govuk-esm/all.mjs", preload: true

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "laa-apply-for-criminal-legal-aid",
   "private": "true",
   "dependencies": {
-    "govuk-frontend": "4.2.0"
+    "govuk-frontend": "4.3.0"
   },
   "scripts": {
-    "postinstall": "bin/importmap pin govuk-frontend@4.2.0"
+    "postinstall": "bin/importmap pin govuk-frontend@4.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.2.0.tgz#1248eb8025c5f8aa6a80282e92da4c81263caf0c"
-  integrity sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==
+govuk-frontend@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.0.tgz#83cd9fdf5df73ebfa2d974fc91f926e19015bc6e"
+  integrity sha512-U8IyhayW5tpEktTU1Ea2wYyUsmS6UQWkuec/ebB51keSCUfZtrLsj5u9oa6GtwzTatk+3NYMOEEclGNTz4/FKQ==


### PR DESCRIPTION
## Description of change
No breaking changes or new features really, but good to be always in the latest version as they fix things behind the scenes.

Changelog:
https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.0

## Notes for reviewer
After checkout, just in case run stop the server, run `rails assets:clobber` and then run `bin/dev` again. Don't think is purely necessary but might avoid any issues.