### PR TITLE
Remove preload from importmap

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,4 +1,4 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application", preload: true
-pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.3.0/govuk-esm/all.mjs", preload: true
+pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.3.0/govuk-esm/all.mjs"


### PR DESCRIPTION
## Description of change
When running `yarn` it will remove the `preload: true` anyways causing a change to the working branch.

Apparently there is no way at the moment of specifying preload when using the `bin/importmap` command.

## How to manually test the feature
Once you checkout the branch, run `yarn` to pull the latest npm modules. The `importmap.rb` file should not change.