### PR TITLE
CRIMAP-171 Add IoJ to task list and improve existing tasks logic

### DIFF
--- a/app/forms/steps/case/ioj_form.rb
+++ b/app/forms/steps/case/ioj_form.rb
@@ -18,11 +18,14 @@ module Steps
                   if: -> { types.include?(ioj_type.to_s) }
       end
 
+      def types=(ary)
+        super(ary.compact_blank) if ary
+      end
+
       private
 
       def validate_types
-        errors.add(:types, :invalid) if !types.is_a?(Array) || types.compact_blank.empty?
-        errors.add(:types, :invalid) if (types.compact_blank - IojReasonType.values.map(&:to_s)).any?
+        errors.add(:types, :invalid) if types.empty? || (types - IojReasonType.values.map(&:to_s)).any?
       end
 
       def persist!

--- a/app/models/concerns/routing.rb
+++ b/app/models/concerns/routing.rb
@@ -5,7 +5,9 @@ module Routing
     include Rails.application.routes.url_helpers
   end
 
+  # :nocov:
   def default_url_options
     {}
   end
+  # :nocov:
 end

--- a/app/presenters/tasks/base_task.rb
+++ b/app/presenters/tasks/base_task.rb
@@ -18,14 +18,22 @@ module Tasks
       end
     end
 
+    def fulfilled?(task_class)
+      task_class.new(crime_application:).status.completed?
+    end
+
+    # Used by the `Routing` module to build the urls
+    def default_url_options
+      { id: crime_application }
+    end
+
     def status
       return TaskStatus::NOT_APPLICABLE if not_applicable?
       return TaskStatus::UNREACHABLE unless can_start?
-
+      return TaskStatus::NOT_STARTED unless in_progress?
       return TaskStatus::COMPLETED if completed?
-      return TaskStatus::IN_PROGRESS if in_progress?
 
-      TaskStatus::NOT_STARTED
+      TaskStatus::IN_PROGRESS
     end
 
     def path

--- a/app/presenters/tasks/case_details.rb
+++ b/app/presenters/tasks/case_details.rb
@@ -1,7 +1,7 @@
 module Tasks
   class CaseDetails < BaseTask
     def path
-      edit_steps_case_urn_path(crime_application)
+      edit_steps_case_urn_path
     end
 
     def not_applicable?
@@ -19,9 +19,10 @@ module Tasks
       crime_application.case.present?
     end
 
-    # TODO: update when all case details steps are implemented
     def completed?
-      false
+      crime_application.case.values_at(
+        :hearing_court_name, :hearing_date
+      ).all?(&:present?)
     end
   end
 end

--- a/app/presenters/tasks/client_details.rb
+++ b/app/presenters/tasks/client_details.rb
@@ -1,7 +1,7 @@
 module Tasks
   class ClientDetails < BaseTask
     def path
-      edit_steps_client_details_path(crime_application)
+      edit_steps_client_details_path
     end
 
     def not_applicable?
@@ -23,7 +23,9 @@ module Tasks
     # NOTE: might be refined for the scenario the correspondence type
     # is `other_address` but there is no `CorrespondenceAddress` record
     def completed?
-      crime_application.applicant&.correspondence_address_type.present?
+      crime_application.applicant.values_at(
+        :telephone_number, :correspondence_address_type
+      ).all?(&:present?)
     end
   end
 end

--- a/app/presenters/tasks/ioj.rb
+++ b/app/presenters/tasks/ioj.rb
@@ -1,13 +1,24 @@
 module Tasks
   class Ioj < BaseTask
-    # TODO: update when we have the case details steps
+    def path
+      edit_steps_case_ioj_path
+    end
 
+    # TODO: update when we have passporting
     def not_applicable?
       false
     end
 
     def can_start?
-      false
+      fulfilled?(CaseDetails)
+    end
+
+    def in_progress?
+      crime_application.case.ioj.present?
+    end
+
+    def completed?
+      crime_application.case.ioj.types.any?
     end
   end
 end

--- a/spec/presenters/tasks/base_task_spec.rb
+++ b/spec/presenters/tasks/base_task_spec.rb
@@ -25,6 +25,30 @@ RSpec.describe Tasks::BaseTask do
     end
   end
 
+  describe '#fulfilled?' do
+    before do
+      allow_any_instance_of(
+        Tasks::ClientDetails
+      ).to receive(:status).and_return(status)
+    end
+
+    context 'for a completed task' do
+      let(:status) { TaskStatus::COMPLETED }
+
+      it 'returns true' do
+        expect(subject.fulfilled?(Tasks::ClientDetails)).to be(true)
+      end
+    end
+
+    context 'for an incomplete task' do
+      let(:status) { TaskStatus::IN_PROGRESS }
+
+      it 'returns false' do
+        expect(subject.fulfilled?(Tasks::ClientDetails)).to be(false)
+      end
+    end
+  end
+
   describe '#path' do
     it { expect(subject.path).to eq('') }
   end
@@ -59,6 +83,7 @@ RSpec.describe Tasks::BaseTask do
     context 'task is completed' do
       let(:can_start) { true }
       let(:completed) { true }
+      let(:in_progress) { true }
 
       it { expect(subject.status).to eq(TaskStatus::COMPLETED) }
     end

--- a/spec/presenters/tasks/client_details_spec.rb
+++ b/spec/presenters/tasks/client_details_spec.rb
@@ -3,7 +3,15 @@ require 'rails_helper'
 RSpec.describe Tasks::ClientDetails do
   subject { described_class.new(crime_application:) }
 
-  let(:crime_application) { instance_double(CrimeApplication, to_param: '12345') }
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      applicant: applicant,
+    )
+  end
+
+  let(:applicant) { nil }
 
   describe '#path' do
     it { expect(subject.path).to eq('/applications/12345/steps/client/details') }
@@ -18,10 +26,6 @@ RSpec.describe Tasks::ClientDetails do
   end
 
   describe '#in_progress?' do
-    before do
-      allow(crime_application).to receive(:applicant).and_return(applicant)
-    end
-
     context 'when we have an applicant record' do
       let(:applicant) { double }
 
@@ -29,25 +33,29 @@ RSpec.describe Tasks::ClientDetails do
     end
 
     context 'when we do not have yet an applicant record' do
-      let(:applicant) { nil }
-
       it { expect(subject.in_progress?).to be(false) }
     end
   end
 
   describe '#completed?' do
-    before do
-      allow(crime_application).to receive(:applicant).and_return(applicant)
-    end
-
     context 'when we have completed contact details' do
-      let(:applicant) { double(correspondence_address_type: 'something') }
+      let(:applicant) do
+        Applicant.new(
+          telephone_number: '123456789',
+          correspondence_address_type: 'something'
+        )
+      end
 
       it { expect(subject.completed?).to be(true) }
     end
 
     context 'when we have not completed yet contact details' do
-      let(:applicant) { nil }
+      let(:applicant) do
+        Applicant.new(
+          telephone_number: '123456789',
+          correspondence_address_type: ''
+        )
+      end
 
       it { expect(subject.completed?).to be(false) }
     end

--- a/spec/presenters/tasks/ioj_spec.rb
+++ b/spec/presenters/tasks/ioj_spec.rb
@@ -3,10 +3,29 @@ require 'rails_helper'
 RSpec.describe Tasks::Ioj do
   subject { described_class.new(crime_application:) }
 
-  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      case: instance_double(Case, ioj:),
+    )
+  end
+
+  let(:ioj) { instance_double(Ioj, types: ioj_types) }
+  let(:ioj_types) { [] }
+
+  # We assume the completeness of the case details here, as
+  # their statuses are tested in its own spec, no need to repeat
+  let(:case_details_fulfilled) { true }
+
+  before do
+    allow(
+      subject
+    ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details_fulfilled)
+  end
 
   describe '#path' do
-    it { expect(subject.path).to eq('') }
+    it { expect(subject.path).to eq('/applications/12345/steps/case/ioj') }
   end
 
   describe '#not_applicable?' do
@@ -14,6 +33,38 @@ RSpec.describe Tasks::Ioj do
   end
 
   describe '#can_start?' do
-    it { expect(subject.can_start?).to be(false) }
+    context 'when the case details task has been completed' do
+      it { expect(subject.can_start?).to be(true) }
+    end
+
+    context 'when the case details task has not been completed yet' do
+      let(:case_details_fulfilled) { false }
+
+      it { expect(subject.can_start?).to be(false) }
+    end
+  end
+
+  describe '#in_progress?' do
+    context 'when we have an Ioj record' do
+      it { expect(subject.in_progress?).to be(true) }
+    end
+
+    context 'when we do not have yet an Ioj record' do
+      let(:ioj) { nil }
+
+      it { expect(subject.in_progress?).to be(false) }
+    end
+  end
+
+  describe '#completed?' do
+    context 'when we have completed the Ioj details' do
+      let(:ioj_types) { ['foobar'] }
+
+      it { expect(subject.completed?).to be(true) }
+    end
+
+    context 'when we have not completed yet the Ioj details' do
+      it { expect(subject.completed?).to be(false) }
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Some refactor and improvement of the previous existing tasks, and adding the new IoJ task to the task list.

We still need to revisit the `Client` task after we introduce the DWP check.

In a follow-up PR the review and declaration tasks will also be added.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-171

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="715" alt="Screenshot 2022-10-24 at 09 49 49" src="https://user-images.githubusercontent.com/687910/197487730-ff353fcd-344c-4100-972c-9d2813cbf484.png">
<img width="714" alt="Screenshot 2022-10-24 at 09 50 04" src="https://user-images.githubusercontent.com/687910/197487733-2ce4e5c3-f41c-48e9-be3a-99aa52c8ed70.png">


## How to manually test the feature
The case task will be completed once the contact details page is completed (telephone number and correspondence address type). Then the IoJ will appear as "ready to start", if you save and come back later at that point it will show as "in progress". If you complete the IoJ it will show as "completed".