### PR TITLE
Use rails specific simplecov config

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,12 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'simplecov'
 SimpleCov.minimum_coverage 100
 
-SimpleCov.start do
+SimpleCov.start 'rails' do
   add_filter 'config/initializers'
   add_filter 'config/routes.rb'
   add_filter 'spec/'
+  add_filter 'app/mailers/application_mailer.rb'
+  add_filter 'app/jobs/application_job.rb'
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Description of change

Updates SimpleCov to use rails specific config option.

There was an issue where it was reporting false positives locally, and after some manual testing it seems like this will fix the issue.

Added some filters for rails classes that are useful to have as starting points for non MVP functionality but don't need to be covered at the moment i.e. jobs / mailers etc.

## How to manually test the feature
- run `rake` locally you should have no errors in the coverage report.
- If you take away the `# :nocov` from the `CaseDecisionTree` class, and then rerun rake you will see it will be reported as a failure in the coverage report (this was not happening before this change)
