### PR TITLE
CRIMAP-101 Make corrs selector dynamic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,8 @@ gem 'sentry-ruby'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'pry'
   gem 'dotenv-rails'
+  gem 'pry'
   gem 'rspec-rails'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'sentry-ruby'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'pry'
   gem 'dotenv-rails'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
@@ -158,6 +159,9 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.4.2)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -301,6 +305,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (~> 3.1.0)
   importmap-rails
   pg (~> 1.4)
+  pry
   puma
   rails (~> 7.0.3)
   rspec-rails

--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Steps
   module Client
     class ContactDetailsForm < Steps::BaseFormObject
@@ -30,8 +28,8 @@ module Steps
         if applicant_has_home_address?
           CorrespondenceTypeAnswer.values
         else
-          CorrespondenceTypeAnswer.values.reject do |val| 
-            val.value == :home_address 
+          CorrespondenceTypeAnswer.values.reject do |val|
+            val.value == :home_address
           end
         end
       end
@@ -39,7 +37,7 @@ module Steps
       private
 
       def applicant_has_home_address?
-        applicant.has_home_address?
+        applicant.home_address?
       end
 
       def string_choices

--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -26,9 +26,9 @@ module Steps
 
       def choices
         if applicant_has_home_address?
-          CorrespondenceTypeAnswer.values
+          CorrespondenceType.values
         else
-          CorrespondenceTypeAnswer.values.reject do |val|
+          CorrespondenceType.values.reject do |val|
             val.value == :home_address
           end
         end

--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -17,28 +17,20 @@ module Steps
                 presence: true
 
       validates :correspondence_address_type,
-                inclusion: { in: :string_choices },
-                presence: true
+                inclusion: { in: :string_choices }
 
       def telephone_number=(str)
         super(str.delete(' ')) if str
       end
 
       def choices
-        if applicant_has_home_address?
-          CorrespondenceType.values
-        else
-          CorrespondenceType.values.reject do |val|
-            val.value == :home_address
-          end
-        end
+        values = CorrespondenceType.values.dup
+        values.delete(CorrespondenceType::HOME_ADDRESS) unless applicant.home_address?
+
+        values
       end
 
       private
-
-      def applicant_has_home_address?
-        applicant.home_address?
-      end
 
       def string_choices
         choices.map(&:to_s)

--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module Steps
   module Client
     class ContactDetailsForm < Steps::BaseFormObject
@@ -25,10 +27,20 @@ module Steps
       end
 
       def choices
-        CorrespondenceTypeAnswer.values
+        if applicant_has_home_address?
+          CorrespondenceTypeAnswer.values
+        else
+          CorrespondenceTypeAnswer.values.reject do |val| 
+            val.value == :home_address 
+          end
+        end
       end
 
       private
+
+      def applicant_has_home_address?
+        applicant.has_home_address?
+      end
 
       def string_choices
         choices.map(&:to_s)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,14 @@
 class Person < ApplicationRecord
   belongs_to :crime_application
   has_many :addresses, dependent: :destroy
+
+  def has_home_address?
+    home_address.address_line_one.present?
+  end
+
+  private
+
+  def home_address
+    addresses.find_by(type: 'HomeAddress')
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,7 +2,7 @@ class Person < ApplicationRecord
   belongs_to :crime_application
   has_many :addresses, dependent: :destroy
 
-  def has_home_address?
+  def home_address?
     home_address.address_line_one.present?
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,13 +2,9 @@ class Person < ApplicationRecord
   belongs_to :crime_application
   has_many :addresses, dependent: :destroy
 
+  has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
+
   def home_address?
     home_address.address_line_one.present?
-  end
-
-  private
-
-  def home_address
-    addresses.find_by(type: 'HomeAddress')
   end
 end

--- a/app/value_objects/correspondence_type.rb
+++ b/app/value_objects/correspondence_type.rb
@@ -1,4 +1,4 @@
-class CorrespondenceTypeAnswer < ValueObject
+class CorrespondenceType < ValueObject
   VALUES = [
     HOME_ADDRESS = new(:home_address),
     PROVIDERS_OFFICE_ADDRESS = new(:providers_office_address),

--- a/spec/forms/steps/client/contact_details_form_spec.rb
+++ b/spec/forms/steps/client/contact_details_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::Client::ContactDetailsForm do
   let(:arguments) { {
     crime_application: crime_application,
     telephone_number: telephone_number,
-    correspondence_address_type: correspondence_address_type,
+    correspondence_address_type: correspondence_address_type
   } }
 
   let(:crime_application) { instance_double(CrimeApplication) }

--- a/spec/forms/steps/client/contact_details_form_spec.rb
+++ b/spec/forms/steps/client/contact_details_form_spec.rb
@@ -4,15 +4,41 @@ RSpec.describe Steps::Client::ContactDetailsForm do
   let(:arguments) { {
     crime_application: crime_application,
     telephone_number: telephone_number,
-    correspondence_address_type: correspondence_address_type
+    correspondence_address_type: correspondence_address_type,
   } }
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
   let(:telephone_number) { nil }
   let(:correspondence_address_type) { nil }
+  let(:has_home_address) { nil }
 
   subject { described_class.new(arguments) }
+
+  before do
+    allow(subject).to receive(:applicant_has_home_address?).and_return(has_home_address)
+  end
+
+  describe '#choices' do
+    context 'when applicant has home address' do
+      let(:has_home_address) { true }
+      it 'returns all correspondence address types' do
+        expect(subject.choices.map(&:value)).to match(
+          [:home_address, 
+           :providers_office_address,
+           :other_address])
+      end
+    end
+
+    context 'when applicant has no home address' do
+      let(:has_home_address) { false }
+      it 'returns all correspondence address types' do
+        expect(subject.choices.map(&:value)).to match(
+           [:providers_office_address, 
+           :other_address])
+      end
+    end
+  end
 
   describe '#save' do
     context 'when telephone_number is blank' do
@@ -27,7 +53,7 @@ RSpec.describe Steps::Client::ContactDetailsForm do
 
     context 'when telephone_number contains letters' do
       let(:telephone_number) { 'not a telephone_number' }
-      let(:correspondence_address_type) { 'home_address' }
+      let(:correspondence_address_type) { 'other_address' }
 
       it 'has a validation error on the field' do
         expect(subject).to_not be_valid
@@ -37,7 +63,7 @@ RSpec.describe Steps::Client::ContactDetailsForm do
 
     context 'when telephone_number is valid' do
       let(:telephone_number) { '07000 000 000' }
-      let(:correspondence_address_type) { 'home_address' }
+      let(:correspondence_address_type) { 'other_address' }
 
       it 'removes spaces from input' do
         expect(subject.telephone_number).to eq('07000000000')
@@ -47,7 +73,7 @@ RSpec.describe Steps::Client::ContactDetailsForm do
                       association_name: :applicant,
                       expected_attributes: {
                         'telephone_number' => "07000000000",
-                        'correspondence_address_type' => 'home_address'
+                        'correspondence_address_type' => 'other_address'
                       }
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Person, type: :model do
       let(:address_line_one) { '1 North Pole' }
 
       it 'returns true when a home address has values' do
-        expect(subject.has_home_address?).to be(true)
+        expect(subject.home_address?).to be(true)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Person, type: :model do
       let(:address_line_one) { nil }
 
       it 'returns false when a home address does not have values' do
-        expect(subject.has_home_address?).to be(false)
+        expect(subject.home_address?).to be(false)
       end
     end
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Person, type: :model do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) { {} }
+
+  let(:mock_home_address) { 
+    instance_double(
+      'Address', 
+      address_line_one: address_line_one
+    )
+  }
+
+
+  before do
+    allow(subject).to receive(:home_address).and_return(mock_home_address)
+  end
+
+  describe '#has_home_address?' do
+    context 'home address is not blank' do
+
+      let(:address_line_one) { '1 North Pole' }
+
+      it 'returns true when a home address has values' do
+        expect(subject.has_home_address?).to be(true)
+      end
+    end
+
+    context 'home address has is blank' do
+
+      let(:address_line_one) { nil }
+
+      it 'returns false when a home address does not have values' do
+        expect(subject.has_home_address?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Person, type: :model do
     )
   }
 
-
   before do
     allow(subject).to receive(:home_address).and_return(mock_home_address)
   end

--- a/spec/value_objects/correspondence_type_spec.rb
+++ b/spec/value_objects/correspondence_type_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CorrespondenceTypeAnswer do
+RSpec.describe CorrespondenceType do
   subject { described_class.new(value) }
 
   let(:value) { :foo }


### PR DESCRIPTION
## Description of change

Dynamically changes the Correspondence Address selection on the contact details page


## Link to relevant ticket
[CRIMAP-101](https://dsdmoj.atlassian.net/browse/CRIMAP-101)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="996" alt="Screenshot 2022-08-11 at 16 21 33" src="https://user-images.githubusercontent.com/13377553/184169395-ba85fc11-f579-4ef2-9de4-753161a94bc8.png">


### After changes:

- when no home address:
<img width="692" alt="Screenshot 2022-08-11 at 15 39 53" src="https://user-images.githubusercontent.com/13377553/184159705-b92310b7-b34a-4854-81eb-506e99a506ae.png">


## How to manually test the feature
Go through the form to the client details page, you should see all three options available to select a Correspondence address:
- Same as home address
- Provider's address
- Somewhere else

Open rails console, run the following:
```
ha = HomeAddress.last
ha.address_line_one = nil
ha.save
```
Reload the page. You should see only the following options now:
- Provider's address
- Somewhere else

Submit the form - validations should work as before.
