### PR TITLE
Use latest dev-api on staging.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ gem 'sentry-ruby'
 
 gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', tag: 'v0.2.0'
 
+# Temporary utitily to add a data api to apply.
+gem 'laa_crime_apply_dev_api', github: 'ministryofjustice/laa-crime-apply-dev-api',
+ref: 'ab62064cb64d2b6888eb2c18944ca815239ec2ce'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
@@ -37,7 +41,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'laa_crime_apply_dev_api', github: 'ministryofjustice/laa-crime-apply-dev-api'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-crime-apply-dev-api.git
-  revision: a77c5a298440eb373a4a66c3f8932c9ea36846aa
+  revision: ab62064cb64d2b6888eb2c18944ca815239ec2ce
+  ref: ab62064cb64d2b6888eb2c18944ca815239ec2ce
   specs:
-    laa_crime_apply_dev_api (0.1.0)
+    laa_crime_apply_dev_api (0.2.0)
       dry-schema (>= 1.10)
       jbuilder (>= 2.11)
       rails (>= 7.0)
@@ -137,7 +138,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.9, >= 0.9)
       zeitwerk (~> 2.6)
-    dry-schema (1.11.2)
+    dry-schema (1.11.3)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.16, >= 0.16)
       dry-core (~> 0.9, >= 0.9)


### PR DESCRIPTION
## Description of change

Uses the lasted version of https://github.com/ministryofjustice/laa-crime-apply-dev-api and makes it available in all environments. (Previously it was only available in development.)

## Link to relevant ticket
[CRIMRE-62](https://dsdmoj.atlassian.net/browse/CRIMRE-62)

## Notes for reviewer

This has been tested in development, and can be confirmed by viewing the schema at (/api/schemas/application.json)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
