### PR TITLE
Return applications having applicants with name

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -1,7 +1,7 @@
 class CrimeApplicationsController < ApplicationController
   def index
     # TODO: scope will change as we know more
-    @applications = CrimeApplication.all
+    @applications = CrimeApplication.joins(:people).includes(:applicant).merge(Applicant.with_name)
   end
 
   def edit; end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,6 +4,8 @@ class Person < ApplicationRecord
 
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
 
+  scope :with_name, -> { where.not(first_name: [nil, '']) }
+
   def home_address?
     home_address.address_line_one.present?
   end

--- a/spec/controllers/crime_applications_controller_spec.rb
+++ b/spec/controllers/crime_applications_controller_spec.rb
@@ -1,14 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe CrimeApplicationsController, type: :controller do
-
-  describe '#index' do
-    let(:applications) { CrimeApplication.all } 
-
-    it 'creates @applications' do
-      get :index
-      expect(@controller.instance_variable_get(:@applications)).to match(applications)
-    end
-  end
-
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Dashboard' do
+  describe 'list of applications' do
+    before :all do
+      # sets up a few test records
+      app1 = CrimeApplication.create
+      app2 = CrimeApplication.create
+      app3 = CrimeApplication.create
+
+      Applicant.create(crime_application: app1, first_name: 'John', last_name: 'Doe')
+      Applicant.create(crime_application: app2, first_name: '', last_name: '')
+      Applicant.create(crime_application: app3)
+
+      # sets up a valid session
+      get '/steps/client/has_partner'
+
+      # page actually under test
+      get '/crime_applications'
+    end
+
+    after :all do
+      # do not leave left overs in the test database
+      CrimeApplication.destroy_all
+    end
+
+    it 'contains only applications having the applicant name entered' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Your applications'
+
+      assert_select 'tbody.govuk-table__body' do
+        assert_select 'tr.govuk-table__row', 1 do
+          assert_select 'a.govuk-link', count: 1, text: 'John Doe'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This improves a bit the dashboard `#index` (list) action so that it only returns applications that have advanced enough to at the very least have an applicant with a name, as otherwise the dashboard either blows app (if there is no applicant record yet) or shows a blank name, no link (if the applicant has no name).

Move the index controller test to a `request` test `spec/requests/dashboard_spec.rb` as it makes a lot of sense for this to be a request test, and much easier to test (although slower I reckon as we are not mocking and we are using real records).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-90

## How to manually test the feature
Dashboard will not blow up if there are crime_application records without an applicant relationship. Also, applicants without a `first_name` will not show. Removed N+1 query.