### PR TITLE
CRIMAP-119-select-court-from-list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem 'dartsass-rails', '~> 0.4.0'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 
-# gem 'hmcts_common_platform', '0.1.0', git: 'git@github.com:ministryofjustice/hmcts_common_platform'
 gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', tag: 'v0.2.0'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'dartsass-rails', '~> 0.4.0'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 
+# gem 'hmcts_common_platform', '0.1.0', git: 'git@github.com:ministryofjustice/hmcts_common_platform'
+gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', tag: 'v0.2.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/ministryofjustice/hmcts_common_platform.git
+  revision: f45aa2fddd05e238493c0c3e202de309ae93acb4
+  tag: v0.2.0
+  specs:
+    hmcts_common_platform (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -321,6 +328,7 @@ DEPENDENCIES
   erb_lint
   faraday (~> 2.4)
   govuk_design_system_formbuilder (~> 3.1.0)
+  hmcts_common_platform!
   importmap-rails
   pg (~> 1.4)
   pry

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -1,0 +1,27 @@
+class Court
+  def initialize(name:)
+    @name = name
+  end
+
+  attr_reader :name
+
+  class << self
+    # TODO: we still need to confirm which courts to list.
+    #
+    # In the meantime use the CourtCentre csv from hmcts_common_platform gem
+    # and filters by oucode_l1_code to produce a list of magistrates' and crown courts.
+    #
+    def all
+      @all ||= begin
+        oucode_l1_code = %w[B C]
+
+        rows = HmctsCommonPlatform::Reference::CourtCentre.csv.select do |cc|
+          oucode_l1_code.include? cc['oucode_l1_code']
+        end
+
+        rows.map { |r| new(name: r['oucode_l3_name']) }
+            .sort_by(&:name)
+      end
+    end
+  end
+end

--- a/app/views/steps/case/hearing_details/edit.html.erb
+++ b/app/views/steps/case/hearing_details/edit.html.erb
@@ -8,8 +8,8 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :hearing_court_name, autocomplete: 'off',
-                             width: 'three-quarters', label: { size: 'm' } %>
+      <%= f.govuk_collection_select :hearing_court_name, Court.all, :name, :name,
+                                    options: { include_blank: true } %>
 
       <%= f.govuk_date_field :hearing_date, maxlength_enabled: true %>
 

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Court, type: :model do
+  describe '.all' do
+    subject(:all) { described_class.all }
+
+    it 'returns required courts as expected' do
+      expect(Digest::MD5.hexdigest(all.map(&:name).join)).to eq '4cdc39a4fa9cfe2aeb4984fe1dbab5d1'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Uses https://github.com/ministryofjustice/hmcts_common_platform/ gem to create a list of court names.

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897/backlog?selectedIssue=CRIMAP-119&text=crimap-11

## Notes for reviewer

We are waiting to confirm the final list of court name. This may impact on which source we use for the court names.  (See ticket for more discussion.)

If the source and way of filtering used in this PR is compatible with the finalised list, submit a PR to the hmcts_common_platform to exposed the L1_code instead of accessing the gem's csv file.

The width of the court name input has been increased to accommodate the wider names in this list. This may change once the final list is confirmed. 

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/124 adds accessible autocomplete to court name.

## Screenshots of changes (if applicable)

### Before changes:

<img width="732" alt="Screenshot 2022-10-06 at 11 21 12" src="https://user-images.githubusercontent.com/34935/194292813-21266188-2af1-4f33-a181-d0072d668c19.png">


### After changes:

<img width="703" alt="Screenshot 2022-10-06 at 11 38 26" src="https://user-images.githubusercontent.com/34935/194292726-e08adf2e-c7be-4cef-92c9-bec498e99bb3.png">


<img width="1073" alt="Screenshot 2022-10-06 at 11 40 10" src="https://user-images.githubusercontent.com/34935/194292973-bcf2a27b-4305-47c1-b8db-18992d365c74.png">

## How to manually test the feature
