### PR TITLE
CRIMAP-149 Implement Court Search Javascript on the Details of Next Court Hearing Page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,7 +9,8 @@
 
 // NOTE: accessible-autocomplete copied from:
 // https://github.com/alphagov/accessible-autocomplete/blob/main/src/autocomplete.css
-// last_commit:aff5a284dba8ed674706bb8db3b3c1b7752c1285
+// commit:aff5a284dba8ed674706bb8db3b3c1b7752c1285
+// customised to include govuk styling in local/custom.scss
 @import "local/accessible-autocomplete";
 
 // App-specific custom styles and overrides

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,5 +7,10 @@
 // https://github.com/alphagov/govuk-frontend/pull/2453
 @import "local/suggestions";
 
+// NOTE: accessible-autocomplete copied from:
+// https://github.com/alphagov/accessible-autocomplete/blob/main/src/autocomplete.css
+// last_commit:aff5a284dba8ed674706bb8db3b3c1b7752c1285
+@import "local/accessible-autocomplete";
+
 // App-specific custom styles and overrides
 @import "local/custom";

--- a/app/assets/stylesheets/local/accessible-autocomplete.scss
+++ b/app/assets/stylesheets/local/accessible-autocomplete.scss
@@ -1,0 +1,166 @@
+.autocomplete__wrapper {
+  position: relative;
+}
+
+.autocomplete__hint,
+.autocomplete__input {
+  -webkit-appearance: none;
+  border: 2px solid #0b0c0c;
+  border-radius: 0; /* Safari 10 on iOS adds implicit border rounding. */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
+  width: 100%;
+}
+
+.autocomplete__input {
+  background-color: transparent;
+  position: relative;
+}
+
+.autocomplete__hint {
+  color: #b1b4b6;
+  position: absolute;
+}
+
+.autocomplete__input--default {
+  padding: 5px;
+}
+.autocomplete__input--focused {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px;
+}
+
+.autocomplete__input--show-all-values {
+  padding: 5px 34px 5px 5px; /* Space for arrow. Other padding should match .autocomplete__input--default. */
+  cursor: pointer;
+}
+
+.autocomplete__dropdown-arrow-down{
+  z-index: -1;
+  display: inline-block;
+  position: absolute;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  top: 10px;
+}
+
+.autocomplete__menu {
+  background-color: #fff;
+  border: 2px solid #0B0C0C;
+  border-top: 0;
+  color: #0B0C0C;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - 4px);
+}
+
+.autocomplete__menu--visible {
+  display: block;
+}
+
+.autocomplete__menu--hidden {
+  display: none;
+}
+
+.autocomplete__menu--overlay {
+  box-shadow: rgba(0, 0, 0, 0.256863) 0px 2px 6px;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+
+.autocomplete__menu--inline {
+  position: relative;
+}
+
+.autocomplete__option {
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+}
+
+.autocomplete__option > * {
+  pointer-events: none;
+}
+
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.autocomplete__option--odd {
+  background-color: #FAFAFA;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: #1d70b8;
+  border-color: #1d70b8;
+  color: white;
+  outline: none;
+}
+
+@media (-ms-high-contrast: active), (forced-colors: active) {
+  .autocomplete__menu {
+    border-color: FieldText;
+  }
+
+  .autocomplete__option {
+    background-color: Field;
+    color: FieldText;
+  }
+
+  .autocomplete__option--focused,
+  .autocomplete__option:hover {
+    forced-color-adjust: none; /* prevent backplate from obscuring text */
+    background-color: Highlight;
+    border-color: Highlight;
+    color: HighlightText;
+
+    /* Prefer SelectedItem / SelectedItemText in browsers that support it */
+    background-color: SelectedItem;
+    border-color: SelectedItem;
+    color: SelectedItemText;
+    outline-color: SelectedItemText;
+  }
+}
+
+.autocomplete__option--no-results {
+  background-color: #FAFAFA;
+  color: #646b6f;
+  cursor: not-allowed;
+}
+
+.autocomplete__hint,
+.autocomplete__input,
+.autocomplete__option {
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.autocomplete__hint,
+.autocomplete__option {
+  padding: 5px;
+}
+
+@media (min-width: 641px) {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -22,3 +22,9 @@
   position: sticky;
   top: 1%;
 }
+
+// style accessible autocomplete
+.autocomplete__wrapper * {
+  @include govuk-typography-common();
+}
+

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,3 +14,10 @@ if ($inputs) {
     new Input($inputs[i]).init()
   }
 }
+
+import accessibleAutocomplete from 'accessible-autocomplete'
+
+accessibleAutocomplete.enhanceSelectElement({
+  selectElement: document.querySelector('#steps-case-hearing-details-form-hearing-court-name-field'),
+  defaultValue: ''
+})

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,3 +3,4 @@
 pin "application", preload: true
 pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.3.1/govuk-esm/all.mjs"
 pin_all_from "app/javascript/local", under: "local"
+pin "accessible-autocomplete", to: "https://ga.jspm.io/npm:accessible-autocomplete@2.0.4/dist/accessible-autocomplete.min.js"

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -51,7 +51,7 @@ en:
         offence_name: For example, robbery
         date: For example, 12 11 2007
       steps_case_hearing_details_form:
-        hearing_court_name: For example, Cardiff
+        hearing_court_name: For example, Cardiff Crown Court
         hearing_date: For example, 27 3 2024
 
     label:

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Court, type: :model do
     subject(:all) { described_class.all }
 
     it 'returns required courts as expected' do
-      expect(Digest::MD5.hexdigest(all.map(&:name).join)).to eq '4cdc39a4fa9cfe2aeb4984fe1dbab5d1'
+      digest_of_expected_court_names = '4cdc39a4fa9cfe2aeb4984fe1dbab5d1'
+
+      expect(Digest::MD5.hexdigest(all.map(&:name).join)).to eq digest_of_expected_court_names
     end
   end
 end


### PR DESCRIPTION
## Description of change
Adds accessible-autocomplete to court name select.

## Link to relevant ticket

https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-149

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1073" alt="Screenshot 2022-10-06 at 11 40 10" src="https://user-images.githubusercontent.com/34935/194297587-0d63073d-ca96-4222-9c24-58ffa0b1687f.png">

### After changes:
<img width="716" alt="Screenshot 2022-10-06 at 12 09 01" src="https://user-images.githubusercontent.com/34935/194298246-bc62d745-e261-4ae9-a6e1-e5f5da814de8.png">
<img width="705" alt="Screenshot 2022-10-06 at 12 09 15" src="https://user-images.githubusercontent.com/34935/194298262-806a006d-445d-4998-9fac-a6eb1560dfa8.png">
<img width="745" alt="Screenshot 2022-10-06 at 12 09 24" src="https://user-images.githubusercontent.com/34935/194298273-d14cf715-43d3-4225-af33-80c57e9bfcac.png">


## How to manually test the feature
