### PR TITLE
Allow api requests on staging.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,10 @@ Rails.application.routes.draw do
   # catch-all route
   # :nocov:
   match '*path', to: 'errors#not_found', via: :all, constraints:
-    lambda { |_request| !Rails.application.config.consider_all_requests_local }
+    lambda { |request|
+      not_dev_api_request = !request.url['api/applications']
+      Rails.env.production? && not_dev_api_request
+    }
+
   # :nocov:
 end


### PR DESCRIPTION
Co-authored-by: willmcb <william.mcbrien@digital.justice.gov.uk>

## Description of change

Modify the catch all routing constraint so that it ignores requests to the dev api when in a production environment.

## Link to relevant ticket

## Notes for reviewer

Reluctantly proposing this change to Apply in order to allow us to use the dev api on staging.

The dev api's routes are loaded after those in Apply. This was fine in development and test because the catch all's constraint   ignored test and dev requests (so as to show the rails errors etc).  However, on staging the catch all constraint was satisfied, preventing any requests to the dev api. 

We also considered explicitly adding the dev api routes to apply, and removing the catch all altogether.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
