### PR TITLE
CRIMAP-154 Reset correspondence address when not applicable

### DIFF
--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -32,8 +32,16 @@ module Steps
 
       def persist!
         applicant.update(
-          attributes
+          attributes.merge(
+            reset_address_if_needed
+          )
         )
+      end
+
+      def reset_address_if_needed
+        {}.tap do |attrs|
+          attrs.merge!(correspondence_address: nil) unless correspondence_address_type.other_address?
+        end
       end
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,6 +3,7 @@ class Person < ApplicationRecord
   has_many :addresses, dependent: :destroy
 
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
+  has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'
 
   scope :with_name, -> { where.not(first_name: [nil, '']) }
 


### PR DESCRIPTION
## Description of change
As we do in other places, if provider changes the correspondence type selection from `other` to anything else (like home or provider's office) we reset the previously entered correspondence address (if any).

As this is a `has_one` relationship, nilling the attribute will remove the record from the `Addresses` table.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-154

## How to manually test the feature
Go to contact details and select "other address", enter a correspondence address, then go back and change selection, the correspondence address record will be deleted.