### PR TITLE
CRIMAP-75 Implement basic court hearing step

### DIFF
--- a/app/controllers/steps/case/hearing_details_controller.rb
+++ b/app/controllers/steps/case/hearing_details_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class HearingDetailsController < Steps::CaseStepController
+      def edit
+        @form_object = HearingDetailsForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(HearingDetailsForm, as: :hearing_details)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/hearing_details_form.rb
+++ b/app/forms/steps/case/hearing_details_form.rb
@@ -1,0 +1,23 @@
+module Steps
+  module Case
+    class HearingDetailsForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :case
+
+      attribute :hearing_court_name, :string
+      attribute :hearing_date, :multiparam_date
+
+      validates :hearing_court_name, presence: true
+      validates :hearing_date, presence: true,
+                multiparam_date: { allow_past: false, allow_future: true }
+
+      private
+
+      def persist!
+        kase.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -1,6 +1,6 @@
 module Decisions
   class CaseDecisionTree < BaseDecisionTree
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
     def destination
       case step_name
       when :urn
@@ -23,11 +23,14 @@ module Decisions
         after_delete_offence_date
       when :charges_summary
         after_charges_summary
+      when :hearing_details
+        # TODO: update when we have next step
+        show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
 
     private
 
@@ -62,8 +65,7 @@ module Decisions
     end
 
     def after_charges_summary
-      # TODO: update when we have next step
-      return show('/home', action: :index) if form_object.add_offence.no?
+      return edit(:hearing_details) if form_object.add_offence.no?
 
       edit_new_charge
     end

--- a/app/views/steps/case/hearing_details/edit.html.erb
+++ b/app/views/steps/case/hearing_details/edit.html.erb
@@ -1,0 +1,19 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :hearing_court_name, autocomplete: 'off',
+                             width: 'three-quarters', label: { size: 'm' } %>
+
+      <%= f.govuk_date_field :hearing_date, maxlength_enabled: true %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -134,3 +134,15 @@ en:
               invalid_year: Enter a valid year
               year_too_early: Date is too far in the past
               future_not_allowed: Offence dates cannot be in the future
+        steps/case/hearing_details_form:
+          attributes:
+            hearing_court_name:
+              blank: Enter a court name
+            hearing_date:
+              blank: Date of next hearing cannot be blank
+              invalid: Enter a valid next hearing date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_late: Date of next hearing is too far in the future
+              past_not_allowed: Date of next hearing must be in the future

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -30,6 +30,8 @@ en:
         date: Offence date %{index}
       steps_case_charges_summary_form:
         add_offence: Do you want to add another offence?
+      steps_case_hearing_details_form:
+        hearing_date: Date of next hearing
 
     hint:
       steps_client_has_partner_form:
@@ -48,6 +50,9 @@ en:
       steps_case_charges_form:
         offence_name: For example, robbery
         date: For example, 12 11 2007
+      steps_case_hearing_details_form:
+        hearing_court_name: For example, Cardiff
+        hearing_date: For example, 27 3 2024
 
     label:
       steps_client_has_partner_form:
@@ -96,3 +101,5 @@ en:
         offence_name: Offence name
       steps_case_charges_summary_form:
         add_offence_options: *YESNO
+      steps_case_hearing_details_form:
+        hearing_court_name: Court name

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -116,3 +116,7 @@ en:
         offence_details:
           change_link_html: Change <span class="govuk-visually-hidden">offence</span>
           remove_link_html: Remove <span class="govuk-visually-hidden">offence</span>
+      hearing_details:
+        edit:
+          page_title: Next hearing court details
+          heading: Enter the details of the next court hearing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
         edit_step :codefendants
         crud_step :charges, param: :charge_id
         edit_step :charges_summary
+        edit_step :hearing_details
       end
     end
   end

--- a/db/migrate/20220928100647_add_court_hearing_fields_to_cases.rb
+++ b/db/migrate/20220928100647_add_court_hearing_fields_to_cases.rb
@@ -1,0 +1,6 @@
+class AddCourtHearingFieldsToCases < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :hearing_court_name, :string
+    add_column :cases, :hearing_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_16_151948) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_28_100647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -40,6 +40,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_16_151948) do
     t.string "cc_appeal_fin_change_maat_id"
     t.text "cc_appeal_fin_change_details"
     t.string "has_codefendants"
+    t.string "hearing_court_name"
+    t.date "hearing_date"
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/case/hearing_details_controller_spec.rb
+++ b/spec/controllers/steps/case/hearing_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::HearingDetailsController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::HearingDetailsForm, Decisions::CaseDecisionTree
+end

--- a/spec/forms/steps/case/hearing_details_form_spec.rb
+++ b/spec/forms/steps/case/hearing_details_form_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::HearingDetailsForm do
+  let(:arguments) { {
+    crime_application: crime_application,
+    hearing_court_name: 'Cardiff Court',
+    hearing_date: Date.tomorrow,
+  } }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:hearing_court_name) }
+      it { should validate_presence_of(:hearing_date) }
+    end
+
+    context 'hearing_date' do
+      it_behaves_like 'a multiparam date validation',
+                      attribute_name: :hearing_date,
+                      allow_past: false, allow_future: true
+    end
+
+    context 'when validations pass' do
+      it_behaves_like 'a has-one-association form',
+                      association_name: :case,
+                      expected_attributes: {
+                        'hearing_court_name' => 'Cardiff Court',
+                        'hearing_date' => Date.tomorrow,
+                      }
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and answer is `no`' do
       let(:add_offence) { YesNoAnswer::NO }
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination(:hearing_details, :edit, id: crime_application) }
     end
   end
 
@@ -182,6 +182,15 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:charge) { Charge.new(id: '20') }
       let(:form_object) { double('FormObject', case: kase, record: charge) }
       it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: charge) }
+    end
+  end
+
+  context 'when the step is `hearing_details`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :hearing_details }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
     end
   end
 end


### PR DESCRIPTION
## Description of change
This includes the route, controller, view and form object as well as new required DB attributes on the `cases` table.

Court name input text, does not implement the dropdown or typeahead / suggestions yet. That will be part of a separate task/PR as it requires further research around where this data is coming from or how to "store" it in our application (if we do).

Co-Authored-By: timpeat <tim@timpeat.com>
Co-Authored-By: Chris Gannon <cjgannon@gmail.com>

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-75

## Notes for reviewer
No courts suggestions/typeahead yet. It will be part of a follow-up PR.

## Screenshots of changes (if applicable)
![Screenshot 2022-09-28 at 13 13 38](https://user-images.githubusercontent.com/687910/192775889-7be20a54-4c57-480e-a43c-442f1308c1ab.png)
![Screenshot 2022-09-28 at 13 13 45](https://user-images.githubusercontent.com/687910/192775896-1984968a-dc91-4b1b-a7f9-8ec061413895.png)

## How to manually test the feature
This step comes after the offences "basket".