### PR TITLE
Some minor fixes to markup and back links

### DIFF
--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header(path: :back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -1,18 +1,15 @@
 <% title t('.page_title') %>
-<% step_header(path: root_path) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
+    <%= render partial: 'shared/flash_banner' %>
+
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-  </div> 
-</div>
 
-<%= render partial: 'shared/flash_banner' %>
-
-<div class="govuk-button-group">
-  <%= button_to crime_applications_path,
-    class: 'govuk-button govuk-button--start',
-    data: { module: 'govuk-button' } do; t('.start_button'); end %>
+    <%= button_to crime_applications_path,
+                  class: 'govuk-button govuk-button--start',
+                  data: { module: 'govuk-button' } do; t('.start_button'); end %>
+  </div>
 </div>
 
 <div class="govuk-grid-row">
@@ -45,7 +42,7 @@
               <strong class="govuk-tag govuk-tag--blue">In progress</strong>
             </td>
             <td class="govuk-table__cell">
-              <%= button_to confirm_destroy_crime_application_path(app.id), method: :get,
+              <%= button_to confirm_destroy_crime_application_path(app), method: :get,
                 class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
                 data: { module: 'govuk-button' } do; t('.delete_button'); end %>
             </td>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -3,13 +3,13 @@
     <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
       <div class="govuk-notification-banner__header">
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Success
+          <%= t('flash.success.title') %>
         </h2>
       </div>
       <div class="govuk-notification-banner__content">
-        <h3 class="govuk-notification-banner__heading">
+        <p class="govuk-notification-banner__heading">
           <%= msg %>
-        </h3>
+        </p>
       </div>
     </div>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,6 @@ en:
     formats:
       default: '%-d %B %Y'  # 3 January 2019
       short: '%d/%m/%Y'     # 03/01/2019
+  flash:
+    success:
+      title: Success

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Dashboard' do
 
       assert_select 'div.govuk-notification-banner--success', 1 do
         assert_select 'h2', 'Success'
-        assert_select 'h3', 'Jane Doe’s application has been permanently deleted'
+        assert_select 'p', 'Jane Doe’s application has been permanently deleted'
       end
     end
   end


### PR DESCRIPTION
## Description of change
Mainly changes in the flash banner markup according to the design system guidelines (position above the page h1, avoid using h3 in banner content).

Added the banner to the `govuk-grid-column-full` container also as per guidelines.

https://design-system.service.gov.uk/components/notification-banner/

Fixed the back link in the task list and removed the back link in the dashboard index as it is not accurate where it will take the user. Civil Apply doesn't have back link in their dashboard either.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-92
https://dsdmoj.atlassian.net/browse/CRIMAP-95


<img width="1067" alt="Screenshot 2022-08-23 at 09 44 55" src="https://user-images.githubusercontent.com/687910/186114307-fa86da16-061f-4895-a757-534ad4e011a0.png">
