### PR TITLE
CRIMAP-125 Initial commit of offences CSV

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -1,6 +1,8 @@
 class Charge < ApplicationRecord
   belongs_to :case
-  belongs_to :offence, optional: true
+
+  # This will potentially change to retrieve the offence from the CSV
+  # belongs_to :offence, optional: true
 
   has_many :offence_dates, dependent: :destroy
   accepts_nested_attributes_for :offence_dates, allow_destroy: true

--- a/app/models/concerns/csv_queryable.rb
+++ b/app/models/concerns/csv_queryable.rb
@@ -1,0 +1,56 @@
+require 'csv'
+
+module CsvQueryable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :row
+  end
+
+  def initialize(row:)
+    @row = row
+  end
+
+  def ==(other)
+    other.is_a?(self.class) && other.row == row
+  end
+  alias === ==
+  alias eql? ==
+
+  def hash
+    [self.class, row].hash
+  end
+
+  class_methods do
+    def csv_filepath(filepath)
+      self.filepath = filepath
+    end
+
+    def csv_attributes(*attrs)
+      attrs.each do |name|
+        define_method(name) { row[name.to_s].strip }
+      end
+    end
+
+    def find(code)
+      find_by(code:)
+    end
+
+    def find_by(**query)
+      attr, value = query.first
+      all.find { |obj| obj.public_send(attr) == value }
+    end
+
+    def all
+      @all ||= csv.map { |row| new(row:) }
+    end
+
+    private
+
+    attr_accessor :filepath
+
+    def csv
+      CSV.read(@filepath, headers: true)
+    end
+  end
+end

--- a/app/models/concerns/csv_queryable.rb
+++ b/app/models/concerns/csv_queryable.rb
@@ -3,9 +3,7 @@ require 'csv'
 module CsvQueryable
   extend ActiveSupport::Concern
 
-  included do
-    attr_reader :row
-  end
+  attr_reader :row
 
   def initialize(row:)
     @row = row
@@ -30,10 +28,6 @@ module CsvQueryable
       attrs.each do |name|
         define_method(name) { row[name.to_s].strip }
       end
-    end
-
-    def find(code)
-      find_by(code:)
     end
 
     def find_by(**query)

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -1,3 +1,10 @@
-class Offence < ApplicationRecord
-  alias_attribute :code, :id
+class Offence
+  include CsvQueryable
+
+  csv_filepath Rails.root.join('config/data/offences.csv')
+
+  csv_attributes :code,
+                 :name,
+                 :offence_class,
+                 :offence_type
 end

--- a/config/data/offences.csv
+++ b/config/data/offences.csv
@@ -1,0 +1,234 @@
+code,name,offence_class,offence_type
+TH68010,Theft from a shop,F/G/K,CE Either Way
+CJ88116,Assault by beating,H,CS Summary Non-Motoring
+CD71039,Criminal damage to property valued under £5000,C,CE Either Way
+RT88191,Use a motor vehicle on a road / public place without third party insurance,H,CM Summary - Motoring
+MD71530,Possess a controlled drug of Class B - Cannabis / Cannabis Resin,H,CE Either Way
+CJ88144,Possess knife blade / sharp pointed article in a public place - Criminal Justice Act 1988,H,CE Either Way
+PL96001,Assault a constable in the execution of his / her duty,H,CS Summary Non-Motoring
+FA06001,Fraud by false representation,F/G/K,CE Either Way
+PH97003,Harassment - breach of a restraining order on conviction,H,CE Either Way
+CJ88001,Common assault,H,CS Summary Non-Motoring
+OF61102,Assault a person thereby occasioning them actual bodily harm,C,CE Either Way
+PU86004,Section 4 words / behaviour - fear unlawful violence,H,CS Summary Non-Motoring
+RT88333,Drive whilst disqualified,H,CM Summary - Motoring
+PC53001,Possess an offensive weapon in a public place,H,CE Either Way
+PU86116,Section 4A words / behaviour to cause harassment / alarm / distress,H,CS Summary Non-Motoring
+TH68036,Burglary dwelling and theft - no violence,E,CE Either Way
+TH68037,Burglary other than dwelling - theft,E,CE Either Way
+TH68023,Robbery,C/B,CI Indictable
+RT88334,Drive a motor vehicle otherwise than in accordance with a licence,H,CM Summary - Motoring
+AS14001,Breach a criminal behaviour order,H,CE Either Way
+PL96003,Obstruct/resist a constable in execution of duty,H,CS Summary Non-Motoring
+RT88007,Drive motor vehicle when alcohol level above limit,H,CM Summary - Motoring
+RT88026,Drive a motor vehicle dangerously,H,CE Either Way
+TH68020,Theft - other - including theft by finding,F/G/K,CE Either Way
+PU86149,"Use threatening / abusive words / behaviour likely to cause harassment, alarm or distress",H,CS Summary Non-Motoring
+PK78008,Make indecent photograph / pseudo-photograph of a child,J,CE Either Way
+BA76001,Fail to surrender to police / court bail at the appointed time,H,CS Summary Non-Motoring
+PH97004,Harassment without violence,H,CS Summary Non-Motoring
+RT88584,Drive motor vehicle with a proportion of a specified controlled drug above the specified limit,H,CM Summary - Motoring
+CD98067,Racially / religiously aggravated intentional harassment / alarm / distress - words / writing,H,CE Either Way
+PU86003,Affray,H,CE Either Way
+TH68007,Theft from a motor vehicle,F/G/K,CE Either Way
+CJ88149,Assault by beating of an emergency worker,H,CE Either Way
+FL96001,Breach a non-molestation order - Family Law Act 1996,H,CE Either Way
+MD71210,Possess a controlled drug of Class A - Cocaine,C,CE Either Way
+TH68073,Handle stolen goods,F/G/K,CE Either Way
+RT88010,Fail to provide specimen for analysis - vehicle driver,H,CM Summary - Motoring
+MD71231,Possess with intent to supply a controlled drug of Class A - Heroin,B,CE Either Way
+TH68001,Theft from the person of another,F/G/K,CE Either Way
+CJ67002,Drunk and disorderly in a public place,H,CS Summary Non-Motoring
+MD71526,Possess with intent to supply a controlled drug of Class B - Cannabis,B,CE Either Way
+SX03007,Sexual assault on a female,D,CE Either Way
+MD71230,Possess with intent to supply a controlled drug of Class A - Cocaine,B,CE Either Way
+SX03204,Sex offenders register - fail comply with notification requirements - SOA 2003,H,CE Either Way
+MD71211,Possess a controlled drug of Class A - Heroin,C,CE Either Way
+OF61131,Wound / inflict grievous bodily harm without intent,C,CE Either Way
+MD71234,Possess with intent to supply a controlled drug of Class A - Crack Cocaine,B,CE Either Way
+OF61016,Section 18 - wounding  with intent,B,CI Indictable
+TH68027,Burglary other than dwelling with intent to steal,E,CE Either Way
+TH68050,Take a motor vehicle without the owners consent,H,CM Summary - Motoring
+RT88578,Fail to stop a mechanically propelled vehicle when required by constable / traffic warden,H,CM Summary - Motoring
+RT88575,Drive a mechanically propelled vehicle on a road / in a public place without due care and attention,H,CM Summary - Motoring
+PC02021,Acquire / use / possess criminal property,B POCA,CE Either Way
+TH68078,Going equipped for theft - not motor vehicle,E,CE Either Way
+TH78011,Make off without making payment,H,CE Either Way
+TH68006,Theft of pedal cycle,F/G/K,CE Either Way
+TH68026,Burglary dwelling - with intent to steal,E,CE Either Way
+TH68013,Theft of motor vehicle,F/G/K,CE Either Way
+CA81001,Vehicle interference - motor vehicle,H,CS Summary Non-Motoring
+OF61017,Section 18 - grievous bodily harm with intent,B,CI Indictable
+TH68023A,Attempt robbery ,C,CI Indictable
+SX03220,Breach SHPO / interim SHPO / SOPO / interim SOPO / foreign travel order ,H,CE Either Way
+TH68002,Theft in dwelling other than an automatic machine or meter,F/G/K,CE Either Way
+MD71531,Produce controlled drug of Class B - cannabis,B,CE Either Way
+OF61014,Threats to kill,B,CE Either Way
+MT88007,Send letter / communication / article conveying a threatening message,H,CE Either Way
+RT88218,Driver of a vehicle fail to stop after a road accident,H,CM Summary - Motoring
+SX56025,Indecent assault on a girl under the age of 14 years ,J or D,CE Either Way
+CD98070,Racially / religiously aggravated common assault / beating,C,CE Either Way
+CJ88150,Common assault of an emergency worker,H,CE Either Way
+TH68072,Handling stolen goods - Theft Act 1968,F/G/K,CE Either Way
+CD98075,Racially / religiously aggravated harassment / alarm / distress by words / writing,H,CS Summary Non-Motoring
+CD71043,Threat to damage / destroy property,C,CE Either Way
+SS92039,Dishonestly fail notify change of circumstances affecting entitlement to social security benefit / advantage / payment,F/G/K,CE Either Way
+BA76002,Fail to answer to court / police bail as soon as practicable,H,CS Summary Non-Motoring
+MD71220,Possess a controlled drug of Class B - Amphetamine,H,CE Either Way
+SX03017,Assault a girl under 13 ,J,CE Either Way
+SX03002,Rape a woman 16 years of age or over - SOA 2003 ,J,CI Indictable
+TH68026A,Attempt burglary dwelling with intent to steal,E,CE Either Way
+MD71022,Possess a class C controlled drug,H,CE Either Way
+CA03005,Send by public communication network an offensive / indecent / obscene / menacing message / matter,H,CS Summary Non-Motoring
+TH68010A,Attempt theft from shop,F/G/K,CE Either Way
+CJ94005,Intimidate a witness / juror,I,CE Either Way
+CJ88148,Threaten a person with a blade / sharply pointed article in a public place,H,CE Either Way
+MD71225,Possess a controlled drug of Class B - Other,H,CE Either Way
+CJ88115,Possess indecent photograph / pseudo-photograph of a child ,J,CE Either Way
+MD71131C,Conspire to supply a class A controlled drug - heroin ,B,CI Indictable
+CY33049,Assault / ill-treat / neglect / abandon a child / young person to cause unnecessary suffering / injury,B,CE Either Way
+DA05001,Fail to attend for / remain for duration of initial assessment following test for class A drug,H,CS Summary Non-Motoring
+SX03128,Exposure - SOA 2003,D,CE Either Way
+TH68003,Theft by employee,F/G/K,CE Either Way
+MD71214,Possess a controlled drug of Class A - Crack Cocaine,C,CE Either Way
+CL77001,Use violence to secure entry to premises,H,CS Summary Non-Motoring
+CD98066,Racially / religiously aggravated fear / provocation of violence by words / writing,H,CE Either Way
+PH97009,Harassment - put in fear of violence,H,CE Either Way
+PL84001,Detainee / person charged fail / refuse to provide a sample for Class 'A' drug test,H,CS Summary Non-Motoring
+PH97006,Stalking without fear / alarm / distress,H,CS Summary Non-Motoring
+MD71130C,Conspire to supply a class A controlled drug - cocaine ,B,CI Indictable
+MD71131,Supply a controlled drug of Class A - Heroin,B,CE Either Way
+SC15004,Engage in controlling / coercive behaviour in an intimate / family relationship,H,CE Either Way
+COML030,Commit an act / series of acts with intent to pervert the course of public justice ,I,CI Indictable
+RT88220,Driver of a vehicle involved in a road accident fail to report that accident,H,CM Summary - Motoring
+TH68027A,Attempt burglary other than dwelling with intent to steal,E,CE Either Way
+FA06003,Fraud by abuse of position - Fraud Act 2006,F/G/K,CE Either Way
+AS14004,Individual fail to comply with a community protection notice,H,CS Summary Non-Motoring
+MD71134,Supply a controlled drug of Class A - Crack Cocaine,B,CE Either Way
+RT88096,Use a motor vehicle on a road without a valid test certificate,H,CM Summary - Motoring
+CJ08004,Possess extreme pornographic image portraying an act of intercourse / oral sex with a dead / alive animal ,D,CE Either Way
+PK78003,Distribute an indecent photograph / pseudo-photograph of a child,J,CE Either Way
+PC02020,Conceal / disguise / convert / transfer / remove criminal property,B POCA,CE Either Way
+FI68247,Possess a weapon for the discharge of a noxious liquid / gas / electrical incapacitation device / thing,B,CE Either Way
+PH97005,Harassment - breach of a restraining order after acquittal,H,CE Either Way
+MD71171,Concerned in supply of heroin ,B,CE Either Way
+ID10001,Possess / control identity documents with intent ,F,CI Indictable
+CD71015,Arson,C,CE Either Way
+EA03501,Extradition - Arrested under a Part 1 warrant  ,H,VA Misc. Applications
+AW06001,Cause unnecessary suffering to a protected animal - Animal Welfare Act 2006,H,CS Summary Non-Motoring
+SX56026,Indecent assault on a girl under the age of 16 years ,J,CE Either Way
+BA76005,Arrest by a constable for breaking / likely to break bail conditions - duty to surrender into the custody of a court,H,CS Summary Non-Motoring
+MD71219,Possess a controlled drug of Class A - Other,C,CE Either Way
+SX56028,Indecent assault on boy under the age of 14 years,J or D,CE Either Way
+RT88340,Drive a vehicle whilst unfit through drugs,H,CM Summary - Motoring
+CD71003,Arson with intent / reckless as to whether life was endangered ,B,CI Indictable
+SX03025,Offender 18 or over engage in penetrative sexual activity with a girl 13 to 15 - SOA 2003,J,CI Indictable
+SX03224A,Adult attempt to engage in sexual communication with a child,H,CE Either Way
+COML017,False imprisonment ,B,CI Indictable
+ED96015,Parent knowingly child not attending failed to ensure regular attendance at school,H,CS Summary Non-Motoring
+TH68146,Aggravated vehicle taking - ( initial taker ) and vehicle damage under £5000,H,CE Either Way
+COML025,Murder - victim one year of age or older ,A,CI Indictable
+SX03005,Assault a female 13 and over by penetration with part of body / a thing - SOA 2003,J,CI Indictable
+CD71038,Criminal damage to property - value over £5000,C,CE Either Way
+PR52043,Without authority possess inside a prison an item specified in section 40D(3B),H,CE Either Way
+MD71245,Possess with intent to supply a controlled drug of Class B - Other,B,CE Either Way
+MD71134C,Conspire to supply a class A controlled drug - crack cocaine,B,CI Indictable
+PU86002,Public order - violent disorder,B,CE Either Way
+EA03501,Extradition - Arrested under a Part 1 warrant,H,CO Criminal Related
+SX03013,Rape a girl under 13 ,J,CI Indictable
+RT88008,In charge of motor vehicle - alcohol level above limit,H,CM Summary - Motoring
+DD91034,Owner / person in charge of dog dangerously out of control causing injury,C,CE Either Way
+TH68045,Aggravated burglary - dwelling ,B,CI Indictable
+OF61095,Assault with intent to resist arrest,H,CE Either Way
+MD71233,Possess with intent to supply a controlled drug of Class A - MDMA,B,CE Either Way
+CJ09001,Possess a prohibited image of a child,J,CE Either Way
+MD71174,Concerned in the supply of crack cocaine ,B,CE Either Way
+CD71040,Destroy / damage property of a value unknown,C,CE Either Way
+PR52024,Bring / throw / convey a List 'A' prohibited article into / out of a prison ,B/C/H,CI Indictable
+FA06002,Dishonestly fail to disclose information to make a gain for self / another or cause / expose other to a loss,F/G/K,CE Either Way
+FA06004,Possess / control article for use in fraud - Fraud Act 2006,F/G/K,CE Either Way
+PC53002,Threaten a person with an offensive weapon in a public place ,H,CE Either Way
+PH97011,Stalking involving serious alarm / distress,H,CE Either Way
+TH68052,Drive a motor vehicle which had been taken without the owner's consent,H,CM Summary - Motoring
+MD71213,Possess a controlled drug of Class A - MDMA,C,CE Either Way
+AS14002,Fail to comply with a section 35 direction excluding a person from an area,H,CS Summary Non-Motoring
+PL02049,Assault designated / accredited person / inspector,H,CS Summary Non-Motoring
+MD71170,Concerned in supply of cocaine,B,CE Either Way
+MD71533,Concerned in the supply of a controlled drug of Class B - cannabis,B,CE Either Way
+SX56070,Rape a female under 16 ,J,CI Indictable
+AW06029,Duty of person responsible for animal to ensure welfare - Animal Welfare Act 2006,H,CS Summary Non-Motoring
+COML025A,Attempt murder - victim aged 1 year or over,A,CI Indictable
+RT88526,Cause serious injury by dangerous driving ,C/B,CE Either Way
+FI68321,Possess an imitation firearm with intent to cause fear of violence,B,CI Indictable
+SS92036,Dishonestly make a false statement to obtain a benefit / advantage / payment,F/G/K,CE Either Way
+SX03001,Rape a girl aged 13 / 14 / 15 - SOA 2003 ,J,CI Indictable
+OF61017A,Attempt to cause grievous bodily harm with intent to do grievous bodily harm,B,CI Indictable
+TH68054,Carried in / on a motor vehicle taken without the owners consent,H,CM Summary - Motoring
+SX03015,Assault a girl under 13 by penetration with a part of your body / a thing - SOA 2003,J,CI Indictable
+SX03158,Offender 18  or over engage in non penetrative sexual activity with girl 13 to 15 - SOA 2003 ,J,CE Either Way
+MD71552,Possess a controlled drug of Class B - cannabinoid receptor agonists,H,CE Either Way
+MD71130,Supply a controlled drug of Class A - Cocaine ,C,CE Either Way
+COML062,Act of outraging public decency - common law,H,CE Either Way
+SX56029,Indecent assault on boy under the age of 16 years ,J or D,CE Either Way
+COML020,Kidnap - common law,B,CI Indictable
+RT88076,Fail to stop vehicle when directed by PC / traffic warden / traffic officer / CSO engaged in regulation of road traffic,H,CM Summary - Motoring
+TH68007A,Attempt theft from motor vehicle,F/G/K,CE Either Way
+COML016,Escape from lawful custody,C,CI Indictable
+TH68081,Going equipped for burglary,E,CE Either Way
+TH68058,Abstract / use without authority electricity,F/G/K,CE Either Way
+DA05002,Fail to attend / remain for follow-up assessment following a test for presence of Class A drug - Drugs Act 2005,H,CS Summary Non-Motoring
+CA03009,Persistently make use of public communication network to cause annoyance / inconvenience / anxiety,H,CS Summary Non-Motoring
+TH68141,Aggravated vehicle taking - (initial taker) and dangerous driving,H,CE Either Way
+RT88221,Driver of a vehicle fail to stop after road accident - give name and address of self and owner / vehicle details,H,CM Summary - Motoring
+MT88005,Send communication / article of an indecent / offensive nature,H,CE Either Way
+VG24005,Begging in a public place,H,CS Summary Non-Motoring
+CD98074,Racially / religiously aggravated criminal damage,C,CE Either Way
+TH68071,Blackmail ,B,CI Indictable
+FI68421,Possess a firearm of length less than 30cm / 60cm - prohibited weapon ,B,CI Indictable
+SX03019,Cause / incite a girl under 13 to engage in sexual activity - no penetration,J,CE Either Way
+TH68023C,Conspire to commit robbery ,C,CI Indictable
+CJ15005,Disclose private sexual photographs and films with intent to cause distress,D,CE Either Way
+MD71239,Possess with intent to supply a controlled drug of Class A - Other ,B,CE Either Way
+TH68026C,Conspire to commit a burglary dwelling with intent to steal ,B,CI Indictable
+IC60006,Gross Indecency with a girl under fourteen years,J,CE Either Way
+SX03224,Engage in Sexual Communication with a child ,H,CE Either Way
+TH68144,Aggravated vehicle taking - ( initial taker ) and property damage under £5000,H,CE Either Way
+RT88567,Fail to give information relating to the identification of the driver / rider of a vehicle when required,H,CM Summary - Motoring
+TH68001A,Attempt theft from the person of another,F/G/K,CE Either Way
+MD71442,Possess with intent to supply a controlled drug of Class C - Other,C,CE Either Way
+SX03018,Assault a boy under 13 by touching - SOA 2003,J,CE Either Way
+RT88339,Drive whilst unfit through drink,H,CM Summary - Motoring
+MD71145C,Conspire to supply a class B controlled drug - other,B,CI Indictable
+CD71039A,Attempt criminal damage to property valued under £5000,C,CS Summary Non-Motoring
+MD71529,Concerned in production of a controlled drug of Class B - cannabis,B,CE Either Way
+TH68020A,Attempt theft - other - including by theft 'finding',F/G/K,CE Either Way
+RT88011,Fail to provide specimen - person in charge of vehicle,H,CM Summary - Motoring
+FI68010,Possess ammunition for a firearm without a certificate ,C,CE Either Way
+MD71240,Possess with intent to supply a controlled drug of Class B - Amphetamine ,B,CE Either Way
+CD98002,Breach of an anti-social behaviour order,H,CE Either Way
+MD71070,Obstruct an authorised person in exercise of a section 23 power to detain / search a person / vehicle / vessel re drugs,H,CE Either Way
+MD71139C,Conspire to supply a class A controlled drug - other ,B,CI Indictable
+MD71517,Possess with intent to supply a controlled drug of Class B - Cannabis Resin ,B,CE Either Way
+SX03225A,Adult attempt to meet a girl under 16 years of age following grooming ,D,CE Either Way
+MD71532,Supply a controlled drug of Class B - cannabis,B,CE Either Way
+TH68012,Theft from a meter / automatic machine ,F/G/K,CE Either Way
+PH97010,Stalking involving fear of violence,H,CE Either Way
+TH68079,Going equipped for theft of a motor vehicle,E,CE Either Way
+SX03029A,Attempt to cause / incite a girl 13 to 15 to engage in sexual activity - offender 18 or over - penetration,J,CI Indictable
+VE94158,Fraudulently use a registration mark / registration document,H,CE Either Way
+MT88006,Send letter / communication / article conveying indecent / offensive message,H,CE Either Way
+TH68147,Aggravated vehicle taking - (driver did not take) and dangerous driving,H,CE Either Way
+FI68320,Possess a firearm with intent to cause fear of violence,B,CI Indictable
+TH68044,Burglary dwelling - theft / attempt theft with violence,B,CI Indictable
+SX03162,Offender 18 or over cause / incite a girl 13 to 15 to engage in sexual activity - no penetration - SOA 2003,J,CE Either Way
+SX03014,Rape of a boy under 13 - SOA 2003,J,CI Indictable
+FA06001C,Conspire to commit fraud by false representation - Fraud Act 2006,F/G/K,CI Indictable
+SX03008,Sexual assault on a male,D,CE Either Way
+IC60005,Gross indecency with a boy under the age of fourteen years of age,J,CE Either Way
+MT88008,Send letter / communication / article conveying false information,H,CE Either Way
+OF61016A,Section 18 - attempt wounding with intent,B,CI Indictable
+PR52044,Unauthorised possession in prison of knife or offensive weapon ,H,CE Either Way
+VG24018,Vagrant - being found in or upon enclosed premises,H,CS Summary Non-Motoring
+LG02001,Drunk in charge of a child under the age of seven years,H,CS Summary Non-Motoring
+PR52028,Bring / throw / convey a List 'B' prohibited article into / out of a prison - Prison Act 1952,H,CE Either Way
+TH68006A,Attempt theft of pedal cycle,F/G/K,CE Either Way

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -1,14 +1,80 @@
 require 'rails_helper'
 
 RSpec.describe Offence, type: :model do
-  subject { described_class.new(attributes) }
-  let(:attributes) { {} }
+  describe '.find' do
+    it 'is a short form of `find_by(code:)`' do
+      expect(described_class).to receive(:find_by).with(code: 'FA06001')
+      described_class.find('FA06001')
+    end
+  end
 
-  describe '#code' do
-    let(:attributes) { { id: 'ABC123'} }
+  describe '.find_by' do
+    context 'can search by code' do
+      subject { described_class.find_by(code: 'FA06001') }
 
-    it 'is an alias of the `id` attribute' do
-      expect(subject.code).to eq('ABC123')
+      it 'returns the offence found' do
+        expect(subject).to be_a(described_class)
+      end
+
+      it 'has the offence attributes' do
+        expect(subject.code).to eq('FA06001')
+        expect(subject.name).to eq('Fraud by false representation')
+        expect(subject.offence_class).to eq('F/G/K')
+        expect(subject.offence_type).to eq('CE Either Way')
+      end
+    end
+
+    context 'can search by name' do
+      subject { described_class.find_by(name: 'Fraud by false representation') }
+
+      it 'returns the offence found' do
+        expect(subject.code).to eq('FA06001')
+      end
+    end
+
+    context 'when no offence is found' do
+      subject { described_class.find_by(code: 'XYZ123') }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.all' do
+    subject { described_class.all }
+
+    it 'returns all offences' do
+      expect(subject).to all(be_a(described_class))
+      expect(subject.size).to eq(233)
+    end
+
+    it 'keeps the same order as in the CSV file' do
+      expect(subject.first.code).to eq('TH68010')
+      expect(subject.last.code).to eq('TH68006A')
+    end
+  end
+
+  describe 'equality methods' do
+    let(:offence_one) { described_class.new(row: 'row_A') }
+    let(:offence_two) { described_class.new(row: 'row_A') }
+    let(:offence_three) { described_class.new(row: 'row_B') }
+
+    describe '#==' do
+      it 'considers same type/same row equal' do
+        expect(offence_one).to eq(offence_two)
+      end
+
+      it 'considers same type/different row not equal' do
+        expect(offence_one).to_not eq(offence_three)
+      end
+    end
+
+    describe '#hash' do
+      it 'considers same type/same row equal' do
+        expect(offence_one.hash).to eq(offence_two.hash)
+      end
+
+      it 'considers same type/different row not equal' do
+        expect(offence_one.hash).to_not eq(offence_three.hash)
+      end
     end
   end
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -1,13 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Offence, type: :model do
-  describe '.find' do
-    it 'is a short form of `find_by(code:)`' do
-      expect(described_class).to receive(:find_by).with(code: 'FA06001')
-      described_class.find('FA06001')
-    end
-  end
-
   describe '.find_by' do
     context 'can search by code' do
       subject { described_class.find_by(code: 'FA06001') }


### PR DESCRIPTION
## Description of change
Store the CSV file containing the pre-filtered list of offences and their attributes, and a thin layer to read it and perform basic operations like find by code (or by name if that make sense), and retrieve all offences.

This is inspired by HMCTS common platform with a very similar approach: https://github.com/ministryofjustice/hmcts_common_platform

I've made some small tweaks and modifications to better fit our purposes (also implemented the equality methods), but overall is exactly the same.

We might not need the Offences DB table anymore but for now I'm not doing anything on that front until we've validated this other alternative (CSV file).

I've just reused the same `Offence` model but removed its ActiveRecord capabilities so it is just a simple PORO/entity for now.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-125

## Notes for reviewer
Old DB table and related code not yet removed.

## How to manually test the feature
After checkout, open a ruby console and run, for example:

```ruby
Offence.all

Offence.find('TH68010')
Offence.find_by(code: 'TH68010')
Offence.find_by(name: 'Theft from a shop')

o = Offence.find('TH68010')
o.code
=> "TH68010"
o.name
=> "Theft from a shop"
o.offence_class
=> "F/G/K"
o.offence_type
=> "CE Either Way"
```