### PR TITLE
CRIMAP-127 List of added offences

### DIFF
--- a/app/forms/steps/case/charges_summary_form.rb
+++ b/app/forms/steps/case/charges_summary_form.rb
@@ -7,6 +7,8 @@ module Steps
       attribute :add_offence, :value_object, source: YesNoAnswer
       validates :add_offence, inclusion: { in: :choices }
 
+      delegate :charges, to: :kase
+
       def choices
         YesNoAnswer.values
       end

--- a/app/presenters/charge_presenter.rb
+++ b/app/presenters/charge_presenter.rb
@@ -1,0 +1,15 @@
+class ChargePresenter < BasePresenter
+  # TODO: some methods produce mock data for now
+
+  def offence_name
+    super || id
+  end
+
+  def offence_class
+    'H'
+  end
+
+  def offence_dates
+    super.pluck(:date).compact
+  end
+end

--- a/app/views/steps/case/charges_summary/edit.html.erb
+++ b/app/views/steps/case/charges_summary/edit.html.erb
@@ -5,6 +5,38 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
+    <h1 class="govuk-heading-xl">
+      <%=t '.heading', count: @form_object.charges.size %>
+    </h1>
+
+    <dl class="govuk-summary-list">
+      <% @form_object.charges.present_each(ChargePresenter) do |charge| %>
+        <div class="govuk-summary-list__row">
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              <%= charge.offence_name %>
+            </p>
+
+            <% if charge.offence_class %>
+              <p class="govuk-caption-m govuk-!-margin-bottom-2 govuk-!-margin-top-0">
+                <%= t('.list.offence_class', class: charge.offence_class) %>
+              </p>
+            <% end %>
+
+            <% charge.offence_dates.each do |date| %>
+              <p class="govuk-body govuk-!-margin-bottom-0"><%= l(date) %></p>
+            <% end %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to t('.list.change_link_html'), edit_steps_case_charges_path(charge_id: charge) %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to t('.list.remove_link_html'), '#' %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :add_offence, @form_object.choices, :value,
                                            inline: true %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -93,3 +93,11 @@ en:
       charges_summary:
         edit:
           page_title: Offences summary list
+          heading:
+            zero: You have not added offences yet
+            one: You have added %{count} offence
+            other: You have added %{count} offences
+          list:
+            offence_class: Class %{class}
+            change_link_html: Change <span class="govuk-visually-hidden">offence</span>
+            remove_link_html: Remove <span class="govuk-visually-hidden">offence</span>

--- a/spec/presenters/charge_presenter_spec.rb
+++ b/spec/presenters/charge_presenter_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ChargePresenter do
+  subject { described_class.new(charge) }
+
+  let(:charge) {
+    instance_double(
+      Charge,
+      id: '7a6f571e-f072-40a2-b0a1-aa79353141f8',
+      offence_name: offence_name,
+      offence_dates: offence_dates_double,
+    )
+  }
+
+  let(:offence_dates_double) { double }
+  let(:offence_name) { 'Robbery' }
+
+  # TODO: just a mock
+  describe '#offence_name' do
+    context 'we have a name' do
+      it { expect(subject.offence_name).to eq('Robbery') }
+    end
+
+    context 'we do not have a name' do
+      let(:offence_name) { nil }
+      it { expect(subject.offence_name).to eq('7a6f571e-f072-40a2-b0a1-aa79353141f8') }
+    end
+  end
+
+  # TODO: just a mock
+  describe '#offence_class' do
+    it { expect(subject.offence_class).to eq('H') }
+  end
+
+  describe '#offence_dates' do
+    it 'retrieves the `date` attribute from the collection' do
+      expect(offence_dates_double).to receive(:pluck).and_return([nil, nil])
+      expect(subject.offence_dates).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Little follow-up PR to #106, so we have something to "see" if the offences page is adding offences and dates as expected.

It is still kind of a mock (there is a presenter with some mock data), and no remove functionality implemented yet, that will be next in another PR, but the "change" link will work.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-127

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="781" alt="Screenshot 2022-09-15 at 09 42 04" src="https://user-images.githubusercontent.com/687910/190359715-1b564ad7-97ee-4efa-a572-d9777fd5c1bc.png">

