### PR TITLE
CRIMAP-91 Task list page and basic presenters

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,7 @@
+// Components or full features
 @import "local/govuk";
-@import "local/custom";
 @import "local/info_card";
+@import "local/task_list";
+
+// App-specific custom styles and overrides
+@import "local/custom";

--- a/app/assets/stylesheets/local/task_list.scss
+++ b/app/assets/stylesheets/local/task_list.scss
@@ -1,0 +1,67 @@
+// Task list pattern custom styles
+// This component is not yet part of the GOV.UK frontend distribution
+// https://design-system.service.gov.uk/patterns/task-list-pages
+
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  @include govuk-font($size:24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(0);
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+.app-task-list__tag {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -1,0 +1,3 @@
+class CrimeApplicationsController < ApplicationController
+  def edit; end
+end

--- a/app/presenters/task_list/base_task_renderer.rb
+++ b/app/presenters/task_list/base_task_renderer.rb
@@ -1,0 +1,31 @@
+module TaskList
+  class BaseTaskRenderer
+    include ActionView::Helpers::UrlHelper
+
+    attr_reader :view, :name
+
+    delegate :tag, to: :view
+    delegate :t!, to: I18n
+
+    def initialize(view, name:)
+      @view = view
+      @name = name
+    end
+
+    # :nocov:
+    def self.render(view, **kwargs)
+      new(view, **kwargs).render
+    end
+
+    def render
+      raise 'implement in subclasses'
+    end
+    # :nocov:
+
+    private
+
+    def tag_id
+      [name, 'status'].join('-')
+    end
+  end
+end

--- a/app/presenters/task_list/progress_tag.rb
+++ b/app/presenters/task_list/progress_tag.rb
@@ -1,0 +1,32 @@
+module TaskList
+  class ProgressTag < BaseTaskRenderer
+    attr_reader :status
+
+    DEFAULT_CLASSES = %w[govuk-tag app-task-list__tag].freeze
+
+    STATUSES = {
+      completed: nil,
+      in_progress: 'govuk-tag--blue',
+      not_started: 'govuk-tag--grey',
+      unreachable: 'govuk-tag--grey',
+      not_applicable: 'govuk-tag--grey',
+    }.freeze
+
+    def initialize(view, name:, status:)
+      super(view, name: name)
+      @status = status
+    end
+
+    def render
+      tag.strong id: tag_id, class: tag_classes do
+        t!("tasklist.status.#{status}")
+      end
+    end
+
+    private
+
+    def tag_classes
+      DEFAULT_CLASSES | Array(STATUSES.fetch(status))
+    end
+  end
+end

--- a/app/presenters/task_list/task.rb
+++ b/app/presenters/task_list/task.rb
@@ -1,0 +1,13 @@
+module TaskList
+  class Task < BaseTaskRenderer
+    def render
+      tag.li class: 'app-task-list__item' do
+        tag.span class: 'app-task-list__task-name' do
+          link_to_if false, t!("tasklist.task.#{name}"), '#', aria: { describedby: tag_id }
+        end.concat(
+          ProgressTag.render(view, name: name, status: :not_applicable)
+        )
+      end
+    end
+  end
+end

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -1,0 +1,66 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <!-- TODO: this will be implemented a bit later -->
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
+    <p class="govuk-body govuk-!-margin-bottom-7">You have completed 0 of 10 sections.</p>
+
+    <ol class="app-task-list">
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">1.</span> <%=t 'tasklist.heading.client_details' %>
+        </h2>
+        <ul class="app-task-list__items">
+          <%= TaskList::Task.render(self, name: :client_details) %>
+        </ul>
+      </li>
+
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">2.</span> <%=t 'tasklist.heading.case_details' %>
+        </h2>
+        <ul class="app-task-list__items">
+          <%= TaskList::Task.render(self, name: :case_details) %>
+          <%= TaskList::Task.render(self, name: :justification_for_legal_aid) %>
+        </ul>
+      </li>
+
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">3.</span> <%=t 'tasklist.heading.means_assessment' %>
+        </h2>
+        <ul class="app-task-list__items">
+          <%= TaskList::Task.render(self, name: :income_assessment) %>
+          <%= TaskList::Task.render(self, name: :capital_assessment) %>
+          <%= TaskList::Task.render(self, name: :check_your_answers) %>
+          <%= TaskList::Task.render(self, name: :check_assessment_result) %>
+        </ul>
+      </li>
+
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">4.</span> <%=t 'tasklist.heading.supporting_evidence' %>
+        </h2>
+        <ul class="app-task-list__items">
+          <%= TaskList::Task.render(self, name: :evidence_upload) %>
+        </ul>
+      </li>
+
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">5.</span> <%=t 'tasklist.heading.review' %>
+        </h2>
+        <ul class="app-task-list__items">
+          <%= TaskList::Task.render(self, name: :application_review) %>
+          <%= TaskList::Task.render(self, name: :application_submission) %>
+        </ul>
+      </li>
+    </ol>
+
+    <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
+  </div>
+</div>

--- a/config/locales/en/tasklist.yml
+++ b/config/locales/en/tasklist.yml
@@ -1,0 +1,32 @@
+---
+en:
+  tasklist:
+    heading:
+      client_details: About your client
+      case_details: About the case
+      means_assessment: Means assessment
+      supporting_evidence: Supporting evidence
+      review: Review and confirm
+    task:
+      client_details: Client details
+      case_details: Case details
+      justification_for_legal_aid: Justification for legal aid
+      income_assessment: Income assessment
+      capital_assessment: Capital assessment
+      check_your_answers: Check your answers
+      check_assessment_result: Check means assessment result
+      evidence_upload: Upload evidence
+      application_review: Review the application
+      application_submission: Confirm declaration and submit application
+    status:
+      completed: Completed
+      in_progress: In progress
+      not_started: Not started
+      unreachable: Cannot yet start
+      not_applicable: Not applicable
+
+  crime_applications:
+    edit:
+      page_title: Applicaton task list
+      heading: Make a new application
+      back_to_applications: Back to your applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :crime_applications, except: [:new, :update]
+
   namespace :steps do
     namespace :client do
       edit_step :has_partner

--- a/spec/presenters/task_list/progress_tag_spec.rb
+++ b/spec/presenters/task_list/progress_tag_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe TaskList::ProgressTag do
+  include ActionView::TestCase::Behavior
+
+  subject { described_class.new(view, name: name, status: status) }
+
+  let(:name) { :foobar_task }
+
+  describe 'STATUS_TAGS' do
+    it 'contains a map of statuses and their CSS classes' do
+      expect(
+        described_class::STATUSES
+      ).to eq(
+        completed: nil,
+        in_progress: 'govuk-tag--blue',
+        not_started: 'govuk-tag--grey',
+        unreachable: 'govuk-tag--grey',
+        not_applicable: 'govuk-tag--grey',
+      )
+    end
+  end
+
+  describe '.render' do
+    it 'initialises the object and call the render instance method' do
+      expect(
+        described_class
+      ).to receive(:new).with(view, name: 'name', status: 'status')
+
+      described_class.new(view, name: 'name', status: 'status')
+    end
+  end
+
+  describe '#render' do
+    context 'for a `completed` status' do
+      let(:status) { :completed }
+      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag">Completed</strong>') }
+    end
+
+    context 'for an `in_progress` status' do
+      let(:status) { :in_progress }
+      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--blue">In progress</strong>') }
+    end
+
+    context 'for a `not_started` status' do
+      let(:status) { :not_started }
+      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Not started</strong>') }
+    end
+
+    context 'for an `unreachable` status' do
+      let(:status) { :unreachable }
+      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Cannot yet start</strong>') }
+    end
+
+    context 'for a `not_applicable` status' do
+      let(:status) { :not_applicable }
+      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Not applicable</strong>') }
+    end
+
+    context 'for an unknown status' do
+      let(:status) { :anything_else }
+
+      it 'raises an exception' do
+        expect { subject.render }.to raise_error(KeyError)
+      end
+    end
+  end
+end

--- a/spec/presenters/task_list/task_spec.rb
+++ b/spec/presenters/task_list/task_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe TaskList::Task do
+  include ActionView::TestCase::Behavior
+
+  subject { described_class.new(view, name: name) }
+
+  let(:name) { :foobar_task }
+
+  describe '.render' do
+    it 'initialises the object and call the render instance method' do
+      expect(
+        described_class
+      ).to receive(:new).with(view, name: 'name')
+
+      described_class.new(view, name: 'name')
+    end
+  end
+
+  describe '#render' do
+    # Ensure we don't rely on any real locales, so we have predictable tests
+    before do
+      allow(subject).to receive(:t!).with('tasklist.task.foobar_task').and_return('Foo Bar Task Locale')
+      allow(subject).to receive(:t!).with('tasklist.task.not_applicable').and_return('Not applicable')
+    end
+
+    # NOTE: for now there is no logic behind to know which status tag to render,
+    # or the link to the corresponding step page, etc. That will come next.
+    it 'renders the task HTML element with its status tag' do
+      expect(
+        subject.render
+      ).to eq(
+        '<li class="app-task-list__item">' +
+        '<span class="app-task-list__task-name">Foo Bar Task Locale</span>' +
+        '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Not applicable</strong>' +
+        '</li>'
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This is just a first stab at the task list. For now the markup and styling is as accurate as it gets, also the localisations and the main categories and tasks are there.

However **it has no logic**. It is for now just a first iteration and logic will be added on follow-up PRs, along with any necessary changes and refactors.

The main idea is the task list will be an object (not yet in this version) which has tasks (`Task`), that contain the logic, or knowledge about if they are completed, or in progress, etc. so they can render their corresponding badge (`ProgressTag`).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-91

## Notes for reviewer
This is a first iteration, it is intended to be evolved but didn't want to wait too much as there might be other dependencies with this work in other tickets so at least we have something to play with it.
Tasks are not dynamic and do not know if they are completed or not yet, the tag is hardcoded to `Not applicable` for now.

## Screenshots of changes (if applicable)
<img width="613" alt="Screenshot 2022-08-15 at 17 04 08" src="https://user-images.githubusercontent.com/687910/184671678-1c98c6c6-e49d-4e12-9b0e-ae6a81c895e8.png">

## How to manually test the feature
Checkout and go manually to the following page (the ID doesn't matter, we are not yet retrieving real apps from the DB in this PR): `http://localhost:3000/crime_applications/123/edit`