### PR TITLE
Support second level associations in form concern

### DIFF
--- a/app/forms/concerns/steps/has_one_association.rb
+++ b/app/forms/concerns/steps/has_one_association.rb
@@ -3,7 +3,8 @@ module Steps
     extend ActiveSupport::Concern
 
     class_methods do
-      attr_accessor :association_name
+      attr_accessor :association_name,
+                    :through_association
 
       def build(crime_application)
         super(
@@ -12,12 +13,21 @@ module Steps
       end
 
       # Return the record if already exists, or initialise a blank one
-      def associated_record(parent)
+      def associated_record(crime_application)
+        parent = if through_association
+                   # :nocov: enable coverage once we use this in any form
+                   crime_application.public_send(through_association)
+                   # :nocov:
+                 else
+                   crime_application
+                 end
+
         parent.public_send(association_name) || parent.public_send("build_#{association_name}")
       end
 
-      def has_one_association(name)
+      def has_one_association(name, through: nil)
         self.association_name = name
+        self.through_association = through
 
         define_method(name) do
           @_assoc ||= self.class.associated_record(crime_application)


### PR DESCRIPTION
## Description of change
Sometimes we may have 2nd level associations in a form object.

For example this may be the case for IoJ:

`application -> (has_one) case -> (has_one) ioj`

The current `Steps::HasOneAssociation` does not support this, and only supports first level relationships.

With these changes, the module is prepared to be used in second level relationships as well if it was needed.

To use it in this way, just do:

```ruby
include Steps::HasOneAssociation
has_one_association :ioj, through: :case
```

Then the form object and controller behaves exactly the same as we've been doing with 1st level associations.

This may be used in PR #136, if we decide to keep the `IoJ` as a `has_one` in the `case` instead of moving the relationship to the `crime_application`.
