### PR TITLE
CRIMAP-129 Enhancement of offence datalist with JS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,5 +3,9 @@
 @import "local/info_card";
 @import "local/task_list";
 
+// NOTE: suggestions input component not yet part of GOV.UK frontend
+// https://github.com/alphagov/govuk-frontend/pull/2453
+@import "local/suggestions";
+
 // App-specific custom styles and overrides
 @import "local/custom";

--- a/app/assets/stylesheets/local/suggestions.scss
+++ b/app/assets/stylesheets/local/suggestions.scss
@@ -1,0 +1,43 @@
+.govuk-input__suggestions-header {
+  margin-bottom: 0;
+  padding: 5px;
+  @include govuk-font($size: 19, $weight: bold);
+  border-width: $govuk-border-width-form-element $govuk-border-width-form-element 0 $govuk-border-width-form-element;
+  border-style: solid;
+  border-color: currentColor;
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+}
+
+.govuk-input__suggestions-list {
+  max-height: 300px;
+  margin-top: 0;
+  margin-left: 0;
+  padding-left: 0;
+  overflow-y: scroll;
+  list-style-type: none;
+  border-top-width: $govuk-border-width-form-element;
+  border-right-width: $govuk-border-width-form-element;
+  border-bottom-width: $govuk-border-width-form-element;
+  border-left-width: $govuk-border-width-form-element;
+  border-style: solid;
+  border-color: currentColor;
+}
+
+.govuk-input__suggestion {
+  @include govuk-font($size: 19);
+  position: relative;
+  padding: 5px;
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+}
+
+.govuk-input__suggestion:focus {
+  outline: 0;
+  background-color: $govuk-focus-colour;
+}
+
+// [change: new class]
+.govuk-input__suggestion-caption {
+  color: $govuk-secondary-text-colour;
+  display: block;
+}

--- a/app/assets/stylesheets/local/suggestions.scss
+++ b/app/assets/stylesheets/local/suggestions.scss
@@ -29,6 +29,7 @@
   padding: 5px;
   border-bottom: solid #b1b4b6;
   border-width: 1px 0;
+  cursor: default; // [change: added cursor style]
 }
 
 .govuk-input__suggestion:focus {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,14 @@
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
 import { initAll } from 'govuk-frontend'
 initAll()
+
+// NOTE: suggestions input component not yet part of GOV.UK frontend
+// https://github.com/alphagov/govuk-frontend/pull/2453
+import Input from "local/suggestions"
+
+const $inputs = document.querySelectorAll('[data-module="govuk-input"]')
+if ($inputs) {
+  for (let i = 0; i < $inputs.length; i++) {
+    new Input($inputs[i]).init()
+  }
+}

--- a/app/javascript/local/suggestions.js
+++ b/app/javascript/local/suggestions.js
@@ -1,0 +1,220 @@
+// [change: commented out all polyfills imports]
+// import 'govuk-frontend/vendor/polyfills/Function/prototype/bind'
+// addEventListener, event.target normalization and DOMContentLoaded
+// import '../../vendor/polyfills/Event'
+// import '../../vendor/polyfills/Element/prototype/classList'
+
+function Input ($module) {
+  this.$module = $module
+}
+
+Input.prototype.init = function () {
+  this.$formGroup = this.$module.parentNode // .form-group [change: immediate parent]
+
+  var suggestionsSourceId = this.$module.getAttribute('data-suggestions')
+
+  if (suggestionsSourceId) {
+    this.suggestions = document.getElementById(suggestionsSourceId)
+
+    this.$formGroup.setAttribute('role', 'combobox')
+    this.$formGroup.setAttribute('aria-owns', this.$module.getAttribute('id'))
+    this.$formGroup.setAttribute('aria-haspopup', 'listbox')
+    this.$formGroup.setAttribute('aria-expanded', 'false')
+
+    this.$suggestionsHeader = document.createElement('h2')
+    this.$suggestionsHeader.setAttribute('class', 'govuk-input__suggestions-header')
+    this.$suggestionsHeader.textContent = this.$module.getAttribute('data-suggestions-header') || 'Suggestions'
+    this.$suggestionsHeader.hidden = true
+
+    this.$ul = document.createElement('ul')
+    this.$ul.setAttribute('id', this.$module.getAttribute('id') + '-suggestions')
+    this.$ul.addEventListener('click', this.handleSuggestionClicked.bind(this))
+    this.$ul.addEventListener('keydown', this.handleSuggestionsKeyDown.bind(this))
+    this.$ul.hidden = true
+    this.$ul.setAttribute('class', 'govuk-input__suggestions-list')
+    this.$ul.setAttribute('role', 'listbox')
+
+    this.$formGroup.appendChild(this.$suggestionsHeader)
+    this.$formGroup.appendChild(this.$ul)
+
+    this.$module.removeAttribute('list') // [change: deactivate browser-native suggestions]
+    this.$module.setAttribute('aria-autocomplete', 'list')
+    this.$module.setAttribute('aria-controls', this.$module.getAttribute('id') + '-suggestions')
+
+    this.$module.addEventListener('input', this.handleInputInput.bind(this))
+    this.$module.addEventListener('keydown', this.handleInputKeyDown.bind(this))
+  }
+}
+
+// On input, update the options and display the list
+Input.prototype.handleInputInput = function (event) {
+  this.updateSuggestions()
+}
+
+Input.prototype.updateSuggestions = function () {
+  if (this.$module.value.trim().length < 2) {
+    this.hideSuggestions()
+    return
+  }
+
+  // Build an array of regexes that search for each word of the query
+  var queryRegexes = this.$module.value.trim()
+    .replace(/['’]/g, '')
+    .replace(/[.,"/#!$%^&*;:{}=\-_~()]/g, ' ')
+    .split(/\s+/).map(function (word) {
+      return new RegExp('\\b' + word, 'i')
+    })
+
+  var matchingOptions = []
+
+  for (var option of this.suggestions.getElementsByTagName('option')) {
+    var optionTextAndSynonyms = [option.textContent]
+    var synonyms = option.getAttribute('data-synonyms')
+
+    if (synonyms) {
+      optionTextAndSynonyms = optionTextAndSynonyms.concat(synonyms.split('|'))
+    }
+
+    if (
+      (
+        optionTextAndSynonyms.find(function (name) {
+          return (queryRegexes.filter(function (regex) { return name.search(regex) >= 0 }).length === queryRegexes.length)
+        })
+      )
+    ) { matchingOptions.push(option) }
+  }
+
+  if (matchingOptions.length === 0) {
+    this.displayNoSuggestionsFound()
+  } else if (matchingOptions.length === 1 && matchingOptions[0].textContent === this.$module.value.trim()) {
+    this.hideSuggestions()
+  } else {
+    this.updateSuggestionsWithOptions(matchingOptions)
+  }
+}
+
+Input.prototype.updateSuggestionsWithOptions = function (options) {
+  // Remove all the existing suggestions
+  this.$ul.textContent = ''
+
+  for (var option of options) {
+    var li = document.createElement('li')
+    li.textContent = option.textContent
+    li.setAttribute('role', 'option')
+    li.setAttribute('tabindex', '-1')
+    li.setAttribute('aria-selected', option.value === this.$module.value)
+    li.setAttribute('data-value', option.value)
+    li.setAttribute('class', 'govuk-input__suggestion')
+    // li.addEventListener('mouseenter', this.handleMouseEntered.bind(this))
+
+    // [change: support captions]
+    if (option.dataset.caption) {
+      var caption = document.createElement('span')
+      caption.textContent = option.dataset.caption
+      caption.setAttribute('class', 'govuk-input__suggestion-caption')
+      li.append(caption)
+    }
+
+    this.$ul.appendChild(li)
+  }
+
+  this.$ul.hidden = false
+  this.$suggestionsHeader.hidden = false
+  this.$formGroup.setAttribute('aria-expanded', 'true')
+}
+
+Input.prototype.handleSuggestionClicked = function (event) {
+  var suggestionClicked = event.target
+  this.selectSuggestion(suggestionClicked)
+}
+
+Input.prototype.selectSuggestion = function (option) {
+  option.setAttribute('aria-selected', 'true')
+  this.$module.value = option.dataset.value // [change: use `data-value`]
+
+  this.$module.focus()
+  this.hideSuggestions()
+}
+
+// On key down, check if the key pressed an up/down arrow or tab
+Input.prototype.handleInputKeyDown = function (event) {
+  switch (event.keyCode) {
+    // Down
+    case 40:
+      if (this.$ul.hidden !== true) {
+        // Move focus to first option if there are any.
+        if (this.$ul.querySelector('li[role="option"]')) {
+          this.moveFocusToOptions()
+        }
+        event.preventDefault()
+      }
+      break
+    // Up
+    case 38:
+      if (this.$ul.hidden !== true) {
+        // Move focus to last option if there are any.
+        if (this.$ul.querySelector('li[role="option"]')) {
+          this.moveFocusToOptions(false)
+        }
+        event.preventDefault()
+      }
+      break
+    // Tab
+    case 9:
+      this.hideSuggestions()
+      break
+  }
+}
+
+// Note: this has to be triggered on keydown instead of keyup so that if another
+// character is pressed, the focus can be moved to the input before the keyup event
+// is fired, allowing the character to be entered into the input.
+Input.prototype.handleSuggestionsKeyDown = function (event) {
+  var optionSelected
+  switch (event.keyCode) {
+    // Down
+    case 40:
+      optionSelected = this.$ul.querySelector('li:focus')
+      if (optionSelected.nextSibling) {
+        optionSelected.nextSibling.focus()
+      }
+      event.preventDefault()
+      break
+    // Up
+    case 38:
+      optionSelected = this.$ul.querySelector('li:focus')
+      if (optionSelected.previousSibling) {
+        optionSelected.previousSibling.focus()
+      } else {
+        this.$module.focus()
+      }
+      event.preventDefault()
+      break
+    // Enter
+    case 13:
+      optionSelected = this.$ul.querySelector('li:focus')
+      this.selectSuggestion(optionSelected)
+      event.preventDefault()
+      break
+    default:
+      this.$module.focus()
+  }
+}
+
+Input.prototype.moveFocusToOptions = function () {
+  this.$ul.getElementsByTagName('li')[0].focus()
+}
+
+Input.prototype.hideSuggestions = function () {
+  this.$ul.hidden = true
+  this.$suggestionsHeader.hidden = true
+  this.$formGroup.setAttribute('aria-expanded', 'false')
+}
+
+Input.prototype.displayNoSuggestionsFound = function () {
+  this.$ul.hidden = true
+  this.$suggestionsHeader.hidden = true
+  this.$formGroup.setAttribute('aria-expanded', 'false')
+}
+
+export default Input

--- a/app/javascript/local/suggestions.js
+++ b/app/javascript/local/suggestions.js
@@ -125,6 +125,12 @@ Input.prototype.updateSuggestionsWithOptions = function (options) {
 
 Input.prototype.handleSuggestionClicked = function (event) {
   var suggestionClicked = event.target
+
+  // [change: support captions]
+  if (suggestionClicked.tagName !== 'li') {
+    suggestionClicked = suggestionClicked.closest('li')
+  }
+
   this.selectSuggestion(suggestionClicked)
 }
 

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -10,15 +10,17 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :offence_name, label: { size: 'm' },
-                             autocomplete: 'off', list: :offences_list %>
+      <% suggestions_id = f.field_id(:offence_name, :field, :suggestions).tr('_', '-') %>
 
-      <%= tag.datalist(
-            options_from_collection_for_select(
-              Offence.all.presented_map(OffencePresenter), :name, :offence_class
-            ),
-            id: :offences_list
-          ) %>
+      <%= f.govuk_text_field :offence_name, label: { size: 'm' }, autocomplete: 'off',
+                             data: { suggestions: suggestions_id, module: 'govuk-input' },
+                             list: suggestions_id %>
+
+      <datalist id="<%= suggestions_id %>">
+        <% Offence.all.present_each(OffencePresenter) do |o| %>
+          <%= tag.option(o.name, data: { caption: o.offence_class }) %>
+        <% end %>
+      </datalist>
 
       <%= f.govuk_fieldset legend: { text: t('.offence_dates_fieldset_legend') } do %>
         <%= f.fields_for :offence_dates do |od| %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,3 +2,4 @@
 
 pin "application", preload: true
 pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.3.1/govuk-esm/all.mjs"
+pin_all_from "app/javascript/local", under: "local"


### PR DESCRIPTION
## Description of change
Preliminary discovery work and first rough version of the javascript enhancement in the offences `datalist`.

This produces a "suggestions" dropdown, with consistent look and feel across all browsers, when javascript is enabled.

When javascript is disabled the normal "datalist" is shown instead so functionality is not lost.

Fair disclaimers:

- We are piggybacking on a draft PR for an unfinished work, not part of the GOV.UK Frontend yet. And it might not be part of it for a long time, if ever.

- It just doesn't work out of the box. I had to made a few modifications to the javascript.

- Additionally, to show the offence class, I also had to extend the functionality with a `data-caption` feature. This has an impact on the render of the datalist markup too.

- I've marked all this modifications with `[change: xyz]` so it is easy to identify them.

Finally, for the sake of simplification and this initial version, I've removed the "Class Z, Y, Z" from the non-javascript datalist. Keeping it required additional changes to the javascript and I wanted to keep these modifications as light and limited as possible.

Some modifications I'm thinking contributing back to the draft PR.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-129

## Notes for reviewer
I've added disclaimers.

## Screenshots of changes (if applicable)
<img width="721" alt="Screenshot 2022-09-23 at 16 03 26" src="https://user-images.githubusercontent.com/687910/191992090-4594e494-938e-4d0d-9aed-32397586deb8.png">

## How to manually test the feature
Checkout. Recompile assets, if there is any issue clobber and recompile. Go to the offences page and enter 2 or more chars.