### PR TITLE
Identify deployment environment in github workflow

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -106,6 +106,7 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     needs: build
+    environment: staging
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description of change
By explicitly identifying the environment where the workflow performs the deploy, we can set rules and assign reviewers.

This is mostly used for production environments (to assign reviewers), which we don't have yet, but for staging environment it can also be useful and we can then enable the setting "Require deployments to succeed before merging", so a merge to `main` can't happen if there is a deploy to `staging` in progress.

<img width="845" alt="Screenshot 2022-09-07 at 12 03 30" src="https://user-images.githubusercontent.com/687910/188863216-e9b289cd-b080-4473-bc15-cfd9eee6b826.png">

<img width="824" alt="Screenshot 2022-09-07 at 12 03 45" src="https://user-images.githubusercontent.com/687910/188863228-47caccb5-8094-4854-adda-706bd9088e21.png">
