### PR TITLE
Hide secondary button on some steps

### DIFF
--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -31,7 +31,7 @@ module Steps
       if params.key?(:commit_draft)
         # Validations will not be run when saving a draft
         @form_object.save!
-        redirect_to root_path # TODO: this will go to the task list
+        redirect_to edit_crime_application_path(current_crime_application)
       elsif @form_object.save
         redirect_to decision_tree_class.new(@form_object, as: opts.fetch(:as)).destination
       else

--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -5,19 +5,11 @@
 module FormBuilderHelper
   def continue_button(primary: :save_and_continue, secondary: :save_and_come_back_later)
     submit_button(primary) do
-      submit_button(secondary, secondary: true, name: 'commit_draft') if show_secondary_button?
+      submit_button(secondary, secondary: true, name: 'commit_draft') if secondary
     end
   end
 
   private
-
-  # The `save and come back later` might not always be needed,
-  # this method can have logic for show/hide.
-  # :nocov:
-  def show_secondary_button?
-    true
-  end
-  # :nocov:
 
   def submit_button(i18n_key, opts = {}, &block)
     govuk_submit I18n.t("helpers.submit.#{i18n_key}"), **opts, &block

--- a/app/views/steps/client/details/edit.html.erb
+++ b/app/views/steps/client/details/edit.html.erb
@@ -17,7 +17,7 @@
 
       <%= f.govuk_date_field :date_of_birth, maxlength_enabled: true, legend: { size: 'm' } %>
 
-      <%= f.continue_button %>
+      <%= f.continue_button(secondary: false) %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/client/has_partner/edit.html.erb
+++ b/app/views/steps/client/has_partner/edit.html.erb
@@ -9,7 +9,7 @@
         <%= f.govuk_collection_radio_buttons :client_has_partner, @form_object.choices,
                                              :value, inline: true, legend: { tag: 'h1', size: 'xl' } %>
 
-        <%= f.continue_button %>
+        <%= f.continue_button(secondary: false) %>
     <% end %>
   </div>
 </div>

--- a/spec/controllers/steps/client/has_partner_controller_spec.rb
+++ b/spec/controllers/steps/client/has_partner_controller_spec.rb
@@ -3,5 +3,4 @@ require 'rails_helper'
 RSpec.describe Steps::Client::HasPartnerController, type: :controller do
   it_behaves_like 'a starting point step controller'
   it_behaves_like 'a generic step controller', Steps::Client::HasPartnerForm, Decisions::ClientDecisionTree
-  it_behaves_like 'a step that can be drafted', Steps::Client::HasPartnerForm
 end

--- a/spec/support/shared_examples/step_controller_shared_examples.rb
+++ b/spec/support/shared_examples/step_controller_shared_examples.rb
@@ -268,10 +268,9 @@ RSpec.shared_examples 'a step that can be drafted' do |form_class|
           expect(form_object).to receive(:save!).and_return(true)
         end
 
-        # TODO: This will have to change once we decide where the secondary button goes
-        it 'redirects to the root path' do
+        it 'redirects to the application task list' do
           put :update, params: expected_params, session: { crime_application_id: existing_case.id }
-          expect(subject).to redirect_to(root_path)
+          expect(subject).to redirect_to(edit_crime_application_path(existing_case))
         end
       end
 
@@ -280,10 +279,9 @@ RSpec.shared_examples 'a step that can be drafted' do |form_class|
           expect(form_object).to receive(:save!).and_return(false)
         end
 
-        # TODO: This will have to change once we decide where the secondary button goes
-        it 'redirects to the root path' do
+        it 'redirects to the application task list' do
           put :update, params: expected_params, session: { crime_application_id: existing_case.id }
-          expect(subject).to redirect_to(root_path)
+          expect(subject).to redirect_to(edit_crime_application_path(existing_case))
         end
       end
     end


### PR DESCRIPTION
## Description of change
We decided it doesn't make too much sense to show the "Save and come back later" button right from the beginning when the provider didn't enter anything yet.

As we are taking the provider back to the task list, at least we want to wait until past the client details step so they enter first name / last name and there is something to show if they get back to their list of applications.

Made it so we can disable the secondary action in specific steps by passing `secondary: false`. Default it to show secondary action.

## Link to relevant ticket

## Notes for reviewer
I still think it makes more sense to take the provider to their application list (i.e. to the "dashboard") as it will be more likely they want to either continue with another application or start a new one. The task list feels like a weird choice, but at least is easy to change if we decide so down the line.

## Screenshots of changes (if applicable)
<img width="743" alt="Screenshot 2022-08-18 at 14 52 11" src="https://user-images.githubusercontent.com/687910/185412004-be03c966-97ab-4573-b067-06db31596c43.png">
<img width="715" alt="Screenshot 2022-08-18 at 14 52 34" src="https://user-images.githubusercontent.com/687910/185412057-a3be740f-220b-4078-b69b-20879274ae3c.png">

## How to manually test the feature
After checking out the code, you must restart the server as this code is part of an initialiser that only runs once. The has partner, and client details steps will not show secondary action, any other steps after that will show it.