### PR TITLE
Implement inquiry mechanism for value objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,11 @@ Naming/MethodParameterName:
   AllowedNames:
     - as
 
+# Rubocop mistakenly consider `#values` method as being called on a Hash
+Style/HashEachMethods:
+  Exclude:
+    - app/value_objects/value_object.rb
+
 Naming/PredicateName:
   AllowedMethods:
     - has_one_association

--- a/app/value_objects/correspondence_type_answer.rb
+++ b/app/value_objects/correspondence_type_answer.rb
@@ -4,20 +4,4 @@ class CorrespondenceTypeAnswer < ValueObject
     PROVIDERS_OFFICE_ADDRESS = new(:providers_office_address),
     OTHER_ADDRESS = new(:other_address)
   ].freeze
-
-  def self.values
-    VALUES
-  end
-
-  def home_address?
-    value == :home_address
-  end
-
-  def providers_office_address?
-    value == :providers_office_address
-  end
-
-  def other_address?
-    value == :other_address
-  end
 end

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -19,4 +19,24 @@ class ValueObject
   def hash
     [ValueObject, self.class, value].hash
   end
+
+  class << self
+    def inherited(subclass)
+      TracePoint.trace(:end) do
+        # Define inquiry methods for each value in the value object,
+        # i.e. `#coffee?` returns true for value `:coffee`, false for `:tea`
+        # :nocov:
+        subclass.values.each do |value|
+          define_method("#{value}?") { value.eql?(self) }
+        end
+        # :nocov:
+      end
+
+      super
+    end
+
+    def values
+      const_defined?(:VALUES) ? self::VALUES : []
+    end
+  end
 end

--- a/app/value_objects/yes_no_answer.rb
+++ b/app/value_objects/yes_no_answer.rb
@@ -3,16 +3,4 @@ class YesNoAnswer < ValueObject
     YES = new(:yes),
     NO  = new(:no)
   ].freeze
-
-  def self.values
-    VALUES
-  end
-
-  def yes?
-    value == :yes
-  end
-
-  def no?
-    value == :no
-  end
 end

--- a/spec/value_objects/correspondence_type_answer_spec.rb
+++ b/spec/value_objects/correspondence_type_answer_spec.rb
@@ -12,40 +12,4 @@ RSpec.describe CorrespondenceTypeAnswer do
       )
     end
   end
-
-  describe '#home_address?' do
-    context 'when value is `home_address`' do
-      let(:value) { :home_address }
-      it { expect(subject.home_address?).to eq(true) }
-    end
-
-    context 'when value is not `home_address`' do
-      let(:value) { :providers_office_address }
-      it { expect(subject.home_address?).to eq(false) }
-    end
-  end
-  describe '#providers_office_address?' do
-    context 'when value is `providers_office_address`' do
-      let(:value) { :providers_office_address }
-      it { expect(subject.providers_office_address?).to eq(true) }
-    end
-
-    context 'when value is not `providers_office_address`' do
-      let(:value) { :home_address }
-      it { expect(subject.providers_office_address?).to eq(false) }
-    end
-  end
-
-  describe '#other_address?' do
-    context 'when value is `providers_office_address`' do
-      let(:value) { :other_address }
-      it { expect(subject.other_address?).to eq(true) }
-    end
-
-    context 'when value is not `other_address`' do
-      let(:value) { :providers_office_address }
-      it { expect(subject.other_address?).to eq(false) }
-    end
-  end
-
 end

--- a/spec/value_objects/value_object_spec.rb
+++ b/spec/value_objects/value_object_spec.rb
@@ -65,4 +65,27 @@ RSpec.describe ValueObject do
       expect(foo_one.to_sym).to eq(:one)
     end
   end
+
+  describe '.values' do
+    it 'returns an empty array for the superclass' do
+      expect(described_class.values).to eq([])
+    end
+  end
+
+  describe 'inquiry methods' do
+    Fruit = Class.new(ValueObject) do
+      const_set(:VALUES, [new(:apple), new(:banana)])
+    end
+
+    let(:fruit_one) { Fruit.new(:apple) }
+    let(:fruit_two) { Fruit.new(:banana) }
+
+    it 'defines inquiry methods for each of the values' do
+      expect(fruit_one.apple?).to eq(true)
+      expect(fruit_one.banana?).to eq(false)
+
+      expect(fruit_two.apple?).to eq(false)
+      expect(fruit_two.banana?).to eq(true)
+    end
+  end
 end

--- a/spec/value_objects/yes_no_answer_spec.rb
+++ b/spec/value_objects/yes_no_answer_spec.rb
@@ -10,28 +10,4 @@ RSpec.describe YesNoAnswer do
       expect(described_class.values.map(&:to_s)).to eq(%w(yes no))
     end
   end
-
-  describe '#yes?' do
-    context 'when value is `yes`' do
-      let(:value) { :yes }
-      it { expect(subject.yes?).to eq(true) }
-    end
-
-    context 'when value is not `yes`' do
-      let(:value) { :no }
-      it { expect(subject.yes?).to eq(false) }
-    end
-  end
-
-  describe '#no?' do
-    context 'when value is `no`' do
-      let(:value) { :no }
-      it { expect(subject.no?).to eq(true) }
-    end
-
-    context 'when value is not `no`' do
-      let(:value) { :yes }
-      it { expect(subject.no?).to eq(false) }
-    end
-  end
 end


### PR DESCRIPTION
## Description of change
I've probably spent more time that I should on this little QoL thing, but in the end it is kind of nice :-)

Instead of implementing again and again inquiry methods for each of the values on a value-object (although in many cases it is not necessary if they are not inspected later on), now the  superclass `ValueObject` takes care of defining this "question mark" methods to ask a value object about its values.

It iterates through all defined values in the `VALUES` constant declaring methods like `yes?` or `no?` or `home_address?` etc.

Also moved to the superclass the class method `.values`. This makes for leaner value objects, to the point many will only have the `VALUES` constant and nothing else.

Any more complicated inquiry logic can be defined as separated methods in each value object like before.
Tests are also leaner as no need to test in every instance the inquiry methods, the "definition" of these methods is tested in the superclass.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
In a console you can do the following (considering the existing value-object we already have):

```ruby
c = CorrespondenceTypeAnswer.new('home_address')
c.home_address?
=> true
c.other_address?
=> false
c.foobar?
(irb):6:in `<main>': undefined method `foobar?'
c.methods - Object.methods
=> [:value, :home_address?, :providers_office_address?, :other_address?, :to_sym]
```