### PR TITLE
CRIMAP-113 Add submission confirmation page

### DIFF
--- a/app/controllers/steps/submission/confirmation_controller.rb
+++ b/app/controllers/steps/submission/confirmation_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Submission
+    class ConfirmationController < Steps::SubmissionStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -5,8 +5,7 @@ module Decisions
       when :review
         edit(:declaration)
       when :declaration
-        # TODO: update when we have next step
-        show('/home', action: :index)
+        show(:confirmation)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end

--- a/app/views/steps/submission/confirmation/show.en.html.erb
+++ b/app/views/steps/submission/confirmation/show.en.html.erb
@@ -1,0 +1,39 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-6">
+      <h1 class="govuk-panel__title">
+        Application complete
+      </h1>
+      <div class="govuk-panel__body">
+        Your reference number<br>
+        <strong>
+          <%= present(current_crime_application).laa_reference %>
+        </strong>
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+
+    <p class="govuk-body">
+      We’ll check your application to see if your client is entitled to legal aid.
+    </p>
+
+    <p class="govuk-body">
+      We’ll let you know our decision by email.
+    </p>
+
+    <p class="govuk-body">
+      <a href="#">Give feedback</a> to help us improve this service.
+    </p>
+
+    <div class="govuk-button-group govuk-!-margin-top-8">
+      <%= link_button t('.view_application'), crime_applications_path %>
+      <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -135,3 +135,8 @@ en:
       declaration:
         edit:
           page_title: Declaration
+      confirmation:
+        show:
+          page_title: Application submitted
+          view_application: View completed application
+          back_to_applications: Back to all applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
       namespace :submission do
         edit_step :review
         edit_step :declaration
+        show_step :confirmation
       end
     end
   end

--- a/spec/controllers/steps/submission/confirmation_controller_spec.rb
+++ b/spec/controllers/steps/submission/confirmation_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::ConfirmationController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Decisions::SubmissionDecisionTree do
     let(:step_name) { :declaration }
 
     context 'has correct next step' do
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination(:confirmation, :show, id: crime_application) }
     end
   end
 end


### PR DESCRIPTION
## Description of change
This is just a show action, rendering a localised view (as there is no complex logic or anything like that, just some content).

Updated the decision tree, so this page is shown right after the declaration page.

In another PR, the green button "View completed application" will be implemented to show a read-only view of the "check your answers". At the moment, it just goes to the list of applications.

Note: for now there is no logic to mark applications as submitted (and of course, no actual "submission" to any place). This is all smoke and mirrors until we flesh out next pieces of the puzzle.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-113
https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=2711%3A6381

## Notes for reviewer
We don't have yet a link for the survey/feedback.

## Screenshots of changes (if applicable)
<img width="720" alt="Screenshot 2022-10-24 at 12 38 55" src="https://user-images.githubusercontent.com/687910/197517439-91e744ba-2450-41d5-9d3d-7981605f0201.png">

## How to manually test the feature
Signed the declaration, and next page will be this confirmation.