### PR TITLE
Remove hardcoded status from list and add status from application

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -5,7 +5,6 @@ class CrimeApplicationsController < ApplicationController
   def index
     # TODO: scope will change as we know more
     @applications = CrimeApplication
-                    .viewable
                     .joins(:people)
                     .includes(:applicant)
                     .merge(Applicant.with_name)

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -5,6 +5,7 @@ class CrimeApplicationsController < ApplicationController
   def index
     # TODO: scope will change as we know more
     @applications = CrimeApplication
+                    .viewable
                     .joins(:people)
                     .includes(:applicant)
                     .merge(Applicant.with_name)

--- a/app/forms/steps/client/has_partner_form.rb
+++ b/app/forms/steps/client/has_partner_form.rb
@@ -13,7 +13,7 @@ module Steps
 
       def persist!
         crime_application.update(
-          attributes.merge(status: ApplicationStatus::IN_PROGRESS.to_s)
+          attributes
         )
       end
     end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -5,12 +5,6 @@ class CrimeApplication < ApplicationRecord
   has_many :people, dependent: :destroy
   has_many :addresses, through: :people
 
-  scope :viewable, -> { where(status: ApplicationStatus.viewable_statuses) }
-
   enum status: ApplicationStatus.enum_values,
-       _default: ApplicationStatus.enum_values[:initialised]
-
-  def pretty_status
-    status.titleize.upcase
-  end
+       _default: ApplicationStatus.enum_values[:in_progress]
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -5,6 +5,12 @@ class CrimeApplication < ApplicationRecord
   has_many :people, dependent: :destroy
   has_many :addresses, through: :people
 
+  scope :viewable, -> { where(status: ApplicationStatus.viewable_statuses) }
+
   enum status: ApplicationStatus.enum_values,
        _default: ApplicationStatus.enum_values[:initialised]
+
+  def pretty_status
+    status.titleize.upcase
+  end
 end

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -8,4 +8,8 @@ class ApplicationStatus < ValueObject
   def self.enum_values
     values.to_h { |value| [value.to_sym, value.to_s] }
   end
+
+  def self.viewable_statuses
+    [IN_PROGRESS.to_s, SUBMITTED.to_s]
+  end
 end

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -1,15 +1,10 @@
 class ApplicationStatus < ValueObject
   VALUES = [
-    INITIALISED = new(:initialised),
     IN_PROGRESS = new(:in_progress),
     SUBMITTED   = new(:submitted)
   ].freeze
 
   def self.enum_values
     values.to_h { |value| [value.to_sym, value.to_s] }
-  end
-
-  def self.viewable_statuses
-    [IN_PROGRESS.to_s, SUBMITTED.to_s]
   end
 end

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -37,7 +37,7 @@
               LAA-a1234b
             </td>
             <td class="govuk-table__cell">
-              <strong class="govuk-tag govuk-tag--blue">In progress</strong>
+              <strong class="govuk-tag govuk-tag--blue"><%= app.pretty_status %></strong>
             </td>
             <td class="govuk-table__cell">
               <%= button_to confirm_destroy_crime_application_path(app), method: :get,

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -37,7 +37,7 @@
               LAA-a1234b
             </td>
             <td class="govuk-table__cell">
-              <strong class="govuk-tag govuk-tag--blue"><%= app.pretty_status %></strong>
+              <%= render 'shared/application_status_tag', status_tag: app.status %>
             </td>
             <td class="govuk-table__cell">
               <%= button_to confirm_destroy_crime_application_path(app), method: :get,

--- a/app/views/shared/_application_status_tag.html.erb
+++ b/app/views/shared/_application_status_tag.html.erb
@@ -1,0 +1,6 @@
+<% if status_tag == 'in_progress' %>
+  <strong class="govuk-tag govuk-tag--blue"><%= t(".tag.#{status_tag}") %></strong>
+<% elsif status_tag == 'submitted' %>
+  <strong class="govuk-tag govuk-tag--green"><%= t(".tag.#{status_tag}") %></strong>
+<% end %>
+

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -1,0 +1,6 @@
+en:
+  shared:
+    application_status_tag:
+      tag:
+        in_progress: IN PROGRESS
+        submitted: SUBMITTED

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Steps::Client::HasPartnerForm do
       it 'saves the record' do
         expect(crime_application).to receive(:update).with(
           'client_has_partner' => YesNoAnswer::YES,
-          status: 'in_progress',
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -19,4 +19,9 @@ RSpec.describe CrimeApplication, type: :model do
   it 'has an initial status value of "initialised"' do
     expect(subject.status).to eq('initialised')
   end
+
+  it 'can output a pretty_status' do
+    subject.in_progress!
+    expect(subject.pretty_status).to eq('IN PROGRESS')
+  end
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -9,19 +9,13 @@ RSpec.describe CrimeApplication, type: :model do
       expect(
         described_class.statuses
       ).to eq(
-        'initialised' => 'initialised',
         'in_progress' => 'in_progress',
         'submitted' => 'submitted',
       )
     end
   end
 
-  it 'has an initial status value of "initialised"' do
-    expect(subject.status).to eq('initialised')
-  end
-
-  it 'can output a pretty_status' do
-    subject.in_progress!
-    expect(subject.pretty_status).to eq('IN PROGRESS')
+  it 'has an initial status value of "in_progress"' do
+    expect(subject.status).to eq('in_progress')
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -40,13 +40,15 @@ RSpec.describe 'Dashboard' do
   describe 'list of applications' do
     before :all do
       # sets up a few test records
-      app1 = CrimeApplication.create
+      app1 = CrimeApplication.create(status: 'in_progress')
       app2 = CrimeApplication.create
       app3 = CrimeApplication.create
+      app4 = CrimeApplication.create(status: 'initialised')
 
       Applicant.create(crime_application: app1, first_name: 'John', last_name: 'Doe')
       Applicant.create(crime_application: app2, first_name: '', last_name: '')
       Applicant.create(crime_application: app3)
+      Applicant.create(crime_application: app4, first_name: 'Jane', last_name: 'Doe')
 
       # page actually under test
       get crime_applications_path
@@ -66,15 +68,19 @@ RSpec.describe 'Dashboard' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
           assert_select 'button.govuk-button', count: 1, text: 'Delete'
+          assert_select 'strong.govuk-tag', count: 1, text: 'IN PROGRESS'
         end
       end
+
+      expect(response.body).to_not include('Jane Doe')
+      expect(response.body).to_not include('INITIALISED')
     end
   end
 
   describe 'deleting applications' do
     before :all do
       # sets up a few test records
-      app = CrimeApplication.create
+      app = CrimeApplication.create(status: 'in_progress')
 
       Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe')
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -43,12 +43,10 @@ RSpec.describe 'Dashboard' do
       app1 = CrimeApplication.create(status: 'in_progress')
       app2 = CrimeApplication.create
       app3 = CrimeApplication.create
-      app4 = CrimeApplication.create(status: 'initialised')
 
       Applicant.create(crime_application: app1, first_name: 'John', last_name: 'Doe')
       Applicant.create(crime_application: app2, first_name: '', last_name: '')
       Applicant.create(crime_application: app3)
-      Applicant.create(crime_application: app4, first_name: 'Jane', last_name: 'Doe')
 
       # page actually under test
       get crime_applications_path

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe ApplicationStatus do
       ).to eq({ initialised: 'initialised', in_progress: 'in_progress', submitted: 'submitted' })
     end
   end
+
+  describe '.viewable_statuses' do
+    it 'returns a map of values, used as an enum definition' do
+      expect(
+        described_class.viewable_statuses
+      ).to eq(['in_progress', 'submitted'])
+    end
+  end
 end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(initialised in_progress submitted)
+        %w(in_progress submitted)
       )
     end
   end
@@ -17,15 +17,7 @@ RSpec.describe ApplicationStatus do
     it 'returns a map of values, used as an enum definition' do
       expect(
         described_class.enum_values
-      ).to eq({ initialised: 'initialised', in_progress: 'in_progress', submitted: 'submitted' })
-    end
-  end
-
-  describe '.viewable_statuses' do
-    it 'returns a map of values, used as an enum definition' do
-      expect(
-        described_class.viewable_statuses
-      ).to eq(['in_progress', 'submitted'])
+      ).to eq({ in_progress: 'in_progress', submitted: 'submitted' })
     end
   end
 end


### PR DESCRIPTION
## Description of change
Removes hard coded "IN PROGRESS" from the dashboard and instead gets the value from the application object.

## Link to relevant ticket
[CRIMAP-116](https://dsdmoj.atlassian.net/browse/CRIMAP-116)

## Notes for reviewer
Added a pretty_status method to the CrimeApplication, happy to move to a presenter / decorator at a later date - think its fine here for now.

## How to manually test the feature
- create a case > in progress should be viewable on the list page
- in the rails console generate a case with an "initialised" status it should not be viewable on the crime_applications page
