### PR TITLE
Tweak dashboard table css and markup

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -1,2 +1,9 @@
 // App-specific custom styles and overrides
+// Please use BEM convention: http://getbem.com/naming/
 //
+.app-dashboard-table {
+  .govuk-table__header,
+  .govuk-table__cell {
+    vertical-align: middle;
+  }
+}

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -14,24 +14,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <table class="govuk-table">
+    <table class="govuk-table app-dashboard-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header">Name</th>
-          <th class="govuk-table__header">Start date</th>
-          <th class="govuk-table__header">LAA reference</th>
-          <th class="govuk-table__header">Status</th>
-          <th class="govuk-table__header">Action</th>
+          <th scope="col" class="govuk-table__header"><%= t('.table_headings.applicant_name') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.table_headings.created_at') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.table_headings.reference') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.table_headings.status') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.table_headings.action') %></th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
         <% @applications.each do |app| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <%= link_to app.applicant.full_name, 
-                edit_crime_application_path(app), 
-                class: 'govuk-link' %>
-            </td>
+            <th scope="row" class="govuk-table__header">
+              <%= link_to app.applicant.full_name, edit_crime_application_path(app) %>
+            </th>
             <td class="govuk-table__cell">
               <%= l(app.created_at) %>
             </td>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -6,6 +6,12 @@ en:
       heading: Your applications
       start_button: Make a new application
       delete_button: Delete
+      table_headings:
+        applicant_name: Name
+        created_at: Start date
+        reference: LAA reference
+        status: Status
+        action: Action
     edit:
       page_title: Application task list
       heading: Make a new application

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Dashboard' do
 
       assert_select 'tbody.govuk-table__body' do
         assert_select 'tr.govuk-table__row', 1 do
-          assert_select 'a.govuk-link', count: 1, text: 'John Doe'
+          assert_select 'a', count: 1, text: 'John Doe'
           assert_select 'button.govuk-button', count: 1, text: 'Delete'
         end
       end


### PR DESCRIPTION
## Description of change
The vertical alignment (top) in the table rows was driving me crazy LOL.
Now it is aligned in the middle and universe balance has been restored.

Also added a bit of extra markup to the table according to the design system (mainly the `scope` attribute), and i18n.

## Screenshots of changes (if applicable)

### Before changes:
<img width="1054" alt="Screenshot 2022-08-23 at 11 44 00" src="https://user-images.githubusercontent.com/687910/186139783-cfb2b88f-8893-47a0-8ac7-2d1477cb718e.png">

### After changes:
<img width="1059" alt="Screenshot 2022-08-23 at 11 44 11" src="https://user-images.githubusercontent.com/687910/186139799-75a243d0-4e41-4556-bd12-36677e927d40.png">
