### PR TITLE
CRIMAP-109 Implement co-defendants deletion

### DIFF
--- a/app/controllers/steps/case/codefendants_controller.rb
+++ b/app/controllers/steps/case/codefendants_controller.rb
@@ -14,7 +14,13 @@ module Steps
       private
 
       def step_name
-        params.key?('add_codefendant') ? :add_codefendant : :codefendants_finished
+        if params.key?('add_codefendant')
+          :add_codefendant
+        elsif params.to_s.include?('"_destroy"=>"1"')
+          :delete_codefendant
+        else
+          :codefendants_finished
+        end
       end
 
       def additional_permitted_params

--- a/app/forms/steps/case/codefendant_fieldset_form.rb
+++ b/app/forms/steps/case/codefendant_fieldset_form.rb
@@ -1,6 +1,7 @@
 module Steps
   module Case
     class CodefendantFieldsetForm < Steps::BaseFormObject
+      attribute :_destroy, :boolean
       attribute :id, :string
       attribute :first_name, :string
       attribute :last_name, :string

--- a/app/forms/steps/case/codefendants_form.rb
+++ b/app/forms/steps/case/codefendants_form.rb
@@ -6,7 +6,7 @@ module Steps
 
       delegate :codefendants_attributes=, to: :kase
 
-      validates_with CodefendantsValidator
+      validates_with CodefendantsValidator, unless: :any_marked_for_destruction?
 
       def codefendants
         @codefendants ||= begin
@@ -20,12 +20,23 @@ module Steps
         end
       end
 
+      def any_marked_for_destruction?
+        codefendants.any?(&:_destroy)
+      end
+
+      def show_destroy?
+        codefendants.size > 1
+      end
+
       def add_blank_codefendant
         kase.codefendants.create!
       end
 
       private
 
+      # If validation passes, the actual saving of the `case` performs
+      # the updates or destroys of the associated `codefendant` records,
+      # as we are using `accepts_nested_attributes_for`
       def persist!
         kase.save
       end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -2,5 +2,5 @@ class Case < ApplicationRecord
   belongs_to :crime_application
 
   has_many :codefendants, dependent: :destroy
-  accepts_nested_attributes_for :codefendants
+  accepts_nested_attributes_for :codefendants, allow_destroy: true
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -5,7 +5,9 @@ module Decisions
       when :urn
         after_urn
       when :add_codefendant
-        edit_codefendants
+        edit_codefendants(add_blank: true)
+      when :delete_codefendant
+        edit_codefendants(add_blank: false)
       when :codefendants_finished
         # Next step when we have it
         show('/home', action: :index)
@@ -20,8 +22,8 @@ module Decisions
       show('/home', action: :index)
     end
 
-    def edit_codefendants
-      form_object.add_blank_codefendant
+    def edit_codefendants(add_blank:)
+      form_object.add_blank_codefendant if add_blank
       edit(:codefendants)
     end
   end

--- a/app/views/steps/case/codefendants/edit.html.erb
+++ b/app/views/steps/case/codefendants/edit.html.erb
@@ -15,6 +15,10 @@
 
           <%= c.govuk_text_field :last_name, label: { text: t("helpers.label.#{f.object_name}.last_name") },
                                  autocomplete: 'off', width: 'three-quarters' %>
+
+          <%= c.button t('.remove_button'), type: :submit, value: '1', name: c.field_name(:_destroy, index: nil),
+                       class: %w(govuk-button govuk-button--warning),
+                       data: { module: 'govuk-button' } if @form_object.show_destroy? %>
         <% end %>
       <% end %>
 

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -77,3 +77,4 @@ en:
           heading: Enter the details of any co-defendants in the case
           codefendant_legend: Co-defendant %{index}
           add_button: Add another co-defendant
+          remove_button: Remove co-defendant

--- a/spec/controllers/steps/case/codefendants_controller_spec.rb
+++ b/spec/controllers/steps/case/codefendants_controller_spec.rb
@@ -1,5 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::CodefendantsController, type: :controller do
-  it_behaves_like 'a generic step controller', Steps::Case::CodefendantsForm, Decisions::CaseDecisionTree
+  it_behaves_like 'a generic step controller', Steps::Case::CodefendantsForm, Decisions::CaseDecisionTree do
+    describe 'additional CRUD actions' do
+      let(:existing_case) { CrimeApplication.create }
+
+      context 'adding a new codefendant' do
+        it 'has the expected step name' do
+          expect(
+            subject
+          ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :add_codefendant)
+
+          put :update, params: { id: existing_case, add_codefendant: '' }
+        end
+      end
+
+      context 'deleting a codefendant' do
+        let(:form_class_params_name) { Steps::Case::CodefendantsForm.name.underscore }
+        let(:codefendant_attributes) {
+          {
+            codefendants_attributes: {
+              '0' => { first_name: 'John', last_name: 'Doe', _destroy: '1', id: '12345' }
+            }
+          }
+        }
+
+        it 'has the expected step name' do
+          expect(
+            subject
+          ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :delete_codefendant)
+
+          put :update, params: { id: existing_case, form_class_params_name => codefendant_attributes }
+        end
+      end
+
+      context 'finishing codefendants' do
+        it 'has the expected step name' do
+          expect(
+            subject
+          ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :codefendants_finished)
+
+          put :update, params: { id: existing_case, foo: { bar: '1' } }
+        end
+      end
+    end
+  end
 end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe Decisions::CaseDecisionTree do
     end
   end
 
+  context 'when the step is `delete_codefendant`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :delete_codefendant }
+
+    it 'gets back to the codefendants page' do
+      is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+    end
+  end
+
   context 'when the step is `codefendants_finished`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :codefendants_finished }


### PR DESCRIPTION
## Description of change
Follow-up to PR #89.

Implement the delete functionality.
It works automatically thanks to `accepts_nested_attributes_for`.

The only complication is we don't want to run validations when removing a co-defendant, as for once, removing a blank one will give us errors, but also, if any previous co-defendant are edited (like blanking any of their text fields) it will also give us errors on those unrelated fields.

This was solved by bypassing validations if any of the records are marked for destruction (`_destroy` param).

Also, on removal, we circle back to the same page, similar to adding another, but in this case we don't add another blank record obviously.

Note: we only show delete buttons after there is more than 1 co-defendant, as deleting the only one in the page would leave the page empty. If the provider don't want any co-defendant they can always go back to the previous 'yes-no' step and select no. This will (when the step is finished) delete any existing codefendants, in case there are left overs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-109

## Notes for reviewer
Conflict of interest will be implemented in a follow-up PR.

## Screenshots of changes (if applicable)
![Screenshot 2022-09-01 at 12 12 27](https://user-images.githubusercontent.com/687910/187900752-c7f8de6d-6912-4233-ad3b-d8e0b3aaca6e.png)

## How to manually test the feature
