### PR TITLE
Simplify collection refinements

### DIFF
--- a/app/lib/refinements/decorate_collection.rb
+++ b/app/lib/refinements/decorate_collection.rb
@@ -6,12 +6,6 @@ module Refinements
         yield decorator.new(obj)
       end
     end
-
-    def self.included(base)
-      refine base do
-        import_methods Refinements::DecorateCollection
-      end
-    end
     # :nocov:
   end
 end

--- a/app/lib/refinements/present_collection.rb
+++ b/app/lib/refinements/present_collection.rb
@@ -6,12 +6,6 @@ module Refinements
         yield presenter.new(obj)
       end
     end
-
-    def self.included(base)
-      refine base do
-        import_methods Refinements::PresentCollection
-      end
-    end
     # :nocov:
   end
 end

--- a/config/initializers/refinements.rb
+++ b/config/initializers/refinements.rb
@@ -1,12 +1,7 @@
-require_relative '../../app/lib/refinements/decorate_collection'
-require_relative '../../app/lib/refinements/present_collection'
+Dir[File.expand_path('app/lib/refinements') + '/*.rb'].each { |f| require f }
 
-class Array
-  include Refinements::DecorateCollection
-  include Refinements::PresentCollection
-end
+Array.include Refinements::DecorateCollection,
+              Refinements::PresentCollection
 
-class ActiveRecord::Relation
-  include Refinements::DecorateCollection
-  include Refinements::PresentCollection
-end
+ActiveRecord::Relation.include Refinements::DecorateCollection,
+                               Refinements::PresentCollection


### PR DESCRIPTION
## Description of change
It turned out we don't really need these to be pure refinements as we want these methods to be in all arrays and all AR relations, and we are accomplishing that just by including the modules.

Previous code was working because of that, not really because of the `refine`.

I would keep the structure as in the future we might have pure refinements that are to be used in specific classes or modules in a more surgical way.