### PR TITLE
CRIMAP-176 Implement date stamp logic on submission

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,6 +128,6 @@ RSpec/NestedGroups:
   Max: 5
 
 RSpec/ExampleLength:
-  Max: 13
+  Max: 16
   Exclude:
     - spec/presenters/summary/sections/*

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -42,6 +42,13 @@
   }
 }
 
+.app-summary-list--compact {
+  dt, dd {
+    margin-bottom: 0 !important;
+    padding-bottom: 0 !important;
+  }
+}
+
 // style accessible autocomplete
 .autocomplete__wrapper * {
   @include govuk-typography-common();

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -25,14 +25,17 @@ class CrimeApplicationPresenter < BasePresenter
     applicant.present?
   end
 
-  def submitted_date
-    l(submitted_at, format: :datetime) if submitted_at
-  end
-
   # - If case type is “date stampable”, we use the date stamp value
-  # - If case type is non “date stampable”, we use the submission date as the date stamp
-  def application_date_stamp
-    date = date_stampable? ? date_stamp : submitted_at
+  # - If case type is non “date stampable”, and the application is submitted,
+  #   we use the submission date as the date stamp
+  #
+  def interim_date_stamp
+    date = if date_stampable?
+             date_stamp
+           elsif submitted?
+             submitted_at
+           end
+
     l(date, format: :datetime) if date
   end
 

--- a/app/services/application_submission.rb
+++ b/app/services/application_submission.rb
@@ -10,9 +10,13 @@ class ApplicationSubmission
   # submitted, to enable post-submission journeys.
   #
   def call
+    submitted_at = Time.current
+    date_stamp = crime_application.date_stamp || submitted_at
+
     crime_application.update!(
       status: ApplicationStatus::SUBMITTED.value,
-      submitted_at: Time.current,
+      submitted_at: submitted_at,
+      date_stamp: date_stamp,
     )
   end
 end

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -49,12 +49,12 @@
           <%= @crime_application.applicant_dob %>
         </p>
 
-        <% if @crime_application.application_date_stamp %>
+        <% if @crime_application.interim_date_stamp %>
           <h3 class="govuk-heading-s">
             <%= t('.aside.date_stamp') %>
           </h3>
           <p class="govuk-body">
-            <%= @crime_application.application_date_stamp %>
+            <%= @crime_application.interim_date_stamp %>
           </p>
         <% end %>
       <% end %>

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -5,12 +5,32 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
 
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      <strong><%= t('.laa_reference') %></strong> <%= @crime_application.laa_reference %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-7">
-      <strong><%= t('.date_stamp') %></strong> <%= @crime_application.application_date_stamp %>
-    </p>
+    <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-8 app-summary-list--compact">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t('.laa_reference') %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @crime_application.laa_reference %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t('.date_stamp') %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @crime_application.application_date_stamp %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t('.date_submitted') %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @crime_application.submitted_date %>
+        </dd>
+      </div>
+    </dl>
 
     <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
 

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -19,7 +19,7 @@
           <%= t('.date_stamp') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @crime_application.application_date_stamp %>
+          <%= l(@crime_application.date_stamp, format: :datetime) %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -27,7 +27,7 @@
           <%= t('.date_submitted') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @crime_application.submitted_date %>
+          <%= l(@crime_application.submitted_at, format: :datetime) %>
         </dd>
       </div>
     </dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
   time:
     formats:
       <<: *DATE_FORMATS
-      datetime: '%-l:%M%P %-d %b %Y'  # 2:45pm 3 Jan 2019
+      datetime: '%-d %B %Y %-l:%M%P'  # 3 January 2019 2:45pm
 
   flash:
     success:

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -20,6 +20,7 @@ en:
       heading: Application for criminal legal aid certificate
       laa_reference: "LAA reference:"
       date_stamp: "Date stamp:"
+      date_submitted: "Date submitted:"
       print_application: Print application
       back_to_applications: Back to all applications
     edit:

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe CrimeApplicationPresenter do
     instance_double(CrimeApplication,
                     id: 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
                     created_at: DateTime.new(2022, 1, 12),
+                    submitted_at: nil,
                     status: 'in_progress',
-                    date_stamp: Date.new(2022, 2, 1),
+                    date_stamp: DateTime.new(2022, 2, 1),
                     case: case_double,
                     applicant: applicant)
   end
@@ -29,13 +30,27 @@ RSpec.describe CrimeApplicationPresenter do
     context 'when a case is date stampable' do
       let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
-      it { expect(subject.application_date_stamp).to eq('1 Feb 2022') }
+      it { expect(subject.application_date_stamp).to eq('1 February 2022 12:00am') }
     end
 
     context 'when a case is not date stampable' do
       let(:case_type) { CaseType::INDICTABLE.to_s }
 
-      it { expect(subject.application_date_stamp).to be_nil }
+      context 'and the application is submitted' do
+        before do
+          allow(subject).to receive(:submitted_at).and_return(DateTime.new(2022, 2, 15))
+        end
+
+        it 'uses the `submitted_at` attribute as the date stamp' do
+          expect(subject.application_date_stamp).to eq('15 February 2022 12:00am')
+        end
+      end
+
+      context 'and the application is not yet submitted' do
+        it 'returns nil' do
+          expect(subject.application_date_stamp).to be_nil
+        end
+      end
     end
   end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -31,15 +31,34 @@ RSpec.describe 'Dashboard' do
       get crime_application_path(app)
     end
 
-    it 'shows the application' do
+    it 'renders the certificate page' do
       expect(response).to have_http_status(:success)
 
       assert_select 'h1', 'Application for criminal legal aid certificate'
+    end
 
+    it 'has the application details' do
+      assert_select 'dl.govuk-summary-list:nth-of-type(1)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(1)' do
+          assert_select 'dt:nth-of-type(1)', 'LAA reference:'
+          assert_select 'dd:nth-of-type(1)', /^LAA-[[:alnum:]]{6}$/
+        end
+        assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
+          assert_select 'dt:nth-of-type(1)', 'Date stamp:'
+          assert_select 'dd:nth-of-type(1)', '31 December 2022 12:00am'
+        end
+        assert_select 'div.govuk-summary-list__row:nth-of-type(3)' do
+          assert_select 'dt:nth-of-type(1)', 'Date submitted:'
+          assert_select 'dd:nth-of-type(1)', '31 December 2022 12:00am'
+        end
+      end
+    end
+
+    it 'has a read only version of the check your answers' do
       # client details section, no change links
       assert_select 'h2', 'Client details'
 
-      assert_select 'dl.govuk-summary-list:nth-of-type(1)' do
+      assert_select 'dl.govuk-summary-list:nth-of-type(2)' do
         assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(1)' do
           assert_select 'dt:nth-of-type(1)', 'First name'
           assert_select 'dd:nth-of-type(1)', 'Jane'

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -15,7 +15,11 @@ RSpec.describe 'Dashboard' do
   describe 'show an application certificate (once an application is completed)' do
     before :all do
       # sets up a test record
-      app = CrimeApplication.create(status: :submitted, submitted_at: Date.new(2022, 12, 31))
+      app = CrimeApplication.create(
+        status: :submitted,
+        date_stamp: Date.new(2022, 12, 25),
+        submitted_at: Date.new(2022, 12, 31),
+      )
 
       Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe')
     end
@@ -45,7 +49,7 @@ RSpec.describe 'Dashboard' do
         end
         assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
           assert_select 'dt:nth-of-type(1)', 'Date stamp:'
-          assert_select 'dd:nth-of-type(1)', '31 December 2022 12:00am'
+          assert_select 'dd:nth-of-type(1)', '25 December 2022 12:00am'
         end
         assert_select 'div.govuk-summary-list__row:nth-of-type(3)' do
           assert_select 'dt:nth-of-type(1)', 'Date submitted:'

--- a/spec/services/application_submission_spec.rb
+++ b/spec/services/application_submission_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationSubmission do
   let(:crime_application) do
     instance_double(
       CrimeApplication,
+      date_stamp:,
     )
   end
 
@@ -14,20 +15,38 @@ RSpec.describe ApplicationSubmission do
   end
 
   describe '#call' do
-    let(:submitted_date) { Date.new(2022, 12, 31) }
+    let(:submitted_date) { DateTime.new(2022, 12, 31) }
 
     before do
       travel_to submitted_date
     end
 
-    it 'marks the application as submitted' do
-      expect(
-        crime_application
-      ).to receive(:update!).with(
-        status: :submitted, submitted_at: submitted_date
-      )
+    context 'when `date_stamp` attribute is `nil`' do
+      let(:date_stamp) { nil }
 
-      expect(subject.call).to be(true)
+      it 'marks the application as submitted, setting the `date_stamp` to the submission date' do
+        expect(
+          crime_application
+        ).to receive(:update!).with(
+          status: :submitted, submitted_at: submitted_date, date_stamp: submitted_date
+        )
+
+        expect(subject.call).to be(true)
+      end
+    end
+
+    context 'when there is already a `date_stamp`' do
+      let(:date_stamp) { DateTime.new(2022, 12, 15) }
+
+      it 'marks the application as submitted, do not change the `date_stamp`' do
+        expect(
+          crime_application
+        ).to receive(:update!).with(
+          status: :submitted, submitted_at: submitted_date, date_stamp: date_stamp
+        )
+
+        expect(subject.call).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
The date stamp logic is a bit more tricky than anticipated, but in summary, it follows these broad rules:

- If case type is “date stampable”, we set and use the date stamp value across the application
- If case type is non “date stampable”, we don't set it until submission, at which time this becomes the date stamp

Across the application there are places (mainly task list) where the date stamp needs to show even if the application is not yet submitted, so the logic has been improved to cope with this.

On the certificate page (post submission) we've added in addition to the date stamp, the submission date. For non-stampable case types these 2 dates will be identical. For stampable case types, the dates will differ.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-176

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="770" alt="Screenshot 2022-10-26 at 12 07 43" src="https://user-images.githubusercontent.com/687910/198011121-7e20934e-3566-4c73-a65a-51ea325a7d4b.png">


## How to manually test the feature
NOTE: at the moment is possible to re-submit applications even if they are already in the SUBMITTED status. There is a separate ticket to handle this to stop a provider from performing actions on a submitted application (as it becomes read-only).

But ignoring this fact, you can run through the application, select a stamplable case type to have an initial date_stamp, which if you submit the application, will remain.
For non-stampable case types, on submission, the date stamp becomes the submitted_at date, both dates will match.