### PR TITLE
CRIMAP-157 Review offences

### DIFF
--- a/app/presenters/summary/components/offence_answer.rb
+++ b/app/presenters/summary/components/offence_answer.rb
@@ -1,0 +1,18 @@
+module Summary
+  module Components
+    class OffenceAnswer < BaseAnswer
+      # This component receives as `value` a presented `charge`
+      delegate :offence_name,
+               :offence_class,
+               :offence_dates, to: :value
+
+      def value?
+        super && value.complete?
+      end
+
+      def to_partial_path
+        'steps/submission/shared/offence_answer'
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -11,6 +11,7 @@ module Summary
         Sections::ClientDetails.new(crime_application),
         Sections::ContactDetails.new(crime_application),
         Sections::CaseDetails.new(crime_application),
+        Sections::Offences.new(crime_application),
       ].select(&:show?)
     end
   end

--- a/app/presenters/summary/sections/offences.rb
+++ b/app/presenters/summary/sections/offences.rb
@@ -1,0 +1,25 @@
+module Summary
+  module Sections
+    class Offences < Sections::BaseSection
+      def name
+        :offences
+      end
+
+      def answers
+        charges.map.with_index(1) do |charge, index|
+          Components::OffenceAnswer.new(
+            :offence_details, ChargePresenter.new(charge),
+            change_path: edit_steps_case_charges_path(charge),
+            i18n_opts: { index: }
+          )
+        end.select(&:show?)
+      end
+
+      private
+
+      def charges
+        @charges ||= crime_application.case.charges
+      end
+    end
+  end
+end

--- a/app/views/steps/submission/shared/_offence_answer.html.erb
+++ b/app/views/steps/submission/shared/_offence_answer.html.erb
@@ -1,0 +1,23 @@
+<%
+  content_for(:row_question, flush: true) do
+    t("summary.questions.#{offence_answer.question}.question", **offence_answer.i18n_opts)
+  end
+%>
+
+<% content_for(:row_answer, flush: true) do %>
+  <p class="govuk-body govuk-!-margin-bottom-1">
+    <%= offence_answer.offence_name %>
+  </p>
+
+  <p class="govuk-caption-m">
+    <%= offence_answer.offence_class || t("summary.questions.#{offence_answer.question}.unknown_class") %>
+  </p>
+
+  <% offence_answer.offence_dates.map do |date| %>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <%= l(date) %>
+    </p>
+  <% end %>
+<% end %>
+
+<%= render partial: 'steps/submission/shared/summary_row', locals: { row: offence_answer } %>

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -12,6 +12,7 @@ en:
       client_details: Client details
       contact_details: Contact details
       case_details: Case details
+      offences: Offences
 
     questions:
       # BEGIN client details section
@@ -63,3 +64,9 @@ en:
           cc_appeal: Appeal to crown court
           cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances
       # END case details section
+
+      # BEGIN offences section
+      offence_details:
+        question: "Offence %{index}"
+        unknown_class: Class not specified
+      # END offences section

--- a/spec/presenters/summary/components/offence_answer_spec.rb
+++ b/spec/presenters/summary/components/offence_answer_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe Summary::Components::OffenceAnswer do
+  subject { described_class.new(question, value) }
+
+  let(:question) { 'Question?' }
+  let(:value) { double(Charge) }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('steps/submission/shared/offence_answer')
+    end
+  end
+
+  describe '#value?' do
+    it 'calls `#complete?` on the value' do
+      expect(value).to receive(:complete?)
+      subject.value?
+    end
+
+    context 'when there is no value' do
+      let(:value) { nil }
+
+      it 'returns false' do
+        expect(subject.value?).to be(false)
+      end
+    end
+  end
+
+  describe 'methods delegation' do
+    it 'delegates `offence_name`' do
+      expect(value).to receive(:offence_name)
+      subject.offence_name
+    end
+
+    it 'delegates `offence_class`' do
+      expect(value).to receive(:offence_class)
+      subject.offence_class
+    end
+
+    it 'delegates `offence_dates`' do
+      expect(value).to receive(:offence_dates)
+      subject.offence_dates
+    end
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -20,6 +20,7 @@ describe Summary::HtmlPresenter do
           Summary::Sections::ClientDetails,
           Summary::Sections::ContactDetails,
           Summary::Sections::CaseDetails,
+          Summary::Sections::Offences,
         ]
       )
     end

--- a/spec/presenters/summary/sections/offences_spec.rb
+++ b/spec/presenters/summary/sections/offences_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe Summary::Sections::Offences do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      case: kase,
+    )
+  end
+
+  let(:kase) do
+    instance_double(
+      Case,
+      charges: [charge],
+    )
+  end
+
+  let(:charge) do
+    instance_double(
+      Charge,
+      to_param: '321',
+    )
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:offences) }
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+    let(:complete) { true }
+
+    before do
+      allow(charge).to receive(:complete?).and_return(complete)
+    end
+
+    it 'has the correct rows' do
+      expect(answers.count).to eq(1)
+
+      expect(answers[0]).to be_an_instance_of(Summary::Components::OffenceAnswer)
+      expect(answers[0].question).to eq(:offence_details)
+      expect(answers[0].change_path).to match('applications/12345/steps/case/charges/321')
+      expect(answers[0].value).to be_an_instance_of(ChargePresenter)
+      expect(answers[0].i18n_opts).to eq({ index: 1 })
+    end
+
+    context 'when the charge is not complete' do
+      let(:complete) { false }
+
+      it 'does not show the row' do
+        expect(answers.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'Rendering a summary row of type `OffenceAnswer`' do
+  let(:crime_application) { CrimeApplication.new(status: ApplicationStatus::IN_PROGRESS.to_s) }
+
+  let(:answer) do
+    Summary::Components::OffenceAnswer.new(
+      :offence_details, presented_charge, change_path: '/edit', i18n_opts: { index: 1 }
+    )
+  end
+
+  let(:presented_charge) do
+    double(
+      'PresentedCharge',
+      offence_name: 'My offence name',
+      offence_class: offence_class,
+      offence_dates: [Date.new(2000, 11, 3)],
+    )
+  end
+
+  let(:offence_class) { 'Offence class' }
+
+  before do
+    allow(view).to receive(:current_crime_application).and_return(crime_application)
+    render answer
+  end
+
+  # No need to test again the application status or the change link,
+  # as we tested it in `value_answer` and all these partials behave the same
+  # because they render a common partial, where that logic resides.
+
+  it 'renders the expected row' do
+    assert_select 'div.govuk-summary-list__row', 1 do
+      assert_select 'dt.govuk-summary-list__key', text: 'Offence 1'
+      assert_select 'dd.govuk-summary-list__value p:nth-of-type(1)', count: 1, text: 'My offence name'
+      assert_select 'dd.govuk-summary-list__value p:nth-of-type(2).govuk-caption-m', count: 1, text: 'Offence class'
+      assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '3 Nov 2000'
+      assert_select 'dd.govuk-summary-list__actions a', text: 'Change Offence 1'
+    end
+  end
+
+  context 'when the offence has no class' do
+    let(:offence_class) { nil }
+
+    it 'shows a placeholder copy' do
+      assert_select 'dd.govuk-summary-list__value p.govuk-caption-m', 'Class not specified'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add the offences section to the check your answers page.

This renders a slightly different markup as the offences are indexed, and shows more details like the class or the dates.

In order to do this in a clean way, a specific "OffenceAnswer" component has been created, with its corresponding view partial. Other than that it behaves the same as other answers really.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-157

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="794" alt="Screenshot 2022-10-19 at 11 08 20" src="https://user-images.githubusercontent.com/687910/196662698-8cd36b64-ff6b-4017-92fb-12bcba5aca16.png">

## How to manually test the feature
