### PR TITLE
Enable case details in task list

### DIFF
--- a/app/presenters/tasks/case_details.rb
+++ b/app/presenters/tasks/case_details.rb
@@ -1,8 +1,7 @@
 module Tasks
   class CaseDetails < BaseTask
-    # TODO: update when we have the case details steps
     def path
-      ''
+      edit_steps_case_urn_path(crime_application)
     end
 
     def not_applicable?
@@ -15,12 +14,12 @@ module Tasks
       crime_application.applicant&.nino.present?
     end
 
-    # TODO: update when we have the case details steps
+    # If we have a `case` record we consider this in progress
     def in_progress?
-      false
+      crime_application.case.present?
     end
 
-    # TODO: update when we have the case details steps
+    # TODO: update when all case details steps are implemented
     def completed?
       false
     end

--- a/spec/presenters/tasks/case_details_spec.rb
+++ b/spec/presenters/tasks/case_details_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe Tasks::CaseDetails do
   subject { described_class.new(crime_application: crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:crime_application) { instance_double(CrimeApplication, to_param: '12345') }
 
   describe '#path' do
-    it { expect(subject.path).to eq('') }
+    it { expect(subject.path).to eq('/applications/12345/steps/case/urn') }
   end
 
   describe '#not_applicable?' do
@@ -30,7 +30,19 @@ RSpec.describe Tasks::CaseDetails do
   end
 
   describe '#in_progress?' do
-    it { expect(subject.in_progress?).to eq(false) }
+    before do
+      allow(crime_application).to receive(:case).and_return(kase)
+    end
+
+    context 'when we have a case record' do
+      let(:kase) { double }
+      it { expect(subject.in_progress?).to eq(true) }
+    end
+
+    context 'when we do not have yet a case record' do
+      let(:kase) { nil }
+      it { expect(subject.in_progress?).to eq(false) }
+    end
   end
 
   describe '#completed?' do


### PR DESCRIPTION
## Description of change
Now that we have some of the case details steps, we can update this task so it links to the first step (URN) and also to know when it is in progress or not.

We will not be able to set the "completed" status tag until we have finalised all the case details step so that will need to change sometime in the future.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="725" alt="Screenshot 2022-09-05 at 09 55 29" src="https://user-images.githubusercontent.com/687910/188409980-639454ff-afb7-4f17-a3ce-a3c389703dad.png">

## How to manually test the feature
Start an application and run through the client details up until you pass the NINO step. Then go to the task list and the "Case details" task should be enabled and be able to click the link to go to the URN step.
When you run through some of the case details steps, and go back to the task list, the case details task will be marked as "in progress".