### PR TITLE
CRIMAP-110 Add conflict of interest radio options

### DIFF
--- a/app/forms/steps/case/codefendant_fieldset_form.rb
+++ b/app/forms/steps/case/codefendant_fieldset_form.rb
@@ -5,9 +5,16 @@ module Steps
       attribute :id, :string
       attribute :first_name, :string
       attribute :last_name, :string
+      attribute :conflict_of_interest, :yes_no
 
       validates_presence_of :first_name,
                             :last_name
+
+      validates_inclusion_of :conflict_of_interest, in: :choices
+
+      def choices
+        YesNoAnswer.values
+      end
 
       # Needed for `#fields_for` to render the uuids as hidden fields
       def persisted?

--- a/app/views/steps/case/codefendants/edit.html.erb
+++ b/app/views/steps/case/codefendants/edit.html.erb
@@ -16,6 +16,15 @@
           <%= c.govuk_text_field :last_name, label: { text: t("helpers.label.#{f.object_name}.last_name") },
                                  autocomplete: 'off', width: 'three-quarters' %>
 
+          <%= c.govuk_collection_radio_buttons :conflict_of_interest, c.object.choices,
+                                               :value,
+                                               ->(option) { t("helpers.label.#{f.object_name}.conflict_of_interest_options.#{option}") },
+                                               inline: true,
+                                               legend: {
+                                                 text: t("helpers.legend.#{f.object_name}.conflict_of_interest"),
+                                                 class: 'govuk-fieldset__legend',
+                                               } %>
+
           <%= c.button t('.remove_button'), type: :submit, value: '1', name: c.field_name(:_destroy, index: nil),
                        class: %w(govuk-button govuk-button--warning),
                        data: { module: 'govuk-button' } if @form_object.show_destroy? %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -87,8 +87,12 @@ en:
               blank: Enter first name of co-defendant %{index}
             last_name:
               blank: Enter last name of co-defendant %{index}
+            conflict_of_interest:
+              inclusion: Select yes if there is a conflict of interest with co-defendant %{index}
           attributes:
             first_name:
               blank: Enter a first name
             last_name:
               blank: Enter a last name
+            conflict_of_interest:
+              inclusion: Select yes if there is a conflict of interest

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -20,6 +20,8 @@ en:
         date_of_birth: Date of birth
       steps_client_contact_details_form:
         correspondence_address_type: Correspondence address
+      steps_case_codefendants_form:
+        conflict_of_interest: Is there a conflict of interest with this co-defendant?
 
     hint:
       steps_client_has_partner_form:
@@ -64,3 +66,4 @@ en:
       steps_case_codefendants_form:
         first_name: First name
         last_name: Last name
+        conflict_of_interest_options: *YESNO

--- a/spec/forms/steps/case/codefendant_fieldset_form_spec.rb
+++ b/spec/forms/steps/case/codefendant_fieldset_form_spec.rb
@@ -6,12 +6,22 @@ RSpec.describe Steps::Case::CodefendantFieldsetForm do
     id: record_id,
     first_name: 'John',
     last_name: 'Doe',
+    conflict_of_interest: conflict_of_interest,
   } }
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:record_id) { '12345' }
+  let(:conflict_of_interest) { nil }
 
   subject { described_class.new(arguments) }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
 
   describe '#persisted?' do
     context 'when the record has an ID' do
@@ -27,5 +37,29 @@ RSpec.describe Steps::Case::CodefendantFieldsetForm do
   context 'validations' do
     it { should validate_presence_of(:first_name) }
     it { should validate_presence_of(:last_name) }
+
+    context 'when `conflict_of_interest` is not provided' do
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:conflict_of_interest, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when `conflict_of_interest` is not valid' do
+      let(:conflict_of_interest) { 'maybe' }
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:conflict_of_interest, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when `conflict_of_interest` is valid' do
+      let(:conflict_of_interest) { 'yes' }
+
+      it 'has no validation error' do
+        expect(subject).to be_valid
+      end
+    end
   end
 end

--- a/spec/forms/steps/case/codefendants_form_spec.rb
+++ b/spec/forms/steps/case/codefendants_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Case::CodefendantsForm do
 
   let(:codefendants_attributes) {
     {
-      "0"=>{"first_name"=>"John", "last_name"=>"Doe"},
-      "1"=>{"first_name"=>"Jane", "last_name"=>"Doe"},
+      "0"=>{"first_name"=>"John", "last_name"=>"Doe", "conflict_of_interest"=>"no"},
+      "1"=>{"first_name"=>"Jane", "last_name"=>"Doe", "conflict_of_interest"=>"yes"},
     }
   }
 
@@ -43,9 +43,11 @@ RSpec.describe Steps::Case::CodefendantsForm do
 
         expect(subject.codefendants[0].first_name).to eq('John')
         expect(subject.codefendants[0].last_name).to eq('Doe')
+        expect(subject.codefendants[0].conflict_of_interest).to eq(YesNoAnswer::NO)
 
         expect(subject.codefendants[1].first_name).to eq('Jane')
         expect(subject.codefendants[1].last_name).to eq('Doe')
+        expect(subject.codefendants[1].conflict_of_interest).to eq(YesNoAnswer::YES)
       end
     end
   end
@@ -92,8 +94,8 @@ RSpec.describe Steps::Case::CodefendantsForm do
     context 'when there are errors in any of the codefendants' do
       let(:codefendants_attributes) {
         {
-          "0"=>{"first_name"=>"John", "last_name"=>""},
-          "1"=>{"first_name"=>"", "last_name"=>"Doe"},
+          "0"=>{"first_name"=>"John", "last_name"=>"", "conflict_of_interest"=>""},
+          "1"=>{"first_name"=>"", "last_name"=>"Doe", "conflict_of_interest"=>"yes"},
         }
       }
 
@@ -106,6 +108,9 @@ RSpec.describe Steps::Case::CodefendantsForm do
 
         expect(subject.errors.of_kind?('codefendants-attributes[0].last_name', :blank)).to eq(true)
         expect(subject.errors.messages_for('codefendants-attributes[0].last_name').first).to eq('Enter last name of co-defendant 1')
+
+        expect(subject.errors.of_kind?('codefendants-attributes[0].conflict_of_interest', :inclusion)).to eq(true)
+        expect(subject.errors.messages_for('codefendants-attributes[0].conflict_of_interest').first).to eq('Select yes if there is a conflict of interest with co-defendant 1')
 
         expect(subject.errors.of_kind?('codefendants-attributes[1].first_name', :blank)).to eq(true)
         expect(subject.errors.messages_for('codefendants-attributes[1].first_name').first).to eq('Enter first name of co-defendant 2')


### PR DESCRIPTION
## Description of change
Another follow-up to all previous PRs related to co-defendants.

This I think is the last one. We add the conflict of interest yes-no radios.

Pretty simple PR as almost everything has been done already in previous PRs.

Only pain was configuring the `govuk_collection_radio_buttons`, because we are using nested attributes, the locales are not automagically fetched for us and we must pass them explicitly to the legend and to both options (the yes and the no).

I've [raised an issue](https://github.com/DFE-Digital/govuk-formbuilder/issues/385) in the `govuk-formbuilder` gem repository for a possible enhancement that would make these nested attribute locales work automagically too so we could simplify a lot the code in this view if that happens.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-110

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="606" alt="Screenshot 2022-09-01 at 17 05 46" src="https://user-images.githubusercontent.com/687910/187961203-4e226907-a44f-45e2-af12-5bfb93b7b685.png">
<img width="620" alt="Screenshot 2022-09-01 at 17 06 52" src="https://user-images.githubusercontent.com/687910/187961356-85b34cf5-dfb3-4080-8829-fc794a5b4f5a.png">

## How to manually test the feature
