### PR TITLE
CRIMAP-134 Initial offences DB schema and models

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -3,4 +3,6 @@ class Case < ApplicationRecord
 
   has_many :codefendants, dependent: :destroy
   accepts_nested_attributes_for :codefendants, allow_destroy: true
+
+  has_many :charges, dependent: :destroy
 end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -1,0 +1,10 @@
+class Charge < ApplicationRecord
+  belongs_to :case
+  belongs_to :offence, optional: true
+
+  has_many :offence_dates, dependent: :destroy
+  accepts_nested_attributes_for :offence_dates, allow_destroy: true
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
+end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -1,0 +1,3 @@
+class Offence < ApplicationRecord
+  alias_attribute :code, :id
+end

--- a/app/models/offence_date.rb
+++ b/app/models/offence_date.rb
@@ -1,0 +1,6 @@
+class OffenceDate < ApplicationRecord
+  belongs_to :charge
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
+end

--- a/db/migrate/20220908101956_create_offences_table.rb
+++ b/db/migrate/20220908101956_create_offences_table.rb
@@ -1,0 +1,17 @@
+class CreateOffencesTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :offences, id: :string do |t|
+      t.timestamps
+
+      t.string :name, null: false
+      t.string :offence_class, null: false
+      t.string :offence_type, null: false
+
+      # Rank based on number of occurrences as per Aug 2019 analysis
+      t.integer :rank
+
+      # How many times an offence has been chosen in our service
+      t.integer :frequency, default: 0, null: false
+    end
+  end
+end

--- a/db/migrate/20220908104055_create_charges_table.rb
+++ b/db/migrate/20220908104055_create_charges_table.rb
@@ -1,0 +1,12 @@
+class CreateChargesTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :charges, id: :uuid do |t|
+      t.timestamps
+
+      t.references :case, type: :uuid, foreign_key: true, null: false
+      t.references :offence, type: :string, foreign_key: true
+
+      t.string :offence_name
+    end
+  end
+end

--- a/db/migrate/20220908112104_create_offence_dates_table.rb
+++ b/db/migrate/20220908112104_create_offence_dates_table.rb
@@ -1,0 +1,11 @@
+class CreateOffenceDatesTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :offence_dates, id: :uuid do |t|
+      t.timestamps
+
+      t.references :charge, type: :uuid, foreign_key: true, null: false
+
+      t.date :date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_02_095253) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_08_112104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -43,6 +43,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_095253) do
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 
+  create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "case_id", null: false
+    t.string "offence_id"
+    t.string "offence_name"
+    t.index ["case_id"], name: "index_charges_on_case_id"
+    t.index ["offence_id"], name: "index_charges_on_offence_id"
+  end
+
   create_table "codefendants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "case_id", null: false
     t.datetime "created_at", null: false
@@ -59,6 +69,24 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_095253) do
     t.datetime "updated_at", null: false
     t.string "client_has_partner"
     t.string "status"
+  end
+
+  create_table "offence_dates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "charge_id", null: false
+    t.date "date"
+    t.index ["charge_id"], name: "index_offence_dates_on_charge_id"
+  end
+
+  create_table "offences", id: :string, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.string "offence_class", null: false
+    t.string "offence_type", null: false
+    t.integer "rank"
+    t.integer "frequency", default: 0, null: false
   end
 
   create_table "people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -79,6 +107,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_095253) do
 
   add_foreign_key "addresses", "people"
   add_foreign_key "cases", "crime_applications"
+  add_foreign_key "charges", "cases"
+  add_foreign_key "charges", "offences"
   add_foreign_key "codefendants", "cases"
+  add_foreign_key "offence_dates", "charges"
   add_foreign_key "people", "crime_applications"
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Charge, type: :model do
+  subject { described_class.new(attributes) }
+  let(:attributes) { {} }
+end

--- a/spec/models/offence_date_spec.rb
+++ b/spec/models/offence_date_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe OffenceDate, type: :model do
+  subject { described_class.new(attributes) }
+  let(:attributes) { {} }
+end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Offence, type: :model do
+  subject { described_class.new(attributes) }
+  let(:attributes) { {} }
+
+  describe '#code' do
+    let(:attributes) { { id: 'ABC123'} }
+
+    it 'is an alias of the `id` attribute' do
+      expect(subject.code).to eq('ABC123')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
As we start to tackle the offences step, we need a series of DB tables and models to represent the data and relationships.

This might change slightly later on if we find out some missing attribute, or weird thing, but overall is the high level representation of what we want.

In a later PR a DB seed migration will be created to populate the `Offences` table based on the spreadsheet. Note the rank attribute will be populated based on the offence number of occurrences on the spreadsheet, creating a column we can use to sort by (`asc` 1 to 237). Frequency can be used for our internal analytics and also with enough time for ranking purposes if we want but this will have a bias given the very small number of providers for MVP, etc.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-134

## How to manually test the feature

In a console:

```ruby
# Seed an example offence:
offence = Offence.create(code: 'A123', name: 'Offence name', offence_class: 'K', offence_type: 'foobar')

# Offence has a code (it is the ID and primary key)
offence.code
=> "B123"

# Retrieve any case:
kase = Case.last

# It has (no) charges
kase.charges
=> []

# Let's create a charge for the above offence
charge = kase.charges.create(offence: offence)
=> #<Charge:0x0000000108c18208 ...>

# It has a linked offence
charge.offence
=> #<Offence:0x0000000108f64b28 ...>

# It has (no) dates yet
charge.offence_dates
=> []

# Let's add a date
charge.offence_dates.create(date: Date.yesterday)
=> #<OffenceDate:0x0000000108c21010 ...>

# Accepts nested attributes too
charge.offence_dates_attributes = { date: Date.yesterday, id: nil }
=> {:date=>Thu, 08 Sep 2022, :id=>nil}
charge.offence_dates
=> [... dates instances including the newly created one unsaved ... ]

# Save the above newly created date
charge.save
```