### PR TITLE
Replace hardcoded case type strings/symbols with constants

### DIFF
--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -10,13 +10,13 @@ class CaseType < ValueObject
   ].freeze
 
   DATE_STAMPABLE = [
-    :summary_only,
-    :either_way,
-    :committal,
-    :cc_appeal
+    SUMMARY_ONLY,
+    EITHER_WAY,
+    COMMITTAL,
+    CC_APPEAL,
   ].freeze
 
   def date_stampable?
-    DATE_STAMPABLE.include?(value)
+    DATE_STAMPABLE.include?(self)
   end
 end

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
         before { expect(kase).to receive(:update).and_return(true) }
 
         context 'and `case_type` is "date stampable"' do
-          let(:case_type) { 'summary_only' }
+          let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
           it 'the crime application date stamp is set' do
             expect(crime_application).to receive(:update).with(hash_including(:date_stamp))
@@ -41,7 +41,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
         end
 
         context 'and `case_type` is not "date stampable"' do
-          let(:case_type) { 'indictable' }
+          let(:case_type) { CaseType::INDICTABLE.to_s }
 
           it 'the crime application date stamp is not set' do
             expect(crime_application).not_to receive(:update).with(hash_including(:date_stamp))
@@ -53,7 +53,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
         before { expect(kase).to receive(:update).and_return(false) }
 
         context 'and `case_type` is "date stampable"' do
-          let(:case_type) { 'summary_only' }
+          let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
           it 'the crime application date stamp is not set' do
             expect(crime_application).not_to receive(:update).with(hash_including(:date_stamp))
@@ -81,7 +81,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
     end
 
     context 'when `case_type` is valid' do
-      let(:case_type) { 'indictable' }
+      let(:case_type) { CaseType::INDICTABLE.to_s }
 
       it { is_expected.to be_valid }
 
@@ -195,7 +195,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
     end
 
     context 'when validations pass' do
-      let(:case_type) { 'indictable' }
+      let(:case_type) { CaseType::INDICTABLE.to_s }
 
       it_behaves_like 'a has-one-association form',
                       association_name: :case,

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CrimeApplicationPresenter do
                     created_at: DateTime.new(2022, 1, 12),
                     status: 'in_progress',
                     date_stamp: Date.new(2022, 2, 1),
-                    case: Case.new(case_type: CaseType.new(case_type)),
+                    case: case_double,
                     applicant: applicant)
   end
 
@@ -22,17 +22,18 @@ RSpec.describe CrimeApplicationPresenter do
     )
   end
 
-  let(:case_type) { :indictable }
+  let(:case_double) { instance_double(Case, case_type:) }
+  let(:case_type) { nil }
 
   describe '#application_date_stamp' do
     context 'when a case is date stampable' do
-      let(:case_type) { :summary_only }
+      let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
       it { expect(subject.application_date_stamp).to eq('1 Feb 2022') }
     end
 
     context 'when a case is not date stampable' do
-      let(:case_type) { :indictable }
+      let(:case_type) { CaseType::INDICTABLE.to_s }
 
       it { expect(subject.application_date_stamp).to be_nil }
     end

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 RSpec.describe DateStamper do
   subject { described_class.new(crime_app, case_type) }
 
-  let(:case_type_sym) { CaseType::DATE_STAMPABLE.sample }
-  let(:date) { DateTime.new(2022, 2, 2) }
-  let(:case_type) { CaseType.new(case_type_sym) }
   let(:crime_app) do
     instance_double(
       CrimeApplication,
@@ -19,6 +16,7 @@ RSpec.describe DateStamper do
 
   describe '#call' do
     context 'when case_type is "date stampable" and date_stamp is nil' do
+      let(:case_type) { CaseType::DATE_STAMPABLE.sample }
       let(:date) { nil }
 
       it 'adds a date stamp to the crime app' do
@@ -27,20 +25,9 @@ RSpec.describe DateStamper do
       end
     end
 
-    context 'when case_type is not "date stampable"' do
-      let(:case_type_sym) { :cc_appeal_fin_change }
-
-      it 'resets the the crime applications date stamp' do
-        expect(crime_app).not_to receive(:update)
-
-        result = subject.call
-
-        expect(result).to be(false)
-      end
-    end
-
     context 'when case_type is "date stampable" and has already been date stamped' do
-      let(:case_type_sym) { :cc_appeal_fin_change }
+      let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+      let(:date) { DateTime.new(2022, 2, 2) }
 
       it 'does not update the crime applications a date stamp' do
         expect(crime_app).not_to receive(:update)
@@ -51,8 +38,8 @@ RSpec.describe DateStamper do
       end
     end
 
-    context 'when case_type is not "date stampable" and has no date stamped' do
-      let(:case_type_sym) { :cc_appeal_fin_change }
+    context 'when case_type is not "date stampable"' do
+      let(:case_type) { CaseType::CC_APPEAL_FIN_CHANGE }
       let(:date) { nil }
 
       it 'does not update the crime applications a date stamp' do

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Decisions::CaseDecisionTree do
       end
 
       context 'and case type is not "date stampable"' do
-        let(:case_type) { :indictable }
+        let(:case_type) { CaseType::INDICTABLE.to_s }
 
         context 'and there are no charges input yet' do
           let(:charges_double) { double(any?: false, create!: 'charge') }
@@ -83,7 +83,7 @@ RSpec.describe Decisions::CaseDecisionTree do
       end
 
       context 'and case type is not "date stampable"' do
-        let(:case_type) { :indictable }
+        let(:case_type) { CaseType::INDICTABLE.to_s }
 
         context 'and there are no charges input yet' do
           let(:charges_double) { double(any?: false, create!: 'charge') }

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -21,29 +21,37 @@ RSpec.describe CaseType do
     end
   end
 
+  describe 'DATE_STAMPABLE' do
+    it 'returns date stampable values' do
+      expect(described_class::DATE_STAMPABLE.map(&:to_s)).to eq(
+        %w[
+          summary_only
+          either_way
+          committal
+          cc_appeal
+        ]
+      )
+    end
+  end
+
   describe '#date_stampable?' do
     context 'for date stampable case types' do
       it 'returns true' do
-        date_stampable_types = [
-          described_class.new(:summary_only).date_stampable?,
-          described_class.new(:either_way).date_stampable?,
-          described_class.new(:committal).date_stampable?,
-          described_class.new(:cc_appeal).date_stampable?
-        ]
+        date_stampable_types = described_class::DATE_STAMPABLE
 
-        expect(date_stampable_types).to all(be_truthy)
+        expect(
+          date_stampable_types.map(&:date_stampable?)
+        ).to all(be_truthy)
       end
     end
 
     context 'for non date stampable case types' do
       it 'returns false' do
-        date_stampable_types = [
-          described_class.new(:indictable).date_stampable?,
-          described_class.new(:already_cc_trial).date_stampable?,
-          described_class.new(:cc_appeal_fin_change).date_stampable?
-        ]
+        non_date_stampable_types = described_class.values - described_class::DATE_STAMPABLE
 
-        expect(date_stampable_types).to all(be_falsy)
+        expect(
+          non_date_stampable_types.map(&:date_stampable?)
+        ).to all(be_falsy)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Ensuring we always use, as much as possible, the value object constants to avoid the situation where we rename or add/remove constants later on and we forget to update the tests or worse, some tests keep passing mysteriously.

## Link to relevant ticket

## Notes for reviewer
There are no functional changes, this is a small code refactor, mainly specs.