### PR TITLE
Cleanup temporary code from co-defendants form object

### DIFF
--- a/app/forms/steps/case/codefendants_form.rb
+++ b/app/forms/steps/case/codefendants_form.rb
@@ -9,14 +9,10 @@ module Steps
       validates_with CodefendantsValidator, unless: :any_marked_for_destruction?
 
       def codefendants
-        @codefendants ||= begin
-          add_blank_codefendant if kase.codefendants.empty? # temporary until we have previous step
-
-          kase.codefendants.map do |codefendant|
-            CodefendantFieldsetForm.build(
-              codefendant, crime_application: crime_application
-            )
-          end
+        @codefendants ||= kase.codefendants.map do |codefendant|
+          CodefendantFieldsetForm.build(
+            codefendant, crime_application: crime_application
+          )
         end
       end
 
@@ -26,10 +22,6 @@ module Steps
 
       def show_destroy?
         codefendants.size > 1
-      end
-
-      def add_blank_codefendant
-        kase.codefendants.create!
       end
 
       private

--- a/app/forms/steps/case/has_codefendants_form.rb
+++ b/app/forms/steps/case/has_codefendants_form.rb
@@ -16,8 +16,14 @@ module Steps
 
       def persist!
         kase.update(
-          attributes
+          attributes.merge(
+            reset_codefendants_if_needed
+          )
         )
+      end
+
+      def reset_codefendants_if_needed
+        has_codefendants.no? ? { codefendants: [] } : {}
       end
     end
   end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -4,15 +4,15 @@ module Decisions
     def destination
       case step_name
       when :urn
-        after_urn
+        edit(:case_type)
       when :case_type
-        after_case_type
+        edit(:has_codefendants)
       when :has_codefendants
         after_has_codefendants
       when :add_codefendant
         edit_codefendants(add_blank: true)
       when :delete_codefendant
-        edit_codefendants(add_blank: false)
+        edit_codefendants
       when :codefendants_finished
         # Next step when we have it
         show('/home', action: :index)
@@ -24,24 +24,18 @@ module Decisions
 
     private
 
-    def after_case_type
-      edit('/steps/case/has_codefendants')
-    end
-
-    def after_urn
-      edit('/steps/case/case_type')
-    end
-
     def after_has_codefendants
       if form_object.has_codefendants.yes?
-        edit(:codefendants)
+        edit_codefendants
       else
         show('/home', action: :index)
       end
     end
 
-    def edit_codefendants(add_blank:)
-      form_object.add_blank_codefendant if add_blank
+    def edit_codefendants(add_blank: false)
+      codefendants = form_object.case.codefendants
+      codefendants.create! if add_blank || codefendants.empty?
+
       edit(:codefendants)
     end
   end

--- a/spec/forms/steps/case/codefendants_form_spec.rb
+++ b/spec/forms/steps/case/codefendants_form_spec.rb
@@ -19,23 +19,15 @@ RSpec.describe Steps::Case::CodefendantsForm do
   subject { described_class.new(arguments) }
 
   describe '#codefendants' do
-    # TODO: temporary until we have previous step
     context 'there are no codefendants' do
       let(:codefendants_attributes) { {} }
 
-      it 'adds a blank one to the collection' do
-        expect(case_record.codefendants).to receive(:create!)
-        subject.codefendants
+      it 'returns an empty collection' do
+        expect(subject.codefendants).to eq([])
       end
     end
 
-    # TODO: temporary until we have previous step
     context 'there are existing codefendants' do
-      it 'does not add a blank one to the collection' do
-        expect(subject).not_to receive(:add_blank_codefendant)
-        subject.codefendants
-      end
-
       it 'builds a collection of `CodefendantFieldsetForm` instances' do
         expect(
           subject.codefendants

--- a/spec/forms/steps/case/has_codefendants_form_spec.rb
+++ b/spec/forms/steps/case/has_codefendants_form_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::HasCodefendantsForm do
-  # Note: not using shared examples for form objects yet, to be added
-  # once we have some more form objects and some patterns emerge
-
   let(:arguments) { {
     crime_application: crime_application,
     has_codefendants: has_codefendants
@@ -48,13 +45,26 @@ RSpec.describe Steps::Case::HasCodefendantsForm do
     end
 
     context 'when `has_codefendants` is valid' do
-      let(:has_codefendants) { 'yes' }
+      context 'when answer is `yes`' do
+        let(:has_codefendants) { 'yes' }
 
-      it_behaves_like 'a has-one-association form',
-      association_name: :case,
-      expected_attributes: {
-        'has_codefendants' => YesNoAnswer::YES
-      }
+        it_behaves_like 'a has-one-association form',
+                        association_name: :case,
+                        expected_attributes: {
+                          'has_codefendants' => YesNoAnswer::YES
+                        }
+      end
+
+      context 'when answer is `no`' do
+        let(:has_codefendants) { 'no' }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :case,
+                        expected_attributes: {
+                          'has_codefendants' => YesNoAnswer::NO,
+                          codefendants: [],
+                        }
+      end
     end
   end
 end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Decisions::CaseDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
   let(:crime_application) { instance_double(CrimeApplication) }
+  let(:kase) { instance_double(Case, codefendants: codefendants_double) }
+  let(:codefendants_double) { double('codefendants_collection') }
 
   it_behaves_like 'a decision tree'
 
@@ -18,9 +20,7 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:step_name) { :urn }
 
     context 'has correct next step' do
-      let(:case) { '12AA3456789' }
-
-      it { is_expected.to have_destination('/steps/case/case_type', :edit, id: crime_application) }
+      it { is_expected.to have_destination(:case_type, :edit, id: crime_application) }
     end
   end
 
@@ -29,14 +29,12 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:step_name) { :case_type }
 
     context 'has correct next step' do
-      let(:case) { '12AA3456789' }
-
-      it { is_expected.to have_destination('/steps/case/has_codefendants', :edit, id: crime_application) }
+      it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
     end
   end
 
   context 'when the step is `has_codefendants`' do
-    let(:form_object) { double('FormObject', has_codefendants: has_codefendants) }
+    let(:form_object) { double('FormObject', case: kase, has_codefendants: has_codefendants) }
     let(:step_name) { :has_codefendants }
 
     context 'and answer is `no`' do
@@ -46,29 +44,66 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and answer is `yes`' do
       let(:has_codefendants) { YesNoAnswer::YES }
-      it { is_expected.to have_destination(:codefendants, :edit, id: crime_application) }
+
+      context 'and there are no other codefendants yet' do
+        let(:codefendants_double) { double('codefendants_collection', empty?: true) }
+
+        it 'creates a blank co-defendant record and redirects to the codefendants page' do
+          expect(
+            codefendants_double
+          ).to receive(:create!).at_least(:once)
+
+          is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+        end
+      end
+
+      context 'and there are existing codefendants' do
+        let(:codefendants_double) { double('codefendants_collection', empty?: false) }
+
+        it 'redirects to the codefendants page' do
+          is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+        end
+      end
     end
   end
 
   context 'when the step is `add_codefendant`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', case: kase) }
     let(:step_name) { :add_codefendant }
 
-    it 'creates a blank co-defendant record and gets back to the codefendants page' do
+    it 'creates a blank co-defendant record and redirects to the codefendants page' do
       expect(
-        form_object
-      ).to receive(:add_blank_codefendant).at_least(:once)
+        codefendants_double
+      ).to receive(:create!).at_least(:once)
 
       is_expected.to have_destination(:codefendants, :edit, id: crime_application)
     end
   end
 
   context 'when the step is `delete_codefendant`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', case: kase) }
     let(:step_name) { :delete_codefendant }
 
-    it 'gets back to the codefendants page' do
-      is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+    # Technically the interface will not allow this possibility as we don't allow
+    # deleting the last remaining record, but the test exists as a sanity check.
+    context 'and there are no other codefendants left' do
+      let(:codefendants_double) { double('codefendants_collection', empty?: true) }
+
+      it 'creates a blank co-defendant record and redirects to the codefendants page' do
+        expect(
+          codefendants_double
+        ).to receive(:create!).at_least(:once)
+
+        is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+      end
+    end
+
+    context 'and there are other codefendants left' do
+      let(:codefendants_double) { double('codefendants_collection', empty?: false) }
+
+      it 'redirects to the codefendants page' do
+        is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+      end
     end
   end
 


### PR DESCRIPTION

## Description of change
As we now have the previous yes-no step, I'm removing some of the temporary code I added in the co-defendants form object (and cleaned up the specs).

The temporary code was introduced to simplify development and testing, by creating a blank co-defendant record to start with, just by visiting the co-defendants page.
The decision tree is now in charge of handling this logic as it is bad practise to create records on GET requests.

I've also taken care of resetting any previously entered co-defendants, if the provider go back to the `yes-no` question and selects `no`.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-109
https://dsdmoj.atlassian.net/browse/CRIMAP-111

## How to manually test the feature
Run through the journey up until the "Does your client have any co-defendants in this case?" question. Answer `yes` and a new record will be created, go back, answer `no` and any existing co-defendant record(s) will be deleted from the database.