### PR TITLE
CRIMAP-127 Implement offences summary page

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -8,6 +8,7 @@ class CrimeApplicationsController < ApplicationController
                     .joins(:people)
                     .includes(:applicant)
                     .merge(Applicant.with_name)
+                    .merge(CrimeApplication.order(created_at: :desc))
   end
 
   def create

--- a/app/controllers/steps/case/charges_summary_controller.rb
+++ b/app/controllers/steps/case/charges_summary_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class ChargesSummaryController < Steps::CaseStepController
+      def edit
+        @form_object = ChargesSummaryForm.new(
+          crime_application: current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(ChargesSummaryForm, as: :charges_summary)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/charges_summary_form.rb
+++ b/app/forms/steps/case/charges_summary_form.rb
@@ -1,0 +1,23 @@
+module Steps
+  module Case
+    class ChargesSummaryForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :case
+
+      attribute :add_offence, :value_object, source: YesNoAnswer
+      validates :add_offence, inclusion: { in: :choices }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      # NOTE: this step is not persisting anything to DB.
+      # We only use `add_offence` transiently in the decision tree.
+      def persist!
+        true
+      end
+    end
+  end
+end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -16,8 +16,9 @@ module Decisions
       when :codefendants_finished
         after_codefendants
       when :charges
-        # Next step when we have it
-        show('/home', action: :index)
+        edit(:charges_summary)
+      when :charges_summary
+        after_charges_summary
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -41,10 +42,29 @@ module Decisions
       edit(:codefendants)
     end
 
-    # TODO: update when we have the 'basket' page
     def after_codefendants
-      charge = form_object.case.charges.first_or_create
+      return edit(:charges_summary) if case_charges.any?
+
+      edit_new_charge
+    end
+
+    def after_charges_summary
+      # TODO: update when we have next step
+      return show('/home', action: :index) if form_object.add_offence.no?
+
+      edit_new_charge
+    end
+
+    def edit_new_charge
+      charge = case_charges.create!(
+        offence_dates_attributes: { id: nil } # a blank, first date
+      )
+
       edit(:charges, charge_id: charge)
+    end
+
+    def case_charges
+      @case_charges ||= form_object.case.charges
     end
   end
 end

--- a/app/views/steps/case/charges_summary/edit.html.erb
+++ b/app/views/steps/case/charges_summary/edit.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :add_offence, @form_object.choices, :value,
+                                           inline: true %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -107,3 +107,7 @@ en:
               blank: Enter a last name
             conflict_of_interest:
               inclusion: Select yes if there is a conflict of interest
+        steps/case/charges_summary_form:
+          attributes:
+            add_offence:
+              inclusion: Select yes if you want to add another offence

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -26,6 +26,8 @@ en:
         has_codefendants: Does your client have any co-defendants in this case?
       steps_case_codefendants_form:
         conflict_of_interest: Is there a conflict of interest with this co-defendant?
+      steps_case_charges_summary_form:
+        add_offence: Do you want to add another offence?
 
     hint:
       steps_client_has_partner_form:
@@ -89,3 +91,5 @@ en:
         conflict_of_interest_options: *YESNO
       steps_case_charges_form:
         offence_name: Offence name
+      steps_case_charges_summary_form:
+        add_offence_options: *YESNO

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -90,3 +90,6 @@ en:
           page_title: What has your client been charged with?
           heading: What has your client been charged with?
           offence_name_legend: Offence name
+      charges_summary:
+        edit:
+          page_title: Offences summary list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
         edit_step :has_codefendants
         edit_step :codefendants
         crud_step :charges, param: :charge_id, only: [:edit, :update]
+        edit_step :charges_summary
       end
     end
   end

--- a/spec/controllers/steps/case/charges_summary_controller_spec.rb
+++ b/spec/controllers/steps/case/charges_summary_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::ChargesSummaryController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::ChargesSummaryForm, Decisions::CaseDecisionTree
+end

--- a/spec/forms/steps/case/charges_summary_form_spec.rb
+++ b/spec/forms/steps/case/charges_summary_form_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::ChargesSummaryForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    add_offence: add_offence
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:add_offence) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `add_offence` is not provided' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:add_offence, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when `add_offence` is not valid' do
+      let(:add_offence) { 'maybe' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.of_kind?(:add_offence, :inclusion)).to eq(true)
+      end
+    end
+
+    context 'when there are no errors' do
+      let(:add_offence) { 'yes' }
+
+      it 'returns true' do
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This is as well kind of the boilerplate (although it is totally functional) for the offences summary page, where offences will show and they can be changed, removed, or add another.

For now it only shows the yes-no radios to add another offence, with validation, and the decision tree has been updated to introduce this new flow.

In a follow-up PR, I will add to the summary page the list of offences, as well as the additional edit/delete actions.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-127

## Notes for reviewer
Offences will not show yet on the list/page.

## Screenshots of changes (if applicable)
<img width="655" alt="Screenshot 2022-09-14 at 13 06 05" src="https://user-images.githubusercontent.com/687910/190149264-40375167-3324-4952-85b0-df29c1cba93d.png">

## How to manually test the feature
You reach this page either:

a) after adding one offence for the first time.
b) having added already some offences, if you go back in the journey to the codefendants, after codefendants you will go directly to the offences summary page, instead of to a blank new offence.