### PR TITLE
Crimap 138 date stamp logic

### DIFF
--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -16,6 +16,7 @@ module Steps
                 presence: true,
                 if: -> { case_type&.cc_appeal_fin_change? }
 
+
       def choices
         CaseType.values
       end
@@ -23,6 +24,7 @@ module Steps
       private
 
       def persist!
+        DateStamper.new(crime_application, case_type).call
         kase.update(
           attributes.merge(attributes_to_reset)
         )

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -16,7 +16,6 @@ module Steps
                 presence: true,
                 if: -> { case_type&.cc_appeal_fin_change? }
 
-
       def choices
         CaseType.values
       end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -16,8 +16,8 @@ class CrimeApplicationPresenter < BasePresenter
     l(date_of_birth)
   end
 
-  def pretty_date_stamp
-    l(date_stamp)
+  def application_date_stamp
+    l(date_stamp) if case_type&.date_stampable?
   end
 
   def applicant_name
@@ -44,5 +44,11 @@ class CrimeApplicationPresenter < BasePresenter
 
   def tag_classes
     DEFAULT_CLASSES | Array(STATUSES.fetch(status))
+  end
+
+  def case_type
+    return unless self.case&.case_type
+
+    CaseType.new(self.case.case_type)
   end
 end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -16,6 +16,10 @@ class CrimeApplicationPresenter < BasePresenter
     l(date_of_birth)
   end
 
+  def pretty_date_stamp
+    l(date_stamp)
+  end
+
   def applicant_name
     "#{first_name} #{last_name}"
   end

--- a/app/services/date_stamper.rb
+++ b/app/services/date_stamper.rb
@@ -1,17 +1,26 @@
 class DateStamper
+  DATE_STAMPABLE = [
+    :summary_only,
+    :either_way,
+    :committal,
+    :cc_appeal
+  ].freeze
+
   def initialize(crime_app, case_type)
     @crime_app = crime_app
     @case_type = case_type
   end
 
   def call
-    if @case_type.date_stampable? && @crime_app.date_stamp.nil?
+    # TODO: what happens when we already have a date?
+    if date_stampable?
       @crime_app.update(date_stamp: DateTime.now)
-    elsif !@case_type.date_stampable? && @crime_app.date_stamp.present?
-      @crime_app.update(date_stamp: nil)
-      false
-    else
-      false
     end
+  end
+
+  private
+
+  def date_stampable?
+    DATE_STAMPABLE.include?(@case_type.value.to_sym) && @crime_app.date_stamp.nil?
   end
 end

--- a/app/services/date_stamper.rb
+++ b/app/services/date_stamper.rb
@@ -1,28 +1,32 @@
 class DateStamper
-  DATE_STAMPABLE = [
-    :summary_only,
-    :either_way,
-    :committal,
-    :cc_appeal
-  ].freeze
-
   def initialize(crime_app, case_type)
     @crime_app = crime_app
     @case_type = case_type
   end
 
   def call
-    # TODO: what happens when we already have a date?
-    if date_stampable?
+    # TODO: Confirm provisional Date Stamp logic - 30/09/2022
+    # -------------------------------------------------------
+    #
+    # The first time an application is changed to a “date stampable” case type,
+    # a date stamp is added to the application and the use is show the date
+    # stamp page.
+
+    # If after this the use changes the case type to a non “date stampable” case
+    # type, we leave the date stamp in on the application, and then just not
+    # show, or use it (i.e. not show date stamp page + it will be hidden in the
+    # task list).
+
+    # At the point of submission - we can then calculate when if the date stamp
+    # should apply
+    # -- If case type is “date stampable” then we use the date stamp value
+    # -- If case is non “date stampable” we use the submission date as the date
+    #    stamp.
+
+    if @case_type.date_stampable? && @crime_app.date_stamp.nil?
       @crime_app.update(date_stamp: DateTime.now)
     else
       false
     end
-  end
-
-  private
-
-  def date_stampable?
-    DATE_STAMPABLE.include?(@case_type.value.to_sym) && @crime_app.date_stamp.nil?
   end
 end

--- a/app/services/date_stamper.rb
+++ b/app/services/date_stamper.rb
@@ -1,0 +1,17 @@
+class DateStamper
+  def initialize(crime_app, case_type)
+    @crime_app = crime_app
+    @case_type = case_type
+  end
+
+  def call
+    if @case_type.date_stampable? && @crime_app.date_stamp.nil?
+      @crime_app.update(date_stamp: DateTime.now)
+    elsif !@case_type.date_stampable? && @crime_app.date_stamp.present?
+      @crime_app.update(date_stamp: nil)
+      false
+    else
+      false
+    end
+  end
+end

--- a/app/services/date_stamper.rb
+++ b/app/services/date_stamper.rb
@@ -15,6 +15,8 @@ class DateStamper
     # TODO: what happens when we already have a date?
     if date_stampable?
       @crime_app.update(date_stamp: DateTime.now)
+    else
+      false
     end
   end
 

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -34,8 +34,18 @@ module Decisions
 
     private
 
+    # TODO: determine logic on case type and date stamp
+    #   1. Should the date stamp be updated if the case_type changes
+    #      and the date_stamp is already set
+    #   2. What to do with the date_stamp if case_type changes from "stampable"
+    #   3, When should the date stamp page be shown?
+    #
+    # Holding logic:
+    # Do not update date stamp once it has been set.
+    # Only show date_stamp page if stamped today.
+
     def after_case_type
-      if form_object.crime_application.date_stamp.present?
+      if form_object.crime_application.date_stamp == Time.zone.today
         show(:date_stamp)
       else
         edit(:has_codefendants)

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -34,18 +34,11 @@ module Decisions
 
     private
 
-    # TODO: determine logic on case type and date stamp
-    #   1. Should the date stamp be updated if the case_type changes
-    #      and the date_stamp is already set
-    #   2. What to do with the date_stamp if case_type changes from "stampable"
-    #   3, When should the date stamp page be shown?
-    #
-    # Holding logic:
-    # Do not update date stamp once it has been set.
-    # Only show date_stamp page if stamped today.
-
     def after_case_type
-      if form_object.crime_application.date_stamp == Time.zone.today
+      has_date_stamp = form_object.crime_application.date_stamp
+      is_date_stampable = form_object.case_type.date_stampable?
+
+      if is_date_stampable && has_date_stamp
         show(:date_stamp)
       else
         edit(:has_codefendants)

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -35,12 +35,7 @@ module Decisions
     private
 
     def after_case_type
-      date_stamped = DateStamper.new(
-        form_object.crime_application,
-        form_object.case_type
-      ).call
-
-      if date_stamped
+      if form_object.crime_application.date_stamp.present?
         show(:date_stamp)
       else
         edit(:has_codefendants)

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -6,7 +6,7 @@ module Decisions
       when :urn
         edit(:case_type)
       when :case_type
-        edit(:has_codefendants)
+        after_case_type
       when :has_codefendants
         after_has_codefendants
       when :add_codefendant
@@ -33,6 +33,19 @@ module Decisions
     # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
 
     private
+
+    def after_case_type
+      date_stamped = DateStamper.new(
+        form_object.crime_application,
+        form_object.case_type
+      ).call
+
+      if date_stamped
+        show(:date_stamp)
+      else
+        edit(:has_codefendants)
+      end
+    end
 
     def after_has_codefendants
       if form_object.has_codefendants.yes?

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -8,14 +8,4 @@ class CaseType < ValueObject
     CC_APPEAL = new(:cc_appeal),
     CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change)
   ].freeze
-
-  def date_stampable?
-    date_stampable = [
-      :summary_only,
-      :either_way,
-      :committal,
-      :cc_appeal
-    ]
-    date_stampable.include?(value)
-  end
 end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -8,4 +8,14 @@ class CaseType < ValueObject
     CC_APPEAL = new(:cc_appeal),
     CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change)
   ].freeze
+
+  def date_stampable?
+    date_stampable = [
+      :summary_only,
+      :either_way,
+      :committal,
+      :cc_appeal
+    ]
+    date_stampable.include?(value)
+  end
 end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -8,4 +8,15 @@ class CaseType < ValueObject
     CC_APPEAL = new(:cc_appeal),
     CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change)
   ].freeze
+
+  DATE_STAMPABLE = [
+    :summary_only,
+    :either_way,
+    :committal,
+    :cc_appeal
+  ].freeze
+
+  def date_stampable?
+    DATE_STAMPABLE.include?(value)
+  end
 end

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -48,6 +48,15 @@
         <p class="govuk-body">
           <%= @crime_application.applicant_dob %>
         </p>
+
+        <% if @crime_application.date_stamp.present? %>
+          <h3 class="govuk-heading-s">
+            <%= t('.aside.date_stamp') %>
+          </h3>
+          <p class="govuk-body">
+          <%= @crime_application.pretty_date_stamp %>
+          </p>
+        <% end %>
       <% end %>
     </aside>
   </div>

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -49,12 +49,12 @@
           <%= @crime_application.applicant_dob %>
         </p>
 
-        <% if @crime_application.date_stamp.present? %>
+        <% if @crime_application.application_date_stamp %>
           <h3 class="govuk-heading-s">
             <%= t('.aside.date_stamp') %>
           </h3>
           <p class="govuk-body">
-          <%= @crime_application.pretty_date_stamp %>
+            <%= @crime_application.application_date_stamp %>
           </p>
         <% end %>
       <% end %>

--- a/app/views/steps/case/date_stamp/show.html.erb
+++ b/app/views/steps/case/date_stamp/show.html.erb
@@ -6,8 +6,13 @@
     <h1 class="govuk-heading-l app-inverted-text"><%= t('.heading')%></h1>
 
     <div class="govuk-button-group">
-      <%= link_button t('helpers.submit.save_and_continue'), '#', class: 'app-button--m app-button--inverted' %>
-      <%= link_button t('helpers.submit.save_and_come_back_later'), '#', class: 'govuk-button--secondary' %>
+      <%= link_button t('helpers.submit.save_and_continue'),
+                      edit_steps_case_has_codefendants_path(current_crime_application),
+                      class: 'app-button--m app-button--inverted' %>
+
+      <%= link_button t('helpers.submit.save_and_come_back_later'),
+                      edit_crime_application_path(current_crime_application),
+                      class: 'govuk-button--secondary' %>
     </div>
 
   </div>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -26,6 +26,7 @@ en:
         first_name: First name
         last_name: Last name
         date_of_birth: Date of birth
+        date_stamp: Date stamp
     confirm_destroy:
       page_title: Are you sure you want to delete this application?
       heading: "Are you sure you want to delete %{applicant_name}’s application?"

--- a/db/migrate/20220929082638_add_date_stamp_to_crime_application.rb
+++ b/db/migrate/20220929082638_add_date_stamp_to_crime_application.rb
@@ -1,0 +1,5 @@
+class AddDateStampToCrimeApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :date_stamp, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_28_100647) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_29_082638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_28_100647) do
     t.datetime "updated_at", null: false
     t.string "client_has_partner"
     t.string "status"
+    t.datetime "date_stamp"
   end
 
   create_table "offence_dates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/steps/case/date_stamp_controller_spec.rb
+++ b/spec/controllers/steps/case/date_stamp_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::DateStampController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
   } }
 
   let(:crime_application) { 
-    instance_double(CrimeApplication)
+    instance_double(CrimeApplication, update: true, case: Case.new)
   }
 
   let(:case_type) { nil }
@@ -21,7 +21,42 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
   subject { described_class.new(arguments) }
 
+  describe 'date stamping' do
+    let(:crime_application) { 
+      instance_double(
+        CrimeApplication, 
+        update: true, 
+        case: Case.new,
+        date_stamp: nil
+      )
+    }
+
+    before do
+      subject.save
+    end
+
+    context 'when `case_type` is "date stampable"' do
+      let(:case_type) { 'summary_only' }
+
+      it 'date stamps the crime application' do
+        expect(subject).to be_valid
+        expect(crime_application).to have_received(:update)
+      end
+    end
+
+    context 'when `case_type` is not "date stampable"' do
+      let(:case_type) { 'indictable' }
+
+      it 'does not date stamp the crime application' do
+        expect(subject).to be_valid
+        expect(crime_application).to_not have_received(:update)
+      end
+    end
+  end
+
   describe '#save' do
+
+
     context 'when `case_type` is blank' do
       let(:case_type) { '' }
 

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CrimeApplicationPresenter do
                     created_at: DateTime.new(2022, 01, 12),
                     status: 'in_progress',
                     date_stamp: Date.new(2022, 02, 01),
+                    case: Case.new(case_type: CaseType.new(case_type)),
                     applicant: applicant)
   }
 
@@ -20,6 +21,20 @@ RSpec.describe CrimeApplicationPresenter do
       date_of_birth: Date.new(1990, 02, 01),
     )
   }
+
+  let(:case_type) { :indictable }
+
+  describe '#application_date_stamp' do
+    context 'when a case is date stampable' do
+      let(:case_type) { :summary_only }
+      it { expect(subject.application_date_stamp).to eq('1 Feb 2022') }
+    end
+
+    context 'when a case is not date stampable' do
+      let(:case_type) { :indictable }
+      it { expect(subject.application_date_stamp).to be(nil) }
+    end
+  end
 
   describe '#applicant?' do
     context 'when there is an applicant record' do
@@ -41,10 +56,6 @@ RSpec.describe CrimeApplicationPresenter do
 
     it 'can output the applicant date of birth in the correct format' do
       expect(subject.applicant_dob).to eq('1 Feb 1990')
-    end
-
-    it 'can output the applicant date stamp in the correct format' do
-      expect(subject.pretty_date_stamp).to eq('1 Feb 2022')
     end
 
     it 'can output the subject start date in the correct format' do

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CrimeApplicationPresenter do
                     id: 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
                     created_at: DateTime.new(2022, 01, 12),
                     status: 'in_progress',
+                    date_stamp: Date.new(2022, 02, 01),
                     applicant: applicant)
   }
 
@@ -40,6 +41,10 @@ RSpec.describe CrimeApplicationPresenter do
 
     it 'can output the applicant date of birth in the correct format' do
       expect(subject.applicant_dob).to eq('1 Feb 1990')
+    end
+
+    it 'can output the applicant date stamp in the correct format' do
+      expect(subject.pretty_date_stamp).to eq('1 Feb 2022')
     end
 
     it 'can output the subject start date in the correct format' do

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe DateStamper do
-  let(:case_type_sym) { :summary_only }
+  let(:case_type_sym) { described_class::DATE_STAMPABLE.sample }
   let(:date) { DateTime.new(2022, 02, 02) }
   let(:case_type) { CaseType.new(case_type_sym) }
-  let(:crime_app) { 
+  let(:crime_app) {
     instance_double(
       CrimeApplication,
       date_stamp: date
@@ -20,6 +20,7 @@ RSpec.describe DateStamper do
   describe '#call' do
     context 'when case_type is "date stampable" and date_stamp is nil' do
       let(:date) { nil }
+
       it 'it adds a date stamp to the crime app' do
         expect(crime_app).to receive(:update).with({date_stamp: instance_of(DateTime)})
         subject.call
@@ -30,7 +31,7 @@ RSpec.describe DateStamper do
       let(:case_type_sym) { :cc_appeal_fin_change }
 
       it 'resets the the crime applications date stamp' do
-        expect(crime_app).to receive(:update).with({date_stamp: nil})
+        expect(crime_app).not_to receive(:update)
 
         result = subject.call
 
@@ -42,7 +43,7 @@ RSpec.describe DateStamper do
       let(:case_type_sym) { :cc_appeal_fin_change }
 
       it 'does not update the crime applications a date stamp' do
-        expect(crime_app).to receive(:update).with({date_stamp: nil})
+        expect(crime_app).not_to receive(:update)
 
         result = subject.call
 

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe DateStamper do
+  let(:case_type_sym) { :summary_only }
+  let(:date) { DateTime.new(2022, 02, 02) }
+  let(:case_type) { CaseType.new(case_type_sym) }
+  let(:crime_app) { 
+    instance_double(
+      CrimeApplication,
+      date_stamp: date
+    )
+  }
+
+  subject { described_class.new(crime_app, case_type) }
+
+  before do
+    allow(crime_app).to receive(:update)
+  end
+
+  describe '#call' do
+    context 'when case_type is "date stampable" and date_stamp is nil' do
+      let(:date) { nil }
+      it 'it adds a date stamp to the crime app' do
+        expect(crime_app).to receive(:update).with({date_stamp: instance_of(DateTime)})
+        subject.call
+      end
+    end
+
+    context 'when case_type is not "date stampable"' do
+      let(:case_type_sym) { :cc_appeal_fin_change }
+
+      it 'resets the the crime applications date stamp' do
+        expect(crime_app).to receive(:update).with({date_stamp: nil})
+
+        result = subject.call
+
+        expect(result).to be(false)
+      end
+    end
+
+    context 'when case_type is "date stampable" and has already been date stamped' do
+      let(:case_type_sym) { :cc_appeal_fin_change }
+
+      it 'does not update the crime applications a date stamp' do
+        expect(crime_app).to receive(:update).with({date_stamp: nil})
+
+        result = subject.call
+
+        expect(result).to be(false)
+      end
+    end
+
+    context 'when case_type is not "date stampable" and has no date stamped' do
+      let(:case_type_sym) { :cc_appeal_fin_change }
+      let(:date) { nil }
+
+      it 'does not update the crime applications a date stamp' do
+        expect(crime_app).not_to receive(:update)
+
+        result = subject.call
+
+        expect(result).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DateStamper do
-  let(:case_type_sym) { described_class::DATE_STAMPABLE.sample }
+  let(:case_type_sym) { CaseType::DATE_STAMPABLE.sample }
   let(:date) { DateTime.new(2022, 02, 02) }
   let(:case_type) { CaseType.new(case_type_sym) }
   let(:crime_app) {

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Decisions::CaseDecisionTree do
     allow(
       form_object
     ).to receive(:crime_application).and_return(crime_application)
+
+    allow(crime_application).to receive(:update).and_return(true)
+    allow(crime_application).to receive(:date_stamp).and_return(nil)
   end
 
   context 'when the step is `urn`' do
@@ -27,10 +30,24 @@ RSpec.describe Decisions::CaseDecisionTree do
   end
 
   context 'when the step is `case_type`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { 
+      double(
+        'FormObject', 
+        case_type: case_type, 
+        crime_application: crime_application
+      )
+    }
+
     let(:step_name) { :case_type }
 
-    context 'has correct next step' do
+    context 'if "date stampable"' do
+      let(:case_type) { CaseType::SUMMARY_ONLY }
+
+      it { is_expected.to have_destination(:date_stamp, :show, id: crime_application) }
+    end
+
+    context 'if not "date stampable"' do
+      let(:case_type) { CaseType::INDICTABLE }
       it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
     end
   end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -30,19 +30,38 @@ RSpec.describe Decisions::CaseDecisionTree do
   end
 
   context 'when the step is `case_type`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', case_type: CaseType.new(case_type)) }
     let(:step_name) { :case_type }
 
-    context 'if recently date stamped' do
+    context 'and the application has a date stamp' do
       before do
         allow(crime_application).to receive(:date_stamp) { Date.today }
       end
 
-      it { is_expected.to have_destination(:date_stamp, :show, id: crime_application) }
+      context 'and the case type is "date stampable"' do
+        let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+        it { is_expected.to have_destination(:date_stamp, :show, id: crime_application) }
+      end
+
+      context 'and case type is not "date stampable"' do
+        let(:case_type) { :indictable }
+        it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
+      end
     end
 
-    context 'if not recently date stamped' do
-      it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
+    context 'and the application has no date stamp' do
+      before do
+        allow(crime_application).to receive(:date_stamp) { nil }
+      end
+      context 'and the case type is "date stampable"' do
+        let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+        it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
+      end
+
+      context 'and case type is not "date stampable"' do
+        let(:case_type) { :indictable }
+        it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
+      end
     end
   end
 

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -30,24 +30,18 @@ RSpec.describe Decisions::CaseDecisionTree do
   end
 
   context 'when the step is `case_type`' do
-    let(:form_object) { 
-      double(
-        'FormObject', 
-        case_type: case_type, 
-        crime_application: crime_application
-      )
-    }
-
+    let(:form_object) { double('FormObject') }
     let(:step_name) { :case_type }
 
-    context 'if "date stampable"' do
-      let(:case_type) { CaseType::SUMMARY_ONLY }
+    context 'if recently date stamped' do
+      before do
+        allow(crime_application).to receive(:date_stamp) { Date.today }
+      end
 
       it { is_expected.to have_destination(:date_stamp, :show, id: crime_application) }
     end
 
-    context 'if not "date stampable"' do
-      let(:case_type) { CaseType::INDICTABLE }
+    context 'if not recently date stamped' do
       it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
     end
   end
@@ -188,7 +182,7 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:offence_dates) { [ OffenceDate.new(date: '01, 02, 2000') ] }
       let(:charge) { Charge.new(id: '20', offence_dates: offence_dates) }
       let(:form_object) { double('FormObject', case: kase, record: charge) }
-      
+
       it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: charge) }
     end
   end

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -20,4 +20,31 @@ RSpec.describe CaseType do
       )
     end
   end
+
+  describe '#date_stampable?' do
+    context 'for date stampable case types' do
+      it 'returns true' do
+        date_stampable_types = [
+          CaseType.new(:summary_only).date_stampable?,
+          CaseType.new(:either_way).date_stampable?, 
+          CaseType.new(:committal).date_stampable?, 
+          CaseType.new(:cc_appeal).date_stampable?
+        ]
+
+        expect(date_stampable_types).to all(be_truthy)
+      end
+    end
+
+    context 'for non date stampable case types' do
+      it 'returns false' do
+        date_stampable_types = [
+          CaseType.new(:indictable).date_stampable?, 
+          CaseType.new(:already_cc_trial).date_stampable?, 
+          CaseType.new(:cc_appeal_fin_change).date_stampable?
+        ]
+
+        expect(date_stampable_types).to all(be_falsy)
+      end
+    end
+  end
 end

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -20,31 +20,4 @@ RSpec.describe CaseType do
       )
     end
   end
-
-  describe '#date_stampable?' do
-    context 'for date stampable case types' do
-      it 'returns true' do
-        date_stampable_types = [
-          CaseType.new(:summary_only).date_stampable?,
-          CaseType.new(:either_way).date_stampable?, 
-          CaseType.new(:committal).date_stampable?, 
-          CaseType.new(:cc_appeal).date_stampable?
-        ]
-
-        expect(date_stampable_types).to all(be_truthy)
-      end
-    end
-
-    context 'for non date stampable case types' do
-      it 'returns false' do
-        date_stampable_types = [
-          CaseType.new(:indictable).date_stampable?, 
-          CaseType.new(:already_cc_trial).date_stampable?, 
-          CaseType.new(:cc_appeal_fin_change).date_stampable?
-        ]
-
-        expect(date_stampable_types).to all(be_falsy)
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Description of change

Adds date stamp to the CrimeApplication after the CaseType step, and redirects user to see the "date stamp" page if one is added (its dependant on the case type), or moves them on to the "has codefendants" page if not.

## Link to relevant ticket
[CRIMAP-138](https://dsdmoj.atlassian.net/browse/CRIMAP-138)

## Notes for reviewer

- what are your thoughts on the `DateStamper`? I wanted to encapsulate any logic here in a re-usable component. So we thought it was better as a service than as a method in the `CaseDecisionTree`

## Screenshots of changes (if applicable)

### After changes (added date stamp to task list):
<img width="995" alt="Screenshot 2022-09-29 at 11 28 34" src="https://user-images.githubusercontent.com/13377553/193008174-66dd8796-6184-4a6b-93db-31d610f8b15c.png">

## How to manually test the feature
- create a new application, take it through to case type, if you select: "Summary", "Either way", "committal", "Crown Court Appeal" you should see the date stamp page - if you select any other type it should go on to "has co-defendants" page.
