### PR TITLE
Add right hand column to task list, markup tidy up

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -7,3 +7,8 @@
     vertical-align: middle;
   }
 }
+
+.app-aside__bar--blue {
+  border-top: 2px solid govuk-colour("blue");
+  padding-top: govuk-spacing(2);
+}

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -12,3 +12,9 @@
   border-top: 2px solid govuk-colour("blue");
   padding-top: govuk-spacing(2);
 }
+
+.app-grid-column--sticky {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 1%;
+}

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -1,6 +1,6 @@
 class CrimeApplicationsController < ApplicationController
-  before_action :check_crime_application_presence, except: [:index, :create]
-  before_action :set_applicant_name, only: [:destroy, :confirm_destroy]
+  before_action :check_crime_application_presence,
+                :present_crime_application, except: [:index, :create]
 
   def index
     # TODO: scope will change as we know more
@@ -26,7 +26,7 @@ class CrimeApplicationsController < ApplicationController
     current_crime_application.destroy
     redirect_to crime_applications_path,
                 flash: {
-                  success: t('.success_flash', applicant_name: @applicant_name)
+                  success: t('.success_flash', applicant_name: @crime_application.applicant_name)
                 }
   end
 
@@ -34,9 +34,7 @@ class CrimeApplicationsController < ApplicationController
 
   private
 
-  def set_applicant_name
-    @applicant_name = helpers
-                      .present(current_crime_application)
-                      .applicant_name
+  def present_crime_application
+    @crime_application = helpers.present(current_crime_application)
   end
 end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -19,7 +19,7 @@ class CrimeApplicationPresenter < BasePresenter
   # this is stubbed for now will implement
   # properly when there is the means to do so
   def laa_reference
-    'LAA-a1234b'
+    ['LAA', id[0..5]].join('-')
   end
 
   def status_tag

--- a/app/presenters/task_list/collection.rb
+++ b/app/presenters/task_list/collection.rb
@@ -1,5 +1,5 @@
 module TaskList
-  class Collection < ::BasePresenter
+  class Collection < SimpleDelegator
     attr_reader :view, :crime_application
 
     delegate :size, to: :all_tasks

--- a/app/views/crime_applications/confirm_destroy.html.erb
+++ b/app/views/crime_applications/confirm_destroy.html.erb
@@ -2,38 +2,32 @@
 <% step_header(path: crime_applications_path) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-xl"><%=t('.heading', applicant_name: @applicant_name) %></h1>
-  </div> 
-</div>
-
-
-<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">This application has not been submitted yet</p>
-  </div>
-</div>
+    <h1 class="govuk-heading-xl">
+      <%=t('.heading', applicant_name: @crime_application.applicant_name) %>
+    </h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= t('.subheading') %>
+    </p>
+
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        You cannot undo this action
+        <span class="govuk-warning-text__assistive"><%= t('.warning.title') %></span>
+        <%= t('.warning.text') %>
       </strong>
     </div>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     <%= form_with url: crime_application_path, method: :delete do |f| %>
       <div class="govuk-button-group">
-        <%= f.button t('.confirm_delete_button'), class: "govuk-button govuk-button--warning" %>
+        <%= f.button t('.confirm_delete_button'),
+                     class: 'govuk-button govuk-button--warning',
+                     data: { module: 'govuk-button' } %>
+
         <%= link_to crime_applications_path,
-          class: 'govuk-button govuk-button--primary',
-          data: { module: 'govuk-button' } do; t('.cancel_delete_button'); end %>
+                    class: 'govuk-button govuk-button--primary',
+                    data: { module: 'govuk-button' } do; t('.cancel_delete_button'); end %>
       </div>
     <% end %>
   </div>

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -17,4 +17,15 @@
 
     <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <aside class="app-aside__bar--blue" role="complementary">
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+        <%= t('.reference') %>
+      </h3>
+      <p class="govuk-body">
+        <%= @crime_application.laa_reference %>
+      </p>
+    </aside>
+  </div>
 </div>

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -18,7 +18,7 @@
     <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third app-grid-column--sticky">
     <aside class="app-aside__bar--blue" role="complementary">
       <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
         <%= t('.reference') %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -34,7 +34,7 @@
               <%= app.start_date %>
             </td>
             <td class="govuk-table__cell">
-              LAA-a1234b
+              <%= app.laa_reference %>
             </td>
             <td class="govuk-table__cell">
               <%= app.status_tag %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -20,11 +20,16 @@ en:
       heading: Make a new application
       subheading: Application incomplete
       progress_counter: You have completed %{completed} of %{total} sections.
+      reference: Reference number
       back_to_applications: Back to your applications
     confirm_destroy:
       page_title: Are you sure you want to delete this application?
       heading: "Are you sure you want to delete %{applicant_name}’s application?"
+      subheading: This application has not been submitted yet.
       confirm_delete_button: Yes, delete it
       cancel_delete_button: No, do not delete it
+      warning:
+        title: Warning
+        text: You cannot undo this action
     destroy:
       success_flash: "%{applicant_name}’s application has been permanently deleted"

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe CrimeApplicationPresenter do
-  subject { 
-    described_class.new(
-      CrimeApplication.new(
-        status: 'in_progress', 
-        created_at: DateTime.new(2022, 01, 12))
-    ) 
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) {
+    instance_double(CrimeApplication,
+                    id: 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
+                    created_at: DateTime.new(2022, 01, 12),
+                    status: 'in_progress',
+                    applicant: applicant)
   }
 
   let(:applicant) { 
@@ -18,8 +20,6 @@ RSpec.describe CrimeApplicationPresenter do
 
   describe 'when presenting CrimeApplications' do
     it 'delegates full name to applicant' do
-      allow(subject).to receive(:applicant).and_return(applicant)
-
       expect(applicant).to receive(:first_name)
       expect(applicant).to receive(:last_name)
       expect(subject.applicant_name).to eq('John Doe')

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe 'Dashboard' do
       end
 
       expect(response.body).to_not include('Jane Doe')
-      expect(response.body).to_not include('INITIALISED')
     end
   end
 
@@ -89,11 +88,11 @@ RSpec.describe 'Dashboard' do
 
     it 'allows a user to check before deleting an application' do
       applicant = Applicant.find_by(first_name: "Jane")
-      app = CrimeApplicationPresenter.new(applicant.crime_application)
+      app = applicant.crime_application
 
       get confirm_destroy_crime_application_path(app)
 
-      expect(response.body).to include("Are you sure you want to delete #{app.applicant_name}’s application?")
+      expect(response.body).to include("Are you sure you want to delete Jane Doe’s application?")
       expect(response.body).to include("Yes, delete it")
       expect(response.body).to include("No, do not delete it")
     end


### PR DESCRIPTION
## Description of change
Last batch (maybe) of refinements, tidy up and TLC.

Added the right hand column to the task list page, showing the LAA reference. We pick this from the presenter.

Made the reference in the presenter be a bit more dynamic so is more evident clicking through different applications in the dashboard takes you to different task lists (I think the task list should include also the client's name, I've added a comment in figma design).

As we now use the presenter in the task list, and in the destroy page, made the code in the controller a bit more generic.

Tidy up some html markup and extracted to locales some hardcoded strings.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-91

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1023" alt="Screenshot 2022-08-24 at 12 32 10" src="https://user-images.githubusercontent.com/687910/186408125-4a8a141c-bafe-499f-8c4f-c092e9f1ef6b.png">

## How to manually test the feature
Nothing special, but If the blue bar in the right hand doesn't show, purge local assets and recompile.