### PR TITLE
Enable Rubocop and default linters in ERB

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,13 +1,15 @@
 ---
 # https://github.com/Shopify/erb-lint#configuration
 #
-EnableDefaultLinters: false
+EnableDefaultLinters: true
 exclude:
   - 'node_modules/**/*'
   - 'lib/generators/**/*'
   - 'vendor/**/*'
 
 linters:
+  SpaceAroundErbTag:
+    enabled: false
   ErbSafety:
     enabled: true
     better_html_config: .better-html.yml

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,7 +12,7 @@ linters:
     enabled: true
     better_html_config: .better-html.yml
   Rubocop:
-    enabled: false
+    enabled: true
     rubocop_config:
       inherit_from:
         - .rubocop.yml
@@ -25,6 +25,10 @@ linters:
       Layout/TrailingEmptyLines:
         Enabled: false
       Style/FrozenStringLiteralComment:
+        Enabled: false
+      Style/BlockDelimiters:
+        Enabled: false
+      Style/MultilineIfModifier:
         Enabled: false
       Lint/UselessAssignment:
         Enabled: false

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -1,6 +1,6 @@
 <%= yield :top_of_page %>
 <!DOCTYPE html>
-<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" class="govuk-template">
+<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : 'en' %>" class="govuk-template">
 
 <head>
   <meta charset="utf-8"/>
@@ -17,7 +17,7 @@
   <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png' %>">
   <link rel="apple-touch-icon" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png' %>">
 
-  <%= stylesheet_link_tag "application", media: "all" %>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_importmap_tags %>
 
   <meta property="og:image" content="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png' %>">

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -3,14 +3,14 @@
 <html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : 'en' %>" class="govuk-template">
 
 <head>
-  <meta charset="utf-8"/>
+  <meta charset="utf-8">
   <title><%= yield(:page_title) %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/favicon.ico' %>" type="image/x-icon"/>
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/favicon.ico' %>" type="image/x-icon">
   <link rel="mask-icon" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg' %>" color="blue">
   <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png' %>">
   <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png' %>">

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:case_type, legend: {tag: 'h1', size: 'xl'}) do %>
+      <%= f.govuk_radio_buttons_fieldset(:case_type, legend: { tag: 'h1', size: 'xl' }) do %>
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice.value == :cc_appeal %>
 

--- a/app/views/steps/case/codefendants/edit.html.erb
+++ b/app/views/steps/case/codefendants/edit.html.erb
@@ -26,13 +26,13 @@
                                                } %>
 
           <%= c.button t('.remove_button'), type: :submit, value: '1', name: c.field_name(:_destroy, index: nil),
-                       class: %w(govuk-button govuk-button--warning),
+                       class: %w[govuk-button govuk-button--warning],
                        data: { module: 'govuk-button' } if @form_object.show_destroy? %>
         <% end %>
       <% end %>
 
       <%= f.button t('.add_button'), type: :submit, name: :add_codefendant,
-                   class: %w(govuk-button govuk-button--secondary govuk-!-margin-bottom-8),
+                   class: %w[govuk-button govuk-button--secondary govuk-!-margin-bottom-8],
                    data: { module: 'govuk-button' } %>
 
       <%= f.continue_button %>

--- a/app/views/steps/client/contact_details/edit.html.erb
+++ b/app/views/steps/client/contact_details/edit.html.erb
@@ -11,8 +11,8 @@
       <%= f.govuk_phone_field :telephone_number, autocomplete: 'off', width: 'one-third', label: { size: 'm' } %>
 
       <%= f.govuk_collection_radio_buttons :correspondence_address_type,
-                                            @form_object.choices,
-                                            :value %>
+                                           @form_object.choices,
+                                           :value %>
 
       <%= f.continue_button %>
     <% end %>

--- a/lib/tasks/erblint.rake
+++ b/lib/tasks/erblint.rake
@@ -1,3 +1,3 @@
 task :erblint do
-  sh 'bundle exec erblint .'
+  sh 'bundle exec erblint --lint-all'
 end


### PR DESCRIPTION
## Description of change
Enabling Rubocop and default linters in `erblinter`.

This will run Rubocop on any ruby code found in ERB templates, with the same configuration we have for the rest of the code base. This includes our custom cops (for now just the autocomplete, as per PR #94).

However some cops are highly annoying or return false positives (i.e. Style/BlockDelimiters), thus we can tweak the configuration to disable some of these cops on ERB code, while still using them for normal non-ERB code, to get us to a good balance.

It also enables all the default linters except one I've disabled explicitly:
https://github.com/Shopify/erb-lint#linters

I had to fix a few very minor offences. I did individual commits with each of the fixes for better context.

## How to manually test the feature
This linter is run automatically as part of `rake` or individually with `rake erblint`.
After introducing an offence, the rake task will raise an error and show the offending code.
