### PR TITLE
CRIMAP-155 Review client details

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -26,9 +26,11 @@ linters:
         Enabled: false
       Layout/LineLength:
         Enabled: false
+      Layout/LeadingEmptyLines:
+        Enabled: false
       Layout/TrailingEmptyLines:
         Enabled: false
-      Style/FrozenStringLiteralComment:
+      Layout/TrailingWhitespace:
         Enabled: false
       Style/BlockDelimiters:
         Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
+Style/TrailingCommaInArguments:
+  Enabled: false
+
 Layout/HashAlignment:
   Enabled: false
 
@@ -109,15 +112,19 @@ Naming/PredicateName:
   AllowedMethods:
     - has_one_association
 
-# TODO: adjust these values towards the rubcop defaults
+# TODO: adjust these values towards the rubocop defaults
 RSpec/MultipleMemoizedHelpers:
   Max: 10
 
 RSpec/MultipleExpectations:
   Max: 7
+  Exclude:
+    - spec/presenters/summary/sections/*
 
 RSpec/NestedGroups:
   Max: 5
 
 RSpec/ExampleLength:
   Max: 13
+  Exclude:
+    - spec/presenters/summary/sections/*

--- a/app/controllers/steps/submission/review_controller.rb
+++ b/app/controllers/steps/submission/review_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Submission
     class ReviewController < Steps::SubmissionStepController
+      before_action :set_presenter
+
       def edit
         @form_object = ReviewForm.build(
           current_crime_application
@@ -9,6 +11,14 @@ module Steps
 
       def update
         update_and_advance(ReviewForm, as: :review)
+      end
+
+      private
+
+      def set_presenter
+        @presenter = Summary::HtmlPresenter.new(
+          crime_application: current_crime_application
+        )
       end
     end
   end

--- a/app/presenters/summary/components/base_answer.rb
+++ b/app/presenters/summary/components/base_answer.rb
@@ -1,0 +1,46 @@
+module Summary
+  module Components
+    class BaseAnswer
+      attr_reader :question, :value, :show, :change_path, :i18n_opts
+
+      DEFAULT_OPTIONS = { default: nil, show: nil, change_path: nil, i18n_opts: {} }.freeze
+
+      def initialize(question, value, *args)
+        options = extract_supported_options!(args)
+
+        @question = question
+        @value = value || options[:default]
+        @show = options[:show]
+        @change_path = options[:change_path]
+        @i18n_opts = options[:i18n_opts]
+      end
+
+      def show?
+        show.presence || value?
+      end
+
+      def value?
+        value.present?
+      end
+
+      def change_link?
+        change_path.present?
+      end
+
+      # Used by Rails to determine which partial to render
+      # :nocov:
+      def to_partial_path
+        raise 'implement in subclasses'
+      end
+      # :nocov:
+
+      private
+
+      def extract_supported_options!(args)
+        options = DEFAULT_OPTIONS.merge(args.extract_options!)
+        options.assert_valid_keys(DEFAULT_OPTIONS.keys)
+        options
+      end
+    end
+  end
+end

--- a/app/presenters/summary/components/date_answer.rb
+++ b/app/presenters/summary/components/date_answer.rb
@@ -1,0 +1,9 @@
+module Summary
+  module Components
+    class DateAnswer < BaseAnswer
+      def to_partial_path
+        'steps/submission/shared/date_answer'
+      end
+    end
+  end
+end

--- a/app/presenters/summary/components/free_text_answer.rb
+++ b/app/presenters/summary/components/free_text_answer.rb
@@ -1,0 +1,9 @@
+module Summary
+  module Components
+    class FreeTextAnswer < BaseAnswer
+      def to_partial_path
+        'steps/submission/shared/free_text_answer'
+      end
+    end
+  end
+end

--- a/app/presenters/summary/components/value_answer.rb
+++ b/app/presenters/summary/components/value_answer.rb
@@ -1,0 +1,9 @@
+module Summary
+  module Components
+    class ValueAnswer < BaseAnswer
+      def to_partial_path
+        'steps/submission/shared/value_answer'
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -1,0 +1,15 @@
+module Summary
+  class HtmlPresenter
+    attr_reader :crime_application
+
+    def initialize(crime_application:)
+      @crime_application = crime_application
+    end
+
+    def sections
+      [
+        Sections::ClientDetails.new(crime_application),
+      ].select(&:show?)
+    end
+  end
+end

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -1,0 +1,37 @@
+module Summary
+  module Sections
+    class BaseSection
+      include Routing
+
+      attr_reader :crime_application
+
+      def initialize(crime_application)
+        @crime_application = crime_application
+      end
+
+      # Used by Rails to determine which partial to render.
+      # May be overridden in subclasses.
+      def to_partial_path
+        'steps/submission/shared/section'
+      end
+
+      # May be overridden in subclasses to hide/show if appropriate
+      def show?
+        answers.any?
+      end
+
+      # Used by the `Routing` module to build the `change` urls
+      def default_url_options
+        { id: crime_application }
+      end
+
+      private
+
+      # :nocov:
+      def answers
+        raise 'must be implemented in subclasses'
+      end
+      # :nocov:
+    end
+  end
+end

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -1,0 +1,51 @@
+module Summary
+  module Sections
+    class ClientDetails < Sections::BaseSection
+      def name
+        :client_details
+      end
+
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def answers
+        [
+          Components::FreeTextAnswer.new(
+            :first_name, applicant.first_name,
+            change_path: edit_steps_client_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :last_name, applicant.last_name,
+            change_path: edit_steps_client_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :other_names, applicant.other_names,
+            change_path: edit_steps_client_details_path, show: true
+          ),
+
+          Components::DateAnswer.new(
+            :date_of_birth, applicant.date_of_birth,
+            change_path: edit_steps_client_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :nino, applicant.nino,
+            change_path: edit_steps_client_has_nino_path
+          ),
+
+          # hardcoded for MVP, as we do screening
+          Components::ValueAnswer.new(
+            :passporting, YesNoAnswer::YES
+          ),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      private
+
+      def applicant
+        @applicant ||= crime_application.applicant
+      end
+    end
+  end
+end

--- a/app/views/steps/submission/review/edit.html.erb
+++ b/app/views/steps/submission/review/edit.html.erb
@@ -2,10 +2,14 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
     <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
 
-    <%= step_form @form_object do |f| %>
+    <%= render @presenter.sections %>
+
+    <%= step_form @form_object, html: { class: 'govuk-!-padding-top-6' } do |f| %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/submission/shared/_date_answer.html.erb
+++ b/app/views/steps/submission/shared/_date_answer.html.erb
@@ -1,0 +1,11 @@
+<%
+  content_for(:row_question, flush: true) do
+    t("summary.questions.#{date_answer.question}.question")
+  end
+
+  content_for(:row_answer, flush: true) do
+    l(date_answer.value)
+  end
+%>
+
+<%= render partial: 'steps/submission/shared/summary_row', locals: { row: date_answer } %>

--- a/app/views/steps/submission/shared/_free_text_answer.html.erb
+++ b/app/views/steps/submission/shared/_free_text_answer.html.erb
@@ -1,0 +1,14 @@
+<%
+  content_for(:row_question, flush: true) do
+    t("summary.questions.#{free_text_answer.question}.question", **free_text_answer.i18n_opts)
+  end
+
+  content_for(:row_answer, flush: true) do
+    simple_format(
+      free_text_answer.value.presence || t("summary.questions.#{free_text_answer.question}.absence_answer"),
+      { class: 'govuk-body' }
+    )
+  end
+%>
+
+<%= render partial: 'steps/submission/shared/summary_row', locals: { row: free_text_answer } %>

--- a/app/views/steps/submission/shared/_section.html.erb
+++ b/app/views/steps/submission/shared/_section.html.erb
@@ -1,0 +1,7 @@
+<h2 class="govuk-heading-m">
+  <%= t(section.name, scope: 'summary.sections') %>
+</h2>
+
+<dl class="govuk-summary-list">
+  <%= render section.answers %>
+</dl>

--- a/app/views/steps/submission/shared/_summary_row.html.erb
+++ b/app/views/steps/submission/shared/_summary_row.html.erb
@@ -1,0 +1,31 @@
+<%
+  show_actions = current_crime_application.in_progress? && row.change_link?
+
+  div_classes = ['govuk-summary-list__row']
+  div_classes << 'govuk-summary-list__row--no-actions' unless show_actions
+%>
+
+<div class="<%= div_classes.join(' ') %>">
+  <dt class="govuk-summary-list__key govuk-!-width-one-third">
+    <%= yield(:row_question) %>
+  </dt>
+
+  <dd class="govuk-summary-list__value">
+    <%= yield(:row_answer) %>
+  </dd>
+
+  <% if show_actions %>
+    <%
+      a11y_question = t(
+        "summary.questions.#{row.question}.question_a11y", **{
+          default: t("summary.questions.#{row.question}.question", **row.i18n_opts)
+        }.merge(row.i18n_opts)
+      )
+    %>
+
+    <dd class="govuk-summary-list__actions">
+      <%= link_to t('summary.change_link_html', a11y_question:), row.change_path,
+                  class: 'govuk-link--no-visited-state' %>
+    </dd>
+  <% end %>
+</div>

--- a/app/views/steps/submission/shared/_value_answer.html.erb
+++ b/app/views/steps/submission/shared/_value_answer.html.erb
@@ -1,0 +1,11 @@
+<%
+  content_for(:row_question, flush: true) do
+    t("summary.questions.#{value_answer.question}.question", **value_answer.i18n_opts)
+  end
+
+  content_for(:row_answer, flush: true) do
+    t("summary.questions.#{value_answer.question}.answers.#{value_answer.value}")
+  end
+%>
+
+<%= render partial: 'steps/submission/shared/summary_row', locals: { row: value_answer } %>

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -1,0 +1,30 @@
+en:
+  summary:
+    dictionary:
+      YESNO: &YESNO
+        'yes': 'Yes'
+        'no': 'No'
+
+    change_link_html: Change <span class="govuk-visually-hidden">%{a11y_question}</span>
+
+    sections:
+      client_details: Client details
+
+    questions:
+      # BEGIN client details section
+      first_name:
+        question: First name
+      last_name:
+        question: Last name
+      other_names:
+        question: Other names
+        absence_answer: None
+      date_of_birth:
+        question: Date of birth
+      nino:
+        question: National Insurance number
+      passporting:
+        question: Passporting benefit
+        answers:
+          <<: *YESNO
+      # END client details section

--- a/spec/presenters/summary/components/base_answer_spec.rb
+++ b/spec/presenters/summary/components/base_answer_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+describe Summary::Components::BaseAnswer do
+  subject { described_class.new(question, value, default:, change_path:) }
+
+  let(:question) { 'Question?' }
+  let(:value) { 'Answer!' }
+  let(:change_path) { nil }
+  let(:default) { nil }
+
+  describe 'validates the options' do
+    subject { described_class.new(question, value, test: true) }
+
+    it 'raises an exception' do
+      expect { subject.show? }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#show?' do
+    it 'returns true' do
+      expect(subject.show?).to be(true)
+    end
+
+    context 'when no value is given' do
+      let(:value) { nil }
+
+      it 'returns false' do
+        expect(subject.show?).to be(false)
+      end
+    end
+
+    context 'when `show` is enabled via arguments' do
+      subject { described_class.new(question, nil, show: true) }
+
+      it 'returns true regardless of `value` being nil' do
+        expect(subject.show?).to be(true)
+      end
+    end
+  end
+
+  describe '#value?' do
+    it 'returns true' do
+      expect(subject.value?).to be(true)
+    end
+
+    context 'when no value is given' do
+      let(:value) { nil }
+
+      it 'returns false' do
+        expect(subject.value?).to be(false)
+      end
+    end
+  end
+
+  describe 'can be given a default value' do
+    context 'when value is nil' do
+      let(:value) { nil }
+      let(:default) { 'no' }
+
+      it 'returns the default value' do
+        expect(subject.value).to eq('no')
+      end
+    end
+
+    context 'when value is not nil' do
+      let(:value) { 'yes' }
+      let(:default) { 'no' }
+
+      it 'returns the original value' do
+        expect(subject.value).to eq('yes')
+      end
+    end
+  end
+
+  describe 'can be given i18n options' do
+    context 'when value is nil' do
+      subject { described_class.new(question, value, i18n_opts: { name: 'John' }) }
+
+      it 'returns the options' do
+        expect(subject.i18n_opts).to eq({ name: 'John' })
+      end
+    end
+  end
+
+  describe '#change_link?' do
+    it 'returns false' do
+      expect(subject.change_link?).to be(false)
+    end
+
+    context 'when change_path is given' do
+      let(:change_path) { '/change' }
+
+      it 'returns true' do
+        expect(subject.change_link?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/components/date_answer_spec.rb
+++ b/spec/presenters/summary/components/date_answer_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Summary::Components::DateAnswer do
+  subject { described_class.new(question, value) }
+
+  let(:question) { 'Question?' }
+  let(:value) { 'Answer!' }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('steps/submission/shared/date_answer')
+    end
+  end
+end

--- a/spec/presenters/summary/components/free_text_answer_spec.rb
+++ b/spec/presenters/summary/components/free_text_answer_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Summary::Components::FreeTextAnswer do
+  subject { described_class.new(question, value) }
+
+  let(:question) { 'Question?' }
+  let(:value) { 'Answer!' }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('steps/submission/shared/free_text_answer')
+    end
+  end
+end

--- a/spec/presenters/summary/components/value_answer_spec.rb
+++ b/spec/presenters/summary/components/value_answer_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Summary::Components::ValueAnswer do
+  subject { described_class.new(question, value) }
+
+  let(:question) { 'Question?' }
+  let(:value) { 'Answer!' }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('steps/submission/shared/value_answer')
+    end
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Summary::HtmlPresenter do
+  subject { described_class.new(crime_application:) }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  describe '#sections' do
+    before do
+      allow_any_instance_of(
+        Summary::Sections::BaseSection
+      ).to receive(:show?).and_return(true)
+    end
+
+    it 'has the right sections in the right order' do
+      expect(
+        subject.sections
+      ).to match_instances_array(
+        [
+          Summary::Sections::ClientDetails,
+        ]
+      )
+    end
+  end
+end

--- a/spec/presenters/summary/sections/base_section_spec.rb
+++ b/spec/presenters/summary/sections/base_section_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe Summary::Sections::BaseSection do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  describe '#to_partial_path' do
+    it 'returns the partial path' do
+      expect(subject.to_partial_path).to eq('steps/submission/shared/section')
+    end
+  end
+
+  describe '#show?' do
+    context 'for an empty answers collection' do
+      before do
+        expect(subject).to receive(:answers).and_return([])
+      end
+
+      it 'returns false' do
+        expect(subject.show?).to be(false)
+      end
+    end
+
+    context 'for a not empty answers collection' do
+      before do
+        expect(subject).to receive(:answers).and_return(['blah'])
+      end
+
+      it 'returns true' do
+        expect(subject.show?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Summary::Sections::ClientDetails do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      client_has_partner: 'no',
+      applicant: applicant,
+    )
+  end
+
+  let(:applicant) do
+    instance_double(
+      Applicant,
+      first_name: 'first name',
+      last_name: 'last name',
+      other_names: '',
+      date_of_birth: Date.new(1999, 1, 20),
+      nino: '123456',
+    )
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:client_details) }
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    it 'has the correct rows' do
+      expect(answers.count).to eq(6)
+
+      expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[0].question).to eq(:first_name)
+      expect(answers[0].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[0].value).to eq('first name')
+
+      expect(answers[1]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[1].question).to eq(:last_name)
+      expect(answers[1].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[1].value).to eq('last name')
+
+      expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[2].question).to eq(:other_names)
+      expect(answers[2].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[2].value).to eq('')
+
+      expect(answers[3]).to be_an_instance_of(Summary::Components::DateAnswer)
+      expect(answers[3].question).to eq(:date_of_birth)
+      expect(answers[2].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[3].value).to eq(Date.new(1999, 1, 20))
+
+      expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[4].question).to eq(:nino)
+      expect(answers[4].change_path).to match('applications/12345/steps/client/has_nino')
+      expect(answers[4].value).to eq('123456')
+
+      expect(answers[5]).to be_an_instance_of(Summary::Components::ValueAnswer)
+      expect(answers[5].question).to eq(:passporting)
+      expect(answers[5].change_path).to be_nil
+      expect(answers[5].value).to eq(YesNoAnswer::YES)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include(ViewSpecHelpers, type: :helper)
+  config.include(ViewSpecHelpers, type: :view)
+
   config.before(:each, type: :helper) { initialize_view_helpers(helper) }
+  config.before(:each, type: :view) { initialize_view_helpers(view) }
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/support/matchers/instances_array_matcher.rb
+++ b/spec/support/matchers/instances_array_matcher.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :match_instances_array do |expected_array|
+  match do |actual_array|
+    actual_array.size == expected_array.size &&
+      actual_array.map.with_index { |element, index| element.is_a?(expected_array[index]) }.all?
+  end
+
+  description do
+    "match_instances_array #{expected_array}"
+  end
+
+  failure_message do |actual_array|
+    "expected array `#{expected_array}` to match `#{actual_array}`"
+  end
+end

--- a/spec/views/steps/submission/shared/_date_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_date_answer.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe 'Rendering a summary row of type `DateAnswer`' do
+  let(:crime_application) { CrimeApplication.new(status: ApplicationStatus::IN_PROGRESS.to_s) }
+
+  let(:answer) do
+    Summary::Components::DateAnswer.new(
+      :date_of_birth, Date.new(2008, 11, 22), change_path: '/edit'
+    )
+  end
+
+  before do
+    allow(view).to receive(:current_crime_application).and_return(crime_application)
+    render answer
+  end
+
+  # No need to test again the application status or the change link,
+  # as we tested it in `value_answer` and all these partials behave the same
+  # because they render a common partial, where that logic resides.
+
+  it 'renders the expected row' do
+    assert_select 'div.govuk-summary-list__row', 1 do
+      assert_select 'dt.govuk-summary-list__key', text: 'Date of birth'
+      assert_select 'dd.govuk-summary-list__value', text: '22 Nov 2008'
+      assert_select 'dd.govuk-summary-list__actions a', text: 'Change Date of birth'
+    end
+  end
+end

--- a/spec/views/steps/submission/shared/_free_text_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_free_text_answer.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe 'Rendering a summary row of type `FreeTextAnswer`' do
+  let(:crime_application) { CrimeApplication.new(status: ApplicationStatus::IN_PROGRESS.to_s) }
+
+  let(:answer) do
+    Summary::Components::FreeTextAnswer.new(
+      :first_name, 'John', change_path: '/edit'
+    )
+  end
+
+  before do
+    allow(view).to receive(:current_crime_application).and_return(crime_application)
+    render answer
+  end
+
+  # No need to test again the application status or the change link,
+  # as we tested it in `value_answer` and all these partials behave the same
+  # because they render a common partial, where that logic resides.
+
+  it 'renders the expected row' do
+    assert_select 'div.govuk-summary-list__row', 1 do
+      assert_select 'dt.govuk-summary-list__key', text: 'First name'
+      assert_select 'dd.govuk-summary-list__value', text: 'John'
+      assert_select 'dd.govuk-summary-list__actions a', text: 'Change First name'
+    end
+  end
+end

--- a/spec/views/steps/submission/shared/_value_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_value_answer.html.erb_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe 'Rendering a summary row of type `ValueAnswer`' do
+  let(:crime_application) { CrimeApplication.new(status:) }
+
+  let(:answer) do
+    Summary::Components::ValueAnswer.new(
+      :passporting, :yes, change_path:
+    )
+  end
+
+  before do
+    allow(view).to receive(:current_crime_application).and_return(crime_application)
+    render answer
+  end
+
+  context 'for an `in_progress` application' do
+    let(:status) { ApplicationStatus::IN_PROGRESS.to_s }
+
+    context 'with change link' do
+      let(:change_path) { '/edit' }
+
+      it 'renders the expected row' do
+        assert_select 'div.govuk-summary-list__row--no-actions', 0
+
+        assert_select 'div.govuk-summary-list__row', 1 do
+          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
+          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dd.govuk-summary-list__actions a', text: 'Change Passporting benefit'
+        end
+      end
+    end
+
+    context 'without change link' do
+      let(:change_path) { nil }
+
+      it 'renders the expected row' do
+        assert_select 'div.govuk-summary-list__row--no-actions', 1 do
+          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
+          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dd.govuk-summary-list__actions', 0
+        end
+      end
+    end
+  end
+
+  context 'for a `submitted` application' do
+    let(:status) { ApplicationStatus::SUBMITTED.to_s }
+
+    context 'with change link' do
+      let(:change_path) { '/edit' }
+
+      it 'renders the expected row' do
+        assert_select 'div.govuk-summary-list__row--no-actions', 1 do
+          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
+          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dd.govuk-summary-list__actions', 0
+        end
+      end
+    end
+
+    context 'without change link' do
+      let(:change_path) { nil }
+
+      it 'renders the expected row' do
+        assert_select 'div.govuk-summary-list__row--no-actions', 1 do
+          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
+          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dd.govuk-summary-list__actions', 0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Note: this PR is quite large as it sets out the "framework" to present the "check your answers" page and to edit the answers (change links).

As part of this framework, the `Client details` section has been partially implemented. There are a few remaining questions-answers I'm leaving for a follow-up PR so this one does not grow even larger.

Despite the many files, only 5 classes are the main implementation. The other files are view partials and many tests, including some view tests.

The general idea is: each time we want to add a new section to the check your answers page, we implement a new class inheriting from `Sections::BaseSection` and define all the answers making use of the different "answer" types and their change link, if any.

These classes will render themselves making use of partials. Each type of answer renders slightly different (for example a date answer will render the localised date, while a free text answer will render as it is).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-155

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="714" alt="Screenshot 2022-10-17 at 11 22 48" src="https://user-images.githubusercontent.com/687910/196154359-4d577242-492f-4d73-859e-1eb1cb8a321b.png">

## How to manually test the feature
As this page is not yet part of the wider journey (will be added after we have IoJ step), you can access it manually by going to the /applications/{uuid}/steps/submission/review URL.