### PR TITLE
CRIMAP-129 Enhancement of offence datalist with JS (#115)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,5 +3,9 @@
 @import "local/info_card";
 @import "local/task_list";
 
+// NOTE: suggestions input component not yet part of GOV.UK frontend
+// https://github.com/alphagov/govuk-frontend/pull/2453
+@import "local/suggestions";
+
 // App-specific custom styles and overrides
 @import "local/custom";

--- a/app/assets/stylesheets/local/suggestions.scss
+++ b/app/assets/stylesheets/local/suggestions.scss
@@ -1,0 +1,44 @@
+.govuk-input__suggestions-header {
+  margin-bottom: 0;
+  padding: 5px;
+  @include govuk-font($size: 19, $weight: bold);
+  border-width: $govuk-border-width-form-element $govuk-border-width-form-element 0 $govuk-border-width-form-element;
+  border-style: solid;
+  border-color: currentColor;
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+}
+
+.govuk-input__suggestions-list {
+  max-height: 300px;
+  margin-top: 0;
+  margin-left: 0;
+  padding-left: 0;
+  overflow-y: scroll;
+  list-style-type: none;
+  border-top-width: $govuk-border-width-form-element;
+  border-right-width: $govuk-border-width-form-element;
+  border-bottom-width: $govuk-border-width-form-element;
+  border-left-width: $govuk-border-width-form-element;
+  border-style: solid;
+  border-color: currentColor;
+}
+
+.govuk-input__suggestion {
+  @include govuk-font($size: 19);
+  position: relative;
+  padding: 5px;
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+  cursor: default; // [change: added cursor style]
+}
+
+.govuk-input__suggestion:focus {
+  outline: 0;
+  background-color: $govuk-focus-colour;
+}
+
+// [change: new class]
+.govuk-input__suggestion-caption {
+  color: $govuk-secondary-text-colour;
+  display: block;
+}

--- a/app/controllers/steps/case/date_stamp_controller.rb
+++ b/app/controllers/steps/case/date_stamp_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class DateStampController < Steps::CaseStepController
+      def edit
+        @form_object = DateStampForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(DateStampForm, as: :date_stamp)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/date_stamp_form.rb
+++ b/app/forms/steps/case/date_stamp_form.rb
@@ -1,0 +1,12 @@
+module Steps
+  module Case
+    class DateStampForm < Steps::BaseFormObject
+
+      private
+
+      def persist!
+        # TODO
+      end
+    end
+  end
+end

--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -9,6 +9,12 @@ module FormBuilderHelper
     end
   end
 
+  def inverted_continue_button(primary: :save_and_continue, secondary: :save_and_come_back_later)
+    submit_button(primary, { class: "app-button--m app-button--inverted" }) do
+      submit_button(secondary, secondary: true, name: 'commit_draft') if secondary
+    end
+  end
+
   private
 
   def submit_button(i18n_key, opts = {}, &block)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,14 @@
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
 import { initAll } from 'govuk-frontend'
 initAll()
+
+// NOTE: suggestions input component not yet part of GOV.UK frontend
+// https://github.com/alphagov/govuk-frontend/pull/2453
+import Input from "local/suggestions"
+
+const $inputs = document.querySelectorAll('[data-module="govuk-input"]')
+if ($inputs) {
+  for (let i = 0; i < $inputs.length; i++) {
+    new Input($inputs[i]).init()
+  }
+}

--- a/app/javascript/local/suggestions.js
+++ b/app/javascript/local/suggestions.js
@@ -1,0 +1,226 @@
+// [change: commented out all polyfills imports]
+// import 'govuk-frontend/vendor/polyfills/Function/prototype/bind'
+// addEventListener, event.target normalization and DOMContentLoaded
+// import '../../vendor/polyfills/Event'
+// import '../../vendor/polyfills/Element/prototype/classList'
+
+function Input ($module) {
+  this.$module = $module
+}
+
+Input.prototype.init = function () {
+  this.$formGroup = this.$module.parentNode // .form-group [change: immediate parent]
+
+  var suggestionsSourceId = this.$module.getAttribute('data-suggestions')
+
+  if (suggestionsSourceId) {
+    this.suggestions = document.getElementById(suggestionsSourceId)
+
+    this.$formGroup.setAttribute('role', 'combobox')
+    this.$formGroup.setAttribute('aria-owns', this.$module.getAttribute('id'))
+    this.$formGroup.setAttribute('aria-haspopup', 'listbox')
+    this.$formGroup.setAttribute('aria-expanded', 'false')
+
+    this.$suggestionsHeader = document.createElement('h2')
+    this.$suggestionsHeader.setAttribute('class', 'govuk-input__suggestions-header')
+    this.$suggestionsHeader.textContent = this.$module.getAttribute('data-suggestions-header') || 'Suggestions'
+    this.$suggestionsHeader.hidden = true
+
+    this.$ul = document.createElement('ul')
+    this.$ul.setAttribute('id', this.$module.getAttribute('id') + '-suggestions')
+    this.$ul.addEventListener('click', this.handleSuggestionClicked.bind(this))
+    this.$ul.addEventListener('keydown', this.handleSuggestionsKeyDown.bind(this))
+    this.$ul.hidden = true
+    this.$ul.setAttribute('class', 'govuk-input__suggestions-list')
+    this.$ul.setAttribute('role', 'listbox')
+
+    this.$formGroup.appendChild(this.$suggestionsHeader)
+    this.$formGroup.appendChild(this.$ul)
+
+    this.$module.removeAttribute('list') // [change: deactivate browser-native suggestions]
+    this.$module.setAttribute('aria-autocomplete', 'list')
+    this.$module.setAttribute('aria-controls', this.$module.getAttribute('id') + '-suggestions')
+
+    this.$module.addEventListener('input', this.handleInputInput.bind(this))
+    this.$module.addEventListener('keydown', this.handleInputKeyDown.bind(this))
+  }
+}
+
+// On input, update the options and display the list
+Input.prototype.handleInputInput = function (event) {
+  this.updateSuggestions()
+}
+
+Input.prototype.updateSuggestions = function () {
+  if (this.$module.value.trim().length < 2) {
+    this.hideSuggestions()
+    return
+  }
+
+  // Build an array of regexes that search for each word of the query
+  var queryRegexes = this.$module.value.trim()
+    .replace(/['’]/g, '')
+    .replace(/[.,"/#!$%^&*;:{}=\-_~()]/g, ' ')
+    .split(/\s+/).map(function (word) {
+      return new RegExp('\\b' + word, 'i')
+    })
+
+  var matchingOptions = []
+
+  for (var option of this.suggestions.getElementsByTagName('option')) {
+    var optionTextAndSynonyms = [option.textContent]
+    var synonyms = option.getAttribute('data-synonyms')
+
+    if (synonyms) {
+      optionTextAndSynonyms = optionTextAndSynonyms.concat(synonyms.split('|'))
+    }
+
+    if (
+      (
+        optionTextAndSynonyms.find(function (name) {
+          return (queryRegexes.filter(function (regex) { return name.search(regex) >= 0 }).length === queryRegexes.length)
+        })
+      )
+    ) { matchingOptions.push(option) }
+  }
+
+  if (matchingOptions.length === 0) {
+    this.displayNoSuggestionsFound()
+  } else if (matchingOptions.length === 1 && matchingOptions[0].textContent === this.$module.value.trim()) {
+    this.hideSuggestions()
+  } else {
+    this.updateSuggestionsWithOptions(matchingOptions)
+  }
+}
+
+Input.prototype.updateSuggestionsWithOptions = function (options) {
+  // Remove all the existing suggestions
+  this.$ul.textContent = ''
+
+  for (var option of options) {
+    var li = document.createElement('li')
+    li.textContent = option.textContent
+    li.setAttribute('role', 'option')
+    li.setAttribute('tabindex', '-1')
+    li.setAttribute('aria-selected', option.value === this.$module.value)
+    li.setAttribute('data-value', option.value)
+    li.setAttribute('class', 'govuk-input__suggestion')
+    // li.addEventListener('mouseenter', this.handleMouseEntered.bind(this))
+
+    // [change: support captions]
+    if (option.dataset.caption) {
+      var caption = document.createElement('span')
+      caption.textContent = option.dataset.caption
+      caption.setAttribute('class', 'govuk-input__suggestion-caption')
+      li.append(caption)
+    }
+
+    this.$ul.appendChild(li)
+  }
+
+  this.$ul.hidden = false
+  this.$suggestionsHeader.hidden = false
+  this.$formGroup.setAttribute('aria-expanded', 'true')
+}
+
+Input.prototype.handleSuggestionClicked = function (event) {
+  var suggestionClicked = event.target
+
+  // [change: support captions]
+  if (suggestionClicked.tagName !== 'li') {
+    suggestionClicked = suggestionClicked.closest('li')
+  }
+
+  this.selectSuggestion(suggestionClicked)
+}
+
+Input.prototype.selectSuggestion = function (option) {
+  option.setAttribute('aria-selected', 'true')
+  this.$module.value = option.dataset.value // [change: use `data-value`]
+
+  this.$module.focus()
+  this.hideSuggestions()
+}
+
+// On key down, check if the key pressed an up/down arrow or tab
+Input.prototype.handleInputKeyDown = function (event) {
+  switch (event.keyCode) {
+    // Down
+    case 40:
+      if (this.$ul.hidden !== true) {
+        // Move focus to first option if there are any.
+        if (this.$ul.querySelector('li[role="option"]')) {
+          this.moveFocusToOptions()
+        }
+        event.preventDefault()
+      }
+      break
+    // Up
+    case 38:
+      if (this.$ul.hidden !== true) {
+        // Move focus to last option if there are any.
+        if (this.$ul.querySelector('li[role="option"]')) {
+          this.moveFocusToOptions(false)
+        }
+        event.preventDefault()
+      }
+      break
+    // Tab
+    case 9:
+      this.hideSuggestions()
+      break
+  }
+}
+
+// Note: this has to be triggered on keydown instead of keyup so that if another
+// character is pressed, the focus can be moved to the input before the keyup event
+// is fired, allowing the character to be entered into the input.
+Input.prototype.handleSuggestionsKeyDown = function (event) {
+  var optionSelected
+  switch (event.keyCode) {
+    // Down
+    case 40:
+      optionSelected = this.$ul.querySelector('li:focus')
+      if (optionSelected.nextSibling) {
+        optionSelected.nextSibling.focus()
+      }
+      event.preventDefault()
+      break
+    // Up
+    case 38:
+      optionSelected = this.$ul.querySelector('li:focus')
+      if (optionSelected.previousSibling) {
+        optionSelected.previousSibling.focus()
+      } else {
+        this.$module.focus()
+      }
+      event.preventDefault()
+      break
+    // Enter
+    case 13:
+      optionSelected = this.$ul.querySelector('li:focus')
+      this.selectSuggestion(optionSelected)
+      event.preventDefault()
+      break
+    default:
+      this.$module.focus()
+  }
+}
+
+Input.prototype.moveFocusToOptions = function () {
+  this.$ul.getElementsByTagName('li')[0].focus()
+}
+
+Input.prototype.hideSuggestions = function () {
+  this.$ul.hidden = true
+  this.$suggestionsHeader.hidden = true
+  this.$formGroup.setAttribute('aria-expanded', 'false')
+}
+
+Input.prototype.displayNoSuggestionsFound = function () {
+  this.$ul.hidden = true
+  this.$suggestionsHeader.hidden = true
+  this.$formGroup.setAttribute('aria-expanded', 'false')
+}
+
+export default Input

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -6,7 +6,10 @@ module Decisions
       when :urn
         edit(:case_type)
       when :case_type
-        edit(:has_codefendants)
+       edit(:has_codefendants)
+      when :date_stamp
+       # todo in next PR - redirect to tasklist for now
+       show(:tasklist)
       when :has_codefendants
         after_has_codefendants
       when :add_codefendant

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -10,15 +10,17 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :offence_name, label: { size: 'm' },
-                             autocomplete: 'off', list: :offences_list %>
+      <% suggestions_id = f.field_id(:offence_name, :field, :suggestions).tr('_', '-') %>
 
-      <%= tag.datalist(
-            options_from_collection_for_select(
-              Offence.all.presented_map(OffencePresenter), :name, :offence_class
-            ),
-            id: :offences_list
-          ) %>
+      <%= f.govuk_text_field :offence_name, label: { size: 'm' }, autocomplete: 'off',
+                             data: { suggestions: suggestions_id, module: 'govuk-input' },
+                             list: suggestions_id %>
+
+      <datalist id="<%= suggestions_id %>">
+        <% Offence.all.present_each(OffencePresenter) do |o| %>
+          <%= tag.option(o.name, data: { caption: o.offence_class }) %>
+        <% end %>
+      </datalist>
 
       <%= f.govuk_fieldset legend: { text: t('.offence_dates_fieldset_legend') } do %>
         <%= f.fields_for :offence_dates do |od| %>

--- a/app/views/steps/case/date_stamp/edit.html.erb
+++ b/app/views/steps/case/date_stamp/edit.html.erb
@@ -1,0 +1,12 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row app-inverted--card app-inverted-text">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l app-inverted-text">Your application has been date stamped</h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.inverted_continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,3 +2,4 @@
 
 pin "application", preload: true
 pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.3.1/govuk-esm/all.mjs"
+pin_all_from "app/javascript/local", under: "local"

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -78,6 +78,9 @@ en:
         edit:
           page_title: Enter the case type
           heading:  Enter the case type
+      date_stamp:
+        edit:
+          page_title: Your case has been date stamped
       has_codefendants:
         edit:
           page_title: Does your client have co-defendants?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       namespace :case do
         edit_step :urn
         edit_step :case_type
+        edit_step :date_stamp
         edit_step :has_codefendants
         edit_step :codefendants
         crud_step :charges, param: :charge_id

--- a/spec/controllers/steps/case/date_stamp_controller_spec.rb
+++ b/spec/controllers/steps/case/date_stamp_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::DateStampController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::DateStampForm, Decisions::CaseDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::Case::DateStampForm
+end

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -54,4 +54,47 @@ RSpec.describe FormBuilderHelper, type: :helper do
       end
     end
   end
+
+  describe '#inverted_continue_button' do
+    context 'when there is no secondary action' do
+      let(:expected_markup) {
+        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button app-button--m app-button--inverted" data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>'
+      }
+
+      it 'outputs only the continue button' do
+        expect(
+          builder.inverted_continue_button(secondary: false)
+        ).to eq(expected_markup)
+      end
+    end
+
+    context 'when there is a secondary action' do
+      let(:expected_markup) {
+        '<div class="govuk-button-group"><button type="submit" formnovalidate="formnovalidate" class="govuk-button app-button--m app-button--inverted" data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>' + \
+        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-prevent-double-click="true" name="commit_draft">Save and come back later</button></div>'
+      }
+
+      it 'outputs the continue button together with a save draft button' do
+        expect(
+          builder.inverted_continue_button
+        ).to eq(expected_markup)
+      end
+    end
+
+    context 'button text can be customised' do
+      before do
+        # Ensure we don't rely on specific locales, so we have predictable tests
+        allow(I18n).to receive(:t).with('helpers.submit.find_address').and_return('Find address')
+        allow(I18n).to receive(:t).with('helpers.submit.enter_manually').and_return('Enter address manually')
+      end
+
+      it 'outputs the buttons with specific text' do
+        html = builder.inverted_continue_button(primary: :find_address, secondary: :enter_manually)
+        doc = Nokogiri::HTML.fragment(html)
+
+        assert_select(doc, 'button', attributes: { name: nil }, text: 'Find address' )
+        assert_select(doc, 'button', attributes: { name: 'commit_draft' }, text: 'Enter address manually' )
+      end
+    end
+  end
 end


### PR DESCRIPTION
* CRIMAP-129 Enhancement of offence datalist with JS

Preliminary discovery work and first rough version of the javascript enhancement in the offences `datalist`.

This produces a "suggestions" dropdown, with consistent look and feel across all browsers, when javascript is enabled.

When javascript is disabled the normal "datalist" is shown instead so functionality is not lost.

Fair disclaimers:

- We are piggybacking on a draft PR for an unfinished work, not part of the GOV.UK Frontend yet. And it might not be part of it for a long time, if ever.

- It just doesn't work out of the box. I had to made a few modifications to the javascript.

- Additionally, to show the offence class, I also had to extend the functionality with a `data-caption` feature. This has an impact on the render of the datalist markup too.

- I've marked all this modifications with `[change: xyz]` so it is easy to identify them.

Finally, for the sake of simplification and this initial version, I've removed the "Class Z, Y, Z" from the non-javascript datalist. Keeping it required additional changes to the javascript and I wanted to keep these modifications as light and limited as possible.

Some modifications I'm thinking contributing back to the draft PR.

* Fix for undefined when clicking the offence class

There was a funny intermittent bug where sometimes selecting an offence from the suggestion resulted in an `undefined` offence name in the text input.

The culprit was caused by the introduction of the offence class. If you click the offence class we wouldn't have the attributes of the offence as those are in the `li` element.

This fixes the problem ensuring no matter where you click in the suggestions, we always obtain the `li` element.

## Description of change

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
