### PR TITLE
Move DateStamper call to decision tree, only show date_stamp page once

### DIFF
--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -23,14 +23,7 @@ module Steps
       private
 
       def persist!
-        # TODO: discuss wrapping in a transaction to prevent Case#update
-        # if DateStamper fails
-
-        return false unless kase.update(attributes.merge(attributes_to_reset))
-
-        DateStamper.new(crime_application, case_type).call
-
-        true
+        kase.update(attributes.merge(attributes_to_reset))
       end
 
       def attributes_to_reset

--- a/app/services/date_stamper.rb
+++ b/app/services/date_stamper.rb
@@ -23,7 +23,7 @@ class DateStamper
     # -- If case is non “date stampable” we use the submission date as the date
     #    stamp.
 
-    if @case_type.date_stampable? && @crime_app.date_stamp.nil?
+    if CaseType.new(@case_type).date_stampable? && @crime_app.date_stamp.nil?
       @crime_app.update(date_stamp: DateTime.now)
     else
       false

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -37,10 +37,7 @@ module Decisions
     private
 
     def after_case_type
-      has_date_stamp = current_crime_application.date_stamp
-      is_date_stampable = form_object.case_type.date_stampable?
-
-      if is_date_stampable && has_date_stamp
+      if DateStamper.new(form_object.crime_application, form_object.case.case_type).call
         edit(:date_stamp)
       else
         charges_summary_or_edit_new_charge

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -24,44 +24,6 @@ RSpec.describe Steps::Case::CaseTypeForm do
   let(:cc_appeal_fin_change_details) { nil }
 
   describe '#save' do
-    describe 'date stamping' do
-      let(:kase) { instance_double(Case) }
-
-      after { form.save }
-
-      context 'when case is valid' do
-        before { expect(kase).to receive(:update).and_return(true) }
-
-        context 'and `case_type` is "date stampable"' do
-          let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
-
-          it 'the crime application date stamp is set' do
-            expect(crime_application).to receive(:update).with(hash_including(:date_stamp))
-          end
-        end
-
-        context 'and `case_type` is not "date stampable"' do
-          let(:case_type) { CaseType::INDICTABLE.to_s }
-
-          it 'the crime application date stamp is not set' do
-            expect(crime_application).not_to receive(:update).with(hash_including(:date_stamp))
-          end
-        end
-      end
-
-      context 'when case_type is not valid' do
-        before { expect(kase).to receive(:update).and_return(false) }
-
-        context 'and `case_type` is "date stampable"' do
-          let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
-
-          it 'the crime application date stamp is not set' do
-            expect(crime_application).not_to receive(:update).with(hash_including(:date_stamp))
-          end
-        end
-      end
-    end
-
     context 'when `case_type` is blank' do
       let(:case_type) { '' }
 

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -33,53 +33,39 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:form_object) { double('FormObject', case: kase, case_type: CaseType.new(case_type)) }
     let(:step_name) { :case_type }
 
-    context 'and the application has a date stamp' do
+    context 'and the application already has a date stamp' do
       before do
         allow(crime_application).to receive(:date_stamp) { Time.zone.today }
+        allow(kase).to receive(:case_type).and_return(case_type)
       end
 
-      context 'and the case type is "date stampable"' do
-        let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+      let(:case_type) { CaseType::VALUES.sample }
 
-        it { is_expected.to have_destination(:date_stamp, :edit, id: crime_application) }
+      context 'and there are no charges input yet' do
+        let(:charges_double) { double(any?: false, create!: 'charge') }
+
+        it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
       end
 
-      context 'and case type is not "date stampable"' do
-        let(:case_type) { CaseType::INDICTABLE.to_s }
+      context 'and there are already charges input' do
+        let(:charges_double) { double(any?: true) }
 
-        context 'and there are no charges input yet' do
-          let(:charges_double) { double(any?: false, create!: 'charge') }
-
-          it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
-        end
-
-        context 'and there are already charges input' do
-          let(:charges_double) { double(any?: true) }
-
-          it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
-        end
+        it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
       end
     end
 
     context 'and the application has no date stamp' do
       before do
-        allow(crime_application).to receive(:date_stamp).and_return(nil)
+        allow(crime_application).to receive(:date_stamp)
+        allow(kase).to receive(:case_type).and_return(case_type)
       end
 
       context 'and the case type is "date stampable"' do
+        let(:charges_double) { double(any?: false, create!: 'charge') }
+
         let(:case_type) { CaseType::DATE_STAMPABLE.sample }
 
-        context 'and there are no charges input yet' do
-          let(:charges_double) { double(any?: false, create!: 'charge') }
-
-          it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
-        end
-
-        context 'and there are already charges input' do
-          let(:charges_double) { double(any?: true) }
-
-          it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
-        end
+        it { is_expected.to have_destination(:date_stamp, :edit, id: crime_application) }
       end
 
       context 'and case type is not "date stampable"' do


### PR DESCRIPTION
## Description of change

Only shows the user the date_stamp page on the first time a date_stampable case_type is chose and the form is submitted.
Modified the logic in the case_decision_tree to allow for this - called the DateStamper from the decision tree so it returns false if the date_stamp is not updated by the DateStamper on subsequent re submissions of case_type step.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-148

## How to manually test the feature
Go through user flow up to Case Type step
Select a date stampable Case Type (e.g. Summary Only)
Submit form and be redirected to Case Stamp page
Hit the back button to return to Case Type step 

Resubmit form/ change case type and resubmit and get redirected to charges journey