### PR TITLE
CRIMAP-72 Offence Date Validations

### DIFF
--- a/app/forms/steps/case/charges_form.rb
+++ b/app/forms/steps/case/charges_form.rb
@@ -5,6 +5,8 @@ module Steps
 
       delegate :offence_dates_attributes=, to: :record
 
+      validates_with ChargesValidator 
+
       def offence_dates
         @offence_dates ||= record.offence_dates.map do |offence_date|
           OffenceDateFieldsetForm.build(

--- a/app/forms/steps/case/charges_form.rb
+++ b/app/forms/steps/case/charges_form.rb
@@ -5,7 +5,7 @@ module Steps
 
       delegate :offence_dates_attributes=, to: :record
 
-      validates_with ChargesValidator 
+      validates_with ChargesValidator
 
       def offence_dates
         @offence_dates ||= record.offence_dates.map do |offence_date|

--- a/app/forms/steps/case/offence_date_fieldset_form.rb
+++ b/app/forms/steps/case/offence_date_fieldset_form.rb
@@ -5,6 +5,8 @@ module Steps
       attribute :id, :string
       attribute :date, :multiparam_date
 
+      validates :date, presence: true, multiparam_date: true
+
       # Needed for `#fields_for` to render the uuids as hidden fields
       def persisted?
         id.present?

--- a/app/validators/charges_validator.rb
+++ b/app/validators/charges_validator.rb
@@ -1,0 +1,42 @@
+class ChargesValidator < ActiveModel::Validator
+  attr_reader :record
+
+  def validate(record)
+    @record = record
+
+    record.offence_dates.each.with_index do |offence_date, index|
+      add_indexed_errors(offence_date, index) unless offence_date.valid?
+    end
+  end
+
+  private
+
+  def add_indexed_errors(offence_date, index)
+    offence_date.errors.each do |error|
+      attr_name = indexed_attribute(index, error.attribute)
+
+      record.errors.add(
+        attr_name,
+        error.type,
+        message: error_message(offence_date, error), index: index + 1
+      )
+
+      # We define the attribute getter as it doesn't really exist
+      record.define_singleton_method(attr_name) do
+        offence_date.public_send(error.attribute)
+      end
+    end
+  end
+
+  def indexed_attribute(index, attr)
+    "offence_dates-attributes[#{index}].#{attr}"
+  end
+
+  # `activemodel.errors.models.steps/case/offence_date_fieldset_form.summary.x.y`
+  def error_message(obj, error)
+    I18n.t(
+      "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",
+      scope: [:activemodel, :errors, :models]
+    )
+  end
+end

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -14,13 +14,30 @@
       <%= f.govuk_text_field :offence_name, autocomplete: 'off' %>
 
       <%= f.fields_for :offence_dates do |od| %>
-        <%= od.govuk_fieldset legend: { text: t('.offence_dates_legend', index: od.index + 1) } do %>
-          <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm' } %>
-          <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
-                       class: %w[govuk-button govuk-button--warning],
-                       data: { module: 'govuk-button' } if @form_object.show_destroy? %>
-          <% end %>
+        <% if od.index.zero? %>
+          <%= od.govuk_fieldset legend: { text: t('.offence_dates_legend', index: od.index + 1), described_by: '#add-or-remove-date' } do %>
+            <div class='govuk-hint'>
+              <%= t('.offence_dates_hint') %>
+            </div>
+            <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm', hidden: true } %>
+            <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
+                         class: %w[govuk-button govuk-button--warning],
+                         data: { module: 'govuk-button' } if @form_object.show_destroy? %>
+            <% end %>
+          <% else %>
+          <%= od.govuk_fieldset legend: { text: '', index: od.index + 1, described_by: '#add-or-remove-date' } do %>
+            <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm', hidden: true } %>
+            <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
+                         class: %w[govuk-button govuk-button--warning],
+                         data: { module: 'govuk-button' } if @form_object.show_destroy? %>
+            <% end %>
         <% end %>
+      <% end %>
+
+      <p id="add-or-remove-date" hidden>
+         <%= t('.offence_date_description')%>
+      </p>
+
       <%= f.button t('.add_button'), type: :submit, name: :add_offence_date,
                    class: %w[govuk-button govuk-button--secondary govuk-!-margin-bottom-8],
                    data: { module: 'govuk-button' } %>

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -10,14 +10,17 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
+
       <%= f.govuk_text_field :offence_name, autocomplete: 'off' %>
 
       <%= f.fields_for :offence_dates do |od| %>
-        <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm' } %>
-        <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
-                     class: %w[govuk-button govuk-button--warning],
-                     data: { module: 'govuk-button' } if @form_object.show_destroy? %>
-      <% end %>
+        <%= od.govuk_fieldset legend: { text: t('.offence_dates_legend', index: od.index + 1) } do %>
+          <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm' } %>
+          <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
+                       class: %w[govuk-button govuk-button--warning],
+                       data: { module: 'govuk-button' } if @form_object.show_destroy? %>
+          <% end %>
+        <% end %>
       <%= f.button t('.add_button'), type: :submit, name: :add_offence_date,
                    class: %w[govuk-button govuk-button--secondary govuk-!-margin-bottom-8],
                    data: { module: 'govuk-button' } %>

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -10,33 +10,25 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-
       <%= f.govuk_text_field :offence_name, autocomplete: 'off' %>
 
-      <%= f.fields_for :offence_dates do |od| %>
-        <% if od.index.zero? %>
-          <%= od.govuk_fieldset legend: { text: t('.offence_dates_legend', index: od.index + 1), described_by: '#add-or-remove-date' } do %>
-            <div class='govuk-hint'>
-              <%= t('.offence_dates_hint') %>
-            </div>
-            <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm', hidden: true } %>
-            <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
-                         class: %w[govuk-button govuk-button--warning],
-                         data: { module: 'govuk-button' } if @form_object.show_destroy? %>
-            <% end %>
-          <% else %>
-          <%= od.govuk_fieldset legend: { text: '', index: od.index + 1, described_by: '#add-or-remove-date' } do %>
-            <%= od.govuk_date_field :date, maxlength_enabled: true, legend: { size: 'm', hidden: true } %>
-            <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
-                         class: %w[govuk-button govuk-button--warning],
-                         data: { module: 'govuk-button' } if @form_object.show_destroy? %>
-            <% end %>
+      <%= f.govuk_fieldset legend: { text: t('.offence_dates_fieldset_legend') } do %>
+        <%= f.fields_for :offence_dates do |od| %>
+          <%= od.govuk_date_field :date, maxlength_enabled: true,
+                                  legend: {
+                                    text: t("helpers.legend.#{f.object_name}.date", index: od.index + 1),
+                                    hidden: true
+                                  },
+                                  hint: {
+                                    text: t("helpers.hint.#{f.object_name}.date"),
+                                    hidden: !od.index.zero?
+                                  } %>
+
+          <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
+                        class: %w[govuk-button govuk-button--warning],
+                        data: { module: 'govuk-button' } if @form_object.show_destroy? %>
         <% end %>
       <% end %>
-
-      <p id="add-or-remove-date" hidden>
-         <%= t('.offence_date_description')%>
-      </p>
 
       <%= f.button t('.add_button'), type: :submit, name: :add_offence_date,
                    class: %w[govuk-button govuk-button--secondary govuk-!-margin-bottom-8],

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -111,3 +111,11 @@ en:
           attributes:
             add_offence:
               inclusion: Select yes if you want to add another offence
+        steps/case/offence_date_fieldset_form:
+          attributes:
+            date:
+              future_not_allowed: Offence date cannot be in the future
+          summary:
+            date:
+              blank: Offence dates cannot be blank
+              future_not_allowed: Offence dates cannot be in the future

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -114,8 +114,19 @@ en:
         steps/case/offence_date_fieldset_form:
           attributes:
             date:
+              blank: Offence date cannot be blank
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date is too far in the past
               future_not_allowed: Offence date cannot be in the future
           summary:
             date:
               blank: Offence dates cannot be blank
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date is too far in the past
               future_not_allowed: Offence dates cannot be in the future

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -26,6 +26,8 @@ en:
         has_codefendants: Does your client have any co-defendants in this case?
       steps_case_codefendants_form:
         conflict_of_interest: Is there a conflict of interest with this co-defendant?
+      steps_case_charges_form:
+        date: Offence date %{index}
       steps_case_charges_summary_form:
         add_offence: Do you want to add another offence?
 
@@ -45,6 +47,7 @@ en:
         urn: For example, ‘12 AB 3456789’.
       steps_case_charges_form:
         offence_name: For example, robbery
+        date: For example, 12 11 2007
 
     label:
       steps_client_has_partner_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -89,11 +89,8 @@ en:
         edit:
           page_title: What has your client been charged with?
           heading: What has your client been charged with?
-          offence_name_legend: Offence name
-          offence_dates_legend: Offence dates
-          offence_dates_hint: For example, 12 11 2007 
-          offence_date_description: Add or remove an offence date
-          add_button: Add another date 
+          offence_dates_fieldset_legend: Offence dates
+          add_button: Add another date
           remove_button: Remove date
         confirm_destroy:
           page_title: Delete offence confirmation

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -90,8 +90,10 @@ en:
           page_title: What has your client been charged with?
           heading: What has your client been charged with?
           offence_name_legend: Offence name
-          offence_dates_legend: Offence date %{index}
-          add_button: Add another date
+          offence_dates_legend: Offence dates
+          offence_dates_hint: For example, 12 11 2007 
+          offence_date_description: Add or remove an offence date
+          add_button: Add another date 
           remove_button: Remove date
         confirm_destroy:
           page_title: Delete offence confirmation

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -90,7 +90,7 @@ en:
           page_title: What has your client been charged with?
           heading: What has your client been charged with?
           offence_name_legend: Offence name
-          offence_date_legend: Offence date %{index}
+          offence_dates_legend: Offence date %{index}
           add_button: Add another date
           remove_button: Remove date
         confirm_destroy:

--- a/spec/forms/steps/case/charges_form_spec.rb
+++ b/spec/forms/steps/case/charges_form_spec.rb
@@ -22,7 +22,28 @@ RSpec.describe Steps::Case::ChargesForm do
   subject { described_class.new(arguments) }
 
   describe 'validations' do
-    # TODO: validations
+    context 'offence dates' do
+      let(:offence_dates_attributes) {
+        {
+         '0'=>{ 'date(3i)'=>'03', 'date(2i)'=>'11', 'date(1i)'=>'3000' },
+         '1'=>{ 'date(3i)'=>'', 'date(2i)'=>'', 'date(1i)'=>'' },
+        }
+      }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'sets the errors with their index' do
+        expect(subject).to_not be_valid
+
+        expect(subject.errors.of_kind?('offence_dates-attributes[0].date', :future_not_allowed)).to eq(true)
+        expect(subject.errors.messages_for('offence_dates-attributes[0].date').first).to eq('Offence dates cannot be in the future')
+
+        expect(subject.errors.of_kind?('offence_dates-attributes[1].date', :blank)).to eq(true)
+        expect(subject.errors.messages_for('offence_dates-attributes[1].date').first).to eq('Offence dates cannot be blank')
+      end
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
## Description of change
Adds validations and fixes the labels and hint text of the offence dates on the charges page 

## Link to relevant ticket
[CRIMAP-72](https://dsdmoj.atlassian.net/browse/CRIMAP-72)

## Notes for reviewer
- you views on accessibility would be appreciated
- note: I haven't removed the blank date initialisation in the cases decision tree in the PR. Can raise another one when we decide the best way to do this.

## Screenshots of changes (if applicable)

### Before changes:
<img width="741" alt="Screenshot 2022-09-21 at 10 09 59" src="https://user-images.githubusercontent.com/13377553/191464510-6333c08d-6c4b-4176-aada-61be004f4c58.png">

### After changes:
<img width="743" alt="Screenshot 2022-09-21 at 10 10 32" src="https://user-images.githubusercontent.com/13377553/191464657-7b802ef4-e036-4446-998c-c027d5a8162e.png">


## How to manually test the feature
- try to submit dates in the future 
- try to submit blank dates

