### PR TITLE
Adds basic "date stamp" page without any business logic

### DIFF
--- a/app/controllers/steps/case/date_stamp_controller.rb
+++ b/app/controllers/steps/case/date_stamp_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Case
+    class DateStampController < Steps::CaseStepController
+      def show; end
+    end
+  end
+end

--- a/app/views/steps/case/date_stamp/show.html.erb
+++ b/app/views/steps/case/date_stamp/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row app-inverted--card app-inverted-text">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l app-inverted-text">Your application has been date stamped</h1>
+    <h1 class="govuk-heading-l app-inverted-text"><%= t('.heading')%></h1>
 
     <div class="govuk-button-group">
       <%= link_button t('helpers.submit.save_and_continue'), '#', class: 'app-button--m app-button--inverted' %>

--- a/app/views/steps/case/date_stamp/show.html.erb
+++ b/app/views/steps/case/date_stamp/show.html.erb
@@ -6,12 +6,8 @@
     <h1 class="govuk-heading-l app-inverted-text">Your application has been date stamped</h1>
 
     <div class="govuk-button-group">
-      <%= link_to '#',
-                  class: 'govuk-button app-button--m app-button--inverted',
-                  data: { module: 'govuk-button' } do; t('.continue'); end %>
-      <%= link_to '#',
-                  class: 'govuk-button govuk-button--secondary',
-                  data: { module: 'govuk-button' } do; t('.come_back_later'); end %>
+      <%= link_button t('helpers.submit.save_and_continue'), '#', class: 'app-button--m app-button--inverted' %>
+      <%= link_button t('helpers.submit.save_and_come_back_later'), '#', class: 'govuk-button--secondary' %>
     </div>
 
   </div>

--- a/app/views/steps/case/date_stamp/show.html.erb
+++ b/app/views/steps/case/date_stamp/show.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row app-inverted--card app-inverted-text">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l app-inverted-text">Your application has been date stamped</h1>
+
+    <div class="govuk-button-group">
+      <%= link_to '#',
+                  class: 'govuk-button app-button--m app-button--inverted',
+                  data: { module: 'govuk-button' } do; t('.continue'); end %>
+      <%= link_to '#',
+                  class: 'govuk-button govuk-button--secondary',
+                  data: { module: 'govuk-button' } do; t('.come_back_later'); end %>
+    </div>
+
+  </div>
+</div>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -81,6 +81,7 @@ en:
       date_stamp:
         show:
           page_title: Your application has been date stamped
+          heading: Your application has been date stamped
       has_codefendants:
         edit:
           page_title: Does your client have co-defendants?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -78,6 +78,11 @@ en:
         edit:
           page_title: Enter the case type
           heading:  Enter the case type
+      date_stamp:
+        show:
+          page_title: Your application has been date stampled
+          continue: Save and continue
+          come_back_later: Save and come back later
       has_codefendants:
         edit:
           page_title: Does your client have co-defendants?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -80,9 +80,7 @@ en:
           heading:  Enter the case type
       date_stamp:
         show:
-          page_title: Your application has been date stampled
-          continue: Save and continue
-          come_back_later: Save and come back later
+          page_title: Your application has been date stamped
       has_codefendants:
         edit:
           page_title: Does your client have co-defendants?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       namespace :case do
         edit_step :urn
         edit_step :case_type
+        show_step :date_stamp
         edit_step :has_codefendants
         edit_step :codefendants
         crud_step :charges, param: :charge_id


### PR DESCRIPTION
## Description of change

PR adds a basic, essentially static, "date stamp" page. Logic etc. to follow in a future PR.

## Link to relevant ticket
[CRIMAP-49](https://dsdmoj.atlassian.net/browse/CRIMAP-49)

## Screenshots of changes (if applicable)

### Before changes:
n/a - this is a new page

### After changes:
<img width="996" alt="Screenshot 2022-09-27 at 16 25 48" src="https://user-images.githubusercontent.com/13377553/192568612-f61caaae-ecb7-44e9-a259-258a9d499929.png">


## How to manually test the feature
- currently this is "outside" the step flow. you need to hit the URL directly. Also note the buttons don't really do anything at the moment - this will come in a future PR.
- open an application and go to `/case/date_stamp`
