### PR TITLE
Add client details to task list aside

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -11,6 +11,10 @@
 .app-aside__bar--blue {
   border-top: 2px solid govuk-colour("blue");
   padding-top: govuk-spacing(2);
+
+  h3 {
+    margin-bottom: 0;
+  }
 }
 
 .app-grid-column--sticky {

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -6,14 +6,22 @@ class CrimeApplicationPresenter < BasePresenter
     'submitted'   => 'govuk-tag--green',
   }.freeze
 
-  delegate :first_name, :last_name, to: :applicant
+  delegate :first_name, :last_name, :date_of_birth, to: :applicant
 
   def start_date
     l(created_at)
   end
 
+  def applicant_dob
+    l(date_of_birth)
+  end
+
   def applicant_name
     "#{first_name} #{last_name}"
+  end
+
+  def applicant?
+    applicant.present?
   end
 
   # this is stubbed for now will implement

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -20,12 +20,35 @@
 
   <div class="govuk-grid-column-one-third app-grid-column--sticky">
     <aside class="app-aside__bar--blue" role="complementary">
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
-        <%= t('.reference') %>
+      <h3 class="govuk-heading-s">
+        <%= t('.aside.reference') %>
       </h3>
       <p class="govuk-body">
         <%= @crime_application.laa_reference %>
       </p>
+
+      <% if @crime_application.applicant? %>
+        <h3 class="govuk-heading-s">
+          <%= t('.aside.first_name') %>
+        </h3>
+        <p class="govuk-body">
+          <%= @crime_application.first_name %>
+        </p>
+
+        <h3 class="govuk-heading-s">
+          <%= t('.aside.last_name') %>
+        </h3>
+        <p class="govuk-body">
+          <%= @crime_application.last_name %>
+        </p>
+
+        <h3 class="govuk-heading-s">
+          <%= t('.aside.date_of_birth') %>
+        </h3>
+        <p class="govuk-body">
+          <%= @crime_application.applicant_dob %>
+        </p>
+      <% end %>
     </aside>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,20 @@
 en:
+  dictionary:
+    DATE_FORMATS: &DATE_FORMATS
+      default: '%-d %b %Y'  # 3 Jan 2019
+      compact: '%d/%m/%Y'   # 03/01/2019
+
   service:
     name: Apply for criminal legal aid
+
+  date:
+    formats:
+      <<: *DATE_FORMATS
   time:
     formats:
-      default: '%-d %B %Y'  # 3 January 2019
-      short: '%d/%m/%Y'     # 03/01/2019
+      <<: *DATE_FORMATS
+      datetime: '%-l:%M%P %-d %b %Y'  # 2:45pm 3 Jan 2019
+
   flash:
     success:
       title: Success

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -20,8 +20,12 @@ en:
       heading: Make a new application
       subheading: Application incomplete
       progress_counter: You have completed %{completed} of %{total} sections.
-      reference: Reference number
       back_to_applications: Back to your applications
+      aside:
+        reference: Reference number
+        first_name: First name
+        last_name: Last name
+        date_of_birth: Date of birth
     confirm_destroy:
       page_title: Are you sure you want to delete this application?
       heading: "Are you sure you want to delete %{applicant_name}’s application?"

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -15,8 +15,21 @@ RSpec.describe CrimeApplicationPresenter do
     double(
       Applicant, 
       first_name: 'John', 
-      last_name: 'Doe') 
+      last_name: 'Doe',
+      date_of_birth: Date.new(1990, 02, 01),
+    )
   }
+
+  describe '#applicant?' do
+    context 'when there is an applicant record' do
+      it { expect(subject.applicant?).to eq(true) }
+    end
+
+    context 'when there is no applicant record' do
+      let(:applicant) { nil }
+      it { expect(subject.applicant?).to eq(false) }
+    end
+  end
 
   describe 'when presenting CrimeApplications' do
     it 'delegates full name to applicant' do
@@ -25,8 +38,12 @@ RSpec.describe CrimeApplicationPresenter do
       expect(subject.applicant_name).to eq('John Doe')
     end
 
+    it 'can output the applicant date of birth in the correct format' do
+      expect(subject.applicant_dob).to eq('1 Feb 1990')
+    end
+
     it 'can output the subject start date in the correct format' do
-      expect(subject.start_date).to eq('12 January 2022')
+      expect(subject.start_date).to eq('12 Jan 2022')
     end
 
     it 'has an LAA an reference stubbed' do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Dashboard' do
       # sets up a test record
       app = CrimeApplication.create
 
-      Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe')
+      Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe', date_of_birth: Date.new(1990, 02, 01))
     end
 
     after :all do
@@ -34,6 +34,21 @@ RSpec.describe 'Dashboard' do
 
       assert_select 'h1', 'Make a new application'
       assert_select 'h2', 'Application incomplete'
+
+      # aside details
+      assert_select 'div.govuk-grid-column-one-third aside', 1 do
+        assert_select 'h3:nth-of-type(1)', 'Reference number'
+        assert_select 'p:nth-of-type(1)', /^LAA-[[:alnum:]]{6}$/
+
+        assert_select 'h3:nth-of-type(2)', 'First name'
+        assert_select 'p:nth-of-type(2)', 'Jane'
+
+        assert_select 'h3:nth-of-type(3)', 'Last name'
+        assert_select 'p:nth-of-type(3)', 'Doe'
+
+        assert_select 'h3:nth-of-type(4)', 'Date of birth'
+        assert_select 'p:nth-of-type(4)', '1 Feb 1990'
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change
I totally missed there was another figma slide where these details are shown.

Glad we now have the presenter all setup so it was kind of just reusing almost everything, I just added a couple more methods to the presenter.

DRY the time/date format. The `datetime` format is not used yet, but will be used for the stamp date.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-120

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1041" alt="Screenshot 2022-08-25 at 10 40 21" src="https://user-images.githubusercontent.com/687910/186638984-8a26d63f-a4ca-45ae-901d-e047c36caa14.png">

## How to manually test the feature
A brand new application will only show the LAA reference. Once the client details step is completed, the task list page for that application will show the additional details.