### PR TITLE
Add `cc_appeal_fin_change` to date stampable types

### DIFF
--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -14,6 +14,7 @@ class CaseType < ValueObject
     EITHER_WAY,
     COMMITTAL,
     CC_APPEAL,
+    CC_APPEAL_FIN_CHANGE,
   ].freeze
 
   def date_stampable?

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DateStamper do
     end
 
     context 'when case_type is not "date stampable"' do
-      let(:case_type) { CaseType::CC_APPEAL_FIN_CHANGE }
+      let(:case_type) { CaseType::INDICTABLE }
       let(:date) { nil }
 
       it 'does not update the crime applications a date stamp' do

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CaseType do
           either_way
           committal
           cc_appeal
+          cc_appeal_fin_change
         ]
       )
     end


### PR DESCRIPTION
## Description of change
Confirmed with Carolina, `Appeal to crown court with changes in financial circumstances` is a date stampable case type.

Only non-stampable ones are: `Indictable` and `Trial already in crown court`.
