### PR TITLE
Use rubocop for specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-performance
+  - rubocop-rspec
   # Add custom cops for this project below
   - ./lib/rubocop/custom_cops/govuk_formbuilder/text_field_autocomplete.rb
 
@@ -15,7 +16,6 @@ AllCops:
     - 'lib/tasks/**/*'
     - 'lib/generators/**/*'
     - 'features/**/*'
-    - 'spec/**/*'
     - 'vendor/**/*'
 
 ####################################
@@ -42,6 +42,42 @@ Style/TrailingCommaInArrayLiteral:
 
 Layout/HashAlignment:
   Enabled: false
+
+# TODO: fix and enable the following rspec cops
+#
+# CONTEXT: RubocopRspec was enabled part way though this codebase. The
+# following cops have been disabled with a view to enabling them when the
+# issues have been fixed. Ideally starting from the top of this list and
+# working down.
+
+RSpec/SubjectStub:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/BeforeAfterAll:
+  Enabled: false
+
+RSpec/ExpectInHook:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false
+
+
 
 # Enabled but tweaked cops
 ##########################
@@ -72,3 +108,16 @@ Style/HashEachMethods:
 Naming/PredicateName:
   AllowedMethods:
     - has_one_association
+
+# TODO: adjust these values towards the rubcop defaults
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Max: 7
+
+RSpec/NestedGroups:
+  Max: 5
+
+RSpec/ExampleLength:
+  Max: 13

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :test do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.11.1)
+      rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -328,6 +330,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
+  rubocop-rspec
   selenium-webdriver
   sentry-rails
   sentry-ruby

--- a/spec/attributes/type/multiparam_date_spec.rb
+++ b/spec/attributes/type/multiparam_date_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Type::MultiparamDate do
     it 'is registered with type `:multiparam_date`' do
       expect(
         ActiveModel::Type.lookup(:multiparam_date).is_a?(described_class)
-      ).to eq(true)
+      ).to be(true)
     end
 
     it 'has an underlying type of `:date`' do
@@ -19,11 +19,13 @@ RSpec.describe Type::MultiparamDate do
 
   describe 'when value is `nil`' do
     let(:value) { nil }
+
     it { expect(coerced_value).to be_nil }
   end
 
   describe 'when value is already a date' do
     let(:value) { Date.yesterday }
+
     it { expect(coerced_value).to eq(value) }
   end
 
@@ -32,31 +34,37 @@ RSpec.describe Type::MultiparamDate do
 
     context 'and contains all needed parts' do
       let(:value) { { 3 => date.day, 2 => date.month, 1 => date.year } }
+
       it { expect(coerced_value).to eq(date) }
     end
 
     context 'the parts do not represent a valid date (invalid month)' do
       let(:value) { { 3 => date.day, 2 => 13, 1 => date.year } }
+
       it { expect(coerced_value).to eq(value) }
     end
 
     context 'the parts do not represent a valid date (invalid day)' do
       let(:value) { { 3 => 32, 2 => date.month, 1 => date.year } }
+
       it { expect(coerced_value).to eq(value) }
     end
 
     context 'any part is set to zero' do
       let(:value) { { 3 => date.day, 2 => 0, 1 => date.year } }
+
       it { expect(coerced_value).to eq(value) }
     end
 
     context 'any part is set to nil' do
       let(:value) { { 3 => date.day, 2 => date.month, 1 => nil } }
+
       it { expect(coerced_value).to eq(value) }
     end
 
     context 'any part is missing from the hash' do
       let(:value) { { 3 => date.day, 2 => date.month } }
+
       it { expect(coerced_value).to eq(value) }
     end
   end

--- a/spec/attributes/type/stripped_string_spec.rb
+++ b/spec/attributes/type/stripped_string_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Type::StrippedString do
     it 'is registered with type `:string`' do
       expect(
         ActiveModel::Type.lookup(:string).is_a?(described_class)
-      ).to eq(true)
+      ).to be(true)
     end
 
     it 'has an underlying type of `:string`' do
@@ -19,64 +19,76 @@ RSpec.describe Type::StrippedString do
 
   describe 'when value is `nil`' do
     let(:value) { nil }
+
     it { expect(coerced_value).to be_nil }
   end
 
   describe 'when value is a symbol' do
     let(:value) { :foobar }
+
     it { expect(coerced_value).to eq('foobar') }
   end
 
   describe 'when value is numeric' do
     let(:value) { 123 }
+
     it { expect(coerced_value).to eq('123') }
   end
 
   describe 'when value is true' do
     let(:value) { true }
+
     it { expect(coerced_value).to eq('t') }
-    it { expect(coerced_value.frozen?).to eq(true) }
+    it { expect(coerced_value.frozen?).to be(true) }
   end
 
   describe 'when value is false' do
     let(:value) { false }
+
     it { expect(coerced_value).to eq('f') }
-    it { expect(coerced_value.frozen?).to eq(true) }
+    it { expect(coerced_value.frozen?).to be(true) }
   end
 
   describe 'strip spaces from the string value' do
     context 'no lead or trail spaces' do
       let(:value) { 'foobar' }
+
       it { expect(coerced_value).to eq('foobar') }
     end
 
     context 'leading spaces' do
       let(:value) { ' foobar' }
+
       it { expect(coerced_value).to eq('foobar') }
     end
 
     context 'trailing spaces' do
       let(:value) { 'foobar ' }
+
       it { expect(coerced_value).to eq('foobar') }
     end
 
     context 'leading and trailing spaces' do
       let(:value) { ' foobar ' }
+
       it { expect(coerced_value).to eq('foobar') }
     end
 
     context 'more than one leading or trailing spaces' do
       let(:value) { '   foobar   ' }
+
       it { expect(coerced_value).to eq('foobar') }
     end
 
     describe 'intermediate spaces' do
       let(:value) { ' foo bar ' }
+
       it { expect(coerced_value).to eq('foo bar') }
     end
 
     describe 'more than one intermediate spaces' do
       let(:value) { ' foo   bar ' }
+
       it { expect(coerced_value).to eq('foo   bar') }
     end
   end

--- a/spec/attributes/type/value_object_spec.rb
+++ b/spec/attributes/type/value_object_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Type::ValueObject do
     it 'is registered with type `:value_object`' do
       expect(
         ActiveModel::Type.lookup(:value_object).is_a?(described_class)
-      ).to eq(true)
+      ).to be(true)
     end
 
     it 'has an underlying type of `:value_object`' do
@@ -21,21 +21,25 @@ RSpec.describe Type::ValueObject do
 
   describe 'when value is `nil`' do
     let(:value) { nil }
+
     it { expect(coerced_value).to be_nil }
   end
 
   describe 'when value is a symbol' do
     let(:value) { :yes }
+
     it { expect(coerced_value).to eq(YesNoAnswer::YES) }
   end
 
   describe 'when value is a string' do
     let(:value) { 'yes' }
+
     it { expect(coerced_value).to eq(YesNoAnswer::YES) }
   end
 
   describe 'when value is already a value-object' do
     let(:value) { YesNoAnswer::YES }
+
     it { expect(coerced_value).to eq(YesNoAnswer::YES) }
   end
 
@@ -60,7 +64,7 @@ RSpec.describe Type::ValueObject do
       end
 
       it 'considers same type/different source not equal' do
-        expect(type_one).to_not eq(type_three)
+        expect(type_one).not_to eq(type_three)
       end
     end
 
@@ -70,7 +74,7 @@ RSpec.describe Type::ValueObject do
       end
 
       it 'considers same type/different source not equal' do
-        expect(type_one.hash).to_not eq(type_three.hash)
+        expect(type_one.hash).not_to eq(type_three.hash)
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe ApplicationController do
   controller do
-    def invalid_session; raise Errors::InvalidSession; end
-    def application_not_found; raise Errors::ApplicationNotFound; end
-    def another_exception; raise Exception; end
+    def invalid_session = raise(Errors::InvalidSession)
+    def application_not_found = raise(Errors::ApplicationNotFound)
+    def another_exception = raise(StandardError)
   end
 
   context 'Exceptions handling' do
     context 'Errors::InvalidSession' do
-      it 'should not report the exception, and redirect to the error page' do
+      it 'does not report the exception, and redirect to the error page' do
         routes.draw { get 'invalid_session' => 'anonymous#invalid_session' }
 
         expect(Sentry).not_to receive(:capture_exception)
@@ -20,7 +20,7 @@ RSpec.describe ApplicationController do
     end
 
     context 'Errors::ApplicationNotFound' do
-      it 'should not report the exception, and redirect to the error page' do
+      it 'does not report the exception, and redirect to the error page' do
         routes.draw { get 'application_not_found' => 'anonymous#application_not_found' }
 
         expect(Sentry).not_to receive(:capture_exception)
@@ -35,7 +35,7 @@ RSpec.describe ApplicationController do
         allow(Rails.application.config).to receive(:consider_all_requests_local).and_return(false)
       end
 
-      it 'should report the exception, and redirect to the error page' do
+      it 'reports the exception, and redirect to the error page' do
         routes.draw { get 'another_exception' => 'anonymous#another_exception' }
 
         expect(Sentry).to receive(:capture_exception)

--- a/spec/controllers/steps/case/codefendants_controller_spec.rb
+++ b/spec/controllers/steps/case/codefendants_controller_spec.rb
@@ -17,20 +17,20 @@ RSpec.describe Steps::Case::CodefendantsController, type: :controller do
 
       context 'deleting a codefendant' do
         let(:form_class_params_name) { Steps::Case::CodefendantsForm.name.underscore }
-        let(:codefendant_attributes) {
+        let(:codefendant_attributes) do
           {
             codefendants_attributes: {
               '0' => { first_name: 'John', last_name: 'Doe', _destroy: '1', id: '12345' }
             }
           }
-        }
+        end
 
         it 'has the expected step name' do
           expect(
             subject
           ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :delete_codefendant)
 
-          put :update, params: { id: existing_case, form_class_params_name => codefendant_attributes }
+          put :update, params: { :id => existing_case, form_class_params_name => codefendant_attributes }
         end
       end
 

--- a/spec/controllers/steps/dummy_step_controller_spec.rb
+++ b/spec/controllers/steps/dummy_step_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DummyStepController, type: :controller do
 
     before do
       crime_application.update(
-        navigation_stack: navigation_stack
+        navigation_stack:
       )
 
       get :show, params: { id: crime_application }
@@ -48,7 +48,7 @@ RSpec.describe DummyStepController, type: :controller do
     end
 
     context 'when the current page is not on the stack' do
-      let(:navigation_stack) { %w(/foo /bar /baz) }
+      let(:navigation_stack) { %w[/foo /bar /baz] }
 
       it 'adds it to the end of the stack' do
         expect(crime_application.navigation_stack).to eq(navigation_stack + [dummy_step_path])
@@ -57,7 +57,7 @@ RSpec.describe DummyStepController, type: :controller do
   end
 
   describe '#previous_step_path' do
-    let!(:crime_application) { CrimeApplication.create(navigation_stack: navigation_stack) }
+    let!(:crime_application) { CrimeApplication.create(navigation_stack:) }
 
     before do
       get :show, params: { id: crime_application }
@@ -72,7 +72,7 @@ RSpec.describe DummyStepController, type: :controller do
     end
 
     context 'when the stack has elements' do
-      let(:navigation_stack) { %w(/somewhere /over /the /rainbow) }
+      let(:navigation_stack) { %w[/somewhere /over /the /rainbow] }
 
       it 'returns the element before the current page' do
         # Not '/the', as we've performed a page load and thus added '/dummy_page' at the end

--- a/spec/decorators/address_form_decorator_spec.rb
+++ b/spec/decorators/address_form_decorator_spec.rb
@@ -20,11 +20,13 @@ RSpec.describe AddressFormDecorator do
 
       context 'for a home address' do
         let(:address_type) { HomeAddress.to_s }
+
         it { expect(subject.page_title).to eq('.page_title.applicant.home_address') }
       end
 
       context 'for a correspondence address' do
         let(:address_type) { CorrespondenceAddress.to_s }
+
         it { expect(subject.page_title).to eq('.page_title.applicant.correspondence_address') }
       end
     end
@@ -34,11 +36,13 @@ RSpec.describe AddressFormDecorator do
 
       context 'for a home address' do
         let(:address_type) { HomeAddress.to_s }
+
         it { expect(subject.page_title).to eq('.page_title.partner.home_address') }
       end
 
       context 'for a correspondence address' do
         let(:address_type) { CorrespondenceAddress.to_s }
+
         it { expect(subject.page_title).to eq('.page_title.partner.correspondence_address') }
       end
     end
@@ -50,11 +54,13 @@ RSpec.describe AddressFormDecorator do
 
       context 'for a home address' do
         let(:address_type) { HomeAddress.to_s }
+
         it { expect(subject.heading).to eq('.heading.applicant.home_address') }
       end
 
       context 'for a correspondence address' do
         let(:address_type) { CorrespondenceAddress.to_s }
+
         it { expect(subject.heading).to eq('.heading.applicant.correspondence_address') }
       end
     end
@@ -64,11 +70,13 @@ RSpec.describe AddressFormDecorator do
 
       context 'for a home address' do
         let(:address_type) { HomeAddress.to_s }
+
         it { expect(subject.heading).to eq('.heading.partner.home_address') }
       end
 
       context 'for a correspondence address' do
         let(:address_type) { CorrespondenceAddress.to_s }
+
         it { expect(subject.heading).to eq('.heading.partner.correspondence_address') }
       end
     end
@@ -77,12 +85,14 @@ RSpec.describe AddressFormDecorator do
   describe '#home_address?' do
     context 'for a home address' do
       let(:address_record) { HomeAddress.new }
-      it { expect(subject.home_address?).to eq(true) }
+
+      it { expect(subject.home_address?).to be(true) }
     end
 
     context 'for a correspondence address' do
       let(:address_record) { CorrespondenceAddress.new }
-      it { expect(subject.home_address?).to eq(false) }
+
+      it { expect(subject.home_address?).to be(false) }
     end
   end
 
@@ -94,7 +104,7 @@ RSpec.describe AddressFormDecorator do
   end
 
   describe '#addresses' do
-    let(:form_object) { double('FormObject', addresses: addresses) }
+    let(:form_object) { double('FormObject', addresses:) }
 
     context 'when there is only 1 address in the collection' do
       let(:addresses) { [Struct] }

--- a/spec/forms/steps/address/details_form_spec.rb
+++ b/spec/forms/steps/address/details_form_spec.rb
@@ -1,33 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Address::DetailsForm do
-  let(:arguments) {
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
     {
       crime_application: crime_application,
       record: address_record,
     }.merge(address_attrs)
-  }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:address_record) { Address.new }
 
-  let(:address_attrs) { {
-    address_line_one: 'Address line 1',
+  let(:address_attrs) do
+    {
+      address_line_one: 'Address line 1',
     address_line_two: 'Address line 2',
     city: 'City',
     country: 'Country',
     postcode: 'Postcode',
-  } }
-
-  subject { described_class.new(arguments) }
+    }
+  end
 
   describe 'validations' do
-    it { should validate_presence_of(:address_line_one) }
-    it { should validate_presence_of(:city) }
-    it { should validate_presence_of(:country) }
-    it { should validate_presence_of(:postcode) }
+    it { is_expected.to validate_presence_of(:address_line_one) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:country) }
+    it { is_expected.to validate_presence_of(:postcode) }
 
-    it { should_not validate_presence_of(:address_line_two) }
+    it { is_expected.not_to validate_presence_of(:address_line_two) }
   end
 
   describe '#save' do
@@ -45,9 +47,9 @@ RSpec.describe Steps::Address::DetailsForm do
       end
 
       context 'when the address is the same as in the persisted record' do
-        let(:address_record) {
+        let(:address_record) do
           Address.new(address_attrs)
-        }
+        end
 
         it 'does not save the record but returns true' do
           expect(address_record).not_to receive(:update)

--- a/spec/forms/steps/address/lookup_form_spec.rb
+++ b/spec/forms/steps/address/lookup_form_spec.rb
@@ -1,20 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Address::LookupForm do
-  let(:arguments) { {
-    crime_application: crime_application,
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
     record: address_record,
     postcode: postcode,
-  } }
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:address_record) { Address.new }
   let(:postcode) { 'SW1H 9AJ' }
 
-  subject { described_class.new(arguments) }
-
   describe 'validations' do
-    it { should validate_presence_of(:postcode) }
+    it { is_expected.to validate_presence_of(:postcode) }
   end
 
   describe '#save' do
@@ -24,7 +26,7 @@ RSpec.describe Steps::Address::LookupForm do
 
         it 'adds an `invalid` error on the attribute' do
           expect(subject).not_to be_valid
-          expect(subject.errors.added?(:postcode, :invalid)).to eq(true)
+          expect(subject.errors.added?(:postcode, :invalid)).to be(true)
         end
       end
 
@@ -33,7 +35,7 @@ RSpec.describe Steps::Address::LookupForm do
 
         it 'adds an `invalid` error on the attribute' do
           expect(subject).not_to be_valid
-          expect(subject.errors.added?(:postcode, :invalid)).to eq(true)
+          expect(subject.errors.added?(:postcode, :invalid)).to be(true)
         end
       end
     end
@@ -49,11 +51,11 @@ RSpec.describe Steps::Address::LookupForm do
         it 'updates the record' do
           expect(address_record).to receive(:update).with(
             'postcode' => 'SW1H 9AJ',
-            address_line_one: nil,
-            address_line_two: nil,
-            city: nil,
-            country: nil,
-            lookup_id: nil
+            :address_line_one => nil,
+            :address_line_two => nil,
+            :city => nil,
+            :country => nil,
+            :lookup_id => nil
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/forms/steps/address/results_form_spec.rb
+++ b/spec/forms/steps/address/results_form_spec.rb
@@ -1,11 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Address::ResultsForm do
-  let(:arguments) { {
-    crime_application: crime_application,
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
     record: address_record,
     lookup_id: lookup_id,
-  } }
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:address_record) { Address.new(postcode: 'SW1H 0AX') }
@@ -15,8 +19,6 @@ RSpec.describe Steps::Address::ResultsForm do
   let(:lookup_results) { OrdnanceSurvey::AddressLookupResults.call(json_results) }
 
   let(:json_results) { JSON.parse(file_fixture('address_lookups/success.json').read)['results'] }
-
-  subject { described_class.new(arguments) }
 
   before do
     allow(OrdnanceSurvey::AddressLookup).to receive(:new).and_return(lookup_service)
@@ -61,7 +63,7 @@ RSpec.describe Steps::Address::ResultsForm do
 
       it 'adds an `inclusion` error on the attribute' do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:lookup_id, :inclusion)).to eq(true)
+        expect(subject.errors.of_kind?(:lookup_id, :inclusion)).to be(true)
       end
     end
 
@@ -70,7 +72,7 @@ RSpec.describe Steps::Address::ResultsForm do
 
       it 'adds an `inclusion` error on the attribute' do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:lookup_id, :inclusion)).to eq(true)
+        expect(subject.errors.of_kind?(:lookup_id, :inclusion)).to be(true)
       end
     end
   end
@@ -90,7 +92,7 @@ RSpec.describe Steps::Address::ResultsForm do
           city: 'LONDON',
           country: 'UNITED KINGDOM',
           postcode: 'SW1H 0AX',
-          lookup_id: '23749191',
+          lookup_id: '23749191'
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/forms/steps/base_form_object_spec.rb
+++ b/spec/forms/steps/base_form_object_spec.rb
@@ -2,18 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Steps::BaseFormObject do
   describe '.build' do
-    let(:favourite_meal_form) {
+    let(:favourite_meal_form) do
       Class.new(Steps::BaseFormObject) do
         attribute :favourite_meal, :string
       end
-    }
+    end
 
-    let(:foo_bar_record) {
+    let(:foo_bar_record) do
       Class.new(ApplicationRecord) do
         attr_accessor :favourite_meal
-        def self.load_schema!; @columns_hash = {}; end
+
+        def self.load_schema! = @columns_hash = {}
       end
-    }
+    end
 
     before do
       stub_const('FavouriteMealForm', favourite_meal_form)
@@ -22,9 +23,9 @@ RSpec.describe Steps::BaseFormObject do
 
     context 'for an non active record argument' do
       it 'raises an error' do
-        expect {
+        expect do
           FavouriteMealForm.build(:foobar)
-        }.to raise_exception(ArgumentError)
+        end.to raise_exception(ArgumentError)
       end
     end
 
@@ -64,7 +65,7 @@ RSpec.describe Steps::BaseFormObject do
       end
 
       it 'returns false' do
-        expect(subject.save).to eq(false)
+        expect(subject.save).to be(false)
       end
     end
   end
@@ -73,27 +74,27 @@ RSpec.describe Steps::BaseFormObject do
     context 'when raising exceptions' do
       it {
         expect(subject).to receive(:persist!).and_raise(NoMethodError)
-        expect(subject.save!).to eq(false)
+        expect(subject.save!).to be(false)
       }
     end
 
     context 'when there are no exceptions' do
       it {
         expect(subject).to receive(:persist!).and_return(true)
-        expect(subject.save!).to eq(true)
+        expect(subject.save!).to be(true)
       }
     end
   end
 
   describe '#persisted?' do
     it 'always returns false' do
-      expect(subject.persisted?).to eq(false)
+      expect(subject.persisted?).to be(false)
     end
   end
 
   describe '#new_record?' do
     it 'always returns true' do
-      expect(subject.new_record?).to eq(true)
+      expect(subject.new_record?).to be(true)
     end
   end
 

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -1,36 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::CaseTypeForm do
+  subject(:form) { described_class.new(arguments) }
 
-  let(:arguments) { {
-    crime_application: crime_application,
-    case_type: case_type,
-    cc_appeal_maat_id: cc_appeal_maat_id,
-    cc_appeal_fin_change_maat_id: cc_appeal_fin_change_maat_id,
-    cc_appeal_fin_change_details: cc_appeal_fin_change_details
-  } }
+  let(:arguments) do
+    {
+      crime_application:,
+    case_type:,
+    cc_appeal_maat_id:,
+    cc_appeal_fin_change_maat_id:,
+    cc_appeal_fin_change_details:
+    }
+  end
 
-  let(:crime_application) {
+  let(:crime_application) do
     instance_double(CrimeApplication, date_stamp: nil, case: kase)
-  }
+  end
 
   let(:kase) { Case.new }
-
   let(:case_type) { nil }
   let(:cc_appeal_maat_id) { nil }
   let(:cc_appeal_fin_change_maat_id) { nil }
   let(:cc_appeal_fin_change_details) { nil }
 
-  subject { described_class.new(arguments) }
-
   describe '#save' do
     describe 'date stamping' do
       let(:kase) { instance_double(Case) }
 
-      after { subject.save }
+      after { form.save }
 
       context 'when case is valid' do
-        before { expect(kase).to receive(:update) { true } }
+        before { expect(kase).to receive(:update).and_return(true) }
 
         context 'and `case_type` is "date stampable"' do
           let(:case_type) { 'summary_only' }
@@ -50,7 +50,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
       end
 
       context 'when case_type is not valid' do
-        before { expect(kase).to receive(:update) { false } }
+        before { expect(kase).to receive(:update).and_return(false) }
 
         context 'and `case_type` is "date stampable"' do
           let(:case_type) { 'summary_only' }
@@ -66,8 +66,8 @@ RSpec.describe Steps::Case::CaseTypeForm do
       let(:case_type) { '' }
 
       it 'has is a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:case_type, :inclusion)).to eq(true)
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:case_type, :inclusion)).to be(true)
       end
     end
 
@@ -75,93 +75,104 @@ RSpec.describe Steps::Case::CaseTypeForm do
       let(:case_type) { 'invalid_type' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:case_type, :inclusion)).to eq(true)
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:case_type, :inclusion)).to be(true)
       end
     end
 
     context 'when `case_type` is valid' do
       let(:case_type) { 'indictable' }
+
+      it { is_expected.to be_valid }
+
       it 'passes validation' do
-        expect(subject).to be_valid
-        expect(subject.errors.of_kind?(:case_type, :invalid)).to eq(false)
+        expect(form.errors.of_kind?(:case_type, :invalid)).to be(false)
       end
 
-      context 'non-appeal case type' do
+      context 'when non-appeal case type' do
         context 'with a previous MAAT ID' do
           let(:cc_appeal_maat_id) { '123456' }
           let(:cc_appeal_fin_change_maat_id) { '234567' }
+
+          it { is_expected.to be_valid }
+
           it 'can make MAAT ID fields nil if case types do not require them' do
-            attributes = subject.send(:attributes_to_reset)
-            expect(subject).to be_valid
-            expect(attributes['cc_appeal_maat_id']).to be(nil)
-            expect(attributes['cc_appeal_fin_change_maat_id']).to be(nil)
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['cc_appeal_maat_id']).to be_nil
+            expect(attributes['cc_appeal_fin_change_maat_id']).to be_nil
           end
         end
 
         context 'with details of a change of financial circumstances' do
           let(:cc_appeal_fin_change_details) { 'These are the details' }
+
           it 'can financial change details nil if case type doesnt require it' do
-            attributes = subject.send(:attributes_to_reset)
-            expect(subject).to be_valid
-            expect(attributes['cc_appeal_fin_change_details']).to be(nil)
+            attributes = form.send(:attributes_to_reset)
+            expect(form).to be_valid
+            expect(attributes['cc_appeal_fin_change_details']).to be_nil
           end
         end
       end
 
-      context 'Appeal to crown court' do
+      context 'when Appeal to crown court' do
         context 'with a previous MAAT ID' do
           let(:case_type) { 'cc_appeal' }
           let(:cc_appeal_maat_id) { '123456' }
+
           it 'is valid' do
-            expect(subject).to be_valid
+            expect(form).to be_valid
             expect(
-              subject.errors.of_kind?(
+              form.errors.of_kind?(
                 :cc_appeal_maat_id,
-                :present)
-            ).to eq(false)
+                :present
+              )
+            ).to be(false)
           end
 
           it 'cannot reset MAAT IDs as the are relevant to this case type' do
-            attributes = subject.send(:attributes_to_reset)
+            attributes = form.send(:attributes_to_reset)
             expect(attributes['cc_appeal_maat_id']).to eq(cc_appeal_maat_id)
           end
         end
 
         context 'without a previous MAAT ID' do
           let(:case_type) { 'cc_appeal' }
+
           it 'is also valid' do
-            expect(subject).to be_valid
+            expect(form).to be_valid
             expect(
-              subject.errors.of_kind?(
+              form.errors.of_kind?(
                 :cc_appeal_maat_id,
-                :present)
-            ).to eq(false)
+                :present
+              )
+            ).to be(false)
           end
         end
       end
 
-      context 'Appeal to crown court with changes in financial circumstances' do
+      context 'when Appeal to crown court with changes in financial circumstances' do
         context 'with details of what has changed' do
           let(:case_type) { 'cc_appeal_fin_change' }
           let(:cc_appeal_fin_change_maat_id) { '123456' }
           let(:cc_appeal_fin_change_details) { 'These are the details' }
+
           it 'is valid' do
-            expect(subject).to be_valid
+            expect(form).to be_valid
             expect(
-              subject.errors.of_kind?(
+              form.errors.of_kind?(
                 :cc_appeal_fin_change_details,
-                :present)
-            ).to eq(false)
+                :present
+              )
+            ).to be(false)
           end
 
           it 'cannot reset MAAT IDs as the are relevant to this case type' do
-            attributes = subject.send(:attributes_to_reset)
+            attributes = form.send(:attributes_to_reset)
             expect(attributes['cc_appeal_fin_change_maat_id']).to eq(cc_appeal_fin_change_maat_id)
           end
 
           it 'cannot reset change details as the are relevant to this case type' do
-            attributes = subject.send(:attributes_to_reset)
+            attributes = form.send(:attributes_to_reset)
             expect(attributes['cc_appeal_fin_change_details']).to eq(cc_appeal_fin_change_details)
           end
         end
@@ -169,21 +180,24 @@ RSpec.describe Steps::Case::CaseTypeForm do
         context 'with no details of what has changed' do
           let(:case_type) { 'cc_appeal_fin_change' }
           let(:cc_appeal_maat_id) { '123456' }
+
           it 'is invalid' do
-            expect(subject).to_not be_valid
+            expect(form).not_to be_valid
             expect(
-              subject.errors.of_kind?(
+              form.errors.of_kind?(
                 :cc_appeal_fin_change_details,
-                :blank)
-            ).to eq(true)
+                :blank
+              )
+            ).to be(true)
           end
         end
       end
     end
 
     context 'when validations pass' do
-        let(:case_type) { 'indictable' }
-        it_behaves_like 'a has-one-association form',
+      let(:case_type) { 'indictable' }
+
+      it_behaves_like 'a has-one-association form',
                       association_name: :case,
                       expected_attributes: {
                         'case_type' => CaseType::INDICTABLE,

--- a/spec/forms/steps/case/charges_form_spec.rb
+++ b/spec/forms/steps/case/charges_form_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Steps::Case::ChargesForm do
 
         let(:offence_dates) do
           [
-            OffenceDate.new(date: Date.new(2000, 11, 0o3)),
-            OffenceDate.new(date: Date.new(2009, 0o5, 0o1))
+            OffenceDate.new(date: Date.new(2000, 11, 3)),
+            OffenceDate.new(date: Date.new(2009, 5, 1))
           ]
         end
 

--- a/spec/forms/steps/case/charges_summary_form_spec.rb
+++ b/spec/forms/steps/case/charges_summary_form_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::ChargesSummaryForm do
-  let(:arguments) { {
-    crime_application: crime_application,
-    add_offence: add_offence
-  } }
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+    add_offence:
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:add_offence) { nil }
-
-  subject { described_class.new(arguments) }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -26,8 +28,8 @@ RSpec.describe Steps::Case::ChargesSummaryForm do
       end
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:add_offence, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:add_offence, :inclusion)).to be(true)
       end
     end
 
@@ -39,8 +41,8 @@ RSpec.describe Steps::Case::ChargesSummaryForm do
       end
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:add_offence, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:add_offence, :inclusion)).to be(true)
       end
     end
 

--- a/spec/forms/steps/case/codefendant_fieldset_form_spec.rb
+++ b/spec/forms/steps/case/codefendant_fieldset_form_spec.rb
@@ -1,19 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::CodefendantFieldsetForm do
-  let(:arguments) { {
-    crime_application: crime_application,
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
     id: record_id,
     first_name: 'John',
     last_name: 'Doe',
     conflict_of_interest: conflict_of_interest,
-  } }
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:record_id) { '12345' }
   let(:conflict_of_interest) { nil }
-
-  subject { described_class.new(arguments) }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -25,23 +27,24 @@ RSpec.describe Steps::Case::CodefendantFieldsetForm do
 
   describe '#persisted?' do
     context 'when the record has an ID' do
-      it { expect(subject.persisted?).to eq(true) }
+      it { expect(subject.persisted?).to be(true) }
     end
 
     context 'when the record has no ID' do
       let(:record_id) { nil }
-      it { expect(subject.persisted?).to eq(false) }
+
+      it { expect(subject.persisted?).to be(false) }
     end
   end
 
   context 'validations' do
-    it { should validate_presence_of(:first_name) }
-    it { should validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
 
     context 'when `conflict_of_interest` is not provided' do
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:conflict_of_interest, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:conflict_of_interest, :inclusion)).to be(true)
       end
     end
 
@@ -49,8 +52,8 @@ RSpec.describe Steps::Case::CodefendantFieldsetForm do
       let(:conflict_of_interest) { 'maybe' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:conflict_of_interest, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:conflict_of_interest, :inclusion)).to be(true)
       end
     end
 

--- a/spec/forms/steps/case/codefendants_form_spec.rb
+++ b/spec/forms/steps/case/codefendants_form_spec.rb
@@ -1,22 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::CodefendantsForm do
-  let(:arguments) { {
-    crime_application: crime_application,
-    codefendants_attributes: codefendants_attributes,
-  } }
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+    codefendants_attributes:,
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication, case: case_record) }
   let(:case_record) { Case.new }
 
-  let(:codefendants_attributes) {
+  let(:codefendants_attributes) do
     {
-      "0"=>{"first_name"=>"John", "last_name"=>"Doe", "conflict_of_interest"=>"no"},
-      "1"=>{"first_name"=>"Jane", "last_name"=>"Doe", "conflict_of_interest"=>"yes"},
+      '0' => { 'first_name' => 'John', 'last_name' => 'Doe', 'conflict_of_interest' => 'no' },
+      '1' => { 'first_name' => 'Jane', 'last_name' => 'Doe', 'conflict_of_interest' => 'yes' },
     }
-  }
-
-  subject { described_class.new(arguments) }
+  end
 
   describe '#codefendants' do
     context 'there are no codefendants' do
@@ -51,61 +53,71 @@ RSpec.describe Steps::Case::CodefendantsForm do
       let(:case_record) { Case.create(crime_application: application) }
       let(:codefendant) { Codefendant.create(case: case_record, first_name: 'John', last_name: 'Doe') }
 
-      let(:codefendants_attributes) {
+      let(:codefendants_attributes) do
         {
           '0' => codefendant.slice(:first_name, :last_name, :id).merge(_destroy: '1'),
           '1' => { first_name: 'Jane', last_name: 'Doe' },
         }
-      }
+      end
 
       it 'returns true' do
-        expect(subject.any_marked_for_destruction?).to eq(true)
+        expect(subject.any_marked_for_destruction?).to be(true)
 
-        expect(subject.codefendants[0]._destroy).to eq(true)
-        expect(subject.codefendants[1]._destroy).to eq(false)
+        expect(subject.codefendants[0]._destroy).to be(true)
+        expect(subject.codefendants[1]._destroy).to be(false)
       end
     end
 
     context 'there are no records to be destroyed' do
-      it { expect(subject.any_marked_for_destruction?).to eq(false) }
+      it { expect(subject.any_marked_for_destruction?).to be(false) }
     end
   end
 
   describe '#show_destroy?' do
     context 'there is only 1 codefendant' do
-      let(:codefendants_attributes) { { "0"=>{"first_name"=>"John", "last_name"=>"Doe"} } }
-      it { expect(subject.show_destroy?).to eq(false) }
+      let(:codefendants_attributes) { { '0' => { 'first_name' => 'John', 'last_name' => 'Doe' } } }
+
+      it { expect(subject.show_destroy?).to be(false) }
     end
 
     context 'there are more than 1 codefendant' do
-      it { expect(subject.show_destroy?).to eq(true) }
+      it { expect(subject.show_destroy?).to be(true) }
     end
   end
 
   describe '#save' do
     context 'when there are errors in any of the codefendants' do
-      let(:codefendants_attributes) {
+      let(:codefendants_attributes) do
         {
-          "0"=>{"first_name"=>"John", "last_name"=>"", "conflict_of_interest"=>""},
-          "1"=>{"first_name"=>"", "last_name"=>"Doe", "conflict_of_interest"=>"yes"},
+          '0' => { 'first_name' => 'John', 'last_name' => '', 'conflict_of_interest' => '' },
+          '1' => { 'first_name' => '', 'last_name' => 'Doe', 'conflict_of_interest' => 'yes' },
         }
-      }
+      end
 
       it 'returns false' do
         expect(subject.save).to be(false)
       end
 
       it 'sets the errors with their index' do
-        expect(subject).to_not be_valid
+        expect(subject).not_to be_valid
 
-        expect(subject.errors.of_kind?('codefendants-attributes[0].last_name', :blank)).to eq(true)
-        expect(subject.errors.messages_for('codefendants-attributes[0].last_name').first).to eq('Enter last name of co-defendant 1')
+        expect(subject.errors.of_kind?('codefendants-attributes[0].last_name', :blank)).to be(true)
 
-        expect(subject.errors.of_kind?('codefendants-attributes[0].conflict_of_interest', :inclusion)).to eq(true)
-        expect(subject.errors.messages_for('codefendants-attributes[0].conflict_of_interest').first).to eq('Select yes if there is a conflict of interest with co-defendant 1')
+        expect(subject.errors.messages_for('codefendants-attributes[0].last_name').first).to eq(
+          'Enter last name of co-defendant 1'
+        )
 
-        expect(subject.errors.of_kind?('codefendants-attributes[1].first_name', :blank)).to eq(true)
-        expect(subject.errors.messages_for('codefendants-attributes[1].first_name').first).to eq('Enter first name of co-defendant 2')
+        expect(subject.errors.of_kind?('codefendants-attributes[0].conflict_of_interest', :inclusion)).to be(true)
+
+        expect(subject.errors.messages_for('codefendants-attributes[0].conflict_of_interest').first).to eq(
+          'Select yes if there is a conflict of interest with co-defendant 1'
+        )
+
+        expect(subject.errors.of_kind?('codefendants-attributes[1].first_name', :blank)).to be(true)
+
+        expect(subject.errors.messages_for('codefendants-attributes[1].first_name').first).to eq(
+          'Enter first name of co-defendant 2'
+        )
       end
 
       context 'but we are deleting a codefendant' do

--- a/spec/forms/steps/case/has_codefendants_form_spec.rb
+++ b/spec/forms/steps/case/has_codefendants_form_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::HasCodefendantsForm do
-  let(:arguments) { {
-    crime_application: crime_application,
-    has_codefendants: has_codefendants
-  } }
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+    has_codefendants:
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
   let(:has_codefendants) { nil }
-
-  subject { described_class.new(arguments) }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -26,8 +28,8 @@ RSpec.describe Steps::Case::HasCodefendantsForm do
       end
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:has_codefendants, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:has_codefendants, :inclusion)).to be(true)
       end
     end
 
@@ -39,8 +41,8 @@ RSpec.describe Steps::Case::HasCodefendantsForm do
       end
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:has_codefendants, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:has_codefendants, :inclusion)).to be(true)
       end
     end
 
@@ -62,7 +64,7 @@ RSpec.describe Steps::Case::HasCodefendantsForm do
                         association_name: :case,
                         expected_attributes: {
                           'has_codefendants' => YesNoAnswer::NO,
-                          codefendants: [],
+                          :codefendants => [],
                         }
       end
     end

--- a/spec/forms/steps/case/hearing_details_form_spec.rb
+++ b/spec/forms/steps/case/hearing_details_form_spec.rb
@@ -1,20 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::HearingDetailsForm do
-  let(:arguments) { {
-    crime_application: crime_application,
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
     hearing_court_name: 'Cardiff Court',
     hearing_date: Date.tomorrow,
-  } }
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
-  subject { described_class.new(arguments) }
-
   describe '#save' do
     context 'validations' do
-      it { should validate_presence_of(:hearing_court_name) }
-      it { should validate_presence_of(:hearing_date) }
+      it { is_expected.to validate_presence_of(:hearing_court_name) }
+      it { is_expected.to validate_presence_of(:hearing_date) }
     end
 
     context 'hearing_date' do

--- a/spec/forms/steps/case/offence_date_fieldset_form_spec.rb
+++ b/spec/forms/steps/case/offence_date_fieldset_form_spec.rb
@@ -1,31 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::OffenceDateFieldsetForm do
-  let(:arguments) { {
-    crime_application: crime_application,
-    record: OffenceDate.new(date: "02, 07, 2020"),
-    id: record_id
-  } }
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
+      record: OffenceDate.new(date: '02, 07, 2020'),
+      id: record_id
+    }
+  end
 
   let(:record_id) { '123456' }
   let(:crime_application) { instance_double(CrimeApplication) }
 
-  subject { described_class.new(arguments) }
-
-  describe 'validations' do
-    # TODO: validations
-  end
+  # TODO: validations
 
   describe '#persisted?' do
     context 'when form has an id' do
-      it 'it returns true' do
+      it 'returns true' do
         expect(subject.persisted?).to be(true)
       end
     end
 
     context 'when form has no id' do
       let(:record_id) { nil }
-      it 'it returns false' do
+
+      it 'returns false' do
         expect(subject.persisted?).to be(false)
       end
     end

--- a/spec/forms/steps/case/urn_form_spec.rb
+++ b/spec/forms/steps/case/urn_form_spec.rb
@@ -1,19 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Case::UrnForm do
+  subject { described_class.new(arguments) }
 
-  let(:arguments) { {
-    crime_application: crime_application,
-    urn: urn
-  } }
+  let(:arguments) do
+    {
+      crime_application:,
+    urn:
+    }
+  end
 
-  let(:crime_application) { 
+  let(:crime_application) do
     instance_double(CrimeApplication)
-  }
+  end
 
   let(:urn) { nil }
-
-  subject { described_class.new(arguments) }
 
   describe '#save' do
     context 'when `urn` is blank' do
@@ -21,7 +22,7 @@ RSpec.describe Steps::Case::UrnForm do
 
       it 'has no validation error on the field' do
         expect(subject).to be_valid
-        expect(subject.errors.of_kind?(:urn, :invalid)).to eq(false)
+        expect(subject.errors.of_kind?(:urn, :invalid)).to be(false)
       end
     end
 
@@ -29,18 +30,20 @@ RSpec.describe Steps::Case::UrnForm do
       let(:urn) { 'not a urn' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:urn, :invalid)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:urn, :invalid)).to be(true)
       end
     end
 
     context 'when `urn` is valid' do
       context 'with spaces between numbers' do
         let(:urn) { '12 AB 34 56 78 9' }
+
         it 'passes validation' do
           expect(subject).to be_valid
-          expect(subject.errors.of_kind?(:urn, :invalid)).to eq(false)
+          expect(subject.errors.of_kind?(:urn, :invalid)).to be(false)
         end
+
         it 'removes spaces from input' do
           expect(subject.urn).to eq('12AB3456789')
         end
@@ -48,15 +51,17 @@ RSpec.describe Steps::Case::UrnForm do
 
       context 'with trailing spaces' do
         let(:urn) { ' 12 AB 34 56789 ' }
+
         it 'passed validation' do
           expect(subject).to be_valid
-          expect(subject.errors.of_kind?(:urn, :invalid)).to eq(false)
+          expect(subject.errors.of_kind?(:urn, :invalid)).to be(false)
         end
       end
     end
 
     context 'when validations pass' do
       let(:urn) { '12AB3456789' }
+
       it_behaves_like 'a has-one-association form',
                       association_name: :case,
                       expected_attributes: {

--- a/spec/forms/steps/client/contact_details_form_spec.rb
+++ b/spec/forms/steps/client/contact_details_form_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::ContactDetailsForm do
-  let(:arguments) { {
-    crime_application: crime_application,
-    telephone_number: telephone_number,
-    correspondence_address_type: correspondence_address_type
-  } }
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+    telephone_number:,
+    correspondence_address_type:
+    }
+  end
+  let(:applicant_double) { instance_double(Applicant) }
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
   let(:telephone_number) { nil }
   let(:correspondence_address_type) { nil }
   let(:has_home_address) { true }
-
-  subject { described_class.new(arguments) }
-
-  let(:applicant_double) { instance_double(Applicant) }
 
   before do
     allow(subject).to receive(:applicant).and_return(applicant_double)
@@ -25,20 +26,24 @@ RSpec.describe Steps::Client::ContactDetailsForm do
   describe '#choices' do
     context 'when applicant has home address' do
       let(:has_home_address) { true }
+
       it 'returns all correspondence address types' do
         expect(subject.choices.map(&:value)).to match(
-          [:home_address, 
+          [:home_address,
            :providers_office_address,
-           :other_address])
+           :other_address]
+        )
       end
     end
 
     context 'when applicant has no home address' do
       let(:has_home_address) { false }
+
       it 'returns all correspondence address types' do
         expect(subject.choices.map(&:value)).to match(
-           [:providers_office_address, 
-           :other_address])
+          [:providers_office_address,
+           :other_address]
+        )
       end
     end
   end
@@ -49,8 +54,8 @@ RSpec.describe Steps::Client::ContactDetailsForm do
       let(:correspondence_address_type) { 'home_address' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:telephone_number, :blank)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:telephone_number, :blank)).to be(true)
       end
     end
 
@@ -59,8 +64,8 @@ RSpec.describe Steps::Client::ContactDetailsForm do
       let(:correspondence_address_type) { 'other_address' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:telephone_number, :invalid)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:telephone_number, :invalid)).to be(true)
       end
     end
 
@@ -78,8 +83,8 @@ RSpec.describe Steps::Client::ContactDetailsForm do
       let(:correspondence_address_type) { '' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:correspondence_address_type, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:correspondence_address_type, :inclusion)).to be(true)
       end
     end
 
@@ -88,8 +93,8 @@ RSpec.describe Steps::Client::ContactDetailsForm do
       let(:correspondence_address_type) { 'university_address' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:correspondence_address_type, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:correspondence_address_type, :inclusion)).to be(true)
       end
     end
   end
@@ -108,7 +113,7 @@ RSpec.describe Steps::Client::ContactDetailsForm do
     it_behaves_like 'a has-one-association form',
                     association_name: :applicant,
                     expected_attributes: {
-                      'telephone_number' => "07000000000",
+                      'telephone_number' => '07000000000',
                       'correspondence_address_type' => CorrespondenceType::OTHER_ADDRESS
                     }
   end

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -1,24 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::DetailsForm do
-  let(:arguments) { {
-    crime_application: crime_application,
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
     first_name: 'John',
     last_name: 'Doe',
     other_names: nil,
     date_of_birth: Date.yesterday,
-  } }
+    }
+  end
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
-  subject { described_class.new(arguments) }
-
   describe '#save' do
     context 'validations' do
-      it { should validate_presence_of(:first_name) }
-      it { should validate_presence_of(:last_name) }
-      it { should validate_presence_of(:date_of_birth) }
-      it { should_not validate_presence_of(:other_names) }
+      it { is_expected.to validate_presence_of(:first_name) }
+      it { is_expected.to validate_presence_of(:last_name) }
+      it { is_expected.to validate_presence_of(:date_of_birth) }
+      it { is_expected.not_to validate_presence_of(:other_names) }
     end
 
     context 'date_of_birth' do

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -1,29 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::HasNinoForm do
-  # Note: not using shared examples for form objects yet, to be added
+  # NOTE: not using shared examples for form objects yet, to be added
   # once we have some more form objects and some patterns emerge
 
-  let(:arguments) { {
-    crime_application: crime_application,
-    nino: nino
-  } }
+  subject { described_class.new(arguments) }
 
-  let(:crime_application) { 
+  let(:arguments) do
+    {
+      crime_application:,
+    nino:
+    }
+  end
+
+  let(:crime_application) do
     instance_double(CrimeApplication)
-  }
+  end
 
   let(:nino) { nil }
-
-  subject { described_class.new(arguments) }
 
   describe '#save' do
     context 'when `nino` is blank' do
       let(:nino) { '' }
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
       end
     end
 
@@ -32,8 +34,8 @@ RSpec.describe Steps::Client::HasNinoForm do
         let(:nino) { 'not a NINO' }
 
         it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
         end
       end
 
@@ -41,8 +43,8 @@ RSpec.describe Steps::Client::HasNinoForm do
         let(:nino) { 'BG123456C' }
 
         it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(true)
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
         end
       end
     end
@@ -50,29 +52,34 @@ RSpec.describe Steps::Client::HasNinoForm do
     context 'when `nino` is valid' do
       context 'with spaces between numbers' do
         let(:nino) { 'AB 12 34 56 C' }
+
         it 'passes validation' do
           expect(subject).to be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(false)
+          expect(subject.errors.of_kind?(:nino, :invalid)).to be(false)
         end
+
         it 'removes spaces from input' do
           expect(subject.nino).to eq('AB123456C')
         end
       end
+
       context 'with trailing spaces' do
         let(:nino) { ' AB 1234 56C ' }
+
         it 'passed validation' do
           expect(subject).to be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to eq(false)
+          expect(subject.errors.of_kind?(:nino, :invalid)).to be(false)
         end
       end
     end
 
     context 'when validations pass' do
       let(:nino) { 'AB123456C' }
+
       it_behaves_like 'a has-one-association form',
                       association_name: :applicant,
                       expected_attributes: {
-                        'nino' => "AB123456C"
+                        'nino' => 'AB123456C'
                       }
     end
   end

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -1,18 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::HasPartnerForm do
-  # Note: not using shared examples for form objects yet, to be added
+  # NOTE: not using shared examples for form objects yet, to be added
   # once we have some more form objects and some patterns emerge
 
-  let(:arguments) { {
-    crime_application: crime_application,
-    client_has_partner: client_has_partner,
-  } }
-
-  let(:crime_application) { instance_double(CrimeApplication, client_has_partner: client_has_partner) }
-  let(:client_has_partner) { nil }
-
   subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+    client_has_partner:,
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, client_has_partner:) }
+  let(:client_has_partner) { nil }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -29,8 +31,8 @@ RSpec.describe Steps::Client::HasPartnerForm do
       end
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:client_has_partner, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:client_has_partner, :inclusion)).to be(true)
       end
     end
 
@@ -42,8 +44,8 @@ RSpec.describe Steps::Client::HasPartnerForm do
       end
 
       it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.of_kind?(:client_has_partner, :inclusion)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:client_has_partner, :inclusion)).to be(true)
       end
     end
 
@@ -52,7 +54,7 @@ RSpec.describe Steps::Client::HasPartnerForm do
 
       it 'saves the record' do
         expect(crime_application).to receive(:update).with(
-          'client_has_partner' => YesNoAnswer::YES,
+          'client_has_partner' => YesNoAnswer::YES
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'for a blank value' do
       let(:value) { '' }
+
       it { expect(title).to eq('Apply for criminal legal aid - GOV.UK') }
     end
 
     context 'for a provided value' do
       let(:value) { 'Test page' }
+
       it { expect(title).to eq('Test page - Apply for criminal legal aid - GOV.UK') }
     end
   end
@@ -30,7 +32,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       ).to receive(:consider_all_requests_local).and_return(false)
     end
 
-    it 'should call #title with a blank value' do
+    it 'calls #title with a blank value' do
       expect(helper).to receive(:title).with('')
       helper.fallback_title
     end

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe FormBuilderHelper, type: :helper do
 
   describe '#continue_button' do
     context 'when there is no secondary action' do
-      let(:expected_markup) {
-        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>'
-      }
+      let(:expected_markup) do
+        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button" ' \
+          'data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>'
+      end
 
       it 'outputs only the continue button' do
         expect(
@@ -26,10 +27,14 @@ RSpec.describe FormBuilderHelper, type: :helper do
     end
 
     context 'when there is a secondary action' do
-      let(:expected_markup) {
-        '<div class="govuk-button-group"><button type="submit" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>' + \
-        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-prevent-double-click="true" name="commit_draft">Save and come back later</button></div>'
-      }
+      let(:expected_markup) do
+        '<div class="govuk-button-group">' \
+          '<button type="submit" formnovalidate="formnovalidate" class="govuk-button" ' \
+          'data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>' \
+          '<button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--secondary" ' \
+          'data-module="govuk-button" data-prevent-double-click="true" name="commit_draft">' \
+          'Save and come back later</button></div>'
+      end
 
       it 'outputs the continue button together with a save draft button' do
         expect(
@@ -49,8 +54,8 @@ RSpec.describe FormBuilderHelper, type: :helper do
         html = builder.continue_button(primary: :find_address, secondary: :enter_manually)
         doc = Nokogiri::HTML.fragment(html)
 
-        assert_select(doc, 'button', attributes: { name: nil }, text: 'Find address' )
-        assert_select(doc, 'button', attributes: { name: 'commit_draft' }, text: 'Enter address manually' )
+        assert_select(doc, 'button', attributes: { name: nil }, text: 'Find address')
+        assert_select(doc, 'button', attributes: { name: 'commit_draft' }, text: 'Enter address manually')
       end
     end
   end

--- a/spec/helpers/steps_helper_spec.rb
+++ b/spec/helpers/steps_helper_spec.rb
@@ -2,29 +2,29 @@ require 'rails_helper'
 
 RSpec.describe StepsHelper, type: :helper do
   describe '#step_form' do
-    let(:foo_bar_record) {
+    let(:foo_bar_record) do
       Class.new(ApplicationRecord) do
-        def self.load_schema!; @columns_hash = {}; end
+        def self.load_schema! = @columns_hash = {}
       end
-    }
-
-    before do
-      stub_const('FooBarRecord', foo_bar_record)
     end
-
-    let(:expected_defaults) { {
-      url: {
-        controller: 'steps',
-        action: :update
-      },
+    let(:expected_defaults) do
+      {
+        url: {
+          controller: 'steps',
+          action: :update
+        },
       html: {
         class: 'edit_foo_bar_record'
       },
       method: :put
-    } }
-
-    let(:form_block) { Proc.new {} }
+      }
+    end
+    let(:form_block) { proc {} }
     let(:record) { foo_bar_record.new }
+
+    before do
+      stub_const('FooBarRecord', foo_bar_record)
+    end
 
     it 'acts like FormHelper#form_for with additional defaults' do
       expect(helper).to receive(:form_for).with(record, expected_defaults) do |*_args, &block|
@@ -39,14 +39,15 @@ RSpec.describe StepsHelper, type: :helper do
     end
 
     it 'appends optional css classes if provided' do
-      expect(helper).to receive(:form_for).with(record, expected_defaults.merge(html: {class: %w(test edit_foo_bar_record)}))
+      expect(helper).to receive(:form_for).with(record,
+                                                expected_defaults.merge(html: { class: %w[test edit_foo_bar_record] }))
       helper.step_form(record, html: { class: 'test' })
     end
   end
 
   describe '#step_header' do
-    let(:current_crime_application) { instance_double(CrimeApplication, navigation_stack: navigation_stack) }
-    let(:navigation_stack) { %w(/step1 /step2 /step3) }
+    let(:current_crime_application) { instance_double(CrimeApplication, navigation_stack:) }
+    let(:navigation_stack) { %w[/step1 /step2 /step3] }
 
     before do
       allow(view).to receive(:current_crime_application).and_return(current_crime_application)
@@ -55,7 +56,7 @@ RSpec.describe StepsHelper, type: :helper do
     context 'there is a previous path in the stack' do
       it 'renders the back link to the previous path' do
         helper.step_header
-        expect(view.content_for(:back_link)).to match(/<a class="govuk-back-link" href="\/step2">Back<\/a>/)
+        expect(view.content_for(:back_link)).to match(%r{<a class="govuk-back-link" href="/step2">Back</a>})
       end
     end
 
@@ -64,14 +65,14 @@ RSpec.describe StepsHelper, type: :helper do
 
       it 'renders the back link to the root path as fallback' do
         helper.step_header
-        expect(view.content_for(:back_link)).to match(/<a class="govuk-back-link" href="\/">Back<\/a>/)
+        expect(view.content_for(:back_link)).to match(%r{<a class="govuk-back-link" href="/">Back</a>})
       end
     end
 
     context 'a specific path is provided' do
       it 'renders the back link with the provided path' do
         helper.step_header(path: '/another/step')
-        expect(view.content_for(:back_link)).to match(/<a class="govuk-back-link" href="\/another\/step">Back<\/a>/)
+        expect(view.content_for(:back_link)).to match(%r{<a class="govuk-back-link" href="/another/step">Back</a>})
       end
     end
   end
@@ -106,7 +107,11 @@ RSpec.describe StepsHelper, type: :helper do
         expect(
           helper.govuk_error_summary(form_object)
         ).to eq(
-          '<div class="govuk-error-summary" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title"><h2 id="error-summary-title" class="govuk-error-summary__title">There is a problem on this page</h2><div class="govuk-error-summary__body"><ul class="govuk-list govuk-error-summary__list"><li><a data-turbo="false" href="#steps-base-form-object-base-field-error">can&#39;t be blank</a></li></ul></div></div>'
+          '<div class="govuk-error-summary" role="alert" data-module="govuk-error-summary" ' \
+          'aria-labelledby="error-summary-title"><h2 id="error-summary-title" class="govuk-error-summary__title">' \
+          'There is a problem on this page</h2><div class="govuk-error-summary__body">' \
+          '<ul class="govuk-list govuk-error-summary__list"><li><a data-turbo="false" ' \
+          'href="#steps-base-form-object-base-field-error">can&#39;t be blank</a></li></ul></div></div>'
         )
       end
 
@@ -121,13 +126,19 @@ RSpec.describe StepsHelper, type: :helper do
     it 'builds the link markup styled as a button' do
       expect(
         helper.link_button('Continue', root_path)
-      ).to eq('<a class="govuk-button" role="button" draggable="false" data-module="govuk-button" href="/">Continue</a>')
+      ).to eq(
+        '<a class="govuk-button" role="button" draggable="false" data-module="govuk-button" href="/">Continue</a>'
+      )
     end
 
     it 'appends to the default attributes where possible, otherwise overwrite them' do
       expect(
-        helper.link_button('Continue', root_path, class: 'ga-pageLink', draggable: true, data: { module: 'govuk-button', ga_category: 'category', ga_label: 'label' })
-      ).to eq('<a class="govuk-button ga-pageLink" role="button" draggable="true" data-module="govuk-button" data-ga-category="category" data-ga-label="label" href="/">Continue</a>')
+        helper.link_button('Continue', root_path, class: 'ga-pageLink', draggable: true,
+data: { module: 'govuk-button', ga_category: 'category', ga_label: 'label' })
+      ).to eq(
+        '<a class="govuk-button ga-pageLink" role="button" draggable="true" data-module="govuk-button" ' \
+        'data-ga-category="category" data-ga-label="label" href="/">Continue</a>'
+      )
     end
   end
 end

--- a/spec/lib/feature_flags_spec.rb
+++ b/spec/lib/feature_flags_spec.rb
@@ -23,25 +23,27 @@ describe FeatureFlags do
   describe '#enabled?' do
     context 'test environment on local host' do
       it 'is enabled' do
-        expect(FeatureFlags.enabled_foobar_feature.enabled?).to be true
-        expect(FeatureFlags.enabled_foobar_feature.disabled?).to be false
+        expect(described_class.enabled_foobar_feature.enabled?).to be true
+        expect(described_class.enabled_foobar_feature.disabled?).to be false
       end
+
       it 'is disabled' do
-        expect(FeatureFlags.disabled_foobar_feature.enabled?).to be false
-        expect(FeatureFlags.disabled_foobar_feature.disabled?).to be true
+        expect(described_class.disabled_foobar_feature.enabled?).to be false
+        expect(described_class.disabled_foobar_feature.disabled?).to be true
       end
     end
 
     context 'development environment on local host' do
       before do
-        allow(Rails).to receive(:env).and_return('development'.inquiry)
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
       end
 
       it 'is enabled' do
-        expect(FeatureFlags.enabled_foobar_feature.enabled?).to be true
+        expect(described_class.enabled_foobar_feature.enabled?).to be true
       end
+
       it 'is disabled' do
-        expect(FeatureFlags.disabled_foobar_feature.enabled?).to be false
+        expect(described_class.disabled_foobar_feature.enabled?).to be false
       end
     end
 
@@ -51,10 +53,11 @@ describe FeatureFlags do
       end
 
       it 'is enabled' do
-        expect(FeatureFlags.enabled_foobar_feature.enabled?).to be true
+        expect(described_class.enabled_foobar_feature.enabled?).to be true
       end
+
       it 'is disabled' do
-        expect(FeatureFlags.disabled_foobar_feature.enabled?).to be false
+        expect(described_class.disabled_foobar_feature.enabled?).to be false
       end
     end
   end
@@ -62,23 +65,23 @@ describe FeatureFlags do
   describe 'handling of method_missing' do
     context 'a feature defined in the config' do
       it 'responds true' do
-        expect(FeatureFlags.respond_to?(:enabled_foobar_feature)).to be true
+        expect(described_class.respond_to?(:enabled_foobar_feature)).to be true
       end
     end
 
     context 'a method defined on the superclass' do
       it 'responds true' do
-        expect(FeatureFlags.respond_to?(:object_id)).to be true
+        expect(described_class.respond_to?(:object_id)).to be true
       end
     end
 
     context 'unknown method' do
       it 'responds false' do
-        expect(FeatureFlags.respond_to?(:not_a_real_feature)).to be false
+        expect(described_class.respond_to?(:not_a_real_feature)).to be false
       end
 
       it 'raises an exception' do
-        expect { FeatureFlags.not_a_real_feature }.to raise_exception(NoMethodError)
+        expect { described_class.not_a_real_feature }.to raise_exception(NoMethodError)
       end
     end
   end

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -9,19 +9,19 @@ describe HostEnv do
 
       describe 'HostEnv.staging?' do
         it 'returns false' do
-          expect(HostEnv.staging?).to be false
+          expect(described_class.staging?).to be false
         end
       end
 
       describe 'HostEnv.production?' do
         it 'returns false' do
-          expect(HostEnv.production?).to be false
+          expect(described_class.production?).to be false
         end
       end
 
       describe '.local?' do
         it 'returns true' do
-          expect(HostEnv.local?).to be true
+          expect(described_class.local?).to be true
         end
       end
     end
@@ -29,19 +29,19 @@ describe HostEnv do
     context 'local test rails environment' do
       describe 'HostEnv.staging?' do
         it 'returns false' do
-          expect(HostEnv.staging?).to be false
+          expect(described_class.staging?).to be false
         end
       end
 
       describe '.production?' do
         it 'returns true' do
-          expect(HostEnv.production?).to be false
+          expect(described_class.production?).to be false
         end
       end
 
       describe '.local?' do
         it 'returns true' do
-          expect(HostEnv.local?).to be true
+          expect(described_class.local?).to be true
         end
       end
     end
@@ -49,44 +49,44 @@ describe HostEnv do
 
   describe 'ENV_NAME variable is set in production envs' do
     before do
-      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
       allow(ENV).to receive(:fetch).with('ENV_NAME').and_return(env_name)
     end
 
     context 'staging host' do
       let(:env_name) { HostEnv::STAGING }
 
-      it { expect(HostEnv.local?).to eq(false) }
-      it { expect(HostEnv.staging?).to eq(true) }
-      it { expect(HostEnv.production?).to eq(false) }
+      it { expect(described_class.local?).to be(false) }
+      it { expect(described_class.staging?).to be(true) }
+      it { expect(described_class.production?).to be(false) }
     end
 
     context 'production host' do
       let(:env_name) { HostEnv::PRODUCTION }
 
-      it { expect(HostEnv.local?).to eq(false) }
-      it { expect(HostEnv.staging?).to eq(false) }
-      it { expect(HostEnv.production?).to eq(true) }
+      it { expect(described_class.local?).to be(false) }
+      it { expect(described_class.staging?).to be(false) }
+      it { expect(described_class.production?).to be(true) }
     end
 
     context 'unknown host' do
       let(:env_name) { 'foobar' }
 
-      it { expect(HostEnv.local?).to eq(false) }
-      it { expect(HostEnv.staging?).to eq(false) }
-      it { expect(HostEnv.production?).to eq(false) }
+      it { expect(described_class.local?).to be(false) }
+      it { expect(described_class.staging?).to be(false) }
+      it { expect(described_class.production?).to be(false) }
     end
   end
 
   describe 'when is a production env and the ENV_NAME variable is not set' do
     before do
-      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
     end
 
     it 'raises an exception so we are fully aware' do
-      expect {
-        HostEnv.production?
-      }.to raise_exception(KeyError)
+      expect do
+        described_class.production?
+      end.to raise_exception(KeyError)
     end
   end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Case, type: :model do
   subject { described_class.new(attributes) }
+
   let(:attributes) { {} }
 
   describe '`charges` relationship' do
-    let(:crime_application) { CrimeApplication.create }
-
-    subject(:charges) {
+    subject(:charges) do
       described_class.create(
-        crime_application: crime_application
+        crime_application:
       ).charges
-    }
+    end
+
+    let(:crime_application) { CrimeApplication.create }
 
     it 'initialises a blank `offence_date` when building charges' do
       expect(
@@ -20,15 +21,15 @@ RSpec.describe Case, type: :model do
     end
 
     it 'initialises a blank `offence_date` when adding charges' do
-      expect {
+      expect do
         charges << Charge.new
-      }.to change { OffenceDate.count }.by(1)
+      end.to change(OffenceDate, :count).by(1)
     end
 
     it 'initialises a blank `offence_date` when creating charges' do
-      expect {
+      expect do
         charges.create
-      }.to change { OffenceDate.count }.by(1)
+      end.to change(OffenceDate, :count).by(1)
     end
   end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Charge, type: :model do
   subject { described_class.new(attributes) }
-  let(:attributes) {
-    { offence_name: offence_name }
-  }
+
+  let(:attributes) do
+    { offence_name: }
+  end
 
   let(:offence_name) { nil }
 
@@ -18,11 +19,13 @@ RSpec.describe Charge, type: :model do
 
     context 'for an unknown offence' do
       let(:offence_name) { 'Foobar offence' }
+
       it { expect(subject.offence).to be_nil }
     end
 
     context 'for a blank offence' do
       let(:offence_name) { '' }
+
       it { expect(subject.offence).to be_nil }
     end
   end

--- a/spec/models/codefendant_spec.rb
+++ b/spec/models/codefendant_spec.rb
@@ -1,6 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Codefendant, type: :model do
-  subject { described_class.new(attributes) }
-  let(:attributes) { {} }
-end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CrimeApplication, type: :model do
   subject { described_class.new(attributes) }
+
   let(:attributes) { {} }
 
   describe 'status enum' do
@@ -10,7 +11,7 @@ RSpec.describe CrimeApplication, type: :model do
         described_class.statuses
       ).to eq(
         'in_progress' => 'in_progress',
-        'submitted' => 'submitted',
+        'submitted' => 'submitted'
       )
     end
   end

--- a/spec/models/offence_date_spec.rb
+++ b/spec/models/offence_date_spec.rb
@@ -1,6 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe OffenceDate, type: :model do
-  subject { described_class.new(attributes) }
-  let(:attributes) { {} }
-end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Offence, type: :model do
 
     context 'when no offence is found' do
       subject { described_class.find_by(code: 'XYZ123') }
+
       it { is_expected.to be_nil }
     end
   end
@@ -34,7 +35,7 @@ RSpec.describe Offence, type: :model do
   describe '.find_by_name' do
     it 'is shorthand for `.find_by`' do
       expect(described_class).to receive(:find_by).with(name: 'Foobar')
-      described_class.find_by_name('Foobar')
+      described_class.find_by(name: 'Foobar')
     end
   end
 
@@ -63,7 +64,7 @@ RSpec.describe Offence, type: :model do
       end
 
       it 'considers same type/different row not equal' do
-        expect(offence_one).to_not eq(offence_three)
+        expect(offence_one).not_to eq(offence_three)
       end
     end
 
@@ -73,7 +74,7 @@ RSpec.describe Offence, type: :model do
       end
 
       it 'considers same type/different row not equal' do
-        expect(offence_one.hash).to_not eq(offence_three.hash)
+        expect(offence_one.hash).not_to eq(offence_three.hash)
       end
     end
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,19 +3,21 @@ require 'rails_helper'
 RSpec.describe Person, type: :model do
   subject { described_class.new(attributes) }
 
-  let(:attributes) { {
-    first_name: 'Joe',
+  let(:attributes) do
+    {
+      first_name: 'Joe',
     last_name: 'Bloggs'
-  } }
+    }
+  end
 
   let(:address_line_one) { '1 North Pole' }
 
-  let(:mock_home_address) { 
+  let(:mock_home_address) do
     instance_double(
-      'Address', 
-      address_line_one: address_line_one
+      Address,
+      address_line_one:
     )
-  }
+  end
 
   before do
     allow(subject).to receive(:home_address).and_return(mock_home_address)
@@ -23,7 +25,6 @@ RSpec.describe Person, type: :model do
 
   describe '#has_home_address?' do
     context 'home address is not blank' do
-
       let(:address_line_one) { '1 North Pole' }
 
       it 'returns true when a home address has values' do
@@ -32,7 +33,6 @@ RSpec.describe Person, type: :model do
     end
 
     context 'home address is blank' do
-
       let(:address_line_one) { nil }
 
       it 'returns false when a home address does not have values' do

--- a/spec/presenters/charge_presenter_spec.rb
+++ b/spec/presenters/charge_presenter_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 RSpec.describe ChargePresenter do
   subject { described_class.new(charge) }
 
-  let(:charge) { instance_double(Charge, offence: offence) }
+  let(:charge) { instance_double(Charge, offence:) }
   let(:offence) { double(Offence, offence_class: 'XYZ', offence_type: 'Offence Type') }
 
   describe 'offence attributes delegation' do
     context 'when there is an offence instance' do
-      context '#offence_class' do
+      describe '#offence_class' do
         it 'delegates to the presented offence' do
           expect(offence).to receive(:offence_class)
           subject.offence_class
         end
       end
 
-      context '#offence_type' do
+      describe '#offence_type' do
         it 'delegates to the presented offence' do
           expect(offence).to receive(:offence_type)
           subject.offence_type
@@ -26,11 +26,11 @@ RSpec.describe ChargePresenter do
     context 'when offence instance is `nil`' do
       let(:offence) { nil }
 
-      context '#offence_class' do
+      describe '#offence_class' do
         it { expect(subject.offence_class).to be_nil }
       end
 
-      context '#offence_type' do
+      describe '#offence_type' do
         it { expect(subject.offence_type).to be_nil }
       end
     end

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -3,47 +3,50 @@ require 'rails_helper'
 RSpec.describe CrimeApplicationPresenter do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) {
+  let(:crime_application) do
     instance_double(CrimeApplication,
                     id: 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
-                    created_at: DateTime.new(2022, 01, 12),
+                    created_at: DateTime.new(2022, 0o1, 12),
                     status: 'in_progress',
-                    date_stamp: Date.new(2022, 02, 01),
+                    date_stamp: Date.new(2022, 0o2, 0o1),
                     case: Case.new(case_type: CaseType.new(case_type)),
                     applicant: applicant)
-  }
+  end
 
-  let(:applicant) { 
+  let(:applicant) do
     double(
-      Applicant, 
-      first_name: 'John', 
+      Applicant,
+      first_name: 'John',
       last_name: 'Doe',
-      date_of_birth: Date.new(1990, 02, 01),
+      date_of_birth: Date.new(1990, 0o2, 0o1)
     )
-  }
+  end
 
   let(:case_type) { :indictable }
 
   describe '#application_date_stamp' do
     context 'when a case is date stampable' do
       let(:case_type) { :summary_only }
+
       it { expect(subject.application_date_stamp).to eq('1 Feb 2022') }
     end
 
     context 'when a case is not date stampable' do
       let(:case_type) { :indictable }
-      it { expect(subject.application_date_stamp).to be(nil) }
+
+      it { expect(subject.application_date_stamp).to be_nil }
     end
   end
 
   describe '#applicant?' do
     context 'when there is an applicant record' do
-      it { expect(subject.applicant?).to eq(true) }
+      it { expect(subject.applicant?).to be(true) }
     end
 
     context 'when there is no applicant record' do
       let(:applicant) { nil }
-      it { expect(subject.applicant?).to eq(false) }
+
+      it { expect(subject.applicant?).to be(false) }
     end
   end
 

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe CrimeApplicationPresenter do
   let(:crime_application) do
     instance_double(CrimeApplication,
                     id: 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
-                    created_at: DateTime.new(2022, 0o1, 12),
+                    created_at: DateTime.new(2022, 1, 12),
                     status: 'in_progress',
-                    date_stamp: Date.new(2022, 0o2, 0o1),
+                    date_stamp: Date.new(2022, 2, 1),
                     case: Case.new(case_type: CaseType.new(case_type)),
                     applicant: applicant)
   end
@@ -18,7 +18,7 @@ RSpec.describe CrimeApplicationPresenter do
       Applicant,
       first_name: 'John',
       last_name: 'Doe',
-      date_of_birth: Date.new(1990, 0o2, 0o1)
+      date_of_birth: Date.new(1990, 2, 1)
     )
   end
 

--- a/spec/presenters/offence_presenter_spec.rb
+++ b/spec/presenters/offence_presenter_spec.rb
@@ -1,28 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe OffencePresenter do
-  let(:offence) {
+  let(:offence) do
     instance_double(
       Offence,
-      offence_class: offence_class
+      offence_class:
     )
-  }
+  end
 
   describe '#offence_class' do
     subject { described_class.new(offence).offence_class }
 
     context 'for an offence with 1 class' do
       let(:offence_class) { 'H' }
+
       it { is_expected.to eq('Class H') }
     end
 
     context 'for an offence with 2 classes' do
       let(:offence_class) { 'C/B' }
+
       it { is_expected.to eq('Class C or B') }
     end
 
     context 'for an offence with 3 classes' do
       let(:offence_class) { 'F/G/K' }
+
       it { is_expected.to eq('Class F, G or K') }
     end
   end

--- a/spec/presenters/task_list/collection_spec.rb
+++ b/spec/presenters/task_list/collection_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TaskList::Collection do
   include ActionView::TestCase::Behavior
 
-  subject { described_class.new(view, crime_application: crime_application) }
+  subject { described_class.new(view, crime_application:) }
 
   let(:name) { :foobar_task }
   let(:crime_application) { double }
@@ -24,7 +24,8 @@ RSpec.describe TaskList::Collection do
     it 'has the `means_assessment` section' do
       expect(subject[2].index).to eq(3)
       expect(subject[2].name).to eq(:means_assessment)
-      expect(subject[2].tasks).to eq([:income_assessment, :capital_assessment, :check_your_answers, :check_assessment_result])
+      expect(subject[2].tasks).to eq([:income_assessment, :capital_assessment, :check_your_answers,
+                                      :check_assessment_result])
     end
 
     it 'has the `support_evidence` section' do
@@ -66,7 +67,7 @@ RSpec.describe TaskList::Collection do
 
       expect(
         subject.render
-      ).to match(/<ol class="app-task-list">.*<\/ol>/)
+      ).to match(%r{<ol class="app-task-list">.*</ol>})
     end
   end
 end

--- a/spec/presenters/task_list/section_spec.rb
+++ b/spec/presenters/task_list/section_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TaskList::Section do
-  subject { described_class.new(crime_application, name: name, tasks: tasks, index: index) }
+  subject { described_class.new(crime_application, name:, tasks:, index:) }
 
   let(:name) { :foobar_task }
   let(:tasks) { [:task_one, :task_two] }
@@ -32,9 +32,9 @@ RSpec.describe TaskList::Section do
       expect(
         subject.render
       ).to eq(
-        '<li>' +
-        '<h2 class="app-task-list__section"><span class="app-task-list__section-number">1.</span>Foo Bar Heading</h2>' +
-        '<ul class="app-task-list__items">[task_markup][task_markup]</ul>' +
+        '<li>' \
+        '<h2 class="app-task-list__section"><span class="app-task-list__section-number">1.</span>Foo Bar Heading</h2>' \
+        '<ul class="app-task-list__items">[task_markup][task_markup]</ul>' \
         '</li>'
       )
     end
@@ -45,7 +45,7 @@ RSpec.describe TaskList::Section do
       it 'renders the expected section HTML element' do
         expect(
           subject.render
-        ).to match(/<span class="app-task-list__section-number">3.<\/span>/)
+        ).to match(%r{<span class="app-task-list__section-number">3.</span>})
       end
     end
   end

--- a/spec/presenters/task_list/status_tag_spec.rb
+++ b/spec/presenters/task_list/status_tag_spec.rb
@@ -1,42 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe TaskList::StatusTag do
-  subject { described_class.new(crime_application, name: name, status: status) }
+  subject(:status_tag) { described_class.new(crime_application, name:, status:) }
 
   let(:name) { :foobar_task }
   let(:crime_application) { double }
 
   describe '#render' do
-    context 'for a `completed` status' do
+    context 'with `completed` status' do
       let(:status) { TaskStatus::COMPLETED }
-      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag">Completed</strong>') }
+
+      it {
+        expect(status_tag.render).to eq(
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag">Completed</strong>'
+        )
+      }
     end
 
-    context 'for an `in_progress` status' do
+    context 'with `in_progress` status' do
       let(:status) { TaskStatus::IN_PROGRESS }
-      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--blue">In progress</strong>') }
+
+      it {
+        expect(status_tag.render).to eq(
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--blue">' \
+          'In progress</strong>'
+        )
+      }
     end
 
-    context 'for a `not_started` status' do
+    context 'with `not_started` status' do
       let(:status) { TaskStatus::NOT_STARTED }
-      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Not started</strong>') }
+
+      it {
+        expect(status_tag.render).to eq(
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">' \
+          'Not started</strong>'
+        )
+      }
     end
 
-    context 'for an `unreachable` status' do
+    context 'with `unreachable` status' do
       let(:status) { TaskStatus::UNREACHABLE }
-      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Cannot yet start</strong>') }
+
+      it {
+        expect(status_tag.render).to eq(
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">' \
+          'Cannot yet start</strong>'
+        )
+      }
     end
 
-    context 'for a `not_applicable` status' do
+    context 'with `not_applicable` status' do
       let(:status) { TaskStatus::NOT_APPLICABLE }
-      it { expect(subject.render).to eq('<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Not applicable</strong>') }
+
+      it {
+        expect(status_tag.render).to eq(
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">' \
+          'Not applicable</strong>'
+        )
+      }
     end
 
-    context 'for an unknown status' do
+    context 'with an unknown status' do
       let(:status) { :anything_else }
 
       it 'raises an exception' do
-        expect { subject.render }.to raise_error(KeyError)
+        expect { status_tag.render }.to raise_error(KeyError)
       end
     end
   end

--- a/spec/presenters/task_list/task_spec.rb
+++ b/spec/presenters/task_list/task_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TaskList::Task do
-  subject { described_class.new(crime_application, name: name) }
+  subject { described_class.new(crime_application, name:) }
 
   let(:name) { :foobar_task }
   let(:crime_application) { double }
@@ -14,13 +14,13 @@ RSpec.describe TaskList::Task do
       allow(
         Tasks::BaseTask
       ).to receive(:build).with(
-        name, crime_application: crime_application
+        name, crime_application:
       ).and_return(task_double)
     end
 
-    let(:task_double) {
+    let(:task_double) do
       instance_double(Tasks::BaseTask, status: status, path: '/steps/foobar')
-    }
+    end
 
     context 'for an enabled task' do
       let(:status) { TaskStatus::IN_PROGRESS }
@@ -29,9 +29,10 @@ RSpec.describe TaskList::Task do
         expect(
           subject.render
         ).to eq(
-          '<li class="app-task-list__item">' +
-          '<span class="app-task-list__task-name"><a href="/steps/foobar" aria-describedby="foobar_task-status">Foo Bar Task Locale</a></span>' +
-          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--blue">In progress</strong>' +
+          '<li class="app-task-list__item">' \
+          '<span class="app-task-list__task-name"><a href="/steps/foobar" aria-describedby="foobar_task-status">' \
+          'Foo Bar Task Locale</a></span>' \
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--blue">In progress</strong>' \
           '</li>'
         )
       end
@@ -44,11 +45,12 @@ RSpec.describe TaskList::Task do
         expect(
           subject.render
         ).to eq(
-         '<li class="app-task-list__item">' +
-         '<span class="app-task-list__task-name">Foo Bar Task Locale</span>' +
-         '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">Cannot yet start</strong>' +
-         '</li>'
-       )
+          '<li class="app-task-list__item">' \
+          '<span class="app-task-list__task-name">Foo Bar Task Locale</span>' \
+          '<strong id="foobar_task-status" class="govuk-tag app-task-list__tag govuk-tag--grey">' \
+          'Cannot yet start</strong>' \
+          '</li>'
+        )
       end
     end
   end

--- a/spec/presenters/tasks/base_task_spec.rb
+++ b/spec/presenters/tasks/base_task_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::BaseTask do
-  subject { described_class.new(crime_application: crime_application) }
+  subject { described_class.new(crime_application:) }
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
   describe '.build' do
     context 'for a task with an implementation class' do
       it 'instantiate the implementation' do
-        task = described_class.build(:client_details, crime_application: crime_application)
+        task = described_class.build(:client_details, crime_application:)
 
         expect(task).to be_a(Tasks::ClientDetails)
         expect(task.crime_application).to eq(crime_application)
@@ -17,9 +17,9 @@ RSpec.describe Tasks::BaseTask do
 
     context 'for a task without an implementation class' do
       it 'instantiate the implementation' do
-        task = described_class.build(:foobar_task, crime_application: crime_application)
+        task = described_class.build(:foobar_task, crime_application:)
 
-        expect(task).to be_a(Tasks::BaseTask)
+        expect(task).to be_a(described_class)
         expect(task.crime_application).to eq(crime_application)
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe Tasks::BaseTask do
   end
 
   describe '#not_applicable?' do
-    it { expect(subject.not_applicable?).to eq(true) }
+    it { expect(subject.not_applicable?).to be(true) }
   end
 
   describe '#status' do
@@ -48,6 +48,7 @@ RSpec.describe Tasks::BaseTask do
 
     context 'task is not applicable' do
       let(:not_applicable) { true }
+
       it { expect(subject.status).to eq(TaskStatus::NOT_APPLICABLE) }
     end
 
@@ -58,6 +59,7 @@ RSpec.describe Tasks::BaseTask do
     context 'task is completed' do
       let(:can_start) { true }
       let(:completed) { true }
+
       it { expect(subject.status).to eq(TaskStatus::COMPLETED) }
     end
 

--- a/spec/presenters/tasks/case_details_spec.rb
+++ b/spec/presenters/tasks/case_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::CaseDetails do
-  subject { described_class.new(crime_application: crime_application) }
+  subject { described_class.new(crime_application:) }
 
   let(:crime_application) { instance_double(CrimeApplication, to_param: '12345') }
 
@@ -10,7 +10,7 @@ RSpec.describe Tasks::CaseDetails do
   end
 
   describe '#not_applicable?' do
-    it { expect(subject.not_applicable?).to eq(false) }
+    it { expect(subject.not_applicable?).to be(false) }
   end
 
   describe '#can_start?' do
@@ -20,12 +20,14 @@ RSpec.describe Tasks::CaseDetails do
 
     context 'when we have a NINO' do
       let(:applicant) { double(nino: 'something') }
-      it { expect(subject.can_start?).to eq(true) }
+
+      it { expect(subject.can_start?).to be(true) }
     end
 
     context 'when we do not have a NINO' do
       let(:applicant) { double(nino: nil) }
-      it { expect(subject.can_start?).to eq(false) }
+
+      it { expect(subject.can_start?).to be(false) }
     end
   end
 
@@ -36,16 +38,18 @@ RSpec.describe Tasks::CaseDetails do
 
     context 'when we have a case record' do
       let(:kase) { double }
-      it { expect(subject.in_progress?).to eq(true) }
+
+      it { expect(subject.in_progress?).to be(true) }
     end
 
     context 'when we do not have yet a case record' do
       let(:kase) { nil }
-      it { expect(subject.in_progress?).to eq(false) }
+
+      it { expect(subject.in_progress?).to be(false) }
     end
   end
 
   describe '#completed?' do
-    it { expect(subject.completed?).to eq(false) }
+    it { expect(subject.completed?).to be(false) }
   end
 end

--- a/spec/presenters/tasks/client_details_spec.rb
+++ b/spec/presenters/tasks/client_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::ClientDetails do
-  subject { described_class.new(crime_application: crime_application) }
+  subject { described_class.new(crime_application:) }
 
   let(:crime_application) { instance_double(CrimeApplication, to_param: '12345') }
 
@@ -10,11 +10,11 @@ RSpec.describe Tasks::ClientDetails do
   end
 
   describe '#not_applicable?' do
-    it { expect(subject.not_applicable?).to eq(false) }
+    it { expect(subject.not_applicable?).to be(false) }
   end
 
   describe '#can_start?' do
-    it { expect(subject.can_start?).to eq(true) }
+    it { expect(subject.can_start?).to be(true) }
   end
 
   describe '#in_progress?' do
@@ -24,12 +24,14 @@ RSpec.describe Tasks::ClientDetails do
 
     context 'when we have an applicant record' do
       let(:applicant) { double }
-      it { expect(subject.in_progress?).to eq(true) }
+
+      it { expect(subject.in_progress?).to be(true) }
     end
 
     context 'when we do not have yet an applicant record' do
       let(:applicant) { nil }
-      it { expect(subject.in_progress?).to eq(false) }
+
+      it { expect(subject.in_progress?).to be(false) }
     end
   end
 
@@ -40,12 +42,14 @@ RSpec.describe Tasks::ClientDetails do
 
     context 'when we have completed contact details' do
       let(:applicant) { double(correspondence_address_type: 'something') }
-      it { expect(subject.completed?).to eq(true) }
+
+      it { expect(subject.completed?).to be(true) }
     end
 
     context 'when we have not completed yet contact details' do
       let(:applicant) { nil }
-      it { expect(subject.completed?).to eq(false) }
+
+      it { expect(subject.completed?).to be(false) }
     end
   end
 end

--- a/spec/presenters/tasks/ioj_spec.rb
+++ b/spec/presenters/tasks/ioj_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::Ioj do
-  subject { described_class.new(crime_application: crime_application) }
+  subject { described_class.new(crime_application:) }
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
@@ -10,10 +10,10 @@ RSpec.describe Tasks::Ioj do
   end
 
   describe '#not_applicable?' do
-    it { expect(subject.not_applicable?).to eq(false) }
+    it { expect(subject.not_applicable?).to be(false) }
   end
 
   describe '#can_start?' do
-    it { expect(subject.can_start?).to eq(false) }
+    it { expect(subject.can_start?).to be(false) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,5 @@
-require_relative "../config/environment"
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+require_relative '../config/environment'
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 
 require 'spec_helper'
 require 'rspec/rails'

--- a/spec/requests/charges_summary_spec.rb
+++ b/spec/requests/charges_summary_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Charges/offences summary page' do
 
     kase.charges.create!(
       offence_name: 'Robbery',
-      offence_dates_attributes: { id: nil, date: Date.new(1990, 0o2, 0o1) }
+      offence_dates_attributes: { id: nil, date: Date.new(1990, 2, 1) }
     )
   end
 

--- a/spec/requests/charges_summary_spec.rb
+++ b/spec/requests/charges_summary_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Charges/offences summary page' do
 
     kase.charges.create!(
       offence_name: 'Robbery',
-      offence_dates_attributes: { id: nil, date: Date.new(1990, 02, 01) }
+      offence_dates_attributes: { id: nil, date: Date.new(1990, 0o2, 0o1) }
     )
   end
 
@@ -71,9 +71,9 @@ RSpec.describe 'Charges/offences summary page' do
         # ensure we have at least an additional offence
         charge = crime_application.case.charges.create!
 
-        expect {
+        expect do
           delete steps_case_charges_path(id: crime_application, charge_id: charge)
-        }.to change { Charge.count }.by(-1)
+        end.to change(Charge, :count).by(-1)
 
         expect(response).to have_http_status(:redirect)
         expect(response).to redirect_to(edit_steps_case_charges_summary_path(crime_application))
@@ -89,9 +89,9 @@ RSpec.describe 'Charges/offences summary page' do
 
     context 'when there are no more offences' do
       it 'deletes the offence, creates a brand new one and redirects to the offence page' do
-        expect {
+        expect do
           delete steps_case_charges_path(id: crime_application, charge_id: charge)
-        }.not_to change { Charge.count }
+        end.not_to change(Charge, :count)
 
         new_charge = Charge.last
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe 'Dashboard' do
   describe 'make a new application' do
     it 'creates a new `crime_application` record' do
-      expect {
+      expect do
         post crime_applications_path
-      }.to change { CrimeApplication.count }.by(1)
+      end.to change(CrimeApplication, :count).by(1)
 
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(/has_partner/)
@@ -17,19 +17,22 @@ RSpec.describe 'Dashboard' do
       # sets up a test record
       app = CrimeApplication.create
 
-      Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe', date_of_birth: Date.new(1990, 02, 01))
+      Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe',
+                       date_of_birth: Date.new(1990, 0o2, 0o1))
     end
 
     after :all do
       CrimeApplication.destroy_all
     end
 
-    it 'shows the task list for the application' do
+    before do
       applicant = Applicant.find_by(first_name: 'Jane')
       app = applicant.crime_application
 
       get edit_crime_application_path(app)
+    end
 
+    it 'shows the task list for the application' do
       expect(response).to have_http_status(:success)
 
       assert_select 'h1', 'Make a new application'
@@ -85,7 +88,7 @@ RSpec.describe 'Dashboard' do
         end
       end
 
-      expect(response.body).to_not include('Jane Doe')
+      expect(response.body).not_to include('Jane Doe')
     end
   end
 
@@ -102,23 +105,23 @@ RSpec.describe 'Dashboard' do
     end
 
     it 'allows a user to check before deleting an application' do
-      applicant = Applicant.find_by(first_name: "Jane")
+      applicant = Applicant.find_by(first_name: 'Jane')
       app = applicant.crime_application
 
       get confirm_destroy_crime_application_path(app)
 
-      expect(response.body).to include("Are you sure you want to delete Jane Doe’s application?")
-      expect(response.body).to include("Yes, delete it")
-      expect(response.body).to include("No, do not delete it")
+      expect(response.body).to include('Are you sure you want to delete Jane Doe’s application?')
+      expect(response.body).to include('Yes, delete it')
+      expect(response.body).to include('No, do not delete it')
     end
 
     it 'can delete an application' do
-      applicant = Applicant.find_by(first_name: "Jane")
+      applicant = Applicant.find_by(first_name: 'Jane')
       app = applicant.crime_application
 
-      expect {
+      expect do
         delete crime_application_path(app)
-      }.to change { CrimeApplication.count }.by(-1)
+      end.to change(CrimeApplication, :count).by(-1)
 
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(crime_applications_path)

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Dashboard' do
       app = CrimeApplication.create
 
       Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe',
-                       date_of_birth: Date.new(1990, 0o2, 0o1))
+                       date_of_birth: Date.new(1990, 2, 1))
     end
 
     after :all do

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,26 +1,26 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Healthcheck endpoint" do
+RSpec.describe 'Healthcheck endpoint' do
   let(:error_response)   { '{"healthcheck":"NOT OK"}' }
   let(:success_response) { '{"healthcheck":"OK"}' }
 
   describe 'healthchecks' do
-    it "can report a success" do
+    it 'can report a success' do
       allow(ActiveRecord::Base.connection).to receive(:active?)
         .and_return(true)
 
-      get "/health"
+      get '/health'
       expect(response.body).to eq(success_response)
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
 
-    it "can report a failure" do
+    it 'can report a failure' do
       allow(ActiveRecord::Base.connection).to receive(:active?)
         .and_raise(StandardError)
 
-      get "/health"
+      get '/health'
       expect(response.body).to eq(error_response)
-      expect(response).to have_http_status(503)
+      expect(response).to have_http_status(:service_unavailable)
     end
   end
 

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DateStamper do
   subject { described_class.new(crime_app, case_type) }
 
   let(:case_type_sym) { CaseType::DATE_STAMPABLE.sample }
-  let(:date) { DateTime.new(2022, 0o2, 0o2) }
+  let(:date) { DateTime.new(2022, 2, 2) }
   let(:case_type) { CaseType.new(case_type_sym) }
   let(:crime_app) do
     instance_double(

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe DateStamper do
+  subject { described_class.new(crime_app, case_type) }
+
   let(:case_type_sym) { CaseType::DATE_STAMPABLE.sample }
-  let(:date) { DateTime.new(2022, 02, 02) }
+  let(:date) { DateTime.new(2022, 0o2, 0o2) }
   let(:case_type) { CaseType.new(case_type_sym) }
-  let(:crime_app) {
+  let(:crime_app) do
     instance_double(
       CrimeApplication,
       date_stamp: date
     )
-  }
-
-  subject { described_class.new(crime_app, case_type) }
+  end
 
   before do
     allow(crime_app).to receive(:update)
@@ -21,8 +21,8 @@ RSpec.describe DateStamper do
     context 'when case_type is "date stampable" and date_stamp is nil' do
       let(:date) { nil }
 
-      it 'it adds a date stamp to the crime app' do
-        expect(crime_app).to receive(:update).with({date_stamp: instance_of(DateTime)})
+      it 'adds a date stamp to the crime app' do
+        expect(crime_app).to receive(:update).with({ date_stamp: instance_of(DateTime) })
         subject.call
       end
     end

--- a/spec/services/decisions/address_decision_tree_spec.rb
+++ b/spec/services/decisions/address_decision_tree_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Decisions::AddressDecisionTree do
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
-  it_behaves_like 'a decision tree'
-
   before do
     allow(
       form_object
     ).to receive(:crime_application).and_return(crime_application)
   end
+
+  it_behaves_like 'a decision tree'
 
   context 'when the step is `lookup`' do
     let(:form_object) { double('FormObject') }
@@ -26,11 +26,13 @@ RSpec.describe Decisions::AddressDecisionTree do
 
     context 'if we come from a home address sub-journey' do
       let(:address_record) { HomeAddress.new }
+
       it { is_expected.to have_destination('/steps/client/contact_details', :edit, id: crime_application) }
     end
 
     context 'if we come from a correspondence address sub-journey' do
       let(:address_record) { CorrespondenceAddress.new }
+
       it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
     end
   end
@@ -41,11 +43,13 @@ RSpec.describe Decisions::AddressDecisionTree do
 
     context 'if we come from a home address sub-journey' do
       let(:address_record) { HomeAddress.new }
+
       it { is_expected.to have_destination('/steps/client/contact_details', :edit, id: crime_application) }
     end
 
     context 'if we come from a correspondence address sub-journey' do
       let(:address_record) { CorrespondenceAddress.new }
+
       it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
     end
   end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Decisions::CaseDecisionTree do
   let(:codefendants_double) { double('codefendants_collection') }
   let(:charges_double) { double('charges_collection') }
 
-  it_behaves_like 'a decision tree'
-
   before do
     allow(
       form_object
@@ -19,6 +17,8 @@ RSpec.describe Decisions::CaseDecisionTree do
     allow(crime_application).to receive(:update).and_return(true)
     allow(crime_application).to receive(:date_stamp).and_return(nil)
   end
+
+  it_behaves_like 'a decision tree'
 
   context 'when the step is `urn`' do
     let(:form_object) { double('FormObject') }
@@ -35,31 +35,36 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and the application has a date stamp' do
       before do
-        allow(crime_application).to receive(:date_stamp) { Date.today }
+        allow(crime_application).to receive(:date_stamp) { Time.zone.today }
       end
 
       context 'and the case type is "date stampable"' do
         let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+
         it { is_expected.to have_destination(:date_stamp, :show, id: crime_application) }
       end
 
       context 'and case type is not "date stampable"' do
         let(:case_type) { :indictable }
+
         it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
       end
     end
 
     context 'and the application has no date stamp' do
       before do
-        allow(crime_application).to receive(:date_stamp) { nil }
+        allow(crime_application).to receive(:date_stamp).and_return(nil)
       end
+
       context 'and the case type is "date stampable"' do
         let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+
         it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
       end
 
       context 'and case type is not "date stampable"' do
         let(:case_type) { :indictable }
+
         it { is_expected.to have_destination(:has_codefendants, :edit, id: crime_application) }
       end
     end
@@ -74,11 +79,13 @@ RSpec.describe Decisions::CaseDecisionTree do
 
       context 'and there are charges already' do
         let(:charges_double) { double(any?: true) }
+
         it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
       end
 
       context 'and there are no charges' do
         let(:charges_double) { double(any?: false, create!: 'charge') }
+
         it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
       end
     end
@@ -94,7 +101,7 @@ RSpec.describe Decisions::CaseDecisionTree do
             codefendants_double
           ).to receive(:create!).at_least(:once)
 
-          is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+          expect(subject).to have_destination(:codefendants, :edit, id: crime_application)
         end
       end
 
@@ -102,7 +109,7 @@ RSpec.describe Decisions::CaseDecisionTree do
         let(:codefendants_double) { double('codefendants_collection', empty?: false) }
 
         it 'redirects to the codefendants page' do
-          is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+          expect(subject).to have_destination(:codefendants, :edit, id: crime_application)
         end
       end
     end
@@ -117,7 +124,7 @@ RSpec.describe Decisions::CaseDecisionTree do
         codefendants_double
       ).to receive(:create!).at_least(:once)
 
-      is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+      expect(subject).to have_destination(:codefendants, :edit, id: crime_application)
     end
   end
 
@@ -135,7 +142,7 @@ RSpec.describe Decisions::CaseDecisionTree do
           codefendants_double
         ).to receive(:create!).at_least(:once)
 
-        is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+        expect(subject).to have_destination(:codefendants, :edit, id: crime_application)
       end
     end
 
@@ -143,7 +150,7 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:codefendants_double) { double('codefendants_collection', empty?: false) }
 
       it 'redirects to the codefendants page' do
-        is_expected.to have_destination(:codefendants, :edit, id: crime_application)
+        expect(subject).to have_destination(:codefendants, :edit, id: crime_application)
       end
     end
   end
@@ -154,11 +161,13 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and there are charges already' do
       let(:charges_double) { double(any?: true) }
+
       it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
     end
 
     context 'and there are no charges' do
       let(:charges_double) { double(any?: false, create!: 'charge') }
+
       it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
     end
   end
@@ -191,6 +200,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and answer is `no`' do
       let(:add_offence) { YesNoAnswer::NO }
+
       it { is_expected.to have_destination(:hearing_details, :edit, id: crime_application) }
     end
   end
@@ -198,7 +208,7 @@ RSpec.describe Decisions::CaseDecisionTree do
   context 'when the step is `add_offence_date`' do
     context 'has correct next step' do
       let(:step_name) { :add_offence_date }
-      let(:offence_dates) { [ OffenceDate.new(date: '01, 02, 2000') ] }
+      let(:offence_dates) { [OffenceDate.new(date: '01, 02, 2000')] }
       let(:charge) { Charge.new(id: '20', offence_dates: offence_dates) }
       let(:form_object) { double('FormObject', case: kase, record: charge) }
 
@@ -211,6 +221,7 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:step_name) { :delete_offence_date }
       let(:charge) { Charge.new(id: '20') }
       let(:form_object) { double('FormObject', case: kase, record: charge) }
+
       it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: charge) }
     end
   end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -5,25 +5,27 @@ RSpec.describe Decisions::ClientDecisionTree do
 
   let(:crime_application) { instance_double(CrimeApplication) }
 
-  it_behaves_like 'a decision tree'
-
   before do
     allow(
       form_object
     ).to receive(:crime_application).and_return(crime_application)
   end
 
+  it_behaves_like 'a decision tree'
+
   context 'when the step is `has_partner`' do
-    let(:form_object) { double('FormObject', client_has_partner: client_has_partner) }
+    let(:form_object) { double('FormObject', client_has_partner:) }
     let(:step_name) { :has_partner }
 
     context 'and answer is `no`' do
       let(:client_has_partner) { YesNoAnswer::NO }
+
       it { is_expected.to have_destination('/crime_applications', :edit, id: crime_application) }
     end
 
     context 'and answer is `yes`' do
       let(:client_has_partner) { YesNoAnswer::YES }
+
       it { is_expected.to have_destination(:partner_exit, :show, id: crime_application) }
     end
   end
@@ -48,12 +50,17 @@ RSpec.describe Decisions::ClientDecisionTree do
         ).to receive(:find_or_create_by).with(person: 'applicant').and_return('address')
       end
 
-      it { is_expected.to have_destination('/steps/address/lookup', :edit, id: crime_application, address_id: 'address') }
+      it {
+        expect(subject).to have_destination('/steps/address/lookup', :edit, id: crime_application,
+address_id: 'address')
+      }
     end
   end
 
   context 'when the step is `contact_details`' do
-    let(:form_object) { double('FormObject', applicant: 'applicant', correspondence_address_type: correspondence_address_type) }
+    let(:form_object) do
+      double('FormObject', applicant: 'applicant', correspondence_address_type: correspondence_address_type)
+    end
     let(:step_name) { :contact_details }
 
     context 'and answer is `other_address`' do
@@ -65,16 +72,21 @@ RSpec.describe Decisions::ClientDecisionTree do
         ).to receive(:find_or_create_by).with(person: 'applicant').and_return('address')
       end
 
-      it { is_expected.to have_destination('/steps/address/lookup', :edit, id: crime_application, address_id: 'address') }
+      it {
+        expect(subject).to have_destination('/steps/address/lookup', :edit, id: crime_application,
+address_id: 'address')
+      }
     end
 
     context 'and answer is `home_address`' do
       let(:correspondence_address_type) { CorrespondenceType::HOME_ADDRESS }
+
       it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
     end
 
     context 'and answer is `providers_office_address`' do
       let(:correspondence_address_type) { CorrespondenceType::PROVIDERS_OFFICE_ADDRESS }
+
       it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
     end
   end

--- a/spec/services/ordnance_survey/address_lookup_results_spec.rb
+++ b/spec/services/ordnance_survey/address_lookup_results_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe OrdnanceSurvey::AddressLookupResults do
-  let(:results) { [] }
   subject { described_class.call(results) }
 
-  context '#call' do
+  let(:results) { [] }
+
+  describe '#call' do
     context 'with results' do
       let(:parsed_body) { JSON.parse(file_fixture('address_lookups/success.json').read) }
       let(:results) { parsed_body['results'] }
@@ -23,13 +24,13 @@ RSpec.describe OrdnanceSurvey::AddressLookupResults do
       context '`Address` struct convenience methods' do
         let(:result) { subject[0] }
 
-        context '#compact_address' do
+        describe '#compact_address' do
           it 'returns a shorter version of the full address' do
             expect(result.compact_address).to eq('1, POST OFFICE, BROADWAY, LONDON')
           end
         end
 
-        context '#lookup_id' do
+        describe '#lookup_id' do
           it 'returns the UDPRN identifier' do
             expect(result.lookup_id).to eq('23749191')
           end
@@ -90,8 +91,8 @@ RSpec.describe OrdnanceSurvey::AddressLookupResults do
     end
   end
 
-  context '#address_line' do
-    let(:address) { ["", "address line 1", nil, "somewhere", ""]}
+  describe '#address_line' do
+    let(:address) { ['', 'address line 1', nil, 'somewhere', ''] }
 
     it 'returns a string with no blank sections' do
       expect(described_class.address_line(address)).to eq('address line 1, somewhere')

--- a/spec/services/ordnance_survey/address_lookup_spec.rb
+++ b/spec/services/ordnance_survey/address_lookup_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe OrdnanceSurvey::AddressLookup do
       end
 
       context 'the response cannot be parsed (`header` not found)' do
-        let(:stubbed_json_body) { "{\"unknown\":\"keys\"}" }
+        let(:stubbed_json_body) { '{"unknown":"keys"}' }
 
         it 'has an unsuccessful outcome' do
           expect(service).not_to be_success
@@ -60,7 +60,7 @@ RSpec.describe OrdnanceSurvey::AddressLookup do
       end
 
       context 'the response cannot be parsed (`totalresults` not found)' do
-        let(:stubbed_json_body) { "{\"header\":{\"foo\":\"bar\"}}" }
+        let(:stubbed_json_body) { '{"header":{"foo":"bar"}}' }
 
         it 'has an unsuccessful outcome' do
           expect(service).not_to be_success
@@ -114,7 +114,9 @@ RSpec.describe OrdnanceSurvey::AddressLookup do
         expect(service).not_to be_success
         expect(service.call).to eq([])
         expect(service.last_exception).to be_a(OrdnanceSurvey::AddressLookup::UnsuccessfulLookupError)
-        expect(service.last_exception.message).to eq('{"error":{"statuscode":400,"message":"Parameter postcode cannot be empty."}}')
+        expect(service.last_exception.message).to eq(
+          '{"error":{"statuscode":400,"message":"Parameter postcode cannot be empty."}}'
+        )
       end
     end
 

--- a/spec/support/matchers/validation_helpers.rb
+++ b/spec/support/matchers/validation_helpers.rb
@@ -2,11 +2,11 @@ module ValidationHelpers
   private
 
   def check_errors(object, attribute, error)
-    !object.valid?(validation_context)
+    object.valid?(validation_context)
     errors_for(attribute, object).include?(error)
   end
 
   def errors_for(attribute, object)
-    object.errors.details[attribute].map { |h| h[:error] }.compact
+    object.errors.details[attribute].pluck(:error).compact
   end
 end

--- a/spec/support/shared_examples/decision_tree_shared_examples.rb
+++ b/spec/support/shared_examples/decision_tree_shared_examples.rb
@@ -4,9 +4,9 @@ RSpec.shared_examples 'a decision tree' do
     let(:step_name) { :foobar }
 
     it 'raises an error' do
-      expect {
+      expect do
         subject.destination
-      }.to raise_error(
+      end.to raise_error(
         Decisions::BaseDecisionTree::InvalidStep, "Invalid step 'foobar'"
       )
     end

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -8,10 +8,11 @@ RSpec.shared_examples 'a has-one-association form' do |options|
   def associated_class_name
     reflection = CrimeApplication.reflect_on_association(association_name)
 
-    if reflection.is_a?(ActiveRecord::Reflection::HasOneReflection)
+    case reflection
+    when ActiveRecord::Reflection::HasOneReflection
       # For an `association_name` of `:applicant` it will return `applicant`
       reflection.name.to_s
-    elsif reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+    when ActiveRecord::Reflection::ThroughReflection
       # For an `association_name` of `:applicant_contact_details` it will return `contact_details`
       reflection.source_reflection_name.to_s
     else
@@ -65,8 +66,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 32, 2 => 12, 1 => 2020 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid_day)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid_day)).to be(true)
     end
   end
 
@@ -74,8 +75,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 2 => 12, 1 => 2020 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid_day)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid_day)).to be(true)
     end
   end
 
@@ -83,8 +84,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 25, 2 => 13, 1 => 2020 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid_month)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid_month)).to be(true)
     end
   end
 
@@ -92,8 +93,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 25, 1 => 2020 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid_month)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid_month)).to be(true)
     end
   end
 
@@ -101,8 +102,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 25, 2 => 12, 1 => 1899 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :year_too_early)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :year_too_early)).to be(true)
     end
   end
 
@@ -110,8 +111,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 25, 2 => 12, 1 => 2051 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :year_too_late)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :year_too_late)).to be(true)
     end
   end
 
@@ -119,8 +120,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 25, 2 => 12 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid_year)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid_year)).to be(true)
     end
   end
 
@@ -128,8 +129,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 'foo', 2 => 2, 1 => 'bar' } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid)).to be(true)
     end
   end
 
@@ -137,8 +138,8 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     let(:date) { { 3 => 29, 2 => 2, 1 => 2021 } }
 
     it 'has a validation error on the field' do
-      expect(subject).to_not be_valid
-      expect(subject.errors.added?(attribute_name, :invalid)).to eq(true)
+      expect(subject).not_to be_valid
+      expect(subject.errors.added?(attribute_name, :invalid)).to be(true)
     end
   end
 
@@ -149,12 +150,12 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     if options.fetch(:allow_future, false)
       it 'allows future dates' do
         expect(subject).to be_valid
-        expect(subject.errors.added?(attribute_name, :future_not_allowed)).to eq(false)
+        expect(subject.errors.added?(attribute_name, :future_not_allowed)).to be(false)
       end
     else
       it 'does not allow future dates' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.added?(attribute_name, :future_not_allowed)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.added?(attribute_name, :future_not_allowed)).to be(true)
       end
     end
   end
@@ -166,12 +167,12 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     if options.fetch(:allow_past, true)
       it 'allows past dates' do
         expect(subject).to be_valid
-        expect(subject.errors.added?(attribute_name, :past_not_allowed)).to eq(false)
+        expect(subject.errors.added?(attribute_name, :past_not_allowed)).to be(false)
       end
     else
       it 'does not allow past dates' do
-        expect(subject).to_not be_valid
-        expect(subject.errors.added?(attribute_name, :past_not_allowed)).to eq(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors.added?(attribute_name, :past_not_allowed)).to be(true)
       end
     end
   end

--- a/spec/support/shared_examples/step_controller_shared_examples.rb
+++ b/spec/support/shared_examples/step_controller_shared_examples.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
     # to the shared examples, or to also create the partner associated record.
     #
     context 'when application is found' do
-      let!(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
+      let(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
 
       it 'responds with HTTP success' do
         get :edit, params: { id: existing_case }
@@ -52,7 +52,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
   describe '#update' do
     let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
     let(:form_class_params_name) { form_class.name.underscore }
-    let(:expected_params) { { id: existing_case, form_class_params_name => { foo: 'bar' } } }
+    let(:expected_params) { { :id => existing_case, form_class_params_name => { foo: 'bar' } } }
 
     context 'when application is not found' do
       let(:existing_case) { '12345' }
@@ -121,8 +121,8 @@ RSpec.shared_examples 'an address step controller' do |form_class, decision_tree
     end
 
     context 'when application is found' do
-      let!(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
-      let!(:existing_address) { HomeAddress.find_or_create_by(person: existing_case.applicant) }
+      let(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
+      let(:existing_address) { HomeAddress.find_or_create_by(person: existing_case.applicant) }
 
       it 'responds with HTTP success' do
         get :edit, params: { id: existing_case, address_id: existing_address }
@@ -134,7 +134,9 @@ RSpec.shared_examples 'an address step controller' do |form_class, decision_tree
   describe '#update' do
     let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
     let(:form_class_params_name) { form_class.name.underscore }
-    let(:expected_params) { { id: existing_case, address_id: existing_address, form_class_params_name => { foo: 'bar' } } }
+    let(:expected_params) do
+      { :id => existing_case, :address_id => existing_address, form_class_params_name => { foo: 'bar' } }
+    end
 
     context 'when application is not found' do
       let(:existing_case) { '12345' }
@@ -153,8 +155,8 @@ RSpec.shared_examples 'an address step controller' do |form_class, decision_tree
     end
 
     context 'when an application in progress is found' do
-      let!(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
-      let!(:existing_address) { HomeAddress.find_or_create_by(person: existing_case.applicant) }
+      let(:existing_case) { CrimeApplication.create(applicant: Applicant.new) }
+      let(:existing_address) { HomeAddress.find_or_create_by(person: existing_case.applicant) }
 
       before do
         allow(form_class).to receive(:new).and_return(form_object)
@@ -195,7 +197,7 @@ RSpec.shared_examples 'a step that can be drafted' do |form_class|
   describe '#update' do
     let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
     let(:form_class_params_name) { form_class.name.underscore }
-    let(:expected_params) { { id: existing_case, form_class_params_name => { foo: 'bar' }, commit_draft: '' } }
+    let(:expected_params) { { :id => existing_case, form_class_params_name => { foo: 'bar' }, :commit_draft => '' } }
 
     context 'when application is not found' do
       let(:existing_case) { '12345' }

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(in_progress submitted)
+        %w[in_progress submitted]
       )
     end
   end

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe CaseType do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(
-          summary_only 
-          either_way 
-          indictable 
-          already_cc_trial 
-          committal 
-          cc_appeal 
+        %w[
+          summary_only
+          either_way
+          indictable
+          already_cc_trial
+          committal
+          cc_appeal
           cc_appeal_fin_change
-        )
+        ]
       )
     end
   end
@@ -25,10 +25,10 @@ RSpec.describe CaseType do
     context 'for date stampable case types' do
       it 'returns true' do
         date_stampable_types = [
-          CaseType.new(:summary_only).date_stampable?,
-          CaseType.new(:either_way).date_stampable?, 
-          CaseType.new(:committal).date_stampable?, 
-          CaseType.new(:cc_appeal).date_stampable?
+          described_class.new(:summary_only).date_stampable?,
+          described_class.new(:either_way).date_stampable?,
+          described_class.new(:committal).date_stampable?,
+          described_class.new(:cc_appeal).date_stampable?
         ]
 
         expect(date_stampable_types).to all(be_truthy)
@@ -38,9 +38,9 @@ RSpec.describe CaseType do
     context 'for non date stampable case types' do
       it 'returns false' do
         date_stampable_types = [
-          CaseType.new(:indictable).date_stampable?, 
-          CaseType.new(:already_cc_trial).date_stampable?, 
-          CaseType.new(:cc_appeal_fin_change).date_stampable?
+          described_class.new(:indictable).date_stampable?,
+          described_class.new(:already_cc_trial).date_stampable?,
+          described_class.new(:cc_appeal_fin_change).date_stampable?
         ]
 
         expect(date_stampable_types).to all(be_falsy)

--- a/spec/value_objects/correspondence_type_spec.rb
+++ b/spec/value_objects/correspondence_type_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CorrespondenceType do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w(home_address providers_office_address other_address)
+        %w[home_address providers_office_address other_address]
       )
     end
   end

--- a/spec/value_objects/task_status_spec.rb
+++ b/spec/value_objects/task_status_spec.rb
@@ -9,34 +9,39 @@ RSpec.describe TaskStatus do
     it 'returns all possible values' do
       expect(
         described_class.values.map(&:to_s)
-      ).to eq(%w(completed in_progress not_started unreachable not_applicable))
+      ).to eq(%w[completed in_progress not_started unreachable not_applicable])
     end
   end
 
   describe '#enabled?' do
     context 'for a `completed` status' do
       let(:value) { :completed }
-      it { expect(subject.enabled?).to eq(true) }
+
+      it { expect(subject.enabled?).to be(true) }
     end
 
     context 'for an `in_progress` status' do
       let(:value) { :in_progress }
-      it { expect(subject.enabled?).to eq(true) }
+
+      it { expect(subject.enabled?).to be(true) }
     end
 
     context 'for a `not_started` status' do
       let(:value) { :not_started }
-      it { expect(subject.enabled?).to eq(true) }
+
+      it { expect(subject.enabled?).to be(true) }
     end
 
     context 'for an `unreachable` status' do
       let(:value) { :unreachable }
-      it { expect(subject.enabled?).to eq(false) }
+
+      it { expect(subject.enabled?).to be(false) }
     end
 
     context 'for a `not_applicable` status' do
       let(:value) { :not_applicable }
-      it { expect(subject.enabled?).to eq(false) }
+
+      it { expect(subject.enabled?).to be(false) }
     end
   end
 end

--- a/spec/value_objects/value_object_spec.rb
+++ b/spec/value_objects/value_object_spec.rb
@@ -1,14 +1,18 @@
 require 'rails_helper'
 
+Fruit = Class.new(ValueObject) do
+  const_set(:VALUES, [new(:apple), new(:banana)])
+end
+
 RSpec.describe ValueObject do
+  subject { described_class.new(value) }
+
   before do
-    stub_const('FooValue', Class.new(ValueObject))
-    stub_const('BarValue', Class.new(ValueObject))
+    stub_const('FooValue', Class.new(described_class))
+    stub_const('BarValue', Class.new(described_class))
   end
 
   let(:value) { 'Hello!' }
-  subject     { described_class.new(value) }
-
   let(:foo_one)      { FooValue.new('one') }
   let(:also_foo_one) { FooValue.new('one') }
   let(:foo_two)      { FooValue.new('two') }
@@ -24,15 +28,15 @@ RSpec.describe ValueObject do
     end
 
     it 'considers same class/different value not equal' do
-      expect(foo_one).to_not eq(foo_two)
+      expect(foo_one).not_to eq(foo_two)
     end
 
     it 'considers different class/same value not equal' do
-      expect(foo_one).to_not eq(bar_one)
+      expect(foo_one).not_to eq(bar_one)
     end
 
     it 'considers different class/different value not equal' do
-      expect(foo_two).to_not eq(bar_one)
+      expect(foo_two).not_to eq(bar_one)
     end
   end
 
@@ -42,15 +46,15 @@ RSpec.describe ValueObject do
     end
 
     it 'considers same class/different value not equal' do
-      expect(foo_one.hash).to_not eq(foo_two.hash)
+      expect(foo_one.hash).not_to eq(foo_two.hash)
     end
 
     it 'considers different class/same value not equal' do
-      expect(foo_one.hash).to_not eq(bar_one.hash)
+      expect(foo_one.hash).not_to eq(bar_one.hash)
     end
 
     it 'considers different class/different value not equal' do
-      expect(foo_two.hash).to_not eq(bar_one.hash)
+      expect(foo_two.hash).not_to eq(bar_one.hash)
     end
   end
 
@@ -73,19 +77,15 @@ RSpec.describe ValueObject do
   end
 
   describe 'inquiry methods' do
-    Fruit = Class.new(ValueObject) do
-      const_set(:VALUES, [new(:apple), new(:banana)])
-    end
-
     let(:fruit_one) { Fruit.new(:apple) }
     let(:fruit_two) { Fruit.new(:banana) }
 
     it 'defines inquiry methods for each of the values' do
-      expect(fruit_one.apple?).to eq(true)
-      expect(fruit_one.banana?).to eq(false)
+      expect(fruit_one.apple?).to be(true)
+      expect(fruit_one.banana?).to be(false)
 
-      expect(fruit_two.apple?).to eq(false)
-      expect(fruit_two.banana?).to eq(true)
+      expect(fruit_two.apple?).to be(false)
+      expect(fruit_two.banana?).to be(true)
     end
   end
 end

--- a/spec/value_objects/yes_no_answer_spec.rb
+++ b/spec/value_objects/yes_no_answer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe YesNoAnswer do
 
   describe '.values' do
     it 'returns all possible values' do
-      expect(described_class.values.map(&:to_s)).to eq(%w(yes no))
+      expect(described_class.values.map(&:to_s)).to eq(%w[yes no])
     end
   end
 end


### PR DESCRIPTION
Add rubocop-rspec and use it to check specs.

Prior to this change rubocop was not being used on the specs dir. 

This change: 
1. apply rubocop to the spec directory
2. fix all issues raised by rubocop
3. add rubocop-rspec
4. fix several issues raised by rubocop-rspec
5. disable or modify remaining failing rubocop-rspec cops

Are we happy to merge this as is or would we rather fix outstanding (disabled) rubcop-rspec cops? 