### PR TITLE
CRIMAP-117 Skip address manual entry pages

### DIFF
--- a/app/forms/steps/address/results_form.rb
+++ b/app/forms/steps/address/results_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Address
     class ResultsForm < BaseFormObject
       attribute :lookup_id, :string
-      validates :lookup_id, inclusion: { in: :address_ids }
+      validates :lookup_id, inclusion: { in: :address_ids }, if: :changed?
 
       def addresses
         @addresses ||= lookup_service.call
@@ -25,6 +25,8 @@ module Steps
       end
 
       def persist!
+        return true unless changed?
+
         record.update(
           selected_address.to_h
         )

--- a/app/services/decisions/address_decision_tree.rb
+++ b/app/services/decisions/address_decision_tree.rb
@@ -4,10 +4,8 @@ module Decisions
       case step_name
       when :lookup
         edit(:results)
-      when :results
-        edit(:details)
-      when :details
-        after_details
+      when :results, :details
+        after_address_entered
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -15,7 +13,7 @@ module Decisions
 
     private
 
-    def after_details
+    def after_address_entered
       if form_object.record.is_a?(HomeAddress)
         edit('/steps/client/contact_details')
       else

--- a/spec/services/decisions/address_decision_tree_spec.rb
+++ b/spec/services/decisions/address_decision_tree_spec.rb
@@ -21,10 +21,18 @@ RSpec.describe Decisions::AddressDecisionTree do
   end
 
   context 'when the step is `results`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', record: address_record) }
     let(:step_name) { :results }
 
-    it { is_expected.to have_destination(:details, :edit, id: crime_application) }
+    context 'if we come from a home address sub-journey' do
+      let(:address_record) { HomeAddress.new }
+      it { is_expected.to have_destination('/steps/client/contact_details', :edit, id: crime_application) }
+    end
+
+    context 'if we come from a correspondence address sub-journey' do
+      let(:address_record) { CorrespondenceAddress.new }
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    end
   end
 
   context 'when the step is `details`' do


### PR DESCRIPTION
## Description of change
If the provider finds a suitable address when using the postcode lookup, after selecting this address and submitting the form, we “skip“ the manual entry page.

This applies to home address and correspondence address.

We've been showing these pages as a way to test/debug the address lookup but the original designs and user journey was to not show them.

Still providers can access these pages when entering addresses manually, and will also be accessible from the CYA when we have it.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-117

## How to manually test the feature
After selecting an address from the dropdown, and submitting the form, the next page is no longer the manual entry (with the address pre-filled) but instead the following step.
For home address that is contact details, and for correspondence address that is the home page for now as we don't have case details yet.