### PR TITLE
CRIMAP-155 Review contact details

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -9,6 +9,7 @@ module Summary
     def sections
       [
         Sections::ClientDetails.new(crime_application),
+        Sections::ContactDetails.new(crime_application),
       ].select(&:show?)
     end
   end

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -1,0 +1,65 @@
+module Summary
+  module Sections
+    class ContactDetails < Sections::BaseSection
+      def name
+        :contact_details
+      end
+
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def answers
+        [
+          Components::FreeTextAnswer.new(
+            :home_address, full_address(home_address), show: true,
+            change_path: address_path(home_address)
+          ),
+
+          Components::ValueAnswer.new(
+            :correspondence_address_type, applicant.correspondence_address_type,
+            change_path: edit_steps_client_contact_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :correspondence_address, full_address(correspondence_address),
+            change_path: address_path(correspondence_address)
+          ),
+
+          Components::FreeTextAnswer.new(
+            :telephone_number, applicant.telephone_number,
+            change_path: edit_steps_client_contact_details_path
+          ),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      private
+
+      def applicant
+        @applicant ||= crime_application.applicant
+      end
+
+      def home_address
+        applicant.home_address
+      end
+
+      def correspondence_address
+        applicant.correspondence_address
+      end
+
+      def address_path(address)
+        edit_steps_address_details_path(address) if address
+      end
+
+      def full_address(address)
+        return unless address
+
+        address.slice(
+          :address_line_one,
+          :address_line_two,
+          :postcode,
+          :city,
+          :country
+        ).values.compact_blank.join("\r\n")
+      end
+    end
+  end
+end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -1,6 +1,7 @@
 en:
   summary:
     dictionary:
+      absence_none: &absence_none "None"
       YESNO: &YESNO
         'yes': 'Yes'
         'no': 'No'
@@ -9,6 +10,7 @@ en:
 
     sections:
       client_details: Client details
+      contact_details: Contact details
 
     questions:
       # BEGIN client details section
@@ -18,7 +20,7 @@ en:
         question: Last name
       other_names:
         question: Other names
-        absence_answer: None
+        absence_answer: *absence_none
       date_of_birth:
         question: Date of birth
       nino:
@@ -28,3 +30,19 @@ en:
         answers:
           <<: *YESNO
       # END client details section
+
+      # BEGIN contact details section
+      home_address:
+        question: Home address
+        absence_answer: *absence_none
+      correspondence_address:
+        question: Correspondence address
+      correspondence_address_type:
+        question: Where to send correspondence
+        answers:
+          home_address: Same as home address
+          providers_office_address: Provider’s office
+          other_address: Somewhere else
+      telephone_number:
+        question: UK telephone number
+      # END contact details section

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -18,6 +18,7 @@ describe Summary::HtmlPresenter do
       ).to match_instances_array(
         [
           Summary::Sections::ClientDetails,
+          Summary::Sections::ContactDetails,
         ]
       )
     end


### PR DESCRIPTION
## Description of change
Follow-up to PR #137, to add the client contact details to the review page.

It was agreed with Caroline this to be a separate section to group anything related to contact (addresses, phone), instead of being all together in the Client details section.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-155
https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=2712%3A15417

## Notes for reviewer
The correspondence address row only shows if the "where to send correspondence" is "other address". For home, and provider's office, it will not show.

## Screenshots of changes (if applicable)
<img width="745" alt="Screenshot 2022-10-18 at 11 00 47" src="https://user-images.githubusercontent.com/687910/196408912-9e74e433-6c94-4372-922e-48050e9e4d57.png">
<img width="768" alt="Screenshot 2022-10-18 at 11 00 37" src="https://user-images.githubusercontent.com/687910/196408919-ce04bb97-baf2-4af5-8ca8-4c3e8d51f8b9.png">
<img width="733" alt="Screenshot 2022-10-18 at 11 00 19" src="https://user-images.githubusercontent.com/687910/196408924-c3eefdba-7e0b-4ce2-880f-1f0b2a728c9a.png">

## How to manually test the feature
