### PR TITLE
CRIMAP-109 Enter codefendant names

### DIFF
--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -43,7 +43,13 @@ module Steps
     def permitted_params(form_class)
       params
         .fetch(form_class.model_name.singular, {})
-        .permit(form_class.attribute_names)
+        .permit(form_class.attribute_names + additional_permitted_params)
+    end
+
+    # Some form objects might contain complex attribute structures or nested params.
+    # Override in subclasses to declare any additional parameters that should be permitted.
+    def additional_permitted_params
+      []
     end
 
     def update_navigation_stack

--- a/app/controllers/steps/case/codefendants_controller.rb
+++ b/app/controllers/steps/case/codefendants_controller.rb
@@ -1,0 +1,25 @@
+module Steps
+  module Case
+    class CodefendantsController < Steps::CaseStepController
+      def edit
+        @form_object = CodefendantsForm.new(
+          crime_application: current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(CodefendantsForm, as: step_name)
+      end
+
+      private
+
+      def step_name
+        params.key?('add_codefendant') ? :add_codefendant : :codefendants_finished
+      end
+
+      def additional_permitted_params
+        [codefendants_attributes: Steps::Case::CodefendantFieldsetForm.attribute_names]
+      end
+    end
+  end
+end

--- a/app/controllers/steps/case_step_controller.rb
+++ b/app/controllers/steps/case_step_controller.rb
@@ -1,4 +1,3 @@
-# :nocov:
 module Steps
   class CaseStepController < BaseStepController
     private
@@ -8,4 +7,3 @@ module Steps
     end
   end
 end
-# :nocov:

--- a/app/forms/concerns/steps/has_one_association.rb
+++ b/app/forms/concerns/steps/has_one_association.rb
@@ -23,6 +23,8 @@ module Steps
         define_method(name) do
           @_assoc ||= self.class.associated_record(crime_application)
         end
+
+        alias_method :kase, :case if name == :case
       end
     end
   end

--- a/app/forms/steps/case/codefendant_fieldset_form.rb
+++ b/app/forms/steps/case/codefendant_fieldset_form.rb
@@ -1,0 +1,17 @@
+module Steps
+  module Case
+    class CodefendantFieldsetForm < Steps::BaseFormObject
+      attribute :id, :string
+      attribute :first_name, :string
+      attribute :last_name, :string
+
+      validates_presence_of :first_name,
+                            :last_name
+
+      # Needed for `#fields_for` to render the uuids as hidden fields
+      def persisted?
+        id.present?
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/codefendants_form.rb
+++ b/app/forms/steps/case/codefendants_form.rb
@@ -1,0 +1,34 @@
+module Steps
+  module Case
+    class CodefendantsForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :case
+
+      delegate :codefendants_attributes=, to: :kase
+
+      validates_with CodefendantsValidator
+
+      def codefendants
+        @codefendants ||= begin
+          add_blank_codefendant if kase.codefendants.empty? # temporary until we have previous step
+
+          kase.codefendants.map do |codefendant|
+            CodefendantFieldsetForm.build(
+              codefendant, crime_application: crime_application
+            )
+          end
+        end
+      end
+
+      def add_blank_codefendant
+        kase.codefendants.create!
+      end
+
+      private
+
+      def persist!
+        kase.save
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/urn_form.rb
+++ b/app/forms/steps/case/urn_form.rb
@@ -3,11 +3,9 @@ module Steps
   module Case
     class UrnForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
+      has_one_association :case
 
       URN_REGEXP = /\A[0-9]{2}[A-Z]{2}[0-9]{7}\Z/
-
-      has_one_association :case
-      alias kase case
 
       attribute :urn, :string
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -1,4 +1,6 @@
 class Case < ApplicationRecord
   belongs_to :crime_application
+
   has_many :codefendants, dependent: :destroy
+  accepts_nested_attributes_for :codefendants
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -1,10 +1,14 @@
-# :nocov:
 module Decisions
   class CaseDecisionTree < BaseDecisionTree
     def destination
       case step_name
       when :urn
         after_urn
+      when :add_codefendant
+        edit_codefendants
+      when :codefendants_finished
+        # Next step when we have it
+        show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -15,6 +19,10 @@ module Decisions
     def after_urn
       show('/home', action: :index)
     end
+
+    def edit_codefendants
+      form_object.add_blank_codefendant
+      edit(:codefendants)
+    end
   end
 end
-# :nocov:

--- a/app/validators/codefendants_validator.rb
+++ b/app/validators/codefendants_validator.rb
@@ -1,0 +1,42 @@
+class CodefendantsValidator < ActiveModel::Validator
+  attr_reader :record
+
+  def validate(record)
+    @record = record
+
+    record.codefendants.each.with_index do |codefendant, index|
+      add_indexed_errors(codefendant, index) unless codefendant.valid?
+    end
+  end
+
+  private
+
+  def add_indexed_errors(codefendant, index)
+    codefendant.errors.each do |error|
+      attr_name = indexed_attribute(index, error.attribute)
+
+      record.errors.add(
+        attr_name,
+        error.type,
+        message: error_message(codefendant, error), index: index + 1
+      )
+
+      # We define the attribute getter as it doesn't really exist
+      record.define_singleton_method(attr_name) do
+        codefendant.public_send(error.attribute)
+      end
+    end
+  end
+
+  def indexed_attribute(index, attr)
+    "codefendants-attributes[#{index}].#{attr}"
+  end
+
+  # `activemodel.errors.models.steps/case/codefendant_fieldset_form.summary.x.y`
+  def error_message(obj, error)
+    I18n.t(
+      "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",
+      scope: [:activemodel, :errors, :models]
+    )
+  end
+end

--- a/app/views/steps/case/codefendants/edit.html.erb
+++ b/app/views/steps/case/codefendants/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.fields_for :codefendants do |c| %>
+        <%= c.govuk_fieldset legend: { text: t('.codefendant_legend', index: c.index + 1) } do %>
+          <%= c.govuk_text_field :first_name, label: { text: t("helpers.label.#{f.object_name}.first_name") },
+                                 autocomplete: 'off', width: 'three-quarters' %>
+
+          <%= c.govuk_text_field :last_name, label: { text: t("helpers.label.#{f.object_name}.last_name") },
+                                 autocomplete: 'off', width: 'three-quarters' %>
+        <% end %>
+      <% end %>
+
+      <%= f.button t('.add_button'), type: :submit, name: :add_codefendant,
+                   class: %w(govuk-button govuk-button--secondary govuk-!-margin-bottom-8),
+                   data: { module: 'govuk-button' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -81,3 +81,14 @@ en:
           attributes:
             urn:
               invalid: Enter a valid URN
+        steps/case/codefendant_fieldset_form:
+          summary:
+            first_name:
+              blank: Enter first name of co-defendant %{index}
+            last_name:
+              blank: Enter last name of co-defendant %{index}
+          attributes:
+            first_name:
+              blank: Enter a first name
+            last_name:
+              blank: Enter a last name

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -61,3 +61,6 @@ en:
         postcode: Postcode
       steps_case_urn_form:
         urn: Enter the unique reference number (URN) for your client's case (optional)
+      steps_case_codefendants_form:
+        first_name: First name
+        last_name: Last name

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -71,3 +71,9 @@ en:
       urn:
         edit:
           page_title: Enter your client’s URN
+      codefendants:
+        edit:
+          page_title: Details of co-defendants
+          heading: Enter the details of any co-defendants in the case
+          codefendant_legend: Co-defendant %{index}
+          add_button: Add another co-defendant

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
 
       namespace :case do
         edit_step :urn
-        crud_step :codefendants, param: :codefendant_id
+        edit_step :codefendants
       end
     end
   end

--- a/spec/controllers/steps/case/codefendants_controller_spec.rb
+++ b/spec/controllers/steps/case/codefendants_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::CodefendantsController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::CodefendantsForm, Decisions::CaseDecisionTree
+end

--- a/spec/forms/steps/case/codefendant_fieldset_form_spec.rb
+++ b/spec/forms/steps/case/codefendant_fieldset_form_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::CodefendantFieldsetForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    id: record_id,
+    first_name: 'John',
+    last_name: 'Doe',
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:record_id) { '12345' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#persisted?' do
+    context 'when the record has an ID' do
+      it { expect(subject.persisted?).to eq(true) }
+    end
+
+    context 'when the record has no ID' do
+      let(:record_id) { nil }
+      it { expect(subject.persisted?).to eq(false) }
+    end
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:last_name) }
+  end
+end

--- a/spec/forms/steps/case/codefendants_form_spec.rb
+++ b/spec/forms/steps/case/codefendants_form_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::CodefendantsForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    codefendants_attributes: codefendants_attributes,
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication, case: case_record) }
+  let(:case_record) { Case.new }
+
+  let(:codefendants_attributes) {
+    {
+      "0"=>{"first_name"=>"John", "last_name"=>"Doe"},
+      "1"=>{"first_name"=>"Jane", "last_name"=>"Doe"},
+    }
+  }
+
+  subject { described_class.new(arguments) }
+
+  describe '#codefendants' do
+    # TODO: temporary until we have previous step
+    context 'there are no codefendants' do
+      let(:codefendants_attributes) { {} }
+
+      it 'adds a blank one to the collection' do
+        expect(case_record.codefendants).to receive(:create!)
+        subject.codefendants
+      end
+    end
+
+    # TODO: temporary until we have previous step
+    context 'there are existing codefendants' do
+      it 'does not add a blank one to the collection' do
+        expect(subject).not_to receive(:add_blank_codefendant)
+        subject.codefendants
+      end
+
+      it 'builds a collection of `CodefendantFieldsetForm` instances' do
+        expect(
+          subject.codefendants
+        ).to contain_exactly(Steps::Case::CodefendantFieldsetForm, Steps::Case::CodefendantFieldsetForm)
+
+        expect(subject.codefendants[0].first_name).to eq('John')
+        expect(subject.codefendants[0].last_name).to eq('Doe')
+
+        expect(subject.codefendants[1].first_name).to eq('Jane')
+        expect(subject.codefendants[1].last_name).to eq('Doe')
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'when there are errors in any of the codefendants' do
+      let(:codefendants_attributes) {
+        {
+          "0"=>{"first_name"=>"John", "last_name"=>""},
+          "1"=>{"first_name"=>"", "last_name"=>"Doe"},
+        }
+      }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'sets the errors with their index' do
+        expect(subject).to_not be_valid
+
+        expect(subject.errors.of_kind?('codefendants-attributes[0].last_name', :blank)).to eq(true)
+        expect(subject.errors.messages_for('codefendants-attributes[0].last_name').first).to eq('Enter last name of co-defendant 1')
+
+        expect(subject.errors.of_kind?('codefendants-attributes[1].first_name', :blank)).to eq(true)
+        expect(subject.errors.messages_for('codefendants-attributes[1].first_name').first).to eq('Enter first name of co-defendant 2')
+      end
+    end
+
+    context 'when there are no errors' do
+      it 'saves the record' do
+        expect(case_record).to receive(:save).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -23,4 +23,24 @@ RSpec.describe Decisions::CaseDecisionTree do
       it { is_expected.to have_destination('/home', :index, id: crime_application) }
     end
   end
+
+  context 'when the step is `add_codefendant`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :add_codefendant }
+
+    it 'creates a blank co-defendant record and gets back to the codefendants page' do
+      expect(
+        form_object
+      ).to receive(:add_blank_codefendant).at_least(:once)
+
+      is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+    end
+  end
+
+  context 'when the step is `codefendants_finished`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :codefendants_finished }
+
+    it { is_expected.to have_destination('/home', :index, id: crime_application) }
+  end
 end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Decisions::CaseDecisionTree do
   end
 
   context 'when the step is `urn`' do
-    let(:form_object) { double('FormObject', case: 'case') }
+    let(:form_object) { double('FormObject') }
     let(:step_name) { :urn }
 
     context 'has correct next step' do


### PR DESCRIPTION
## Description of change
Follow-up to previous preparation PR #87.

This implements the controller and form object(s) needed for the CRUD step to add/edit/delete co-defendants.

Note: in this PR only add and edit actions are implemented. In a future PR the delete will also be implemented.

Also only first_name and last_name attributes in this PR. Conflict of interest is a separate ticket and will be added later, otherwise the PR grows too much.

There are some ancillary changes in this PR that were needed as this was our first CRUD step really (addresses was kind of different).

The way this works is slightly different to other steps. Basically, we have a main form object, named `CodefendantsForm` which is in charge of rendering the view which is composed of a collection of `CodefendantFieldsetForm` which are like mini form objects representing each of the individual co-defendant records.

The validation is performed in these individual co-defendant form objects but propagated to the parent form `CodefendantsForm` so errors can be rendered in the summary as well, and are indexed pointing to the specific field with error (as there may be more than 1 co-defendant and all their attributes are named the same really, we have to index them).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-109

## Notes for reviewer
No delete action yet. No conflict of interest yet. Some of the code is temporary until we have previous step (the yes-no question).

## Screenshots of changes (if applicable)
<img width="602" alt="Screenshot 2022-08-31 at 10 40 20" src="https://user-images.githubusercontent.com/687910/187648965-d2b90092-4666-4822-85b5-2cd86fef3833.png">
<img width="626" alt="Screenshot 2022-08-31 at 10 41 01" src="https://user-images.githubusercontent.com/687910/187649138-e03378e9-984b-47e9-b38d-39a59a23e7b2.png">

## How to manually test the feature
Start an application and make sure it has an associated `case` (go to the URN step and enter something). Then go manually to the URL for codefendants (`/applications/{crime_application_id}/steps/case/codefendants`) and it should show a first co-defendant empty, ready to fill. You can enter first name and last name, or trigger errors, etc.