### PR TITLE
CRIMAP-125 Initial setup of `Charges` step

### DIFF
--- a/app/controllers/steps/case/charges_controller.rb
+++ b/app/controllers/steps/case/charges_controller.rb
@@ -1,0 +1,27 @@
+module Steps
+  module Case
+    class ChargesController < Steps::CaseStepController
+      def edit
+        @form_object = ChargesForm.build(
+          charge_record, crime_application: current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          ChargesForm, record: charge_record, as: :charges
+        )
+      end
+
+      private
+
+      def charge_record
+        @charge_record ||= case_charges.find(params[:charge_id])
+      end
+
+      def case_charges
+        @case_charges ||= current_crime_application.case.charges
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/charges_form.rb
+++ b/app/forms/steps/case/charges_form.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class ChargesForm < Steps::BaseFormObject
+      attribute :offence_name, :string
+
+      private
+
+      def persist!
+        record.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -1,6 +1,6 @@
 module Decisions
   class CaseDecisionTree < BaseDecisionTree
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     def destination
       case step_name
       when :urn
@@ -14,13 +14,15 @@ module Decisions
       when :delete_codefendant
         edit_codefendants
       when :codefendants_finished
+        after_codefendants
+      when :charges
         # Next step when we have it
         show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     private
 
@@ -28,7 +30,7 @@ module Decisions
       if form_object.has_codefendants.yes?
         edit_codefendants
       else
-        show('/home', action: :index)
+        after_codefendants
       end
     end
 
@@ -37,6 +39,12 @@ module Decisions
       codefendants.create! if add_blank || codefendants.empty?
 
       edit(:codefendants)
+    end
+
+    # TODO: update when we have the 'basket' page
+    def after_codefendants
+      charge = form_object.case.charges.first_or_create
+      edit(:charges, charge_id: charge)
     end
   end
 end

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -1,0 +1,16 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :offence_name, autocomplete: 'off' %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -41,6 +41,8 @@ en:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
       steps_case_urn_form:
         urn: For example, ‘12 AB 3456789’.
+      steps_case_charges_form:
+        offence_name: For example, robbery
 
     label:
       steps_client_has_partner_form:
@@ -85,3 +87,5 @@ en:
         first_name: First name
         last_name: Last name
         conflict_of_interest_options: *YESNO
+      steps_case_charges_form:
+        offence_name: Offence name

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -85,3 +85,8 @@ en:
           codefendant_legend: Co-defendant %{index}
           add_button: Add another co-defendant
           remove_button: Remove co-defendant
+      charges:
+        edit:
+          page_title: What has your client been charged with?
+          heading: What has your client been charged with?
+          offence_name_legend: Offence name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
         edit_step :case_type
         edit_step :has_codefendants
         edit_step :codefendants
+        crud_step :charges, param: :charge_id, only: [:edit, :update]
       end
     end
   end

--- a/spec/controllers/steps/case/charges_controller_spec.rb
+++ b/spec/controllers/steps/case/charges_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::ChargesController, type: :controller do
+  let(:form_class) { Steps::Case::ChargesForm }
+  let(:decision_tree_class) { Decisions::CaseDecisionTree }
+
+  describe '#edit' do
+    context 'when application is not found' do
+      before do
+        # Needed because some specs that include these examples stub current_crime_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_crime_application).and_return(nil)
+      end
+
+      it 'redirects to the application not found error page' do
+        get :edit, params: { id: '12345', charge_id: '123' }
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when application is found' do
+      let!(:existing_application) { CrimeApplication.create(case: Case.new) }
+      let!(:existing_charge) { Charge.find_or_create_by(case: existing_application.case) }
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: existing_application, charge_id: existing_charge }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) { { id: existing_application, charge_id: existing_charge, form_class_params_name => { foo: 'bar' } } }
+
+    context 'when application is not found' do
+      let(:existing_application) { '12345' }
+      let(:existing_charge) { '123' }
+
+      before do
+        # Needed because some specs that include these examples stub current_crime_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_crime_application).and_return(nil)
+      end
+
+      it 'redirects to the application not found error page' do
+        put :update, params: expected_params
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when an application in progress is found' do
+      let!(:existing_application) { CrimeApplication.create(case: Case.new) }
+      let!(:existing_charge) { Charge.find_or_create_by(case: existing_application.case) }
+
+      before do
+        allow(form_class).to receive(:new).and_return(form_object)
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          expect(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) { instance_double(decision_tree_class, destination: '/expected_destination') }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(decision_tree_class).to receive(:new).and_return(decision_tree)
+
+          put :update, params: expected_params
+
+          expect(response).to have_http_status(:redirect)
+          expect(subject).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          expect(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the question page again' do
+          put :update, params: expected_params, session: { crime_application_id: existing_application.id }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/case/charges_form_spec.rb
+++ b/spec/forms/steps/case/charges_form_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::ChargesForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    record: charge_record,
+    offence_name: offence_name,
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:charge_record) { Charge.new }
+  let(:offence_name) { 'Robbery' }
+
+  subject { described_class.new(arguments) }
+
+  describe 'validations' do
+    # TODO: validations
+  end
+
+  describe '#save' do
+    context 'for valid details' do
+      it 'updates the record' do
+        expect(charge_record).to receive(:update).with(
+          'offence_name' => 'Robbery',
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Routes, controller, form object and view with locales for a very basic initial boilerplate of the `Charges` step.

This already takes care of creating a `charge` record to work with (CRUD) but it only has an attribute, `offence_name` and no validation etc.

This is so we have something to start with and there are not too much code conflicts/clashing.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-73

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="740" alt="Screenshot 2022-09-13 at 16 03 51" src="https://user-images.githubusercontent.com/687910/189937280-ee8fc08e-35a5-4895-9a38-4cb8f52e1c7f.png">

## How to manually test the feature
The step comes right after codefendants, either if you answer `NO` to has codefendants, or after entering some codefendants.