### PR TITLE
Add benefit check service and mock benefit check service

### DIFF
--- a/app/controllers/steps/client/benefit_check_result_controller.rb
+++ b/app/controllers/steps/client/benefit_check_result_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Client
+    class BenefitCheckResultController < Steps::ClientStepController
+      def edit
+        @form_object = BenefitCheckResultForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(BenefitCheckResultForm, as: :benefit_check_result)
+      end
+    end
+  end
+end

--- a/app/forms/steps/client/benefit_check_result_form.rb
+++ b/app/forms/steps/client/benefit_check_result_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Client
+    class BenefitCheckResultForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+
+      has_one_association :applicant
+
+      def benefit_check_result
+        BenefitCheckService.call(crime_application)
+      end
+
+      private
+
+      def persist!
+        true
+      end
+    end
+  end
+end

--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -1,0 +1,8 @@
+class BenefitCheckService
+  def self.call(crime_application)
+    # For now we will just use the mock benefit check service
+    # and implement the full benefit check service functionality later
+
+    MockBenefitCheckService.call(crime_application)
+  end
+end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -1,5 +1,6 @@
 module Decisions
   class ClientDecisionTree < BaseDecisionTree
+    # rubocop:disable Metrics/MethodLength
     def destination
       case step_name
       when :has_partner
@@ -7,13 +8,16 @@ module Decisions
       when :details
         edit(:has_nino)
       when :has_nino
-        after_has_nino
+        edit(:benefit_check_result)
+      when :benefit_check_result
+        after_benefit_check_result
       when :contact_details
         after_contact_details
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 
@@ -26,7 +30,7 @@ module Decisions
       end
     end
 
-    def after_has_nino
+    def after_benefit_check_result
       start_address_journey(
         HomeAddress,
         form_object.applicant

--- a/app/services/mock_benefit_check_service.rb
+++ b/app/services/mock_benefit_check_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class MockBenefitCheckService
+  KNOWN = {
+    'SMITH' => { nino: 'ZZ123459A', dob: '11-Jan-99' },
+    'JONES' => { nino: 'ZZ123458A', dob: '1-Jun-80' },
+    'BLOGGS' => { nino: 'ZZ123457A', dob: '4-Jan-90' },
+    'WRINKLE' => { nino: 'ZZ010150A', dob: '01-Jan-50' },
+    'WALKER' => { nino: 'JA293483A', dob: '10-Jan-80' }, # Used in cucumber tests and specs
+  }.freeze
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  attr_reader :crime_application
+
+  delegate :applicant, to: :crime_application, allow_nil: true
+  delegate :last_name, :nino, :date_of_birth, to: :applicant, allow_nil: true
+
+  def initialize(crime_application)
+    @crime_application = crime_application
+  end
+
+  def call
+    {
+      confirmation_ref: "mocked:#{self.class}",
+      benefit_checker_status: result,
+    }
+  end
+
+  def result
+    known? ? 'Yes' : 'No'
+  end
+
+  def known?
+    key = last_name.to_s.upcase
+    return unless KNOWN.key?(key)
+
+    KNOWN[key] == applicant_data
+  end
+
+  def applicant_data
+    {
+      nino: nino,
+      dob: date_of_birth&.strftime('%d-%b-%y'),
+    }
+  end
+end

--- a/app/services/mock_benefit_check_service.rb
+++ b/app/services/mock_benefit_check_service.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class MockBenefitCheckService
   KNOWN = {
     'SMITH' => { nino: 'ZZ123459A', dob: '11-Jan-99' },

--- a/app/views/steps/client/benefit_check_result/edit.html.erb
+++ b/app/views/steps/client/benefit_check_result/edit.html.erb
@@ -1,0 +1,12 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>Benefit check result: <%= @form_object.benefit_check_result[:benefit_checker_status] %></p>
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -17,6 +17,9 @@ en:
         edit:
           page_title: Enter your client’s NINO
           eforms_link: My client does not have a National Insurance number or cannot find it
+      benefit_check_result:
+        edit:
+          page_title: Benefit check result
       nino_exit:
         show:
           page_title: Use eForms for this application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
         edit_step :has_partner
         edit_step :details
         edit_step :has_nino
+        edit_step :benefit_check_result
         show_step :nino_exit
         show_step :partner_exit
         edit_step :contact_details

--- a/spec/controllers/steps/client/benefit_check_result_controller_spec.rb
+++ b/spec/controllers/steps/client/benefit_check_result_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::BenefitCheckResultController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Client::BenefitCheckResultForm, Decisions::ClientDecisionTree
+end

--- a/spec/forms/steps/client/benefit_check_result_form_spec.rb
+++ b/spec/forms/steps/client/benefit_check_result_form_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::BenefitCheckResultForm do
+  # NOTE: not using shared examples for form objects yet, to be added
+  # once we have some more form objects and some patterns emerge
+
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+    }
+  end
+
+  let(:last_name) { 'Smith' }
+  let(:date_of_birth) { '1999/01/11'.to_date }
+  let(:nino) { 'ZZ123459A' }
+  let(:crime_application) do
+    instance_double(CrimeApplication,
+                    applicant:)
+  end
+
+  let(:applicant) do
+    double(
+      Applicant,
+      last_name:,
+      date_of_birth:,
+      nino:
+    )
+  end
+
+  describe '#benefit_check_result' do
+    context 'for a known national insurance number' do
+      it 'is expected to return the correct result' do
+        expect(subject.benefit_check_result).to eql({ benefit_checker_status: 'Yes',
+  confirmation_ref: 'mocked:MockBenefitCheckService' })
+      end
+    end
+
+    context 'for an unknown national insurance number' do
+      let(:nino) { 'AB123456C' }
+
+      it 'is expected to return the correct result' do
+        expect(subject.benefit_check_result).to eql({ benefit_checker_status: 'No',
+  confirmation_ref: 'mocked:MockBenefitCheckService' })
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'is expected to return true' do
+      expect(subject.save).to be(true)
+    end
+  end
+end

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe BenefitCheckService do
+  subject { described_class.new(crime_application) }
+
+  let(:last_name) { 'Smith' }
+  let(:date_of_birth) { '1999/01/11'.to_date }
+  let(:nino) { 'ZZ123459A' }
+  let(:crime_application) do
+    instance_double(CrimeApplication,
+                    applicant:)
+  end
+
+  let(:applicant) do
+    double(
+      Applicant,
+      last_name:,
+      date_of_birth:,
+      nino:
+    )
+  end
+
+  describe '.call' do
+    describe 'behaviour with mock' do
+      before { stub_const('BenefitCheckService::USE_MOCK', true) }
+
+      it 'returns the right parameters' do
+        result = described_class.call(crime_application)
+        expect(result[:benefit_checker_status]).to eq('Yes')
+        expect(result[:confirmation_ref]).to match('mocked:')
+      end
+
+      context 'with matching data' do
+        let(:date_of_birth) { '1955/01/11'.to_date }
+        let(:nino) { 'ZZ123456A' }
+
+        it 'returns true' do
+          result = described_class.call(crime_application)
+          expect(result[:benefit_checker_status]).to eq('No')
+          expect(result[:confirmation_ref]).to match('mocked:')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Decisions::ClientDecisionTree do
     context 'has correct next step' do
       let(:nino) { 'AA123245A' }
 
+      it { is_expected.to have_destination(:benefit_check_result, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `benefit_check_result`' do
+    let(:form_object) { double('FormObject', applicant: 'applicant') }
+    let(:step_name) { :benefit_check_result }
+
+    context 'has correct next step' do
       before do
         allow(
           HomeAddress

--- a/spec/services/mock_benefit_check_service_spec.rb
+++ b/spec/services/mock_benefit_check_service_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe MockBenefitCheckService do
+  subject { described_class.call(crime_application) }
+
+  let(:last_name) { 'Smith' }
+  let(:date_of_birth) { '1999/01/11'.to_date }
+  let(:nino) { 'ZZ123459A' }
+  let(:crime_application) do
+    instance_double(CrimeApplication,
+                    applicant:)
+  end
+
+  let(:applicant) do
+    double(
+      Applicant,
+      last_name:,
+      date_of_birth:,
+      nino:
+    )
+  end
+
+  describe '.call' do
+    it 'returns confirmation_ref' do
+      expect(subject[:confirmation_ref]).to eq("mocked:#{described_class}")
+    end
+
+    it "returns 'Yes' as in known data" do
+      expect(subject[:benefit_checker_status]).to eq('Yes')
+    end
+
+    context 'with incorrect date' do
+      let(:date_of_birth) { '2012/01/10'.to_date }
+
+      it 'returns no' do
+        expect(subject[:benefit_checker_status]).to eq('No')
+      end
+
+      it 'returns confirmation_ref' do
+        expect(subject[:confirmation_ref]).to eq("mocked:#{described_class}")
+      end
+    end
+
+    context 'with unknown name' do
+      let(:last_name) { 'Unknown' }
+
+      it 'returns no' do
+        expect(subject[:benefit_checker_status]).to eq('No')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds a mock benefit service to check on the benefits status of an applicant. Also adds the BenefitCheckService, but this currently only calls the mock.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-107
https://dsdmoj.atlassian.net/browse/CRIMAP-133

## Screenshot

![0 0 0 0_3000_applications_edfb48aa-54c9-4a5f-a1d3-bd8edf217625_steps_client_benefit_check_result](https://user-images.githubusercontent.com/367349/195066918-51bf6c47-8055-4bf9-93ba-eb90708b81ac.png)

## How to manually test the feature

After the has_nino step, you should see a simple page with the result of the benefit check