### PR TITLE
CRIMAP-97 Add additional actions to developer tools

### DIFF
--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -34,6 +34,6 @@ class CompletedApplicationsController < DashboardController
   # not purging applications on submission yet.
   #
   def current_crime_application
-    @current_crime_application ||= CrimeApplication.submitted.find_by(id: params[:id])
+    @current_crime_application ||= CrimeApplication.not_in_progress.find_by(id: params[:id])
   end
 end

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -1,0 +1,61 @@
+# :nocov:
+module DeveloperTools
+  class CrimeApplicationsController < ApplicationController
+    before_action :check_crime_application_presence
+
+    def destroy
+      current_crime_application.destroy
+      redirect_to crime_applications_path, flash: { success: 'Application has been deleted' }
+    end
+
+    def bypass_dwp
+      find_or_create_applicant
+
+      crime_application.update(
+        navigation_stack: [
+          edit_steps_client_has_partner_path(crime_application),
+          edit_steps_client_details_path(crime_application),
+          edit_steps_client_has_nino_path(crime_application),
+          edit_steps_client_benefit_check_result_path(crime_application),
+        ]
+      )
+
+      redirect_to edit_steps_client_benefit_check_result_path(crime_application)
+    end
+
+    def mark_as_returned
+      current_crime_application.returned!
+      redirect_to crime_applications_path, flash: { success: 'Application marked as returned' }
+    end
+
+    private
+
+    # For developer tools we don't do any scoping, not that
+    # it matters once we purge applications anyways
+    def current_crime_application
+      @current_crime_application ||= CrimeApplication.find_by(id: params[:id])
+    end
+
+    def crime_application
+      @crime_application ||= current_crime_application || initialize_crime_application(
+        client_has_partner: YesNoAnswer::NO,
+      )
+    end
+
+    def find_or_create_applicant
+      Applicant.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
+        surname, details = MockBenefitCheckService::KNOWN.to_a.sample
+
+        record.update(
+          first_name: record.first_name || 'Test',
+          last_name: surname,
+          date_of_birth: details[:dob],
+          has_nino: YesNoAnswer::YES,
+          nino: details[:nino],
+          passporting_benefit: true,
+        )
+      end
+    end
+  end
+end
+# :nocov:

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,28 +3,4 @@ class SessionsController < ApplicationController
     reset_session
     redirect_to root_path
   end
-
-  # NOTE: the following might be reused later on, so leaving it here
-  #
-  # private
-  #
-  # :nocov:
-  # def crime_application
-  #   current_crime_application || initialize_crime_application(
-  #     client_has_partner: YesNoAnswer::NO
-  #   )
-  # end
-  #
-  # def find_or_create_applicant
-  #   Applicant.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
-  #     unless record.persisted?
-  #       record.update(
-  #         first_name: 'John',
-  #         last_name: 'Test',
-  #         date_of_birth: 25.years.ago
-  #       )
-  #     end
-  #   end
-  # end
-  # :nocov:
 end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -4,6 +4,7 @@ class CrimeApplicationPresenter < BasePresenter
   STATUSES = {
     'in_progress' => 'govuk-tag--blue',
     'submitted'   => 'govuk-tag--green',
+    'returned'    => 'govuk-tag--yellow',
   }.freeze
 
   delegate :first_name, :last_name, :date_of_birth, to: :applicant

--- a/app/services/mock_benefit_check_service.rb
+++ b/app/services/mock_benefit_check_service.rb
@@ -1,10 +1,10 @@
 class MockBenefitCheckService
   KNOWN = {
-    'SMITH' => { nino: 'NC123459A', dob: '11-Jan-99' },
-    'JONES' => { nino: 'NC123458A', dob: '1-Jun-80' },
-    'BLOGGS' => { nino: 'NC123457A', dob: '4-Jan-90' },
-    'WRINKLE' => { nino: 'NC010150A', dob: '01-Jan-50' },
-    'WALKER' => { nino: 'JA293483A', dob: '10-Jan-80' }, # Used in cucumber tests and specs
+    'SMITH' => { nino: 'NC123459A', dob: '11-Jan-1999' },
+    'JONES' => { nino: 'NC123458A', dob: '1-Jun-1980' },
+    'BLOGGS' => { nino: 'NC123457A', dob: '4-Jan-1990' },
+    'WRINKLE' => { nino: 'NC010150A', dob: '01-Jan-1950' },
+    'WALKER' => { nino: 'JA293483A', dob: '10-Jan-1980' }, # Used in cucumber tests and specs
   }.freeze
 
   def self.call(*args)
@@ -44,7 +44,7 @@ class MockBenefitCheckService
   def applicant_data
     {
       nino: nino,
-      dob: date_of_birth&.strftime('%d-%b-%y'),
+      dob: date_of_birth&.strftime('%d-%b-%Y'),
     }
   end
 end

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -1,7 +1,8 @@
 class ApplicationStatus < ValueObject
   VALUES = [
     IN_PROGRESS = new(:in_progress),
-    SUBMITTED   = new(:submitted)
+    SUBMITTED   = new(:submitted),
+    RETURNED    = new(:returned),
   ].freeze
 
   def self.enum_values

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -6,26 +6,33 @@
       </span>
     </summary>
     <div class="govuk-details__text app-util--inline-buttons">
-      <% if current_crime_application %>
-        <h4 class="govuk-heading-s">Current Application ID</h4>
-        <p><%= current_crime_application.id %></p>
-      <% end %>
-
-      <h4 class="govuk-heading-s">Destroy session</h4>
-      <p>Deletes all data entered in this session and lets you start a new application from scratch.</p>
-
-      <%= button_to session_path, method: :delete,
-                    class: 'govuk-button govuk-button--warning',
-                    data: { module: 'govuk-button' } do; 'Destroy session'; end %>
-
-      <h4 class="govuk-heading-s">Quick access</h4>
-      <p>Speed up some common test scenarios</p>
+      <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Current Application ID</h4>
+      <p><%= current_crime_application&.id || 'None' %></p>
 
       <div class="govuk-button-group">
         <%= button_to crime_applications_path, method: :get,
                       class: 'govuk-button',
                       data: { module: 'govuk-button' } do; 'Your applications'; end %>
       </div>
+
+      <% if current_crime_application %>
+        <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Quick actions</h4>
+        <p>Speed up some common application actions</p>
+
+        <div class="govuk-button-group">
+          <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
+                        class: 'govuk-button govuk-!-margin-right-1',
+                        data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>
+
+          <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
+                        class: 'govuk-button govuk-!-margin-right-1',
+                        data: { module: 'govuk-button' } do; 'Mark as returned'; end if current_crime_application.submitted? %>
+
+          <%= button_to developer_tools_crime_application_path, method: :delete,
+                        class: 'govuk-button govuk-button--warning',
+                        data: { module: 'govuk-button' } do; 'Destroy'; end %>
+        </div>
+      <% end %>
     </div>
   </details>
 <% end %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -15,6 +15,7 @@ en:
       status:
         in_progress: In progress
         submitted: Submitted
+        returned: Returned
     edit:
       page_title: Application task list
       heading: Make a new application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,10 +21,8 @@ def show_step(name)
 end
 
 Rails.application.routes.draw do
-
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
-
 
   root 'home#index'
 
@@ -36,8 +34,12 @@ Rails.application.routes.draw do
   end
 
   resource :session, only: [:destroy] do
-    member do
-      post :bypass_to_client_details
+  end
+
+  namespace :developer_tools, constraints: -> (_) { FeatureFlags.developer_tools.enabled? } do
+    resources :crime_applications, only: [:update, :destroy], path: 'applications' do
+      put :bypass_dwp, on: :member
+      put :mark_as_returned, on: :member
     end
   end
 
@@ -105,6 +107,5 @@ Rails.application.routes.draw do
       not_dev_api_request = !request.url['api/applications']
       Rails.env.production? && not_dev_api_request
     }
-
   # :nocov:
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe CrimeApplication, type: :model do
         described_class.statuses
       ).to eq(
         'in_progress' => 'in_progress',
-        'submitted' => 'submitted'
+        'submitted' => 'submitted',
+        'returned' => 'returned',
       )
     end
   end

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -106,9 +106,16 @@ RSpec.describe CrimeApplicationPresenter do
         expect(subject.status_tag).to eq(tag)
       end
 
-      it 'can output an in submitted tag' do
+      it 'can output a submitted tag' do
         allow(subject).to receive(:status).and_return('submitted')
         tag = '<strong class="govuk-tag govuk-tag--green">Submitted</strong>'
+
+        expect(subject.status_tag).to eq(tag)
+      end
+
+      it 'can output a returned tag' do
+        allow(subject).to receive(:status).and_return('returned')
+        tag = '<strong class="govuk-tag govuk-tag--yellow">Returned</strong>'
 
         expect(subject.status_tag).to eq(tag)
       end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w[in_progress submitted]
+        %w[in_progress submitted returned]
       )
     end
   end
@@ -17,7 +17,7 @@ RSpec.describe ApplicationStatus do
     it 'returns a map of values, used as an enum definition' do
       expect(
         described_class.enum_values
-      ).to eq({ in_progress: 'in_progress', submitted: 'submitted' })
+      ).to eq({ in_progress: 'in_progress', submitted: 'submitted', returned: 'returned' })
     end
   end
 end


### PR DESCRIPTION
## Description of change
This is a first PR to add some additional actions to the developer tools (in the footer) that will be necessary to progress with the user story in CRIMAP-97 (amend application).

Mainly, I've added a "mark as returned" button that will only show when "viewing" a `submitted` application. This button will put it into a `returned` status which later on can be used to filter in the dashboard and to amend it through the certificate page. This will be done in a separate follow-up PR.

I've also added a quick action to fill up an application up to the DWP check (success) result page, as I kept forgetting myself which combinations of surname, dob and NINO pass the check (mock values).

Overall, reorganised a bit the developer tools into its own controller, leaving the `SessionsController` as might be used in the future when we have the login mechanism.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-97

## Notes for reviewer
To view the certificate of a submitted application, go to this page (awaiting redesign of the dashboard for the links to work):
`/completed/applications/{uuid}`

## Screenshots of changes (if applicable)
<img width="930" alt="Screenshot 2022-10-28 at 10 36 07" src="https://user-images.githubusercontent.com/687910/198557304-113b8f86-52fe-4434-b27c-272d8201554b.png">

## How to manually test the feature
Quick action buttons in the footer show only when you have a current application (i.e. anywhere in the steps journey, or through the dashboard when in the task list or certificate pages).