### PR TITLE
CRIMAP-72 Add .any_marked_for_destruction? to ChargesForm + test

### DIFF
--- a/app/forms/steps/case/charges_form.rb
+++ b/app/forms/steps/case/charges_form.rb
@@ -6,7 +6,7 @@ module Steps
 
       delegate :offence_dates_attributes=, to: :record
 
-      validates_with ChargesValidator
+      validates_with ChargesValidator, unless: :any_marked_for_destruction?
 
       def offence_dates
         @offence_dates ||= record.offence_dates.map do |offence_date|
@@ -14,6 +14,10 @@ module Steps
             offence_date, crime_application:
           )
         end
+      end
+
+      def any_marked_for_destruction?
+        offence_dates.any?(&:_destroy)
       end
 
       def show_destroy?


### PR DESCRIPTION
## Description of change
Allows blank offence dates to be deleted from the Charges page as it makes validations dependant on there not being "_destroy" params in the form attributes sent to the server.


## Link to relevant ticket
[CRIMAP-72](https://dsdmoj.atlassian.net/browse/CRIMAP-72)

## How to manually test the feature
- on Charges page add another date, so there are is a blank date input on the form. Then try to delete this without adding any date into it. The page should reload without the blank date, and not error.