### PR TITLE
CRIMAP-168 Add about controller and privacy page

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,0 +1,3 @@
+class AboutController < ApplicationController
+  def privacy; end
+end

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,150 +1,155 @@
 <% title t('.page_title') %>
-  <h1 class="govuk-heading-xl">Privacy policy</h2>
-  <h2 class="govuk-heading-l">Purpose</h2>
-  <p class="govuk-body">This privacy notice sets out:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the standards that you can expect from the Legal Aid Agency (LAA) when we request or hold personal data about you</li>
-      <li>how you can get access to a copy of your personal data</li>
-      <li>what you can do if you think the standards are not being met</li>
-    </ul>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Privacy policy</h2>
+    <h2 class="govuk-heading-l">Purpose</h2>
+    <p class="govuk-body">This privacy notice sets out:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the standards that you can expect from the Legal Aid Agency (LAA) when we request or hold personal data about you</li>
+        <li>how you can get access to a copy of your personal data</li>
+        <li>what you can do if you think the standards are not being met</li>
+      </ul>
+    </div>
+    <p class="govuk-body">The LAA is an Executive Agency of the Ministry of Justice (MoJ). The MoJ is the data controller for the personal information we hold.</p>
+    <p class="govuk-body">The LAA collects and processes personal data for the exercise of its own and associated public functions. Our public function is to provide legal aid.</p>
+
+    <h2 class="govuk-heading-l">About personal information</h2>
+    <p class="govuk-body">Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you've provided in this service such as:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your financial circumstances</li>
+        <li>information relating to any current or previous legal proceedings concerning you</li>
+      </ul>
+    </div>
+    <p class="govuk-body">We know how important it is to protect customers’ privacy and to comply with data protection laws. We will safeguard your personal data and will only disclose it where it is lawful to do so, or with your consent.</p>
+
+    <h2 class="govuk-heading-l">Types of personal data we process</h2>
+    <p class="govuk-body">We only process personal data that is relevant for the services we provide.</p>
+    <p class="govuk-body">The personal data which you've provided for this service will only be used for the purposes set out below.</p>
+
+    <h2 class="govuk-heading-l">Purpose of processing and the lawful basis for the process</h2>
+    <p class="govuk-body">The LAA collects and processes personal data for the purpose of providing legal aid. Specifically, we use personal data to:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>decide whether you need to make a contribution towards the costs of legal aid and to assist the LAA in collecting those contributions</li>
+        <li>assess claims from your legal representative(s) for payment from the legal aid fund for the work that they've conducted on your behalf</li>
+        <li>conduct periodic assurance audits on legal aid files to ensure that decisions have been made correctly and accurately</li>
+        <li>produce statistics and information on our systems and processes to help us improve them and to assist us in carrying out our functions</li>
+      </ul>
+    </div>
+    <p class="govuk-body">Were the LAA unable to collect this personal information, we would not be able to conduct the activities above, which would prevent us from providing legal aid.</p>
+    <p class="govuk-body">The lawful basis for the LAA collecting and processing your personal data is in the administration of justice and the result of the powers contained in the Legal Aid, Sentencing and Punishment of Offenders Act 2012 (LASPO).</p>
+    <p class="govuk-body">We also collect ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities under the Equality Act 2010.</p>
+    <p class="govuk-body">Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence. Any information published will not identify you or anyone else associated with your legal aid application.</p>
+
+    <h2 class="govuk-heading-l">Who we may share your information with</h2>
+    <p class="govuk-body">We sometimes need to share the personal information we process with other organisations. When this is necessary, we'll comply with all aspects of the relevant data protection laws.</p>
+    <p class="govuk-body">The organisations we may share your personal information with include:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>public authorities such as HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC), Department of Work and Pensions (DWP) and HM Land Registry</li>
+        <li>non-public authorities such as the credit reference agencies Equifax and TransUnion</li>
+        <li>fraud prevention agencies if false or inaccurate information is provided or fraud has been identified</li>
+      </ul>
+    </div>
+    <p class="govuk-body">You can contact our Data Protection Officer for further information on the organisations we may share your personal information with.</p>
+
+    <h2 class="govuk-heading-l">Data Processors</h2>
+    <p class="govuk-body">The LAA may contract with third party data processors to provide email, system administration, document management and IT storage services. Data processors may also provide anonymised statistical information about your use of this service.</p>
+    <p class="govuk-body">Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.</p>
+
+    <h2 class="govuk-heading-l">Details of transfers to third country and safeguards</h2>
+    <p class="govuk-body">It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to the European Economic Area (EEA).</p>
+    <p class="govuk-body">Any transfers made will be in full compliance with all aspects of the data protection law.</p>
+
+    <h2 class="govuk-heading-l">Retention period for information collected</h2>
+    <p class="govuk-body">Your personal information will not be retained for any longer than is necessary for the lawful purposes for which it has been collected and processed. This is to ensure that your personal information does not become inaccurate, out of date or irrelevant.</p>
+    <p class="govuk-body">The LAA have set retention periods for the personal information that we collect. This can be accessed via our website:</p>
+    <p class="govuk-body"><a href='https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'>https://www.gov.uk/government/publications/record-retention-and-disposition-schedules</a></p>
+    <p class="govuk-body">You can also contact our Data Protection Officer for a copy of our retention policies.</p>
+    <p class="govuk-body">We'll ensure that your personal data is secure and protected from loss, misuse or unauthorised access and disclosure. Once the retention period has been reached, your personal data will be permanently and securely deleted and destroyed.</p>
+
+    <h2 class="govuk-heading-l">Access to personal information</h2>
+    <p class="govuk-body">You can find out if we hold any personal data about you by making a ‘subject access request’. If you wish to make a subject access request please contact:</p>
+    <p class="govuk-body">
+      Disclosure Team - Post point 10.25<br>
+      Ministry of Justice<br>
+      102 Petty France<br>
+      London<br>
+      SW1H 9AJ<br>
+    </p>
+    <p class="govuk-body">
+      <a href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>
+    </p>
+
+    <h2 class="govuk-heading-l">When we ask you for personal data</h2>
+    <p class="govuk-body">We promise to tell you why we need your personal data and ask only for the data we need and not collect information that is irrelevant or excessive.</p>
+    <p class="govuk-body">When we collect your personal data, we have responsibilities, and you have rights.</p>
+    <p class="govuk-body">We will:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>protect and ensure that no unauthorised person has access to your personal data</li>
+        <li>share your personal data with other organisations only for legitimate purposes</li>
+        <li>consider your request to correct, stop processing or erase your personal data</li>
+      </ul>
+    </div>
+    <p class="govuk-body">We will not:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>keep your personal data longer than needed</li>
+        <li>make your personal data available for commercial use without your consent</li>
+      </ul>
+    </div>
+    <p class="govuk-body">You can:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>withdraw consent at any time where relevant</li>
+        <li>lodge a complaint with the supervisory authority</li>
+      </ul>
+    </div>
+
+    <h2 class="govuk-heading-l">The Data Protection Officer</h2>
+    <p class="govuk-body">The Data Protection Officer can provide details on:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>agreements we have with other organisations for sharing information</li>
+        <li>circumstances where we can pass on personal information without telling you, for example to help with the prevention or detection of crime or to produce anonymised statistics</li>
+        <li>how we instruct staff to collect, use or delete your personal information</li>
+        <li>how we check that the information we hold is accurate and up-to-date</li>
+        <li>how to make a complaint</li>
+      </ul>
+    </div>
+
+    <p class="govuk-body">Contact the Data Protection Officer at:</p>
+    <p class="govuk-body">
+      The Data Protection Officer<br>
+      Ministry of Justice<br>
+      3rd Floor, Post Point 3.20<br>
+      10 South Colonnades<br>
+      Canary Wharf<br>
+      London<br>
+      E14 4PU<br>
+    </p>
+    <p class="govuk-body">
+      <a href="mailto:privacy@justice.gov.uk">privacy@justice.gov.uk</a>
+    </p>
+
+    <h2 class="govuk-heading-l">Complaints</h2>
+    <p class="govuk-body">When we ask you for information, we will comply with the law. If you do not think that we've handled your information correctly, you can contact the Information Commissioner for independent advice about data protection.</p>
+    <p class="govuk-body">Contact the Information Commissioner at:</p>
+    <p class="govuk-body">
+      Information Commissioner's Office<br>
+      Wycliffe House<br>
+      Water Lane<br>
+      Wilmslow<br>
+      Cheshire<br>
+      SK9 5AF<br>
+      Tel: 0303 123 1113<br>
+    </p>
+    <p class="govuk-body">
+      <a href='http://www.ico.org.uk'>ico.org.uk</a>
+    </p>
   </div>
-  <p class="govuk-body">The LAA is an Executive Agency of the Ministry of Justice (MoJ). The MoJ is the data controller for the personal information we hold.</p>
-  <p class="govuk-body">The LAA collects and processes personal data for the exercise of its own and associated public functions. Our public function is to provide legal aid.</p>
-
-  <h2 class="govuk-heading-l">About personal information</h2>
-  <p class="govuk-body">Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you've provided in this service such as:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your financial circumstances</li>
-      <li>information relating to any current or previous legal proceedings concerning you</li>
-    </ul>
-  </div>
-  <p class="govuk-body">We know how important it is to protect customers’ privacy and to comply with data protection laws. We will safeguard your personal data and will only disclose it where it is lawful to do so, or with your consent.</p>
-
-  <h2 class="govuk-heading-l">Types of personal data we process</h2>
-  <p class="govuk-body">We only process personal data that is relevant for the services we provide.</p>
-  <p class="govuk-body">The personal data which you've provided for this service will only be used for the purposes set out below.</p>
-
-  <h2 class="govuk-heading-l">Purpose of processing and the lawful basis for the process</h2>
-  <p class="govuk-body">The LAA collects and processes personal data for the purpose of providing legal aid. Specifically, we use personal data to:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>decide whether you need to make a contribution towards the costs of legal aid and to assist the LAA in collecting those contributions</li>
-      <li>assess claims from your legal representative(s) for payment from the legal aid fund for the work that they've conducted on your behalf</li>
-      <li>conduct periodic assurance audits on legal aid files to ensure that decisions have been made correctly and accurately</li>
-      <li>produce statistics and information on our systems and processes to help us improve them and to assist us in carrying out our functions</li>
-    </ul>
-  </div>
-  <p class="govuk-body">Were the LAA unable to collect this personal information, we would not be able to conduct the activities above, which would prevent us from providing legal aid.</p>
-  <p class="govuk-body">The lawful basis for the LAA collecting and processing your personal data is in the administration of justice and the result of the powers contained in the Legal Aid, Sentencing and Punishment of Offenders Act 2012 (LASPO).</p>
-  <p class="govuk-body">We also collect ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities under the Equality Act 2010.</p>
-  <p class="govuk-body">Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence. Any information published will not identify you or anyone else associated with your legal aid application.</p>
-
-  <h2 class="govuk-heading-l">Who we may share your information with</h2>
-  <p class="govuk-body">We sometimes need to share the personal information we process with other organisations. When this is necessary, we'll comply with all aspects of the relevant data protection laws.</p>
-  <p class="govuk-body">The organisations we may share your personal information with include:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>public authorities such as HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC), Department of Work and Pensions (DWP) and HM Land Registry</li>
-      <li>non-public authorities such as the credit reference agencies Equifax and TransUnion</li>
-      <li>fraud prevention agencies if false or inaccurate information is provided or fraud has been identified</li>
-    </ul>
-  </div>
-  <p class="govuk-body">You can contact our Data Protection Officer for further information on the organisations we may share your personal information with.</p>
-
-  <h2 class="govuk-heading-l">Data Processors</h2>
-  <p class="govuk-body">The LAA may contract with third party data processors to provide email, system administration, document management and IT storage services. Data processors may also provide anonymised statistical information about your use of this service.</p>
-  <p class="govuk-body">Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.</p>
-
-  <h2 class="govuk-heading-l">Details of transfers to third country and safeguards</h2>
-  <p class="govuk-body">It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to the European Economic Area (EEA).</p>
-  <p class="govuk-body">Any transfers made will be in full compliance with all aspects of the data protection law.</p>
-
-  <h2 class="govuk-heading-l">Retention period for information collected</h2>
-  <p class="govuk-body">Your personal information will not be retained for any longer than is necessary for the lawful purposes for which it has been collected and processed. This is to ensure that your personal information does not become inaccurate, out of date or irrelevant.</p>
-  <p class="govuk-body">The LAA have set retention periods for the personal information that we collect. This can be accessed via our website:</p>
-  <p class="govuk-body"><a href='https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'>https://www.gov.uk/government/publications/record-retention-and-disposition-schedules</a></p>
-  <p class="govuk-body">You can also contact our Data Protection Officer for a copy of our retention policies.</p>
-  <p class="govuk-body">We'll ensure that your personal data is secure and protected from loss, misuse or unauthorised access and disclosure. Once the retention period has been reached, your personal data will be permanently and securely deleted and destroyed.</p>
-
-  <h2 class="govuk-heading-l">Access to personal information</h2>
-  <p class="govuk-body">You can find out if we hold any personal data about you by making a ‘subject access request’. If you wish to make a subject access request please contact:</p>
-  <p class="govuk-body">
-    Disclosure Team - Post point 10.25<br>
-    Ministry of Justice<br>
-    102 Petty France<br>
-    London<br>
-    SW1H 9AJ<br>
-  </p>
-  <p class="govuk-body">
-    <a href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>
-  </p>
-
-  <h2 class="govuk-heading-l">When we ask you for personal data</h2>
-  <p class="govuk-body">We promise to tell you why we need your personal data and ask only for the data we need and not collect information that is irrelevant or excessive.</p>
-  <p class="govuk-body">When we collect your personal data, we have responsibilities, and you have rights.</p>
-  <p class="govuk-body">We will:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>protect and ensure that no unauthorised person has access to your personal data</li>
-      <li>share your personal data with other organisations only for legitimate purposes</li>
-      <li>consider your request to correct, stop processing or erase your personal data</li>
-    </ul>
-  </div>
-  <p class="govuk-body">We will not:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>keep your personal data longer than needed</li>
-      <li>make your personal data available for commercial use without your consent</li>
-    </ul>
-  </div>
-  <p class="govuk-body">You can:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>withdraw consent at any time where relevant</li>
-      <li>lodge a complaint with the supervisory authority</li>
-    </ul>
-  </div>
-
-  <h2 class="govuk-heading-l">The Data Protection Officer</h2>
-  <p class="govuk-body">The Data Protection Officer can provide details on:</p>
-  <div class="govuk-list">
-    <ul class="govuk-list govuk-list--bullet">
-      <li>agreements we have with other organisations for sharing information</li>
-      <li>circumstances where we can pass on personal information without telling you, for example to help with the prevention or detection of crime or to produce anonymised statistics</li>
-      <li>how we instruct staff to collect, use or delete your personal information</li>
-      <li>how we check that the information we hold is accurate and up-to-date</li>
-      <li>how to make a complaint</li>
-    </ul>
-  </div>
-
-  <p class="govuk-body">Contact the Data Protection Officer at:</p>
-  <p class="govuk-body">
-    The Data Protection Officer<br>
-    Ministry of Justice<br>
-    3rd Floor, Post Point 3.20<br>
-    10 South Colonnades<br>
-    Canary Wharf<br>
-    London<br>
-    E14 4PU<br>
-  </p>
-  <p class="govuk-body">
-    <a href="mailto:privacy@justice.gov.uk">privacy@justice.gov.uk</a>
-  </p>
-
-  <h2 class="govuk-heading-l">Complaints</h2>
-  <p class="govuk-body">When we ask you for information, we will comply with the law. If you do not think that we've handled your information correctly, you can contact the Information Commissioner for independent advice about data protection.</p>
-  <p class="govuk-body">Contact the Information Commissioner at:</p>
-  <p class="govuk-body">
-    Information Commissioner's Office<br>
-    Wycliffe House<br>
-    Water Lane<br>
-    Wilmslow<br>
-    Cheshire<br>
-    SK9 5AF<br>
-    Tel: 0303 123 1113<br>
-  </p>
-  <p class="govuk-body">
-    <a href='http://www.ico.org.uk'>ico.org.uk</a>
-  </p>
+</div>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,0 +1,150 @@
+<% title t('.page_title') %>
+  <h1 class="govuk-heading-xl">Privacy policy</h2>
+  <h2 class="govuk-heading-l">Purpose</h2>
+  <p class="govuk-body">This privacy notice sets out:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the standards that you can expect from the Legal Aid Agency (LAA) when we request or hold personal data about you</li>
+      <li>how you can get access to a copy of your personal data</li>
+      <li>what you can do if you think the standards are not being met</li>
+    </ul>
+  </div>
+  <p class="govuk-body">The LAA is an Executive Agency of the Ministry of Justice (MoJ). The MoJ is the data controller for the personal information we hold.</p>
+  <p class="govuk-body">The LAA collects and processes personal data for the exercise of its own and associated public functions. Our public function is to provide legal aid.</p>
+
+  <h2 class="govuk-heading-l">About personal information</h2>
+  <p class="govuk-body">Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you've provided in this service such as:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your financial circumstances</li>
+      <li>information relating to any current or previous legal proceedings concerning you</li>
+    </ul>
+  </div>
+  <p class="govuk-body">We know how important it is to protect customers’ privacy and to comply with data protection laws. We will safeguard your personal data and will only disclose it where it is lawful to do so, or with your consent.</p>
+
+  <h2 class="govuk-heading-l">Types of personal data we process</h2>
+  <p class="govuk-body">We only process personal data that is relevant for the services we provide.</p>
+  <p class="govuk-body">The personal data which you've provided for this service will only be used for the purposes set out below.</p>
+
+  <h2 class="govuk-heading-l">Purpose of processing and the lawful basis for the process</h2>
+  <p class="govuk-body">The LAA collects and processes personal data for the purpose of providing legal aid. Specifically, we use personal data to:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>decide whether you need to make a contribution towards the costs of legal aid and to assist the LAA in collecting those contributions</li>
+      <li>assess claims from your legal representative(s) for payment from the legal aid fund for the work that they've conducted on your behalf</li>
+      <li>conduct periodic assurance audits on legal aid files to ensure that decisions have been made correctly and accurately</li>
+      <li>produce statistics and information on our systems and processes to help us improve them and to assist us in carrying out our functions</li>
+    </ul>
+  </div>
+  <p class="govuk-body">Were the LAA unable to collect this personal information, we would not be able to conduct the activities above, which would prevent us from providing legal aid.</p>
+  <p class="govuk-body">The lawful basis for the LAA collecting and processing your personal data is in the administration of justice and the result of the powers contained in the Legal Aid, Sentencing and Punishment of Offenders Act 2012 (LASPO).</p>
+  <p class="govuk-body">We also collect ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities under the Equality Act 2010.</p>
+  <p class="govuk-body">Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence. Any information published will not identify you or anyone else associated with your legal aid application.</p>
+
+  <h2 class="govuk-heading-l">Who we may share your information with</h2>
+  <p class="govuk-body">We sometimes need to share the personal information we process with other organisations. When this is necessary, we'll comply with all aspects of the relevant data protection laws.</p>
+  <p class="govuk-body">The organisations we may share your personal information with include:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>public authorities such as HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC), Department of Work and Pensions (DWP) and HM Land Registry</li>
+      <li>non-public authorities such as the credit reference agencies Equifax and TransUnion</li>
+      <li>fraud prevention agencies if false or inaccurate information is provided or fraud has been identified</li>
+    </ul>
+  </div>
+  <p class="govuk-body">You can contact our Data Protection Officer for further information on the organisations we may share your personal information with.</p>
+
+  <h2 class="govuk-heading-l">Data Processors</h2>
+  <p class="govuk-body">The LAA may contract with third party data processors to provide email, system administration, document management and IT storage services. Data processors may also provide anonymised statistical information about your use of this service.</p>
+  <p class="govuk-body">Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.</p>
+
+  <h2 class="govuk-heading-l">Details of transfers to third country and safeguards</h2>
+  <p class="govuk-body">It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to the European Economic Area (EEA).</p>
+  <p class="govuk-body">Any transfers made will be in full compliance with all aspects of the data protection law.</p>
+
+  <h2 class="govuk-heading-l">Retention period for information collected</h2>
+  <p class="govuk-body">Your personal information will not be retained for any longer than is necessary for the lawful purposes for which it has been collected and processed. This is to ensure that your personal information does not become inaccurate, out of date or irrelevant.</p>
+  <p class="govuk-body">The LAA have set retention periods for the personal information that we collect. This can be accessed via our website:</p>
+  <p class="govuk-body"><a href='https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'>https://www.gov.uk/government/publications/record-retention-and-disposition-schedules</a></p>
+  <p class="govuk-body">You can also contact our Data Protection Officer for a copy of our retention policies.</p>
+  <p class="govuk-body">We'll ensure that your personal data is secure and protected from loss, misuse or unauthorised access and disclosure. Once the retention period has been reached, your personal data will be permanently and securely deleted and destroyed.</p>
+
+  <h2 class="govuk-heading-l">Access to personal information</h2>
+  <p class="govuk-body">You can find out if we hold any personal data about you by making a ‘subject access request’. If you wish to make a subject access request please contact:</p>
+  <p class="govuk-body">
+    Disclosure Team - Post point 10.25<br>
+    Ministry of Justice<br>
+    102 Petty France<br>
+    London<br>
+    SW1H 9AJ<br>
+  </p>
+  <p class="govuk-body">
+    <a href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>
+  </p>
+
+  <h2 class="govuk-heading-l">When we ask you for personal data</h2>
+  <p class="govuk-body">We promise to tell you why we need your personal data and ask only for the data we need and not collect information that is irrelevant or excessive.</p>
+  <p class="govuk-body">When we collect your personal data, we have responsibilities, and you have rights.</p>
+  <p class="govuk-body">We will:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>protect and ensure that no unauthorised person has access to your personal data</li>
+      <li>share your personal data with other organisations only for legitimate purposes</li>
+      <li>consider your request to correct, stop processing or erase your personal data</li>
+    </ul>
+  </div>
+  <p class="govuk-body">We will not:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>keep your personal data longer than needed</li>
+      <li>make your personal data available for commercial use without your consent</li>
+    </ul>
+  </div>
+  <p class="govuk-body">You can:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>withdraw consent at any time where relevant</li>
+      <li>lodge a complaint with the supervisory authority</li>
+    </ul>
+  </div>
+
+  <h2 class="govuk-heading-l">The Data Protection Officer</h2>
+  <p class="govuk-body">The Data Protection Officer can provide details on:</p>
+  <div class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>agreements we have with other organisations for sharing information</li>
+      <li>circumstances where we can pass on personal information without telling you, for example to help with the prevention or detection of crime or to produce anonymised statistics</li>
+      <li>how we instruct staff to collect, use or delete your personal information</li>
+      <li>how we check that the information we hold is accurate and up-to-date</li>
+      <li>how to make a complaint</li>
+    </ul>
+  </div>
+
+  <p class="govuk-body">Contact the Data Protection Officer at:</p>
+  <p class="govuk-body">
+    The Data Protection Officer<br>
+    Ministry of Justice<br>
+    3rd Floor, Post Point 3.20<br>
+    10 South Colonnades<br>
+    Canary Wharf<br>
+    London<br>
+    E14 4PU<br>
+  </p>
+  <p class="govuk-body">
+    <a href="mailto:privacy@justice.gov.uk">privacy@justice.gov.uk</a>
+  </p>
+
+  <h2 class="govuk-heading-l">Complaints</h2>
+  <p class="govuk-body">When we ask you for information, we will comply with the law. If you do not think that we've handled your information correctly, you can contact the Information Commissioner for independent advice about data protection.</p>
+  <p class="govuk-body">Contact the Information Commissioner at:</p>
+  <p class="govuk-body">
+    Information Commissioner's Office<br>
+    Wycliffe House<br>
+    Water Lane<br>
+    Wilmslow<br>
+    Cheshire<br>
+    SK9 5AF<br>
+    Tel: 0303 123 1113<br>
+  </p>
+  <p class="govuk-body">
+    <a href='http://www.ico.org.uk'>ico.org.uk</a>
+  </p>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title 'Privacy policy' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -21,7 +21,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed Hitchcock, Jones and King to represent them</li>
-      <li>they’ve read the <a href="#">LAA privacy policy</a></li>
+      <li>they’ve read the <a href="/about/privacy">LAA privacy policy</a></li>
       <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy policy)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>they may have to pay towards legal aid</li>

--- a/config/locales/en/about.yml
+++ b/config/locales/en/about.yml
@@ -1,6 +1,0 @@
----
-en:
-  about:
-    privacy:
-      page_title: Privacy policy
-      

--- a/config/locales/en/about.yml
+++ b/config/locales/en/about.yml
@@ -1,0 +1,6 @@
+---
+en:
+  about:
+    privacy:
+      page_title: Privacy policy
+      

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
 
+
   root 'home#index'
 
   resource :errors, only: [] do
@@ -40,8 +41,8 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :about, only: [:show] do
-    get :privacy, to: 'about#privacy'
+  namespace :about do
+    get :privacy
   end
 
   resources :crime_applications, except: [:new, :update], path: 'applications' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :about, only: [:show] do
+    get :privacy, to: 'about#privacy'
+  end
+
   resources :crime_applications, except: [:new, :update], path: 'applications' do
     get :confirm_destroy, on: :member
   end

--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe AboutController do
+  describe '#privacy' do
+    it 'has a 200 response code' do
+      get 'privacy'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add privacy policy page with content from civil apply (to be reviewed in https://dsdmoj.atlassian.net/browse/CRIMAP-150) 

Minor changes to copy where looked to be incorrect in civil. Adding full stop, removing colon from a h2 heading to make consistent. Adding missing into line to an address that is in the civil yml but unused. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-168

## Notes for reviewer
To match https://staging.apply-for-legal-aid.service.justice.gov.uk/privacy_policy?locale=en
