### PR TITLE
CRIMAP-163 Better handling of incomplete offences

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,7 @@
 // Components or full features
 @import "local/govuk";
+@import "local/moj";
+
 @import "local/info_card";
 @import "local/task_list";
 

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -1,0 +1,9 @@
+// MOJ Design System
+// https://design-patterns.service.justice.gov.uk
+//
+// NOTE: using hand-picked components instead of importing
+// the whole library, as we only need a few ones.
+
+// Badge
+// https://design-patterns.service.justice.gov.uk/components/badge/
+@import "@ministryofjustice/frontend/moj/components/badge/badge";

--- a/app/forms/steps/case/charges_summary_form.rb
+++ b/app/forms/steps/case/charges_summary_form.rb
@@ -7,6 +7,8 @@ module Steps
       attribute :add_offence, :value_object, source: YesNoAnswer
       validates :add_offence, inclusion: { in: :choices }
 
+      validate :all_charges_have_details, if: -> { add_offence&.no? }
+
       delegate :charges, to: :kase
 
       def choices
@@ -14,6 +16,10 @@ module Steps
       end
 
       private
+
+      def all_charges_have_details
+        errors.add(:add_offence, :missing_details) unless charges.all?(&:complete?)
+      end
 
       # NOTE: this step is not persisting anything to DB.
       # We only use `add_offence` transiently in the decision tree.

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -9,4 +9,8 @@ class Charge < ApplicationRecord
 
   composed_of :offence, mapping: %i[offence_name name],
               constructor: :find_by_name, allow_nil: true
+
+  def complete?
+    offence_name.present? && offence_dates.pluck(:date).any?
+  end
 end

--- a/app/views/steps/case/charges_summary/_offence_details.html.erb
+++ b/app/views/steps/case/charges_summary/_offence_details.html.erb
@@ -15,6 +15,12 @@
         <%= l(date) %>
       </p>
     <% end %>
+
+    <% unless charge.complete? %>
+      <strong class="moj-badge moj-badge--red">
+        <%= t('.incomplete_tag') %>
+      </strong>
+    <% end %>
   </dd>
 
   <% if show_actions %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -115,6 +115,7 @@ en:
           attributes:
             add_offence:
               inclusion: Select yes if you want to add another offence
+              missing_details: You must complete all offence details in order to proceed
         steps/case/offence_date_fieldset_form:
           attributes:
             date:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -117,6 +117,7 @@ en:
             one: You have added %{count} offence
             other: You have added %{count} offences
         offence_details:
+          incomplete_tag: Incomplete
           change_link_html: Change <span class="govuk-visually-hidden">offence</span>
           remove_link_html: Remove <span class="govuk-visually-hidden">offence</span>
       hearing_details:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "laa-apply-for-criminal-legal-aid",
   "private": "true",
   "dependencies": {
-    "govuk-frontend": "4.3.1"
+    "govuk-frontend": "4.3.1",
+    "@ministryofjustice/frontend": "1.6.0"
   },
   "scripts": {
     "postinstall": "bin/importmap pin govuk-frontend@4.3.1"

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -29,4 +29,46 @@ RSpec.describe Charge, type: :model do
       it { expect(subject.offence).to be_nil }
     end
   end
+
+  describe '#complete?' do
+    before do
+      allow(subject).to receive(:offence_dates).and_return(offence_dates)
+    end
+
+    context 'for an offence with name and dates' do
+      let(:offence_name) { 'Foobar' }
+      let(:offence_dates) { [{ date: 'date' }, { date: nil }] }
+
+      it 'returns true' do
+        expect(subject.complete?).to be(true)
+      end
+    end
+
+    context 'for an offence with no name and dates' do
+      let(:offence_name) { '' }
+      let(:offence_dates) { [{ date: 'date' }, { date: nil }] }
+
+      it 'returns true' do
+        expect(subject.complete?).to be(false)
+      end
+    end
+
+    context 'for an offence with name but no dates' do
+      let(:offence_name) { 'Foobar' }
+      let(:offence_dates) { [{ date: nil }] }
+
+      it 'returns false' do
+        expect(subject.complete?).to be(false)
+      end
+    end
+
+    context 'for an offence with no name and no dates' do
+      let(:offence_name) { '' }
+      let(:offence_dates) { [{ date: nil }] }
+
+      it 'returns false' do
+        expect(subject.complete?).to be(false)
+      end
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,20 @@
 # yarn lockfile v1
 
 
-govuk-frontend@4.3.1:
+"@ministryofjustice/frontend@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.6.0.tgz#a17951012207f1b17d42cefe02ec90667d4ced7f"
+  integrity sha512-LFmDiO3y8l4qey2WDmRnHb98vAVSCD/QSYYEUBwS10ouyBNbYKGHWNLxF1VfulqOa5uPJp/fA2JUT9Pj1T4NUg==
+  dependencies:
+    govuk-frontend "^3.0.0 || ^4.0.0"
+    moment "^2.27.0"
+
+govuk-frontend@4.3.1, "govuk-frontend@^3.0.0 || ^4.0.0":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
   integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
+
+moment@^2.27.0:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
## Description of change
Due to the way the offences page work (a page with nested attributes for details of the offence like offence name and one or more dates), each time the provider adds a new offence through the summary page, a blank record is created in the database, for the provider to fill in the details (offence name and dates).

This usually happens in one go, but if at that point, without finalising all the details, the provider clicks the “save and come back later“ button, for example, or click the “back“ link in the page, they will leave the offence in an incomplete state, maybe missing the name, or the dates, or both.

Removing these empty records is not a nice solution really, as some might contain partially entered details, like the offence name (but no dates) or vice versa, if the provider clicks the save draft button, in order to come back later on to these offences.

Also it breaks the navigation as clicking the "back" link in the summary page might go to a just deleted charge record.

A better solution is to present these incomplete charges for the provider to either remove them or edit and complete them.

Also some additional validation is added to not allow a provider to proceed with incomplete charges in the "basket" page.

Discussed the copy and design with service designer and we decided to go with the MOJ badges.

MOJ library is added to the package.json but only the badge component is used. In a separate PR I will also refactor the task list to use the MOJ import instead of maintaining our own copy of the component.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-163

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="763" alt="Screenshot 2022-10-14 at 09 29 18" src="https://user-images.githubusercontent.com/687910/195800528-a6fa7316-121a-4a8a-b9c5-5ccfd8ba4f0f.png">

### After changes:
<img width="786" alt="Screenshot 2022-10-14 at 09 29 42" src="https://user-images.githubusercontent.com/687910/195800553-3e1f095b-f66f-4e95-9fe5-9d67038c91cd.png">

<img width="633" alt="Screenshot 2022-10-14 at 09 30 09" src="https://user-images.githubusercontent.com/687910/195800625-ba0e1c1e-1c07-428c-98e8-b9c73a895b78.png">

## How to manually test the feature
Go to the offences page, enter an offence, proceed to the basket, then select add another offence YES, but don't enter details, click the back link, and see how it shows as incomplete.
Select add another offence NO and you will get a validation error as well.