### PR TITLE
CRIMAP-170 View completed application

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -11,6 +11,12 @@ class CrimeApplicationsController < ApplicationController
                     .merge(CrimeApplication.order(created_at: :desc))
   end
 
+  def show
+    @presenter = Summary::HtmlPresenter.new(
+      crime_application: current_crime_application
+    )
+  end
+
   def create
     initialize_crime_application do |crime_application|
       redirect_to edit_steps_client_has_partner_path(crime_application)

--- a/app/services/application_submission.rb
+++ b/app/services/application_submission.rb
@@ -1,0 +1,18 @@
+class ApplicationSubmission
+  attr_reader :crime_application
+
+  def initialize(crime_application)
+    @crime_application = crime_application
+  end
+
+  # TODO: for now we don't really know how the submission will work,
+  # this is just a mock, and for now we just mark an application as
+  # submitted, to enable post-submission journeys.
+  #
+  def call
+    crime_application.update!(
+      status: ApplicationStatus::SUBMITTED.value,
+      submitted_at: Time.current,
+    )
+  end
+end

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -5,10 +5,18 @@ module Decisions
       when :review
         edit(:declaration)
       when :declaration
-        show(:confirmation)
+        submit_application
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
+    end
+
+    private
+
+    def submit_application
+      ApplicationSubmission.new(current_crime_application).call
+
+      show(:confirmation)
     end
   end
 end

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -1,0 +1,24 @@
+<% title t('.page_title') %>
+<% step_header(path: :back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <strong><%= t('.laa_reference') %></strong> <%= @crime_application.laa_reference %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <strong><%= t('.date_stamp') %></strong> <%= @crime_application.application_date_stamp %>
+    </p>
+
+    <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+
+    <%= render @presenter.sections %>
+
+    <div class="govuk-button-group govuk-!-margin-top-8">
+      <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+      <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/submission/confirmation/show.en.html.erb
+++ b/app/views/steps/submission/confirmation/show.en.html.erb
@@ -32,7 +32,7 @@
     </p>
 
     <div class="govuk-button-group govuk-!-margin-top-8">
-      <%= link_button t('.view_application'), crime_applications_path %>
+      <%= link_button t('.view_application'), crime_application_path %>
       <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
     </div>
   </div>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -15,12 +15,19 @@ en:
       status:
         in_progress: In progress
         submitted: Submitted
+    show:
+      page_title: Application certificate
+      heading: Application for criminal legal aid certificate
+      laa_reference: "LAA reference:"
+      date_stamp: "Date stamp:"
+      print_application: Print application
+      back_to_applications: Back to all applications
     edit:
       page_title: Application task list
       heading: Make a new application
       subheading: Application incomplete
       progress_counter: You have completed %{completed} of %{total} sections.
-      back_to_applications: Back to your applications
+      back_to_applications: Back to all applications
       aside:
         reference: Reference number
         first_name: First name

--- a/db/migrate/20221025110320_add_submitted_at_field.rb
+++ b/db/migrate/20221025110320_add_submitted_at_field.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_21_110132) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_25_110320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_110132) do
     t.string "status"
     t.datetime "date_stamp"
     t.boolean "declaration_signed"
+    t.datetime "submitted_at"
   end
 
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,8 @@ RSpec.configure do |config|
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.include(ViewSpecHelpers, type: :helper)
   config.include(ViewSpecHelpers, type: :view)
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -12,6 +12,47 @@ RSpec.describe 'Dashboard' do
     end
   end
 
+  describe 'show an application certificate (once an application is completed)' do
+    before :all do
+      # sets up a test record
+      app = CrimeApplication.create(status: :submitted, submitted_at: Date.new(2022, 12, 31))
+
+      Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe')
+    end
+
+    after :all do
+      CrimeApplication.destroy_all
+    end
+
+    before do
+      applicant = Applicant.find_by(first_name: 'Jane')
+      app = applicant.crime_application
+
+      get crime_application_path(app)
+    end
+
+    it 'shows the application' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Application for criminal legal aid certificate'
+
+      # client details section, no change links
+      assert_select 'h2', 'Client details'
+
+      assert_select 'dl.govuk-summary-list:nth-of-type(1)' do
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(1)' do
+          assert_select 'dt:nth-of-type(1)', 'First name'
+          assert_select 'dd:nth-of-type(1)', 'Jane'
+        end
+
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(2)' do
+          assert_select 'dt:nth-of-type(1)', 'Last name'
+          assert_select 'dd:nth-of-type(1)', 'Doe'
+        end
+      end
+    end
+  end
+
   describe 'edit an application (aka task list)' do
     before :all do
       # sets up a test record

--- a/spec/services/application_submission_spec.rb
+++ b/spec/services/application_submission_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationSubmission do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+    )
+  end
+
+  before do
+    allow(crime_application).to receive(:update!).and_return(true)
+  end
+
+  describe '#call' do
+    let(:submitted_date) { Date.new(2022, 12, 31) }
+
+    before do
+      travel_to submitted_date
+    end
+
+    it 'marks the application as submitted' do
+      expect(
+        crime_application
+      ).to receive(:update!).with(
+        status: :submitted, submitted_at: submitted_date
+      )
+
+      expect(subject.call).to be(true)
+    end
+  end
+end

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe Decisions::SubmissionDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :declaration }
 
+    before do
+      # We don't test its implementation as this is tested separately
+      allow_any_instance_of(ApplicationSubmission).to receive(:call).and_return(true)
+    end
+
+    context 'submits the application' do
+      it 'calls the submission service' do
+        expect(
+          ApplicationSubmission
+        ).to receive(:new).with(crime_application).and_call_original
+
+        subject.destination
+      end
+    end
+
     context 'has correct next step' do
       it { is_expected.to have_destination(:confirmation, :show, id: crime_application) }
     end


### PR DESCRIPTION
## Description of change
This is what in the prototype is called the application certificate and is a read-only view of the "review / check your answers" page.

The print button works but is not yet applying the print stylesheet, that will come as part of a separate ticket.

Also, for now I've had to make a lot of assumptions to get to this point, mainly, the "submission" which for not is no more than a mock service `ApplicationSubmission` that sets the `submitted` status in the record.

I've also added a new `submitted_at` DB field because it will be needed for some date stamp logic soon.

In separate PRs, we will introduce checks to make sure a "submitted" application can't be edited, or for what is worth, can't be re-submitted (which at the moment is possible as there is no such validation/check yet).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-170
https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=2711%3A6326

## Notes for reviewer
There are many little details to sort out in separate PRs. I think is best to wait for the redesign of the dashboard to have sub-navigation to implement some of these details (like no delete buttons on submitted applications, or accessing this certificate page from the dashboard list).

## Screenshots of changes (if applicable)
<img width="641" alt="Screenshot 2022-10-25 at 13 06 00" src="https://user-images.githubusercontent.com/687910/197768942-dd0bc72f-bc77-4677-b296-32fbc17ab852.png">

## How to manually test the feature
Go all the way down to the declaration, tick the checkbox and submit the application. Then in the confirmation page click the button "View completed application".