### PR TITLE
Crimap 116 tidy application statuses

### DIFF
--- a/app/forms/steps/client/has_partner_form.rb
+++ b/app/forms/steps/client/has_partner_form.rb
@@ -13,7 +13,7 @@ module Steps
 
       def persist!
         crime_application.update(
-          attributes
+          attributes.merge(status: ApplicationStatus::IN_PROGRESS)
         )
       end
     end

--- a/app/forms/steps/client/has_partner_form.rb
+++ b/app/forms/steps/client/has_partner_form.rb
@@ -13,7 +13,7 @@ module Steps
 
       def persist!
         crime_application.update(
-          attributes.merge(status: ApplicationStatus::IN_PROGRESS)
+          attributes.merge(status: ApplicationStatus::IN_PROGRESS.to_s)
         )
       end
     end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -4,4 +4,11 @@ class CrimeApplication < ApplicationRecord
 
   has_many :people, dependent: :destroy
   has_many :addresses, through: :people
+
+  enum status: {
+    newly_initialised: ApplicationStatus::NEWLY_INITIALISED,
+    in_progress: ApplicationStatus::IN_PROGRESS,
+    completed:   ApplicationStatus::COMPLETED
+  }, _default: :newly_initialised
+
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -5,9 +5,6 @@ class CrimeApplication < ApplicationRecord
   has_many :people, dependent: :destroy
   has_many :addresses, through: :people
 
-  enum status: {
-    newly_initialised: ApplicationStatus::NEWLY_INITIALISED.to_s,
-    in_progress: ApplicationStatus::IN_PROGRESS.to_s,
-    completed:   ApplicationStatus::COMPLETED.to_s
-  }, _default: ApplicationStatus::NEWLY_INITIALISED.to_s
+  enum status: ApplicationStatus.enum_values,
+       _default: ApplicationStatus.enum_values[:initialised]
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -6,8 +6,8 @@ class CrimeApplication < ApplicationRecord
   has_many :addresses, through: :people
 
   enum status: {
-    newly_initialised: ApplicationStatus::NEWLY_INITIALISED,
-    in_progress: ApplicationStatus::IN_PROGRESS,
-    completed:   ApplicationStatus::COMPLETED
-  }, _default: :newly_initialised
+    newly_initialised: ApplicationStatus::NEWLY_INITIALISED.to_s,
+    in_progress: ApplicationStatus::IN_PROGRESS.to_s,
+    completed:   ApplicationStatus::COMPLETED.to_s
+  }, _default: ApplicationStatus::NEWLY_INITIALISED.to_s
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -10,5 +10,4 @@ class CrimeApplication < ApplicationRecord
     in_progress: ApplicationStatus::IN_PROGRESS,
     completed:   ApplicationStatus::COMPLETED
   }, _default: :newly_initialised
-
 end

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -1,7 +1,7 @@
 class ApplicationStatus < ValueObject
   VALUES = [
-    INITIALISED = new(:initialised),
-    IN_PROGRESS = new(:in_progress),
-    COMPLETE = new(:complete),
+    NEWLY_INITIALISED = new(:newly_initialised),
+    IN_PROGRESS       = new(:in_progress),
+    COMPLETED         = new(:completed)
   ].freeze
 end

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -1,7 +1,11 @@
 class ApplicationStatus < ValueObject
   VALUES = [
-    NEWLY_INITIALISED = new(:newly_initialised),
-    IN_PROGRESS       = new(:in_progress),
-    COMPLETED         = new(:completed)
+    INITIALISED = new(:initialised),
+    IN_PROGRESS = new(:in_progress),
+    SUBMITTED   = new(:submitted)
   ].freeze
+
+  def self.enum_values
+    values.to_h { |value| [value.to_sym, value.to_s] }
+  end
 end

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -1,0 +1,7 @@
+class ApplicationStatus < ValueObject
+  VALUES = [
+    INITIALISED = new(:initialised),
+    IN_PROGRESS = new(:in_progress),
+    COMPLETE = new(:complete),
+  ].freeze
+end

--- a/db/migrate/20220822103823_add_status_to_crime_applications.rb
+++ b/db/migrate/20220822103823_add_status_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddStatusToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_09_094812) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_22_103823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_09_094812) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "client_has_partner"
+    t.string "status"
   end
 
   create_table "people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Steps::Client::HasPartnerForm do
       it 'saves the record' do
         expect(crime_application).to receive(:update).with(
           'client_has_partner' => YesNoAnswer::YES,
+          status: ApplicationStatus::IN_PROGRESS,
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Steps::Client::HasPartnerForm do
       it 'saves the record' do
         expect(crime_application).to receive(:update).with(
           'client_has_partner' => YesNoAnswer::YES,
-          status: ApplicationStatus::IN_PROGRESS,
+          status: 'in_progress',
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -4,7 +4,19 @@ RSpec.describe CrimeApplication, type: :model do
   subject { described_class.new(attributes) }
   let(:attributes) { {} }
 
+  describe 'status enum' do
+    it 'has the right values' do
+      expect(
+        described_class.statuses
+      ).to eq(
+        'initialised' => 'initialised',
+        'in_progress' => 'in_progress',
+        'submitted' => 'submitted',
+      )
+    end
+  end
+
   it 'has an initial status value of "initialised"' do
-    expect(subject.status).to match('newly_initialised')
+    expect(subject.status).to eq('initialised')
   end
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -3,4 +3,8 @@ require 'rails_helper'
 RSpec.describe CrimeApplication, type: :model do
   subject { described_class.new(attributes) }
   let(:attributes) { {} }
+
+  it 'has an initial status value of "initialised"' do
+    expect(subject.status).to match('newly_initialised')
+  end
 end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(initialised in_progress complete)
+        %w(initialised in_progress completed)
       )
     end
   end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,8 +8,16 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(newly_initialised in_progress completed)
+        %w(initialised in_progress submitted)
       )
+    end
+  end
+
+  describe '.enum_values' do
+    it 'returns a map of values, used as an enum definition' do
+      expect(
+        described_class.enum_values
+      ).to eq({ initialised: 'initialised', in_progress: 'in_progress', submitted: 'submitted' })
     end
   end
 end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationStatus do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(
+        %w(initialised in_progress complete)
+      )
+    end
+  end
+end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(initialised in_progress completed)
+        %w(newly_initialised in_progress completed)
       )
     end
   end


### PR DESCRIPTION
## Description of change
Adds application status to a crime application

## Notes for reviewer
I was getting clash errors with the key "initialised" so I settled on "newly_initialised"

Another problem was that the `deafult:` in the migration wasn't working so I decided to set it in the enum declaration instead.

## Link to relevant ticket
[CRIMAP-116](https://dsdmoj.atlassian.net/browse/CRIMAP-116)

## How to manually test the feature
- Create a new application, post has_partner if you get the record from the DB it should have a status of `in_progress`
- from the console create a new record with `CrimeApplication.create` - it should have a default status of `newly_initialised`

