### PR TITLE
Rename routes `crime_applications` to `applications`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,24 +37,26 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :crime_applications, except: [:new, :update] do
+  resources :crime_applications, except: [:new, :update], path: 'applications' do
     get :confirm_destroy, on: :member
   end
 
-  scope module: :steps, path: 'steps/:id', as: :steps do
-    namespace :client do
-      edit_step :has_partner
-      edit_step :details
-      edit_step :has_nino
-      show_step :nino_exit
-      show_step :partner_exit
-      edit_step :contact_details
-    end
+  scope 'applications/:id' do
+    namespace :steps do
+      namespace :client do
+        edit_step :has_partner
+        edit_step :details
+        edit_step :has_nino
+        show_step :nino_exit
+        show_step :partner_exit
+        edit_step :contact_details
+      end
 
-    namespace :address do
-      crud_step :lookup,  param: :address_id, only: [:edit, :update]
-      crud_step :results, param: :address_id, only: [:edit, :update]
-      crud_step :details, param: :address_id, only: [:edit, :update]
+      namespace :address do
+        crud_step :lookup,  param: :address_id, only: [:edit, :update]
+        crud_step :results, param: :address_id, only: [:edit, :update]
+        crud_step :details, param: :address_id, only: [:edit, :update]
+      end
     end
   end
 

--- a/spec/presenters/tasks/client_details_spec.rb
+++ b/spec/presenters/tasks/client_details_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Tasks::ClientDetails do
   let(:crime_application) { instance_double(CrimeApplication, to_param: '12345') }
 
   describe '#path' do
-    it { expect(subject.path).to eq('/steps/12345/client/details') }
+    it { expect(subject.path).to eq('/applications/12345/steps/client/details') }
   end
 
   describe '#not_applicable?' do


### PR DESCRIPTION
## Description of change
Small follow-up to PR #70.

Also the steps are now part of this same path, making it more logical when thinking in terms of resources and members:

```
/applications
/applications/:id/edit
/applications/:id/steps/client/has_partner
/applications/:id/steps/client/details
/applications/:id/steps/address/details/:address_id
(...)
```

In terms of functionality everything remains the same, and also named routes are kept the same. This is only an external facing URL rename.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-115

## Notes for reviewer
Check all generated routes with: `rails routes | grep applications`

## How to manually test the feature
Delete existing applications in the DB as they may have wrong navigation stack. everything else should work as before.