### PR TITLE
update mock NINOs to use a valid format

### DIFF
--- a/app/services/mock_benefit_check_service.rb
+++ b/app/services/mock_benefit_check_service.rb
@@ -1,9 +1,9 @@
 class MockBenefitCheckService
   KNOWN = {
-    'SMITH' => { nino: 'ZZ123459A', dob: '11-Jan-99' },
-    'JONES' => { nino: 'ZZ123458A', dob: '1-Jun-80' },
-    'BLOGGS' => { nino: 'ZZ123457A', dob: '4-Jan-90' },
-    'WRINKLE' => { nino: 'ZZ010150A', dob: '01-Jan-50' },
+    'SMITH' => { nino: 'NC123459A', dob: '11-Jan-99' },
+    'JONES' => { nino: 'NC123458A', dob: '1-Jun-80' },
+    'BLOGGS' => { nino: 'NC123457A', dob: '4-Jan-90' },
+    'WRINKLE' => { nino: 'NC010150A', dob: '01-Jan-50' },
     'WALKER' => { nino: 'JA293483A', dob: '10-Jan-80' }, # Used in cucumber tests and specs
   }.freeze
 

--- a/spec/forms/steps/client/benefit_check_result_form_spec.rb
+++ b/spec/forms/steps/client/benefit_check_result_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Steps::Client::BenefitCheckResultForm do
 
   let(:last_name) { 'Smith' }
   let(:date_of_birth) { '1999/01/11'.to_date }
-  let(:nino) { 'ZZ123459A' }
+  let(:nino) { 'NC123459A' }
   let(:crime_application) do
     instance_double(CrimeApplication,
                     applicant:)

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BenefitCheckService do
 
   let(:last_name) { 'Smith' }
   let(:date_of_birth) { '1999/01/11'.to_date }
-  let(:nino) { 'ZZ123459A' }
+  let(:nino) { 'NC123459A' }
   let(:crime_application) do
     instance_double(CrimeApplication,
                     applicant:)

--- a/spec/services/mock_benefit_check_service_spec.rb
+++ b/spec/services/mock_benefit_check_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MockBenefitCheckService do
 
   let(:last_name) { 'Smith' }
   let(:date_of_birth) { '1999/01/11'.to_date }
-  let(:nino) { 'ZZ123459A' }
+  let(:nino) { 'NC123459A' }
   let(:crime_application) do
     instance_double(CrimeApplication,
                     applicant:)


### PR DESCRIPTION
## Description of change

Updates the mock NINOs so they no longer use the invalid ZZ prefix.