### PR TITLE
Add an ERB linter and initial support for custom cops

### DIFF
--- a/.better-html.yml
+++ b/.better-html.yml
@@ -1,0 +1,3 @@
+---
+# https://github.com/Shopify/better-html#configuration
+# NOTE: for now this config is empty as we are using only the defaults.

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,30 @@
+---
+# https://github.com/Shopify/erb-lint#configuration
+#
+EnableDefaultLinters: false
+exclude:
+  - 'node_modules/**/*'
+  - 'lib/generators/**/*'
+  - 'vendor/**/*'
+
+linters:
+  ErbSafety:
+    enabled: true
+    better_html_config: .better-html.yml
+  Rubocop:
+    enabled: false
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      # There are some cops not suitable for ERB files,
+      # disable or tweak as needed below
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/LineLength:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 require:
   - rubocop-rails
   - rubocop-performance
+  # Add custom cops for this project below
+  - ./lib/rubocop/custom_cops/govuk_formbuilder/text_field_autocomplete.rb
 
 AllCops:
   TargetRubyVersion: 3.1

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ end
 group :test do
   gem 'brakeman'
   gem 'capybara'
+  gem 'erb_lint', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,13 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -101,6 +108,13 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    erb_lint (0.2.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.11.0)
     faraday (2.5.2)
       faraday-net_http (>= 2.0, < 3.1)
@@ -256,6 +270,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    smart_properties (1.17.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -301,6 +316,7 @@ DEPENDENCIES
   dartsass-rails (~> 0.4.0)
   debug
   dotenv-rails
+  erb_lint
   faraday (~> 2.4)
   govuk_design_system_formbuilder (~> 3.1.0)
   importmap-rails

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,4 @@ task(:default).prerequisites.clear
 # The following tasks will run, in order, when running `rake` command.
 # Run them individually with `rake rubocop`, `rake spec` ...
 #
-task default: %i[brakeman rubocop spec]
+task default: %i[brakeman rubocop erblint spec]

--- a/lib/rubocop/custom_cops/govuk_formbuilder/text_field_autocomplete.rb
+++ b/lib/rubocop/custom_cops/govuk_formbuilder/text_field_autocomplete.rb
@@ -1,0 +1,31 @@
+module RuboCop
+  module CustomCops
+    module GOVUKFormBuilder
+      # `govuk_text_field` has an explicit autocomplete attribute (on or off)`
+      #
+      # @example
+      #   # bad
+      #   f.govuk_text_field :field_name
+      #
+      #   # good
+      #   f.govuk_text_field :field_name, autocomplete: 'off'
+      #
+      class TextFieldAutocomplete < RuboCop::Cop::Base
+        MSG = 'Add an explicit `autocomplete: \'on|off\'` to `govuk_text_field` inputs.'.freeze
+
+        def_node_matcher :has_autocomplete_attribute?, <<~PATTERN
+          (send _ :govuk_text_field sym (hash <(pair (sym :autocomplete) {(str "on") | (str "off")}) ...>))
+        PATTERN
+
+        # Optimization: don't call `on_send` unless the method name is in this list
+        RESTRICT_ON_SEND = [:govuk_text_field].freeze
+
+        def on_send(node)
+          return if has_autocomplete_attribute?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/erblint.rake
+++ b/lib/tasks/erblint.rake
@@ -1,0 +1,3 @@
+task :erblint do
+  sh 'bundle exec erblint .'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,12 @@ require 'simplecov'
 SimpleCov.minimum_coverage 100
 
 SimpleCov.start 'rails' do
-  add_filter 'config/initializers'
-  add_filter 'config/routes.rb'
-  add_filter 'spec/'
   add_filter 'app/mailers/application_mailer.rb'
   add_filter 'app/jobs/application_job.rb'
+  add_filter 'config/initializers'
+  add_filter 'config/routes.rb'
+  add_filter 'lib/rubocop/'
+  add_filter 'spec/'
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Description of change
This is more of a learning exercise but I went through the rabbit hole of learning (barely) how to code custom Rubocop cops and when I got the matcher working I realised Rubocop doesn't run on ERB files.

So I researched a bit and found out a suitable ERB linter made by the nice folks at Shopify which lets you, in addition to its own linting (including some HTML linting), runs Rubocop on the ERB "ruby" code.

As expected there are some offences already in the views we already have, that's why I've disabled for now some linters.

In a separate PR I will enable some of them and fix the offences, mostly related to simple things like indentation, spacing, double quotes instead of single quotes, etc. Some of these may be annoying so we can discuss how strict we want to be LOL.

NOTE: the erb linter will now run as part of the other linters and tests we have, and also on CI.

## How to manually test the feature
Locally you can run just `rake` or `rake erblint`.
To test the custom cop for autocomplete, enable first in the `.erb-lint.yml` file the Rubocop linter with `enabled: true` and then edit any view that contains a `govuk_text_field` and remove the `autocomplete` property (or set its value to anything other than on / off) and you should get the error when running `rake` or `rake erblint` (together with other offences as mentioned before).