### PR TITLE
CRIMAP-109 Initial co-defendants DB schema and model

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -1,5 +1,4 @@
-# :nocov:
 class Case < ApplicationRecord
   belongs_to :crime_application
+  has_many :codefendants, dependent: :destroy
 end
-# :nocov:

--- a/app/models/codefendant.rb
+++ b/app/models/codefendant.rb
@@ -1,0 +1,6 @@
+class Codefendant < ApplicationRecord
+  belongs_to :case
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,10 +1,14 @@
 class CrimeApplication < ApplicationRecord
-  has_one :applicant, dependent: :destroy
   has_one :case, dependent: :destroy
+
+  has_one :applicant, dependent: :destroy
   has_one :partner, dependent: :destroy
 
   has_many :people, dependent: :destroy
+
+  # Shortcuts through intermediate tables
   has_many :addresses, through: :people
+  has_many :codefendants, through: :case
 
   enum status: ApplicationStatus.enum_values,
        _default: ApplicationStatus.enum_values[:in_progress]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,14 +52,15 @@ Rails.application.routes.draw do
         edit_step :contact_details
       end
 
-      namespace :cases do
-        edit_step :urn
-      end
-
       namespace :address do
         crud_step :lookup,  param: :address_id, only: [:edit, :update]
         crud_step :results, param: :address_id, only: [:edit, :update]
         crud_step :details, param: :address_id, only: [:edit, :update]
+      end
+
+      namespace :case do
+        edit_step :urn
+        crud_step :codefendants, param: :codefendant_id
       end
     end
   end

--- a/db/migrate/20220826083744_create_codefendants_table.rb
+++ b/db/migrate/20220826083744_create_codefendants_table.rb
@@ -1,0 +1,13 @@
+class CreateCodefendantsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :codefendants, id: :uuid do |t|
+      t.references :case, type: :uuid, foreign_key: true, null: false
+
+      t.timestamps
+
+      t.string :first_name
+      t.string :last_name
+      t.string :conflict_of_interest
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_101437) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_26_083744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -36,6 +36,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_101437) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
+  end
+
+  create_table "codefendants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "case_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.string "conflict_of_interest"
+    t.index ["case_id"], name: "index_codefendants_on_case_id"
   end
 
   create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -64,5 +74,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_101437) do
 
   add_foreign_key "addresses", "people"
   add_foreign_key "cases", "crime_applications"
+  add_foreign_key "codefendants", "cases"
   add_foreign_key "people", "crime_applications"
 end

--- a/spec/models/codefendant_spec.rb
+++ b/spec/models/codefendant_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Codefendant, type: :model do
+  subject { described_class.new(attributes) }
+  let(:attributes) { {} }
+end


### PR DESCRIPTION
## Description of change
Just the basic schema that we will require for the co-defendants (a case has many co-defendants, a co-defendant belongs to a case).

Added the routes as well. Rename the existing `cases` namespace to be singular `case` to follow the pattern we have (like `client` or `address`).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-109

## Notes for reviewer
I'm not subclassing `Codefedant` from `Person` because apart from first_name and last_name, all other attributes are not relevant to co-defendants, don't have addresses either, and the relationship is with the Case, not with the CrimeApplication (although we expose a shortcut using `through`).
