### PR TITLE
CRIMAP-67 Add correspondence address sub-journey

### DIFF
--- a/app/decorators/address_form_decorator.rb
+++ b/app/decorators/address_form_decorator.rb
@@ -1,0 +1,42 @@
+class AddressFormDecorator < BaseDecorator
+  def page_title
+    ".page_title.#{i18n_key}"
+  end
+
+  def heading
+    ".heading.#{i18n_key}"
+  end
+
+  def home_address?
+    record.is_a?(HomeAddress)
+  end
+
+  def addresses
+    @addresses ||= begin
+      results = super
+
+      # Add the number of results as the first element of the collection
+      # User has to select something, otherwise there is a validation error
+      results.unshift(address_count_item) if results.any?
+      results
+    end
+  end
+
+  private
+
+  def address_count_item
+    Struct.new(:results_size, :lookup_id) do
+      def compact_address
+        I18n.translate!(:results_count, count: results_size, scope: 'steps.address.results.edit')
+      end
+    end.new(__getobj__.addresses.size)
+  end
+
+  def i18n_key
+    variant.join('.')
+  end
+
+  def variant
+    [record.person.type.underscore, record.type.underscore]
+  end
+end

--- a/app/decorators/base_decorator.rb
+++ b/app/decorators/base_decorator.rb
@@ -1,0 +1,5 @@
+class BaseDecorator < SimpleDelegator
+  def self.decorate(model)
+    ApplicationController.helpers.decorate(model, self)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,8 @@ module ApplicationHelper
 
     title ''
   end
+
+  def decorate(model, decorator_class = nil)
+    (decorator_class || [model.class, :Decorator].join.demodulize.constantize).new(model)
+  end
 end

--- a/app/services/decisions/address_decision_tree.rb
+++ b/app/services/decisions/address_decision_tree.rb
@@ -7,9 +7,20 @@ module Decisions
       when :results
         edit(:details)
       when :details
-        edit('/steps/client/contact_details')
+        after_details
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+
+    private
+
+    def after_details
+      if form_object.record.is_a?(HomeAddress)
+        edit('/steps/client/contact_details')
+      else
+        # TODO: link to next step when we have it
+        show('/home', action: :index)
       end
     end
   end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -7,9 +7,9 @@ module Decisions
       when :details
         edit(:has_nino)
       when :has_nino
-        start_address_journey(HomeAddress, form_object.applicant)
+        after_has_nino
       when :contact_details
-        show('/home', action: :index)
+        after_contact_details
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -22,6 +22,24 @@ module Decisions
         show(:partner_exit)
       else
         edit(:details)
+      end
+    end
+
+    def after_has_nino
+      start_address_journey(
+        HomeAddress,
+        form_object.applicant
+      )
+    end
+
+    def after_contact_details
+      if CorrespondenceType.new(form_object.correspondence_address_type).other_address?
+        start_address_journey(
+          CorrespondenceAddress,
+          form_object.applicant
+        )
+      else
+        show('/home', action: :index)
       end
     end
 

--- a/app/views/steps/address/details/edit.html.erb
+++ b/app/views/steps/address/details/edit.html.erb
@@ -1,11 +1,13 @@
-<% title t('.page_title') %>
+<% @form_object = decorate(@form_object, AddressFormDecorator) %>
+
+<% title t(@form_object.page_title) %>
 <% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t @form_object.heading %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :address_line_one, autocomplete: 'off' %>

--- a/app/views/steps/address/lookup/edit.html.erb
+++ b/app/views/steps/address/lookup/edit.html.erb
@@ -1,4 +1,6 @@
-<% title t('.page_title') %>
+<% @form_object = decorate(@form_object, AddressFormDecorator) %>
+
+<% title t(@form_object.page_title) %>
 <% step_header %>
 
 <div class="govuk-grid-row">
@@ -6,14 +8,15 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third', label: { tag: 'h1', size: 'xl' } %>
+      <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third',
+                             label: { tag: 'h1', size: 'xl', text: t(@form_object.heading) } %>
 
       <p class="govuk-body govuk-!-margin-bottom-2">
         <%= link_to t('.manual_entry'), edit_steps_address_details_path(@form_object.record) %>
       </p>
 
       <p class="govuk-body govuk-!-margin-bottom-6">
-        <%= link_to t('.no_address'), root_path %>
+        <%= link_to t('.no_address'), edit_steps_client_contact_details_path if @form_object.home_address? %>
       </p>
 
       <%= f.continue_button(primary: :find_address) %>

--- a/app/views/steps/address/results/edit.html.erb
+++ b/app/views/steps/address/results/edit.html.erb
@@ -1,4 +1,6 @@
-<% title t('.page_title') %>
+<% @form_object = decorate(@form_object, AddressFormDecorator) %>
+
+<% title t(@form_object.page_title) %>
 <% step_header %>
 
 <%
@@ -10,7 +12,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t @form_object.heading %></h1>
 
     <p class="govuk-label">
       <%=t '.current_postcode' %>
@@ -18,7 +20,7 @@
 
     <p class="govuk-body">
       <strong><%= record.postcode %></strong>
-      <%= link_to t('.change_postcode'), edit_steps_address_lookup_path(record), class: 'govuk-link govuk-!-margin-left-4' %>
+      <%= link_to t('.change_postcode_html'), edit_steps_address_lookup_path(record), class: 'govuk-link govuk-!-margin-left-4' %>
     </p>
 
     <% if addresses.any? %>

--- a/app/views/steps/address/results/edit.html.erb
+++ b/app/views/steps/address/results/edit.html.erb
@@ -37,7 +37,7 @@
 
     <% else %>
 
-      <p class="govuk-body-l">
+      <p class="govuk-body">
         <%=t '.no_results.info' %>
       </p>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -61,8 +61,8 @@ en:
         steps/address/lookup_form:
           attributes:
             postcode:
-              blank: Enter postcode
-              invalid: Enter a postcode in the correct format
+              blank: Enter a postcode
+              invalid: Enter a valid UK postcode
         steps/address/results_form:
           attributes:
             lookup_id:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -4,10 +4,6 @@ en:
     YESNO: &YESNO
       'yes': 'Yes'
       'no': 'No'
-    CORRESPONDENCE_ADDRESS_TYPE: &CORRESPONDENCE_ADDRESS_TYPE
-      'home_address' : 'Same as home address'
-      'providers_office_address' : "Provider's office"
-      'other_address' : 'Somewhere else'
 
   helpers:
     back_link: Back
@@ -49,9 +45,10 @@ en:
         nino: Enter your client’s National Insurance number
       steps_client_contact_details_form:
         telephone_number: UK telephone number
-        correspondence_address_type_options: *CORRESPONDENCE_ADDRESS_TYPE
-      steps_address_lookup_form:
-        postcode: Enter your client’s home address
+        correspondence_address_type_options:
+          home_address: Same as home address
+          providers_office_address: Provider’s office
+          other_address: Somewhere else
       steps_address_results_form:
         lookup_id: Select an address
       steps_address_details_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -28,15 +28,28 @@ en:
     address:
       lookup:
         edit:
-          page_title: Client’s home address
-          manual_entry: Enter address manually
+          page_title:
+            applicant:
+              home_address: Client’s home address
+              correspondence_address: Client’s correspondence address
+          heading:
+            applicant:
+              home_address: Enter your client’s home address
+              correspondence_address: Enter your client’s correspondence address
           no_address: My client does not have a home address
+          manual_entry: Enter address manually
       results:
         edit:
-          page_title: Client’s home address selection
-          heading: Enter your client’s home address
+          page_title:
+            applicant:
+              home_address: Client’s home address selection
+              correspondence_address: Client’s correspondence address selection
+          heading:
+            applicant:
+              home_address: Enter your client’s home address
+              correspondence_address: Enter your client’s correspondence address
           current_postcode: Postcode
-          change_postcode: Change
+          change_postcode_html: Change <span class="govuk-visually-hidden">postcode</span>
           address_not_listed: I can’t find the address in the list
           results_count:
             one: "%{count} address found"
@@ -46,5 +59,11 @@ en:
             manual_entry: Enter address manually
       details:
         edit:
-          page_title: Client’s home address
-          heading: Enter your client’s home address
+          page_title:
+            applicant:
+              home_address: Client’s home address
+              correspondence_address: Client’s correspondence address
+          heading:
+            applicant:
+              home_address: Enter your client’s home address
+              correspondence_address: Enter your client’s correspondence address

--- a/spec/decorators/address_form_decorator_spec.rb
+++ b/spec/decorators/address_form_decorator_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe AddressFormDecorator do
+  subject { described_class.new(form_object) }
+
+  let(:form_object) { double('FormObject', record: address_record) }
+
+  let(:address_record) { instance_double(Address, type: address_type, person: person_record) }
+  let(:person_record)  { instance_double(Person, type: person_type) }
+
+  let(:address_type) { nil }
+  let(:person_type)  { nil }
+
+  # NOTE: we only really have for now `Applicant`, but as these decorator is built
+  # to cope with multiple people types, we are testing it also for `Partner`
+
+  describe '#page_title' do
+    context 'for an applicant' do
+      let(:person_type) { Applicant.to_s }
+
+      context 'for a home address' do
+        let(:address_type) { HomeAddress.to_s }
+        it { expect(subject.page_title).to eq('.page_title.applicant.home_address') }
+      end
+
+      context 'for a correspondence address' do
+        let(:address_type) { CorrespondenceAddress.to_s }
+        it { expect(subject.page_title).to eq('.page_title.applicant.correspondence_address') }
+      end
+    end
+
+    context 'for a partner' do
+      let(:person_type) { Partner.to_s }
+
+      context 'for a home address' do
+        let(:address_type) { HomeAddress.to_s }
+        it { expect(subject.page_title).to eq('.page_title.partner.home_address') }
+      end
+
+      context 'for a correspondence address' do
+        let(:address_type) { CorrespondenceAddress.to_s }
+        it { expect(subject.page_title).to eq('.page_title.partner.correspondence_address') }
+      end
+    end
+  end
+
+  describe '#heading' do
+    context 'for an applicant' do
+      let(:person_type) { Applicant.to_s }
+
+      context 'for a home address' do
+        let(:address_type) { HomeAddress.to_s }
+        it { expect(subject.heading).to eq('.heading.applicant.home_address') }
+      end
+
+      context 'for a correspondence address' do
+        let(:address_type) { CorrespondenceAddress.to_s }
+        it { expect(subject.heading).to eq('.heading.applicant.correspondence_address') }
+      end
+    end
+
+    context 'for a partner' do
+      let(:person_type) { Partner.to_s }
+
+      context 'for a home address' do
+        let(:address_type) { HomeAddress.to_s }
+        it { expect(subject.heading).to eq('.heading.partner.home_address') }
+      end
+
+      context 'for a correspondence address' do
+        let(:address_type) { CorrespondenceAddress.to_s }
+        it { expect(subject.heading).to eq('.heading.partner.correspondence_address') }
+      end
+    end
+  end
+
+  describe '#home_address?' do
+    context 'for a home address' do
+      let(:address_record) { HomeAddress.new }
+      it { expect(subject.home_address?).to eq(true) }
+    end
+
+    context 'for a correspondence address' do
+      let(:address_record) { CorrespondenceAddress.new }
+      it { expect(subject.home_address?).to eq(false) }
+    end
+  end
+
+  describe '.addresses' do
+    let(:form_object) { double('FormObject', addresses: addresses) }
+
+    context 'when there is only 1 address in the collection' do
+      let(:addresses) { [Struct] }
+
+      it 'contains an addresses count item' do
+        expect(subject.addresses[0].lookup_id).to be_nil
+        expect(subject.addresses[0].compact_address).to eq('1 address found')
+      end
+    end
+
+    context 'when there are more than 1 addresses in the collection' do
+      let(:addresses) { [Struct, Struct] }
+
+      it 'contains an addresses count item' do
+        expect(subject.addresses[0].lookup_id).to be_nil
+        expect(subject.addresses[0].compact_address).to eq('2 addresses found')
+      end
+    end
+
+    context 'when there are no addresses in the collection' do
+      let(:addresses) { [] }
+
+      it 'returns an empty array' do
+        expect(subject.addresses).to eq([])
+      end
+    end
+  end
+end

--- a/spec/decorators/base_decorator_spec.rb
+++ b/spec/decorators/base_decorator_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe BaseDecorator do
+  describe '.decorate' do
+    it 'calls the helper method passing self' do
+      expect(
+        ApplicationController.helpers
+      ).to receive(:decorate).with('foobar', described_class)
+
+      described_class.decorate('foobar')
+    end
+  end
+end

--- a/spec/forms/steps/address/results_form_spec.rb
+++ b/spec/forms/steps/address/results_form_spec.rb
@@ -23,41 +23,20 @@ RSpec.describe Steps::Address::ResultsForm do
   end
 
   describe '.addresses' do
-    context 'when 1 address is returned by the service' do
+    context 'when results are returned by the service' do
+      let(:json_results) { super() * 2 }
+
       it 'returns an array of Address struct' do
         expect(subject.addresses).to contain_exactly(Struct, Struct)
       end
 
-      it 'contains an addresses count item' do
-        expect(subject.addresses[0].lookup_id).to be_nil
-        expect(subject.addresses[0].compact_address).to eq('1 address found')
-      end
-
-      it 'contains the addresses' do
-        expect(subject.addresses[1].lookup_id).to eq('23749191')
-        expect(subject.addresses[1].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
-      end
-    end
-
-    context 'when 2 or more addresses are returned by the service' do
-      let(:json_results) { super() * 2 }
-
-      it 'returns an array of Address struct' do
-        expect(subject.addresses).to contain_exactly(Struct, Struct, Struct)
-      end
-
-      it 'contains an addresses count item' do
-        expect(subject.addresses[0].lookup_id).to be_nil
-        expect(subject.addresses[0].compact_address).to eq('2 addresses found')
-      end
-
       # They are dupes but this is ok for this test scenario
       it 'contains the addresses' do
+        expect(subject.addresses[0].lookup_id).to eq('23749191')
+        expect(subject.addresses[0].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
+
         expect(subject.addresses[1].lookup_id).to eq('23749191')
         expect(subject.addresses[1].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
-
-        expect(subject.addresses[2].lookup_id).to eq('23749191')
-        expect(subject.addresses[2].compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -34,5 +34,28 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper).to receive(:title).with('')
       helper.fallback_title
     end
+
+    describe '#decorate' do
+      before do
+        stub_const('FooBar', Class.new)
+        stub_const('FooBarDecorator', Class.new(BaseDecorator))
+      end
+
+      let(:foobar) { FooBar.new }
+
+      context 'for a specific delegator class' do
+        it 'instantiate the decorator with the passed object' do
+          expect(FooBarDecorator).to receive(:new).with(foobar)
+          helper.decorate(foobar, FooBarDecorator)
+        end
+      end
+
+      context 'using the object to infer the delegator class' do
+        it 'instantiate the decorator with the passed object inferring the class' do
+          expect(FooBarDecorator).to receive(:new).with(foobar)
+          helper.decorate(foobar)
+        end
+      end
+    end
   end
 end

--- a/spec/services/decisions/address_decision_tree_spec.rb
+++ b/spec/services/decisions/address_decision_tree_spec.rb
@@ -20,9 +20,17 @@ RSpec.describe Decisions::AddressDecisionTree do
   end
 
   context 'when the step is `details`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', record: address_record) }
     let(:step_name) { :details }
 
-    it { is_expected.to have_destination('/steps/client/contact_details', :edit) }
+    context 'if we come from a home address sub-journey' do
+      let(:address_record) { HomeAddress.new }
+      it { is_expected.to have_destination('/steps/client/contact_details', :edit) }
+    end
+
+    context 'if we come from a correspondence address sub-journey' do
+      let(:address_record) { CorrespondenceAddress.new }
+      it { is_expected.to have_destination('/home', :index) }
+    end
   end
 end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -45,9 +45,24 @@ RSpec.describe Decisions::ClientDecisionTree do
   end
 
   context 'when the step is `contact_details`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', applicant: 'applicant', correspondence_address_type: correspondence_address_type) }
     let(:step_name) { :contact_details }
 
-    it { is_expected.to have_destination('/home', :index) }
+    context 'and answer is `other_address`' do
+      let(:correspondence_address_type) { CorrespondenceType::OTHER_ADDRESS }
+
+      before do
+        allow(
+          CorrespondenceAddress
+        ).to receive(:find_or_create_by).with(person: 'applicant').and_return('address')
+      end
+
+      it { expect(subject.destination).to eq(controller: '/steps/address/lookup', action: :edit, id: 'address') }
+    end
+
+    context 'and answer is any other thing' do
+      let(:correspondence_address_type) { 'whatever' }
+      it { is_expected.to have_destination('/home', :index) }
+    end
   end
 end


### PR DESCRIPTION
## Description of change
We had already the home address sub-journey. The correspondence address one is the same but it customise some of the copy and links in the views accordingly.

In order to do this more clean and to copy with future changes if any, a decorator is used, that enhance the form object and expose some helper methods for the i18n, etc.
Also some logic previously existing in the form object has been moved to this decorator (the addresses counter).

Updated the decision trees to be able to enter this sub-journey from the contact details step, if the selected radio is "other address".

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-67
https://dsdmoj.atlassian.net/browse/CRIMAP-68

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="641" alt="Screenshot 2022-08-15 at 08 49 21" src="https://user-images.githubusercontent.com/687910/184596751-15351848-455f-47d7-ba86-312f67e387ea.png">
<img width="723" alt="Screenshot 2022-08-15 at 08 49 46" src="https://user-images.githubusercontent.com/687910/184596793-dc51e943-4abe-4e2c-ac85-002c5148ff26.png">
<img width="634" alt="Screenshot 2022-08-15 at 08 50 02" src="https://user-images.githubusercontent.com/687910/184596824-e3eba72b-a5d9-4e45-94c3-dbe7b69fec55.png">


## How to manually test the feature
Select "other address" in the contact details step. After finishing the correspondence address sub-journey you will get back to the home page as we don't have yet the next step.