### PR TITLE
Sort out form builder defaults and fix markup

### DIFF
--- a/app/views/steps/address/lookup/edit.html.erb
+++ b/app/views/steps/address/lookup/edit.html.erb
@@ -5,10 +5,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third' %>
+      <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third', label: { tag: 'h1', size: 'xl' } %>
 
       <p class="govuk-body govuk-!-margin-bottom-2">
         <%= link_to t('.manual_entry'), edit_steps_address_details_path(@form_object.record) %>

--- a/app/views/steps/address/results/edit.html.erb
+++ b/app/views/steps/address/results/edit.html.erb
@@ -1,7 +1,10 @@
 <% title t('.page_title') %>
 <% step_header %>
 
-<% record = @form_object.record %>
+<%
+  record = @form_object.record
+  addresses = @form_object.addresses
+%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -18,12 +21,12 @@
       <%= link_to t('.change_postcode'), edit_steps_address_lookup_path(record), class: 'govuk-link govuk-!-margin-left-4' %>
     </p>
 
-    <% if @form_object.addresses.any? %>
+    <% if addresses.any? %>
 
       <%= step_form @form_object do |f| %>
-        <%= f.govuk_collection_select :lookup_id, @form_object.addresses, :lookup_id, :compact_address %>
+        <%= f.govuk_collection_select :lookup_id, addresses, :lookup_id, :compact_address %>
 
-        <p class="govuk-body govuk-!-margin-bottom-8">
+        <p class="govuk-body govuk-!-margin-bottom-6">
           <%= link_to t('.address_not_listed'), edit_steps_address_details_path(record) %>
         </p>
 

--- a/app/views/steps/client/contact_details/edit.html.erb
+++ b/app/views/steps/client/contact_details/edit.html.erb
@@ -10,8 +10,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_phone_field :telephone_number, autocomplete: 'off', width: 'one-third', label: { size: 'm' } %>
 
-      
-      <%= f.govuk_collection_radio_buttons :correspondence_address_type, 
+      <%= f.govuk_collection_radio_buttons :correspondence_address_type,
                                             @form_object.choices,
                                             :value %>
 

--- a/app/views/steps/client/details/edit.html.erb
+++ b/app/views/steps/client/details/edit.html.erb
@@ -8,14 +8,14 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_fieldset legend: { text: t('.full_name_legend'), tag: 'span', size: 'm' } do %>
-        <%= f.govuk_text_field :first_name, width: 'three-quarters' %>
-        <%= f.govuk_text_field :last_name, width: 'three-quarters' %>
+      <%= f.govuk_fieldset legend: { text: t('.full_name_legend') } do %>
+        <%= f.govuk_text_field :first_name, autocomplete: 'off', width: 'three-quarters' %>
+        <%= f.govuk_text_field :last_name, autocomplete: 'off', width: 'three-quarters' %>
       <% end %>
 
-      <%= f.govuk_text_field :other_names, width: 'three-quarters', label: { size: 'm' } %>
+      <%= f.govuk_text_field :other_names, autocomplete: 'off', width: 'three-quarters', label: { size: 'm' } %>
 
-      <%= f.govuk_date_field :date_of_birth, maxlength_enabled: true, legend: { tag: 'span', size: 'm' } %>
+      <%= f.govuk_date_field :date_of_birth, maxlength_enabled: true, legend: { size: 'm' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/client/has_nino/edit.html.erb
+++ b/app/views/steps/client/has_nino/edit.html.erb
@@ -5,14 +5,12 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :nino, width: 'two-thirds', label: { hidden: true } %>
+      <%= f.govuk_text_field :nino, autocomplete: 'off', width: 'one-third', label: { tag: 'h1', size: 'xl' } %>
 
-      <div class='govuk-body' >
+      <p class='govuk-body govuk-!-margin-bottom-6'>
         <%= link_to t('.eforms_link'), steps_client_nino_exit_path %>
-      </div>
+      </p>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/client/has_partner/edit.html.erb
+++ b/app/views/steps/client/has_partner/edit.html.erb
@@ -7,7 +7,7 @@
 
     <%= step_form @form_object do |f| %>
         <%= f.govuk_collection_radio_buttons :client_has_partner, @form_object.choices,
-                                             :value, nil, inline: true %>
+                                             :value, inline: true, legend: { tag: 'h1', size: 'xl' } %>
 
         <%= f.continue_button %>
     <% end %>

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,11 +1,5 @@
 ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
-GOVUKDesignSystemFormBuilder.configure do |config|
-  config.default_legend_tag   = 'h1'
-  config.default_legend_size  = 'xl'
-  config.default_caption_size = 'xl'
-end
-
 GOVUKDesignSystemFormBuilder::FormBuilder.class_eval do
   require 'form_builder_helper'
   include FormBuilderHelper

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -46,12 +46,12 @@ en:
         last_name: Last name
         other_names: Other names (optional)
       steps_client_has_nino_form:
-        nino: Enter their National Insurance number
+        nino: Enter your client’s National Insurance number
       steps_client_contact_details_form:
         telephone_number: UK telephone number
         correspondence_address_type_options: *CORRESPONDENCE_ADDRESS_TYPE
       steps_address_lookup_form:
-        postcode: Postcode
+        postcode: Enter your client’s home address
       steps_address_results_form:
         lookup_id: Select an address
       steps_address_details_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -12,7 +12,6 @@ en:
           full_name_legend: Full name
       has_nino:
         edit:
-          heading: Enter your client's National Insurance number 
           page_title: Enter your client’s NINO
           eforms_link: My client does not have a National Insurance number or can't find it
       nino_exit:
@@ -24,13 +23,12 @@ en:
       contact_details:
         edit:
           page_title: Client’s contact details
-          heading: Enter your client's contact details
+          heading: Enter your client’s contact details
 
     address:
       lookup:
         edit:
           page_title: Client’s home address
-          heading: Enter your client’s home address
           manual_entry: Enter address manually
           no_address: My client does not have a home address
       results:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_09_073216) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_09_094812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description of change
We had non-standard defaults set for the form builder. These are good defaults when an app is mainly done by many 1 question per page, as it saves having to set again and again the same tag, size, etc.

But in reality this app will not have that many individual questions and where we have them, we can customise accordingly.

Removed the custom defaults and tweaked the existing pages where needed to output proper markup, tags and sizes.

Also added `autocomplete: 'off'` if it was missing.

## Link to relevant ticket

## Notes for reviewer
Somehow some of the previous PR didn't commit the last version of the schema.rb, I've added it here otherwise migrations can fail.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Visually there is not that much difference, and everything should look pretty much the same.