### PR TITLE
CRIMAP-96 enter case type

### DIFF
--- a/app/controllers/steps/case/case_type_controller.rb
+++ b/app/controllers/steps/case/case_type_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class CaseTypeController < Steps::CaseStepController
+      def edit
+        @form_object = CaseTypeForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(CaseTypeForm, as: :case_type)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -13,7 +13,7 @@ module Steps
 
       validates :cc_appeal_fin_change_details,
                 presence: true,
-                if: -> { case_type.present? && CaseType.new(case_type).cc_appeal_fin_change? }
+                if: -> { case_type.present? && case_type_val.cc_appeal_fin_change? }
 
       has_one_association :case
 
@@ -42,15 +42,19 @@ module Steps
       end
 
       def appeal_maat_id
-        CaseType.new(case_type).cc_appeal? ? cc_appeal_maat_id : nil
+        case_type_val.new(case_type).cc_appeal? ? cc_appeal_maat_id : nil
       end
 
       def appeal_fin_change_maat_id
-        CaseType.new(case_type).cc_appeal_fin_change? ? cc_appeal_fin_change_maat_id : nil
+        case_type_val.new(case_type).cc_appeal_fin_change? ? cc_appeal_fin_change_maat_id : nil
       end
 
       def appeal_fin_change_details
-        CaseType.new(case_type).cc_appeal_fin_change? ? cc_appeal_fin_change_details : nil
+        case_type_val.cc_appeal_fin_change? ? cc_appeal_fin_change_details : nil
+      end
+
+      def case_type_val
+        CaseType.new(case_type)
       end
     end
   end

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -7,7 +7,21 @@ module Steps
       attribute :previous_maat_id
       attribute :cc_appeal_fin_change_details
 
-      validates :case_type, presence: true
+      validates :case_type,
+                presence: true, 
+                inclusion: { in: :string_choices }
+
+      validates :previous_maat_id, 
+                absence: true, 
+                unless: ->{ case_is_an_appeal_type? } 
+
+      validates :cc_appeal_fin_change_details, 
+                absence: true, 
+                unless: -> { case_is_appeal_with_financial_change? }
+
+      validates :cc_appeal_fin_change_details, 
+                presence: true, 
+                if: -> { case_is_appeal_with_financial_change? }
 
       has_one_association :case
       alias kase case
@@ -17,6 +31,21 @@ module Steps
       end
 
       private
+
+      def case_is_an_appeal_type?
+        return false if case_type.nil?
+        ([CaseType::CC_APPEAL.value, 
+          CaseType::CC_APPEAL_FIN_CHANGE.value].include?(case_type.to_sym))
+      end
+
+      def case_is_appeal_with_financial_change?
+        return false if case_type.nil?
+        CaseType::CC_APPEAL_FIN_CHANGE.value == case_type.to_sym
+      end
+
+      def string_choices
+        choices.map(&:to_s)
+      end
 
       def persist!
         kase.update(

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -13,7 +13,7 @@ module Steps
 
       validates :cc_appeal_fin_change_details,
                 presence: true,
-                if: -> { case_is_appeal_with_fin_change? }
+                if: -> { case_type.present? && CaseType.new(case_type).cc_appeal_fin_change? }
 
       has_one_association :case
 
@@ -22,18 +22,6 @@ module Steps
       end
 
       private
-
-      def case_is_appeal_with_fin_change?
-        return false if case_type.nil?
-
-        CaseType::CC_APPEAL_FIN_CHANGE.value == case_type.to_sym
-      end
-
-      def case_is_appeal?
-        return false if case_type.nil?
-
-        CaseType::CC_APPEAL.value == case_type.to_sym
-      end
 
       def string_choices
         choices.map(&:to_s)
@@ -54,15 +42,15 @@ module Steps
       end
 
       def appeal_maat_id
-        case_is_appeal? ? cc_appeal_maat_id : nil
+        CaseType.new(case_type).cc_appeal? ? cc_appeal_maat_id : nil
       end
 
       def appeal_fin_change_maat_id
-        case_is_appeal_with_fin_change? ? cc_appeal_fin_change_maat_id : nil
+        CaseType.new(case_type).cc_appeal_fin_change? ? cc_appeal_fin_change_maat_id : nil
       end
 
       def appeal_fin_change_details
-        case_is_appeal_with_fin_change? ? cc_appeal_fin_change_details : nil
+        CaseType.new(case_type).cc_appeal_fin_change? ? cc_appeal_fin_change_details : nil
       end
     end
   end

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -1,6 +1,26 @@
 module Steps
   module Case
     class CaseTypeForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      attribute :case_type
+
+      validates :case_type, presence: true
+
+      has_one_association :case
+      alias kase case
+
+      def choices
+        CaseType.values
+      end
+
+      private
+
+      def persist!
+        kase.update(
+          attributes
+        )
+      end
     end
   end
 end

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -3,10 +3,10 @@ module Steps
     class CaseTypeForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
 
-      attribute :case_type
-      attribute :cc_appeal_maat_id
-      attribute :cc_appeal_fin_change_maat_id
-      attribute :cc_appeal_fin_change_details
+      attribute :case_type, type: :string
+      attribute :cc_appeal_maat_id, type: :string
+      attribute :cc_appeal_fin_change_maat_id, type: :string
+      attribute :cc_appeal_fin_change_details, type: :string
 
       validates :case_type,
                 inclusion: { in: :string_choices }

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -4,6 +4,8 @@ module Steps
       include Steps::HasOneAssociation
 
       attribute :case_type
+      attribute :previous_maat_id
+      attribute :cc_appeal_fin_change_details
 
       validates :case_type, presence: true
 

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -24,7 +24,6 @@ module Steps
                 if: -> { case_is_appeal_with_financial_change? }
 
       has_one_association :case
-      alias kase case
 
       def choices
         CaseType.values

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -1,0 +1,6 @@
+module Steps
+  module Case
+    class CaseTypeForm < Steps::BaseFormObject
+    end
+  end
+end

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -8,7 +8,6 @@ module Steps
       attribute :cc_appeal_fin_change_details
 
       validates :case_type,
-                presence: true,
                 inclusion: { in: :string_choices }
 
       validates :previous_maat_id,

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -8,19 +8,19 @@ module Steps
       attribute :cc_appeal_fin_change_details
 
       validates :case_type,
-                presence: true, 
+                presence: true,
                 inclusion: { in: :string_choices }
 
-      validates :previous_maat_id, 
-                absence: true, 
-                unless: ->{ case_is_an_appeal_type? } 
+      validates :previous_maat_id,
+                absence: true,
+                unless: -> { case_is_an_appeal_type? }
 
-      validates :cc_appeal_fin_change_details, 
-                absence: true, 
+      validates :cc_appeal_fin_change_details,
+                absence: true,
                 unless: -> { case_is_appeal_with_financial_change? }
 
-      validates :cc_appeal_fin_change_details, 
-                presence: true, 
+      validates :cc_appeal_fin_change_details,
+                presence: true,
                 if: -> { case_is_appeal_with_financial_change? }
 
       has_one_association :case
@@ -34,12 +34,14 @@ module Steps
 
       def case_is_an_appeal_type?
         return false if case_type.nil?
-        ([CaseType::CC_APPEAL.value, 
-          CaseType::CC_APPEAL_FIN_CHANGE.value].include?(case_type.to_sym))
+
+        [CaseType::CC_APPEAL.value,
+         CaseType::CC_APPEAL_FIN_CHANGE.value].include?(case_type.to_sym)
       end
 
       def case_is_appeal_with_financial_change?
         return false if case_type.nil?
+
         CaseType::CC_APPEAL_FIN_CHANGE.value == case_type.to_sym
       end
 

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -42,11 +42,11 @@ module Steps
       end
 
       def appeal_maat_id
-        case_type_val.new(case_type).cc_appeal? ? cc_appeal_maat_id : nil
+        case_type_val.cc_appeal? ? cc_appeal_maat_id : nil
       end
 
       def appeal_fin_change_maat_id
-        case_type_val.new(case_type).cc_appeal_fin_change? ? cc_appeal_fin_change_maat_id : nil
+        case_type_val.cc_appeal_fin_change? ? cc_appeal_fin_change_maat_id : nil
       end
 
       def appeal_fin_change_details

--- a/app/forms/steps/case/urn_form.rb
+++ b/app/forms/steps/case/urn_form.rb
@@ -1,4 +1,3 @@
-# :nocov:
 module Steps
   module Case
     class UrnForm < Steps::BaseFormObject
@@ -25,4 +24,3 @@ module Steps
     end
   end
 end
-# :nocov:

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -19,7 +19,7 @@ module Decisions
     private
 
     def after_urn
-      show('/home', action: :index)
+      edit('/steps/case/case_type')
     end
 
     def edit_codefendants(add_blank:)

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -1,5 +1,6 @@
 module Decisions
   class CaseDecisionTree < BaseDecisionTree
+    # rubocop:disable Metrics/MethodLength
     def destination
       case step_name
       when :urn
@@ -17,6 +18,7 @@ module Decisions
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -4,6 +4,8 @@ module Decisions
       case step_name
       when :urn
         after_urn
+      when :case_type
+        after_case_type
       when :add_codefendant
         edit_codefendants(add_blank: true)
       when :delete_codefendant
@@ -17,6 +19,10 @@ module Decisions
     end
 
     private
+
+    def after_case_type
+      edit('/steps/case/codefendants')
+    end
 
     def after_urn
       edit('/steps/case/case_type')

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -6,6 +6,6 @@ class CaseType < ValueObject
     ALREADY_CC_TRIAL = new(:already_cc_trial),
     COMMITTAL = new(:committal),
     CC_APPEAL = new(:cc_appeal),
-    CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change),
+    CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change)
   ].freeze
 end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -1,0 +1,11 @@
+class CaseType < ValueObject
+  VALUES = [
+    SUMMARY_ONLY = new(:summary_only),
+    EITHER_WAY = new(:either_way),
+    INTICTABLE = new(:indictable),
+    ALREADY_CC_TRIAL = new(:already_cc_trial),
+    COMMITTAL = new(:committal),
+    CC_APPEAL = new(:cc_appeal),
+    CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change),
+  ].freeze
+end

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -7,7 +7,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset(:case_type, legend: {tag: 'h1', size: 'xl'}) do %>
-        <% @form_object.choices.each do |choice| %>
+        <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice.value == :cc_appeal %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
@@ -23,7 +23,7 @@
 
           <% else %>
 
-            <%= f.govuk_radio_button :case_type, choice.value, link_errors: true %>
+            <%= f.govuk_radio_button :case_type, choice.value, link_errors: index.zero? %>
 
           <% end %>
         <% end %>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -6,12 +6,28 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:case_type, legend: { tag: 'h1', size: 'm'}) do %>
+        <% @form_object.choices.each do |choice| %>
+          <% if choice.value == :cc_appeal %>
 
-      <%= f.govuk_collection_radio_buttons :case_type, 
-        @form_object.choices, 
-        :value, 
-        legend: { tag: 'h1', size: 'xl' } %>
+            <%= f.govuk_radio_button :case_type, choice.value, link_errors: true do %>
+              <%= f.govuk_text_field :previous_maat_id, width: 'one-third', link_errors: true %>
+            <% end %>
 
+          <% elsif choice.value == :cc_appeal_fin_change %>
+
+            <%= f.govuk_radio_button :case_type, choice.value, link_errors: true do %>
+              <%= f.govuk_text_field :previous_maat_id, width: 'one-third', link_errors: true %>
+              <%= f.govuk_text_area :cc_appeal_fin_change_details, link_errors: true %>
+            <% end %>
+
+          <% else %>
+
+            <%= f.govuk_radio_button :case_type, choice.value, link_errors: true %>
+
+          <% end %>
+        <% end %>
+      <% end %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -5,9 +5,14 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
     <%= step_form @form_object do |f| %>
+
+      <%= f.govuk_collection_radio_buttons :case_type, 
+        @form_object.choices, 
+        :value, 
+        legend: { tag: 'h1', size: 'xl' } %>
+
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -11,13 +11,13 @@
           <% if choice.value == :cc_appeal %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :previous_maat_id, width: 'one-third' %>
+              <%= f.govuk_text_field :cc_appeal_maat_id, width: 'one-third' %>
             <% end %>
 
           <% elsif choice.value == :cc_appeal_fin_change %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :previous_maat_id, width: 'one-third' %>
+              <%= f.govuk_text_field :cc_appeal_fin_change_maat_id, width: 'one-third' %>
               <%= f.govuk_text_area :cc_appeal_fin_change_details %>
             <% end %>
 

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -10,15 +10,15 @@
         <% @form_object.choices.each do |choice| %>
           <% if choice.value == :cc_appeal %>
 
-            <%= f.govuk_radio_button :case_type, choice.value, link_errors: true do %>
-              <%= f.govuk_text_field :previous_maat_id, width: 'one-third', link_errors: true %>
+            <%= f.govuk_radio_button :case_type, choice.value do %>
+              <%= f.govuk_text_field :previous_maat_id, width: 'one-third' %>
             <% end %>
 
           <% elsif choice.value == :cc_appeal_fin_change %>
 
-            <%= f.govuk_radio_button :case_type, choice.value, link_errors: true do %>
-              <%= f.govuk_text_field :previous_maat_id, width: 'one-third', link_errors: true %>
-              <%= f.govuk_text_area :cc_appeal_fin_change_details, link_errors: true %>
+            <%= f.govuk_radio_button :case_type, choice.value do %>
+              <%= f.govuk_text_field :previous_maat_id, width: 'one-third' %>
+              <%= f.govuk_text_area :cc_appeal_fin_change_details %>
             <% end %>
 
           <% else %>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -11,13 +11,13 @@
           <% if choice.value == :cc_appeal %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :cc_appeal_maat_id, width: 'one-third' %>
+              <%= f.govuk_text_field :cc_appeal_maat_id, width: 'one-third', autocomplete: 'off' %>
             <% end %>
 
           <% elsif choice.value == :cc_appeal_fin_change %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :cc_appeal_fin_change_maat_id, width: 'one-third' %>
+              <%= f.govuk_text_field :cc_appeal_fin_change_maat_id, width: 'one-third', autocomplete: 'off' %>
               <%= f.govuk_text_area :cc_appeal_fin_change_details %>
             <% end %>
 

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:case_type, legend: { tag: 'h1', size: 'm'}) do %>
+      <%= f.govuk_radio_buttons_fieldset(:case_type, legend: {tag: 'h1', size: 'xl'}) do %>
         <% @form_object.choices.each do |choice| %>
           <% if choice.value == :cc_appeal %>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -84,10 +84,7 @@ en:
         steps/case/case_type_form:
           attributes:
             case_type:
-              invalid: Enter a valid case type
               inclusion: Select a case type
-            previous_maat_id:
-              present: Previous MAAT IDs are optional with appeal case types only
             cc_appeal_fin_change_details:
               blank: Add the details of what has changed
               present: Details of what has changed are required for Appeal to Crown Court with changes to financial circumstances only

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -81,6 +81,16 @@ en:
           attributes:
             urn:
               invalid: Enter a valid URN
+        steps/case/case_type_form:
+          attributes:
+            case_type:
+              invalid: Enter a valid case type
+              blank: Select a case type
+            previous_maat_id:
+              present: Previous MAAT IDs are optional with appeal case types only
+            cc_appeal_fin_change_details:
+              blank: Add the details of what has changed
+              present: Details of what has changed are required for Appeal to Crown Court with changes to financial circumstances only
         steps/case/codefendant_fieldset_form:
           summary:
             first_name:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -85,7 +85,7 @@ en:
           attributes:
             case_type:
               invalid: Enter a valid case type
-              blank: Select a case type
+              inclusion: Select a case type
             previous_maat_id:
               present: Previous MAAT IDs are optional with appeal case types only
             cc_appeal_fin_change_details:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -23,7 +23,7 @@ en:
       steps_case_codefendants_form:
         conflict_of_interest: Is there a conflict of interest with this co-defendant?
       steps_case_case_type_form:
-        case_type: Enter the case type
+        case_type: What is the case type?
 
     hint:
       steps_client_has_partner_form:
@@ -76,7 +76,7 @@ en:
           indictable: Indictable
           already_cc_trial: Trial already in crown court
           committal: Committal for sentence
-          cc_appeal: Appeal to Crown Court
+          cc_appeal: Appeal to crown court
           cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances
         cc_appeal_maat_id: Previous MAAT ID (optional)
         cc_appeal_fin_change_maat_id: Previous MAAT ID (optional)

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -22,6 +22,8 @@ en:
         correspondence_address_type: Correspondence address
       steps_case_codefendants_form:
         conflict_of_interest: Is there a conflict of interest with this co-defendant?
+      steps_case_case_type_form:
+        case_type: Enter the case type
 
     hint:
       steps_client_has_partner_form:
@@ -67,3 +69,12 @@ en:
         first_name: First name
         last_name: Last name
         conflict_of_interest_options: *YESNO
+      steps_case_case_type_form:
+        case_type_options:
+          summary_only: Summary only
+          either_way: Either way
+          indictable: Indictable
+          already_cc_trial: Trial already in crown court
+          committal: Committal for sentence
+          cc_appeal: Appeal to Crown Court
+          cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -78,5 +78,6 @@ en:
           committal: Committal for sentence
           cc_appeal: Appeal to Crown Court
           cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances
-        previous_maat_id: Previous MAAT ID (optional)
+        cc_appeal_maat_id: Previous MAAT ID (optional)
+        cc_appeal_fin_change_maat_id: Previous MAAT ID (optional)
         cc_appeal_fin_change_details: Enter the details of what has changed

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -78,3 +78,5 @@ en:
           committal: Committal for sentence
           cc_appeal: Appeal to Crown Court
           cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances
+        previous_maat_id: Previous MAAT ID (optional)
+        cc_appeal_fin_change_details: Enter the details of what has changed

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -20,10 +20,10 @@ en:
         date_of_birth: Date of birth
       steps_client_contact_details_form:
         correspondence_address_type: Correspondence address
-      steps_case_codefendants_form:
-        conflict_of_interest: Is there a conflict of interest with this co-defendant?
       steps_case_case_type_form:
         case_type: What is the case type?
+      steps_case_codefendants_form:
+        conflict_of_interest: Is there a conflict of interest with this co-defendant?
 
     hint:
       steps_client_has_partner_form:
@@ -65,10 +65,6 @@ en:
         postcode: Postcode
       steps_case_urn_form:
         urn: Enter the unique reference number (URN) for your client's case (optional)
-      steps_case_codefendants_form:
-        first_name: First name
-        last_name: Last name
-        conflict_of_interest_options: *YESNO
       steps_case_case_type_form:
         case_type_options:
           summary_only: Summary only
@@ -81,3 +77,7 @@ en:
         cc_appeal_maat_id: Previous MAAT ID (optional)
         cc_appeal_fin_change_maat_id: Previous MAAT ID (optional)
         cc_appeal_fin_change_details: Enter the details of what has changed
+      steps_case_codefendants_form:
+        first_name: First name
+        last_name: Last name
+        conflict_of_interest_options: *YESNO

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -71,6 +71,10 @@ en:
       urn:
         edit:
           page_title: Enter your client’s URN
+      case_type:
+        edit:
+          page_title: Enter the case type
+          heading:  Enter the case type
       codefendants:
         edit:
           page_title: Details of co-defendants
@@ -78,7 +82,3 @@ en:
           codefendant_legend: Co-defendant %{index}
           add_button: Add another co-defendant
           remove_button: Remove co-defendant
-      case_type:
-        edit:
-          page_title: Enter the case type
-          heading:  Enter the case type

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -77,11 +77,8 @@ en:
           heading: Enter the details of any co-defendants in the case
           codefendant_legend: Co-defendant %{index}
           add_button: Add another co-defendant
-<<<<<<< HEAD
           remove_button: Remove co-defendant
-=======
       case_type:
         edit:
           page_title: Enter the case type
           heading:  Enter the case type
->>>>>>> 3a4ba87 (Add routes / controller / blank page)

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -77,4 +77,11 @@ en:
           heading: Enter the details of any co-defendants in the case
           codefendant_legend: Co-defendant %{index}
           add_button: Add another co-defendant
+<<<<<<< HEAD
           remove_button: Remove co-defendant
+=======
+      case_type:
+        edit:
+          page_title: Enter the case type
+          heading:  Enter the case type
+>>>>>>> 3a4ba87 (Add routes / controller / blank page)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,9 @@ Rails.application.routes.draw do
 
       namespace :case do
         edit_step :urn
+        edit_step :case_type
         edit_step :codefendants
+        crud_step :codefendants, param: :codefendant_id
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,6 @@ Rails.application.routes.draw do
         edit_step :urn
         edit_step :case_type
         edit_step :codefendants
-        crud_step :codefendants, param: :codefendant_id
       end
     end
   end

--- a/db/migrate/20220830134258_add_case_type_to_case.rb
+++ b/db/migrate/20220830134258_add_case_type_to_case.rb
@@ -1,0 +1,5 @@
+class AddCaseTypeToCase < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :case_type, :string
+  end
+end

--- a/db/migrate/20220831110636_add_maat_id_to_case.rb
+++ b/db/migrate/20220831110636_add_maat_id_to_case.rb
@@ -1,0 +1,6 @@
+class AddMaatIdToCase < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :previous_maat_id, :string
+    add_column :cases, :cc_appeal_fin_change_details, :text
+  end
+end

--- a/db/migrate/20220831110636_add_maat_id_to_case.rb
+++ b/db/migrate/20220831110636_add_maat_id_to_case.rb
@@ -1,6 +1,7 @@
 class AddMaatIdToCase < ActiveRecord::Migration[7.0]
   def change
-    add_column :cases, :previous_maat_id, :string
+    add_column :cases, :cc_appeal_maat_id, :string
+    add_column :cases, :cc_appeal_fin_change_maat_id, :string
     add_column :cases, :cc_appeal_fin_change_details, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_134258) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_31_110636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -36,6 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_134258) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "case_type"
+    t.string "previous_maat_id"
+    t.text "cc_appeal_fin_change_details"
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_26_083744) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_134258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_26_083744) do
     t.uuid "crime_application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "case_type"
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,7 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_31_110636) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "case_type"
-    t.string "previous_maat_id"
+    t.string "cc_appeal_maat_id"
+    t.string "cc_appeal_fin_change_maat_id"
     t.text "cc_appeal_fin_change_details"
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end

--- a/spec/controllers/steps/case/case_type_controller_spec.rb
+++ b/spec/controllers/steps/case/case_type_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::CaseTypeController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::CaseTypeForm, Decisions::CaseDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::Case::CaseTypeForm
+end

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Steps::Case::CaseTypeForm do
   let(:arguments) { {
     crime_application: crime_application,
     case_type: case_type,
-    previous_maat_id: previous_maat_id,
+    cc_appeal_maat_id: cc_appeal_maat_id,
+    cc_appeal_fin_change_maat_id: cc_appeal_fin_change_maat_id,
     cc_appeal_fin_change_details: cc_appeal_fin_change_details
   } }
 
@@ -14,7 +15,8 @@ RSpec.describe Steps::Case::CaseTypeForm do
   }
 
   let(:case_type) { nil }
-  let(:previous_maat_id) { nil }
+  let(:cc_appeal_maat_id) { nil }
+  let(:cc_appeal_fin_change_maat_id) { nil }
   let(:cc_appeal_fin_change_details) { nil }
 
   subject { described_class.new(arguments) }
@@ -47,26 +49,22 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
       context 'non-appeal case type' do
         context 'with a previous MAAT ID' do
-          let(:previous_maat_id) { '123456' }
-          it 'is invalid' do
-            expect(subject).to_not be_valid
-            expect(
-              subject.errors.of_kind?(
-                :previous_maat_id, 
-                :present)
-            ).to eq(true)
+          let(:cc_appeal_maat_id) { '123456' }
+          let(:cc_appeal_fin_change_maat_id) { '234567' }
+          it 'can make MAAT ID fields nil if case types do not require them' do
+            attributes = subject.send(:attributes_to_reset)
+            expect(subject).to be_valid
+            expect(attributes['cc_appeal_maat_id']).to be(nil)
+            expect(attributes['cc_appeal_fin_change_maat_id']).to be(nil)
           end
         end
 
         context 'with details of a change of financial circumstances' do
           let(:cc_appeal_fin_change_details) { 'These are the details' }
-          it 'is invalid' do
-            expect(subject).to_not be_valid
-            expect(
-              subject.errors.of_kind?(
-                :cc_appeal_fin_change_details, 
-                :present
-              )).to eq(true)
+          it 'can financial change details nil if case type doesnt require it' do
+            attributes = subject.send(:attributes_to_reset)
+            expect(subject).to be_valid
+            expect(attributes['cc_appeal_fin_change_details']).to be(nil)
           end
         end
       end
@@ -74,14 +72,19 @@ RSpec.describe Steps::Case::CaseTypeForm do
       context 'Appeal to crown court' do
         context 'with a previous MAAT ID' do
           let(:case_type) { 'cc_appeal' }
-          let(:previous_maat_id) { '123456' }
+          let(:cc_appeal_maat_id) { '123456' }
           it 'is valid' do
             expect(subject).to be_valid
             expect(
               subject.errors.of_kind?(
-                :previous_maat_id, 
+                :cc_appeal_maat_id, 
                 :present)
             ).to eq(false)
+          end
+
+          it 'cannot reset MAAT IDs as the are relevant to this case type' do
+            attributes = subject.send(:attributes_to_reset)
+            expect(attributes['cc_appeal_maat_id']).to be(cc_appeal_maat_id)
           end
         end
 
@@ -91,7 +94,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
             expect(subject).to be_valid
             expect(
               subject.errors.of_kind?(
-                :previous_maat_id, 
+                :cc_appeal_maat_id, 
                 :present)
             ).to eq(false)
           end
@@ -101,7 +104,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
       context 'Appeal to crown court with changes in financial circumstances' do
         context 'with details of what has changed' do
           let(:case_type) { 'cc_appeal_fin_change' }
-          let(:previous_maat_id) { '123456' }
+          let(:cc_appeal_fin_change_maat_id) { '123456' }
           let(:cc_appeal_fin_change_details) { 'These are the details' }
           it 'is valid' do
             expect(subject).to be_valid
@@ -111,11 +114,21 @@ RSpec.describe Steps::Case::CaseTypeForm do
                 :present)
             ).to eq(false)
           end
+
+          it 'cannot reset MAAT IDs as the are relevant to this case type' do
+            attributes = subject.send(:attributes_to_reset)
+            expect(attributes['cc_appeal_fin_change_maat_id']).to be(cc_appeal_fin_change_maat_id)
+          end
+
+          it 'cannot reset change details as the are relevant to this case type' do
+            attributes = subject.send(:attributes_to_reset)
+            expect(attributes['cc_appeal_fin_change_details']).to be(cc_appeal_fin_change_details)
+          end
         end
 
         context 'with no details of what has changed' do
           let(:case_type) { 'cc_appeal_fin_change' }
-          let(:previous_maat_id) { '123456' }
+          let(:cc_appeal_maat_id) { '123456' }
           it 'is invalid' do
             expect(subject).to_not be_valid
             expect(
@@ -134,7 +147,8 @@ RSpec.describe Steps::Case::CaseTypeForm do
                       association_name: :case,
                       expected_attributes: {
                         'case_type' => 'indictable',
-                        'previous_maat_id' => nil,
+                        'cc_appeal_maat_id' => nil,
+                        'cc_appeal_fin_change_maat_id' => nil,
                         'cc_appeal_fin_change_details' => nil
                       }
     end

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
       it 'has is a validation error on the field' do
         expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:case_type, :blank)).to eq(true)
+        expect(subject.errors.of_kind?(:case_type, :inclusion)).to eq(true)
       end
     end
 

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::CaseTypeForm do
+
+  let(:arguments) { {
+    crime_application: crime_application,
+    case_type: case_type,
+    previous_maat_id: previous_maat_id,
+    cc_appeal_fin_change_details: cc_appeal_fin_change_details
+  } }
+
+  let(:crime_application) { 
+    instance_double(CrimeApplication)
+  }
+
+  let(:case_type) { nil }
+  let(:previous_maat_id) { nil }
+  let(:cc_appeal_fin_change_details) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when `case_type` is blank' do
+      let(:case_type) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:case_type, :blank)).to eq(true)
+      end
+    end
+
+    context 'when `case_type` is invalid' do
+      let(:case_type) { 'invalid_type' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:case_type, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when `case_type` is valid' do
+      let(:case_type) { 'indictable' }
+      it 'passes validation' do
+        expect(subject).to be_valid
+        expect(subject.errors.of_kind?(:case_type, :invalid)).to eq(false)
+      end
+
+      context 'non-appeal case type' do
+        context 'with a previous MAAT ID' do
+          let(:previous_maat_id) { '123456' }
+          it 'is invalid' do
+            expect(subject).to_not be_valid
+            expect(
+              subject.errors.of_kind?(
+                :previous_maat_id, 
+                :present)
+            ).to eq(true)
+          end
+        end
+
+        context 'with details of a change of financial circumstances' do
+          let(:cc_appeal_fin_change_details) { 'These are the details' }
+          it 'is invalid' do
+            expect(subject).to_not be_valid
+            expect(
+              subject.errors.of_kind?(
+                :cc_appeal_fin_change_details, 
+                :present
+              )).to eq(true)
+          end
+        end
+      end
+
+      context 'Appeal to crown court' do
+        context 'with a previous MAAT ID' do
+          let(:case_type) { 'cc_appeal' }
+          let(:previous_maat_id) { '123456' }
+          it 'is valid' do
+            expect(subject).to be_valid
+            expect(
+              subject.errors.of_kind?(
+                :previous_maat_id, 
+                :present)
+            ).to eq(false)
+          end
+        end
+
+        context 'without a previous MAAT ID' do
+          let(:case_type) { 'cc_appeal' }
+          it 'is also valid' do
+            expect(subject).to be_valid
+            expect(
+              subject.errors.of_kind?(
+                :previous_maat_id, 
+                :present)
+            ).to eq(false)
+          end
+        end
+      end
+
+      context 'Appeal to crown court with changes in financial circumstances' do
+        context 'with details of what has changed' do
+          let(:case_type) { 'cc_appeal_fin_change' }
+          let(:previous_maat_id) { '123456' }
+          let(:cc_appeal_fin_change_details) { 'These are the details' }
+          it 'is valid' do
+            expect(subject).to be_valid
+            expect(
+              subject.errors.of_kind?(
+                :cc_appeal_fin_change_details, 
+                :present)
+            ).to eq(false)
+          end
+        end
+
+        context 'with no details of what has changed' do
+          let(:case_type) { 'cc_appeal_fin_change' }
+          let(:previous_maat_id) { '123456' }
+          it 'is invalid' do
+            expect(subject).to_not be_valid
+            expect(
+              subject.errors.of_kind?(
+                :cc_appeal_fin_change_details, 
+                :blank)
+            ).to eq(true)
+          end
+        end
+      end
+    end
+
+    context 'when validations pass' do
+        let(:case_type) { 'indictable' }
+        it_behaves_like 'a has-one-association form',
+                      association_name: :case,
+                      expected_attributes: {
+                        'case_type' => 'indictable',
+                        'previous_maat_id' => nil,
+                        'cc_appeal_fin_change_details' => nil
+                      }
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -20,7 +20,18 @@ RSpec.describe Decisions::CaseDecisionTree do
     context 'has correct next step' do
       let(:case) { '12AA3456789' }
 
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination('/steps/case/case_type', :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `case_type`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :case_type }
+
+    context 'has correct next step' do
+      let(:case) { '12AA3456789' }
+
+      it { is_expected.to have_destination('/steps/case/codefendants', :edit, id: crime_application) }
     end
   end
 

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -8,7 +8,15 @@ RSpec.describe CaseType do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(summary_only either_way indictable already_cc_trial committal cc_appeal cc_appeal_fin_change)
+        %w(
+          summary_only 
+          either_way 
+          indictable 
+          already_cc_trial 
+          committal 
+          cc_appeal 
+          cc_appeal_fin_change
+        )
       )
     end
   end

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe CaseType do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(
+        %w(summary_only either_way indictable already_cc_trial committal cc_appeal cc_appeal_fin_change)
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds the ability to select a case type for a case

## Link to relevant ticket
[CRIMAP-96](https://dsdmoj.atlassian.net/browse/CRIMAP-96)

## Notes for reviewer
- MAAT ids are only optional for Appeal to crown court types (the last two)
- Details on changes are mandatory for Appeals to CC with a change of financial curcumstances
- Please look at the wording of the errors are they clear?

## Screenshots of changes (if applicable)

### After changes:
<img width="1000" alt="Screenshot 2022-08-31 at 16 00 13" src="https://user-images.githubusercontent.com/13377553/187711296-772501b7-8f27-4c62-ba50-75cfafa1af9e.png">

### Drop downs
<img width="791" alt="Screenshot 2022-08-31 at 16 00 48" src="https://user-images.githubusercontent.com/13377553/187711423-ad150f50-a19e-467e-bd11-14bae6e328cd.png">

---

<img width="582" alt="Screenshot 2022-08-31 at 16 01 20" src="https://user-images.githubusercontent.com/13377553/187711569-77f57cd3-17b2-4886-9730-c3b4e4ca0966.png">

## How to manually test the feature
- go through the regular journey until you reach the case type page
- submit blank --> error
- select either appeal type > add MAAT ID > select non appeal type -> error as MAAT ID present
- do the same for last appeal type with the extra details field
- leave MAAT ID blank on an appeals case --> should not error on submission
- leave extra details page blank on Appeal CC + change of financial circs --> should error as field is blank
- if valid should then redirect to codefendants step