### PR TITLE
Add URN step

### DIFF
--- a/app/controllers/steps/case/urn_controller.rb
+++ b/app/controllers/steps/case/urn_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class UrnController < Steps::CaseStepController
+      def edit
+        @form_object = UrnForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(UrnForm, as: :urn)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/urn_form.rb
+++ b/app/forms/steps/case/urn_form.rb
@@ -2,6 +2,28 @@
 module Steps
   module Case
     class UrnForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      URN_REGEXP = /\A[0-9]{2}[A-Z]{2}[0-9]{7}\Z/
+
+      has_one_association :case
+      alias kase case
+
+      attribute :urn, :string
+
+      validates :urn, format: { with: URN_REGEXP }, allow_blank: true
+
+      def urn=(str)
+        super(str.upcase.delete(' ')) if str
+      end
+
+      private
+
+      def persist!
+        kase.update(
+          attributes
+        )
+      end
     end
   end
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -12,7 +12,9 @@ module Decisions
 
     private
 
-    def after_urn; end
+    def after_urn
+      show('/home', action: :index)
+    end
   end
 end
 # :nocov:

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -40,7 +40,7 @@ module Decisions
           form_object.applicant
         )
       else
-        show('/home', action: :index)
+        edit('/steps/case/urn')
       end
     end
 

--- a/app/views/steps/case/urn/edit.html.erb
+++ b/app/views/steps/case/urn/edit.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :urn, autocomplete: 'off', width: 'one-third', label: { tag: 'h1', size: 'xl' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -77,3 +77,7 @@ en:
               blank: Enter a country
             postcode:
               blank: Enter a postcode
+        steps/case/urn_form:
+          attributes:
+            urn:
+              invalid: Enter a valid URN

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -33,6 +33,8 @@ en:
         telephone_number: For example, 01632 960 001 or +44 808 157 0192. We'll use this to chase your client if they don't pay towards their legal aid.
       steps_address_lookup_form:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
+      steps_case_urn_form:
+        urn: For example, ‘12 AB 3456789’.
 
     label:
       steps_client_has_partner_form:
@@ -57,3 +59,5 @@ en:
         city: Town or city
         country: Country
         postcode: Postcode
+      steps_case_urn_form:
+        urn: Enter the unique reference number (URN) for your client's case (optional)

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -67,3 +67,7 @@ en:
             applicant:
               home_address: Enter your client’s home address
               correspondence_address: Enter your client’s correspondence address
+    case:
+      urn:
+        edit:
+          page_title: Enter your client’s URN

--- a/spec/controllers/steps/case/urn_controller_spec.rb
+++ b/spec/controllers/steps/case/urn_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::UrnController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::UrnForm, Decisions::CaseDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::Case::UrnForm
+end

--- a/spec/forms/steps/case/urn_form_spec.rb
+++ b/spec/forms/steps/case/urn_form_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::UrnForm do
+
+  let(:arguments) { {
+    crime_application: crime_application,
+    urn: urn
+  } }
+
+  let(:crime_application) { 
+    instance_double(CrimeApplication)
+  }
+
+  let(:urn) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when `urn` is blank' do
+      let(:urn) { '' }
+
+      it 'has no validation error on the field' do
+        expect(subject).to be_valid
+        expect(subject.errors.of_kind?(:urn, :invalid)).to eq(false)
+      end
+    end
+
+    context 'when `urn` is invalid' do
+      let(:urn) { 'not a urn' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:urn, :invalid)).to eq(true)
+      end
+    end
+
+    context 'when `urn` is valid' do
+      context 'with spaces between numbers' do
+        let(:urn) { '12 AB 34 56 78 9' }
+        it 'passes validation' do
+          expect(subject).to be_valid
+          expect(subject.errors.of_kind?(:urn, :invalid)).to eq(false)
+        end
+        it 'removes spaces from input' do
+          expect(subject.urn).to eq('12AB3456789')
+        end
+      end
+
+      context 'with trailing spaces' do
+        let(:urn) { ' 12 AB 34 56789 ' }
+        it 'passed validation' do
+          expect(subject).to be_valid
+          expect(subject.errors.of_kind?(:urn, :invalid)).to eq(false)
+        end
+      end
+    end
+
+    context 'when validations pass' do
+      let(:urn) { '12AB3456789' }
+      it_behaves_like 'a has-one-association form',
+                      association_name: :case,
+                      expected_attributes: {
+                        'urn' => '12AB3456789'
+                      }
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Decisions::CaseDecisionTree do
+  subject { described_class.new(form_object, as: step_name) }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  it_behaves_like 'a decision tree'
+
+  before do
+    allow(
+      form_object
+    ).to receive(:crime_application).and_return(crime_application)
+  end
+
+  context 'when the step is `urn`' do
+    let(:form_object) { double('FormObject', case: 'case') }
+    let(:step_name) { :urn }
+
+    context 'has correct next step' do
+      let(:case) { '12AA3456789' }
+
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    end
+  end
+end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Decisions::ClientDecisionTree do
 
     context 'and answer is any other thing' do
       let(:correspondence_address_type) { 'whatever' }
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Adds URN input to user journey after client contact details input
## Link to relevant ticket
[CRIMAP-74](https://dsdmoj.atlassian.net/browse/CRIMAP-74)
Follow user journey to create an application. This step is added to follow after client contact details page. 
Designs as per [Figma screen](https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=2773%3A29320)
## Screenshots of changes (if applicable)

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/45827968/187496163-f8566086-3a50-4857-8647-38bc3be27de6.png">

## How to manually test the feature
Follow user journey to create an application. This step is added to follow after client contact details page. 
Check against designs as per [Figma screen](https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=2773%3A29320)