### PR TITLE
CRIMAP-130 Implement offence destroy action

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -10,6 +10,8 @@ exclude:
 linters:
   SpaceAroundErbTag:
     enabled: false
+  PartialInstanceVariable:
+    enabled: true
   ErbSafety:
     enabled: true
     better_html_config: .better-html.yml

--- a/app/controllers/steps/case/charges_controller.rb
+++ b/app/controllers/steps/case/charges_controller.rb
@@ -13,6 +13,25 @@ module Steps
         )
       end
 
+      def destroy
+        charge_record.destroy
+
+        if case_charges.reload.any?
+          redirect_to edit_steps_case_charges_summary_path,
+                      success: t('.success_flash')
+        else
+          # If this was the last remaining record, redirect
+          # to the charges page with a new blank one
+          charge = case_charges.create!
+          redirect_to edit_steps_case_charges_path(charge_id: charge),
+                      success: t('.success_flash')
+        end
+      end
+
+      def confirm_destroy
+        @charge = helpers.present(charge_record)
+      end
+
       private
 
       def step_name

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -4,5 +4,12 @@ class Case < ApplicationRecord
   has_many :codefendants, dependent: :destroy
   accepts_nested_attributes_for :codefendants, allow_destroy: true
 
-  has_many :charges, dependent: :destroy
+  has_many :charges, dependent: :destroy,
+           before_add: [:initialise_dates]
+
+  private
+
+  def initialise_dates(charge)
+    charge.offence_dates.build  # a blank, first date
+  end
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -69,10 +69,7 @@ module Decisions
     end
 
     def edit_new_charge
-      charge = case_charges.create!(
-        offence_dates_attributes: { id: nil } # a blank, first date
-      )
-
+      charge = case_charges.create!
       edit(:charges, charge_id: charge)
     end
 

--- a/app/views/steps/case/charges/confirm_destroy.html.erb
+++ b/app/views/steps/case/charges/confirm_destroy.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+<% step_header(path: edit_steps_case_charges_summary_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%=t '.heading' %>
+    </h1>
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+      <%= render partial: 'steps/case/charges_summary/offence_details',
+                 locals: { charge: @charge, show_actions: false } %>
+    </dl>
+
+    <%= form_with url: steps_case_charges_path, method: :delete do |f| %>
+      <div class="govuk-button-group">
+        <%= f.button t('.confirm_delete_button'),
+                     class: 'govuk-button govuk-button--warning',
+                     data: { module: 'govuk-button' } %>
+
+        <%= link_to edit_steps_case_charges_summary_path,
+                    class: 'govuk-button govuk-button--primary',
+                    data: { module: 'govuk-button' } do; t('.cancel_delete_button'); end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>

--- a/app/views/steps/case/charges_summary/_offence_details.html.erb
+++ b/app/views/steps/case/charges_summary/_offence_details.html.erb
@@ -1,0 +1,30 @@
+<div class="govuk-summary-list__row">
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <%= charge.offence_name %>
+    </p>
+
+    <% if charge.offence_class %>
+      <p class="govuk-caption-m govuk-!-margin-bottom-2 govuk-!-margin-top-0">
+        <%= t('.offence_class', class: charge.offence_class) %>
+      </p>
+    <% end %>
+
+    <% charge.offence_dates.each do |date| %>
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        <%= l(date) %>
+      </p>
+    <% end %>
+  </dd>
+
+  <% if show_actions %>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to t('.change_link_html'), edit_steps_case_charges_path(charge_id: charge),
+                  class: 'govuk-link--no-visited-state' %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to t('.remove_link_html'), confirm_destroy_steps_case_charges_path(charge_id: charge),
+                  class: 'govuk-link--no-visited-state' %>
+    </dd>
+  <% end %>
+</div>

--- a/app/views/steps/case/charges_summary/edit.html.erb
+++ b/app/views/steps/case/charges_summary/edit.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl">
@@ -11,29 +13,7 @@
 
     <dl class="govuk-summary-list">
       <% @form_object.charges.present_each(ChargePresenter) do |charge| %>
-        <div class="govuk-summary-list__row">
-          <dd class="govuk-summary-list__value">
-            <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= charge.offence_name %>
-            </p>
-
-            <% if charge.offence_class %>
-              <p class="govuk-caption-m govuk-!-margin-bottom-2 govuk-!-margin-top-0">
-                <%= t('.list.offence_class', class: charge.offence_class) %>
-              </p>
-            <% end %>
-
-            <% charge.offence_dates.each do |date| %>
-              <p class="govuk-body govuk-!-margin-bottom-0"><%= l(date) %></p>
-            <% end %>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to t('.list.change_link_html'), edit_steps_case_charges_path(charge_id: charge) %>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to t('.list.remove_link_html'), '#' %>
-          </dd>
-        </div>
+        <%= render partial: 'offence_details', locals: { charge: charge, show_actions: true } %>
       <% end %>
     </dl>
 

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -93,6 +93,13 @@ en:
           offence_date_legend: Offence date %{index}
           add_button: Add another date
           remove_button: Remove date
+        confirm_destroy:
+          page_title: Delete offence confirmation
+          heading: Are you sure you want to delete this offence?
+          confirm_delete_button: Yes, delete it
+          cancel_delete_button: No, do not delete it
+        destroy:
+          success_flash: The offence has been deleted
       charges_summary:
         edit:
           page_title: Offences summary list
@@ -100,7 +107,7 @@ en:
             zero: You have not added offences yet
             one: You have added %{count} offence
             other: You have added %{count} offences
-          list:
-            offence_class: Class %{class}
-            change_link_html: Change <span class="govuk-visually-hidden">offence</span>
-            remove_link_html: Remove <span class="govuk-visually-hidden">offence</span>
+        offence_details:
+          offence_class: Class %{class}
+          change_link_html: Change <span class="govuk-visually-hidden">offence</span>
+          remove_link_html: Remove <span class="govuk-visually-hidden">offence</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,12 @@ end
 
 def crud_step(name, opts = {})
   edit_step name, only: [] do
-    resources only: opts.fetch(:only, [:edit, :update, :destroy]),
+    resources only: [:edit, :update, :destroy],
+              except: opts.fetch(:except, []),
               controller: name, param: opts.fetch(:param),
-              path_names: { edit: '' }
+              path_names: { edit: '' } do
+      get :confirm_destroy, on: :member if parent_resource.actions.include?(:destroy)
+    end
   end
 end
 
@@ -53,9 +56,9 @@ Rails.application.routes.draw do
       end
 
       namespace :address do
-        crud_step :lookup,  param: :address_id, only: [:edit, :update]
-        crud_step :results, param: :address_id, only: [:edit, :update]
-        crud_step :details, param: :address_id, only: [:edit, :update]
+        crud_step :lookup,  param: :address_id, except: [:destroy]
+        crud_step :results, param: :address_id, except: [:destroy]
+        crud_step :details, param: :address_id, except: [:destroy]
       end
 
       namespace :case do
@@ -63,7 +66,7 @@ Rails.application.routes.draw do
         edit_step :case_type
         edit_step :has_codefendants
         edit_step :codefendants
-        crud_step :charges, param: :charge_id, only: [:edit, :update]
+        crud_step :charges, param: :charge_id
         edit_step :charges_summary
       end
     end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Case, type: :model do
+  subject { described_class.new(attributes) }
+  let(:attributes) { {} }
+
+  describe '`charges` relationship' do
+    let(:crime_application) { CrimeApplication.create }
+
+    subject(:charges) {
+      described_class.create(
+        crime_application: crime_application
+      ).charges
+    }
+
+    it 'initialises a blank `offence_date` when building charges' do
+      expect(
+        charges.build.offence_dates
+      ).to contain_exactly(kind_of(OffenceDate))
+    end
+
+    it 'initialises a blank `offence_date` when adding charges' do
+      expect {
+        charges << Charge.new
+      }.to change { OffenceDate.count }.by(1)
+    end
+
+    it 'initialises a blank `offence_date` when creating charges' do
+      expect {
+        charges.create
+      }.to change { OffenceDate.count }.by(1)
+    end
+  end
+end

--- a/spec/requests/charges_summary_spec.rb
+++ b/spec/requests/charges_summary_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'Charges/offences summary page' do
+  before :all do
+    # sets up a few test records
+    app = CrimeApplication.create
+    kase = Case.create(crime_application: app)
+
+    kase.charges.create!(
+      offence_name: 'Robbery',
+      offence_dates_attributes: { id: nil, date: Date.new(1990, 02, 01) }
+    )
+  end
+
+  after :all do
+    # do not leave left overs in the test database
+    CrimeApplication.destroy_all
+  end
+
+  describe 'list of added offences in summary page' do
+    let(:crime_application) { CrimeApplication.first }
+
+    before do
+      get edit_steps_case_charges_summary_path(crime_application)
+    end
+
+    it 'lists the offences with their details and action links' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'You have added 1 offence'
+
+      assert_select 'dl.govuk-summary-list' do
+        assert_select 'div.govuk-summary-list__row', 1 do
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(1)', count: 1, text: 'Robbery'
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(2)', count: 1, text: 'Class H'
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '1 Feb 1990'
+
+          assert_select 'dd.govuk-summary-list__actions:nth-of-type(1) a', count: 1, text: 'Change offence'
+          assert_select 'dd.govuk-summary-list__actions:nth-of-type(2) a', count: 1, text: 'Remove offence'
+        end
+      end
+    end
+  end
+
+  describe 'delete an offence' do
+    let(:crime_application) { CrimeApplication.first }
+    let(:charge) { Charge.first }
+
+    before do
+      get confirm_destroy_steps_case_charges_path(id: crime_application, charge_id: charge)
+    end
+
+    it 'allows a user to confirm before deleting an offence' do
+      assert_select 'dl.govuk-summary-list.govuk-summary-list--no-border' do
+        assert_select 'div.govuk-summary-list__row', 1 do
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(1)', count: 1, text: 'Robbery'
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(2)', count: 1, text: 'Class H'
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '1 Feb 1990'
+
+          assert_select 'dd.govuk-summary-list__actions', count: 0
+        end
+      end
+
+      expect(response.body).to include('Are you sure you want to delete this offence?')
+      expect(response.body).to include('Yes, delete it')
+      expect(response.body).to include('No, do not delete it')
+    end
+
+    context 'when there are other offences' do
+      it 'deletes the offence and redirects back to the summary page' do
+        # ensure we have at least an additional offence
+        charge = crime_application.case.charges.create!
+
+        expect {
+          delete steps_case_charges_path(id: crime_application, charge_id: charge)
+        }.to change { Charge.count }.by(-1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(edit_steps_case_charges_summary_path(crime_application))
+
+        follow_redirect!
+
+        assert_select 'div.govuk-notification-banner--success', 1 do
+          assert_select 'h2', 'Success'
+          assert_select 'p', 'The offence has been deleted'
+        end
+      end
+    end
+
+    context 'when there are no more offences' do
+      it 'deletes the offence, creates a brand new one and redirects to the offence page' do
+        expect {
+          delete steps_case_charges_path(id: crime_application, charge_id: charge)
+        }.not_to change { Charge.count }
+
+        new_charge = Charge.last
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(edit_steps_case_charges_path(id: crime_application, charge_id: new_charge))
+
+        follow_redirect!
+
+        assert_select 'div.govuk-notification-banner--success', 1 do
+          assert_select 'h2', 'Success'
+          assert_select 'p', 'The offence has been deleted'
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -151,11 +151,8 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:charges_double) { double(create!: 'charge') }
 
       # No need to repeat this test, just once is enough as sanity check
-      it 'creates a blank new `charge` record, as well as a blank new associated `offence_date`' do
-        expect(
-          charges_double
-        ).to receive(:create!).with(offence_dates_attributes: { id: nil })
-
+      it 'creates a blank new `charge` record' do
+        expect(charges_double).to receive(:create!)
         subject.destination
       end
 


### PR DESCRIPTION
## Description of change
Another follow-up to previous offence summary page PRs.

This one implements the "Remove" link.
It follows the same pattern we already did for the applications dashboard, with a confirmation page, and shows a flash banner as well.

I tweaked a bit the routes `crud_step` helper to simplify this and to expose the `confirm_destroy` action when we have a `destroy`.

As agreed, if the offence being removed is the last one in the list, we redirects to a brand new offence, but if there are more offences left, we redirect back to the summary page.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-130

## Notes for reviewer
There are some conversations around the wording "delete" or "remove" and also around the dates format. I'm leaving that out of this PR for now, once decided, we can change whatever is needed.

## Screenshots of changes (if applicable)
<img width="732" alt="Screenshot 2022-09-15 at 15 36 07" src="https://user-images.githubusercontent.com/687910/190432728-e9f9748d-f961-45d6-aab7-e8f29a945bfe.png">
<img width="767" alt="Screenshot 2022-09-15 at 15 36 14" src="https://user-images.githubusercontent.com/687910/190432788-9be9cacf-8dfc-4c53-9fa4-3e83761167f4.png">

When deleting the last offence in the list, it goes back to add an offence page:
<img width="764" alt="Screenshot 2022-09-15 at 15 35 38" src="https://user-images.githubusercontent.com/687910/190432832-ab228eee-8096-462d-a79e-36ec2a783e0c.png">

## How to manually test the feature
Have some offences and go to the summary page, you can then delete them.