### PR TITLE
CRIMAP-114 Add declaration page

### DIFF
--- a/app/controllers/steps/submission/declaration_controller.rb
+++ b/app/controllers/steps/submission/declaration_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Submission
+    class DeclarationController < Steps::SubmissionStepController
+      def edit
+        @form_object = DeclarationForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(DeclarationForm, as: :declaration)
+      end
+    end
+  end
+end

--- a/app/forms/steps/submission/declaration_form.rb
+++ b/app/forms/steps/submission/declaration_form.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Submission
+    class DeclarationForm < Steps::BaseFormObject
+      attribute :declaration_signed, :boolean
+      validates :declaration_signed, presence: true
+
+      private
+
+      def persist!
+        crime_application.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -3,6 +3,8 @@ module Decisions
     def destination
       case step_name
       when :review
+        edit(:declaration)
+      when :declaration
         # TODO: update when we have next step
         show('/home', action: :index)
       else

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -1,0 +1,54 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl">
+      Confirm the following and submit application
+    </h1>
+
+    <p class="govuk-body">You agree that:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you’ve obtained a signed declaration from my client</li>
+      <li>you’ve provided correct and complete information in this application</li>
+      <li>you’ll share a copy of the completed application with my client</li>
+    </ul>
+
+    <p class="govuk-body govuk-!-margin-top-8">Your client agrees that:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>they’ve instructed Hitchcock, Jones and King to represent them</li>
+      <li>they’ve read the <a href="#">LAA privacy policy</a></li>
+      <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy policy)</li>
+      <li>we can check their details with bank and credit reference agencies</li>
+      <li>they may have to pay towards legal aid</li>
+      <li>they may have to repay the legal costs if they are found guilty on one or more offences at the end of the case (the 'statutory charge')</li>
+      <li>the information they’ve given is complete and correct</li>
+      <li>they’ll report any changes to their financial situation immediately</li>
+    </ul>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        If your client gives wrong or incomplete information, does not report changes, or is found to have committed benefit fraud, they may:
+        <ul class="govuk-list govuk-list--bullet govuk-!-font-weight-bold">
+          <li>be prosecuted</li>
+          <li>need to pay a financial penalty</li>
+          <li>have their legal aid stopped and have to pay back the costs</li>
+        </ul>
+      </strong>
+    </div>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_check_boxes_fieldset :declaration_signed, multiple: false, legend: { hidden: true } do %>
+        <%= f.govuk_check_box :declaration_signed, 1, 0, multiple: false, link_errors: true %>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -171,3 +171,7 @@ en:
               blank: Enter more detail
             other_justification:
               blank: Enter more detail
+        steps/submission/declaration_form:
+          attributes:
+            declaration_signed:
+              blank: You must confirm that the information on this page is correct in order to submit the application

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -35,6 +35,8 @@ en:
         hearing_date: Date of next hearing
       steps_case_ioj_form:
         types: Why should your client get legal aid?
+      steps_submission_declaration_form:
+        declaration_signed: Confirm and submit application
 
     hint:
       steps_client_has_partner_form:
@@ -139,3 +141,6 @@ en:
           expert_examination: Witnesses may need to be traced or interviewed on their behalf.
           interest_of_another: It is in the interests of another person (such as the person making a complaint or other witness) that they are represented.
           other: Other
+      steps_submission_declaration_form:
+        declaration_signed_options:
+          '1': I, the instructed legal representative, confirm the above is correct.

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -132,3 +132,6 @@ en:
         edit:
           page_title: Review the application
           heading: Review the application
+      declaration:
+        edit:
+          page_title: Declaration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
 
       namespace :submission do
         edit_step :review
+        edit_step :declaration
       end
     end
   end

--- a/db/migrate/20221021110132_add_declaration_signed_field.rb
+++ b/db/migrate/20221021110132_add_declaration_signed_field.rb
@@ -1,0 +1,5 @@
+class AddDeclarationSignedField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :declaration_signed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_13_141243) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_21_110132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_13_141243) do
     t.string "client_has_partner"
     t.string "status"
     t.datetime "date_stamp"
+    t.boolean "declaration_signed"
   end
 
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/steps/submission/declaration_controller_spec.rb
+++ b/spec/controllers/steps/submission/declaration_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::DeclarationController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Submission::DeclarationForm, Decisions::SubmissionDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::Submission::DeclarationForm
+end

--- a/spec/forms/steps/submission/declaration_form_spec.rb
+++ b/spec/forms/steps/submission/declaration_form_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::DeclarationForm do
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      declaration_signed:,
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:declaration_signed) { '1' }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:declaration_signed) }
+
+    context 'when checkbox is not ticked' do
+      let(:declaration_signed) { '0' }
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:declaration_signed, :blank)).to be(true)
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'saves the record' do
+      expect(crime_application).to receive(:update).with(
+        'declaration_signed' => true
+      ).and_return(true)
+
+      expect(subject.save).to be(true)
+    end
+  end
+end

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Decisions::SubmissionDecisionTree do
     let(:step_name) { :review }
 
     context 'has correct next step' do
+      it { is_expected.to have_destination(:declaration, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `declaration`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :declaration }
+
+    context 'has correct next step' do
       it { is_expected.to have_destination('/home', :index, id: crime_application) }
     end
   end


### PR DESCRIPTION
## Description of change
Simple page, with content (may change, awaiting approval) and a check box to confirm, in order to proceed to what will be the final step, the submission confirmation (in a future PR).

Note: because this page is mostly all content, it makes sense to have it as a localised view (`edit.en.html.erb`) and not extract to locales the content as that would make it more difficult to update/translate in the future.

Linked this step to the overall journey, right after the review page.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-114

## Notes for reviewer
Privacy policy page is part of another ticket.

## Screenshots of changes (if applicable)
<img width="560" alt="Screenshot 2022-10-21 at 12 50 40" src="https://user-images.githubusercontent.com/687910/197189486-e7f9bf0a-e8f0-4a57-9740-8ac5b43d730d.png">
<img width="418" alt="Screenshot 2022-10-21 at 12 50 53" src="https://user-images.githubusercontent.com/687910/197189494-87ddaff2-5f28-4648-b03b-9e74ac8a6271.png">

## How to manually test the feature
This pages comes next after the review application page. On submission of the declaration it circles back to the home until we have next step (confirmation page).