### PR TITLE
Configurable summary presenters, reuse in DWP journey

### DIFF
--- a/app/controllers/steps/dwp/confirm_details_controller.rb
+++ b/app/controllers/steps/dwp/confirm_details_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Dwp
     class ConfirmDetailsController < Steps::DwpStepController
+      before_action :set_presenter
+
       def edit
         @form_object = ConfirmDetailsForm.new(
           crime_application: current_crime_application
@@ -9,6 +11,14 @@ module Steps
 
       def update
         update_and_advance(ConfirmDetailsForm, as: :confirm_details)
+      end
+
+      private
+
+      def set_presenter
+        @client_details = Summary::Sections::ClientDetails.new(
+          current_crime_application, editable: false, headless: true
+        )
       end
     end
   end

--- a/app/forms/steps/dwp/confirm_details_form.rb
+++ b/app/forms/steps/dwp/confirm_details_form.rb
@@ -1,12 +1,8 @@
 module Steps
   module Dwp
     class ConfirmDetailsForm < Steps::BaseFormObject
-      include Steps::HasOneAssociation
-      has_one_association :applicant
-
       attribute :confirm_details, :value_object, source: YesNoAnswer
-
-      validates_inclusion_of :confirm_details, in: :choices
+      validates :confirm_details, inclusion: { in: :choices }
 
       def choices
         YesNoAnswer.values

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -5,8 +5,10 @@ module Summary
 
       attr_reader :crime_application
 
-      def initialize(crime_application)
+      def initialize(crime_application, editable: true, headless: false)
         @crime_application = crime_application
+        @editable = editable
+        @headless = headless
       end
 
       # Used by Rails to determine which partial to render.
@@ -18,6 +20,16 @@ module Summary
       # May be overridden in subclasses to hide/show if appropriate
       def show?
         answers.any?
+      end
+
+      # If action links are allowed (i.e. `change` links)
+      def editable?
+        crime_application.in_progress? && @editable
+      end
+
+      # If this section shows the header or not
+      def headless?
+        @headless
       end
 
       # Used by the `Routing` module to build the `change` urls

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -37,9 +37,8 @@ module Summary
             change_path: edit_steps_client_has_nino_path
           ),
 
-          # hardcoded for MVP, as we do screening
           Components::ValueAnswer.new(
-            :passporting, YesNoAnswer::YES
+            :passporting, applicant.passporting_benefit
           ),
         ].select(&:show?)
       end

--- a/app/views/steps/client/benefit_check_result/edit.html.erb
+++ b/app/views/steps/client/benefit_check_result/edit.html.erb
@@ -2,9 +2,7 @@
 <% step_header %>
 
 <div class="govuk-grid-row app-inverted--card app-inverted-text">
-  <div class="govuk-grid-column app-inverted-text">
-
-    <%= govuk_error_summary(@form_object) %>
+  <div class="govuk-grid-column-full">
     <%= step_form @form_object do |f| %>
       <h1 class="govuk-heading-l app-inverted-text"><%= t '.heading' %></h1>
 

--- a/app/views/steps/dwp/confirm_details/edit.html.erb
+++ b/app/views/steps/dwp/confirm_details/edit.html.erb
@@ -2,58 +2,13 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-   <div class="govuk-grid-column-two-thirds">
-      <%= govuk_error_summary(@form_object) %>
-   </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t '.first_name' %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @form_object.applicant.first_name %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t '.last_name' %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @form_object.applicant.last_name %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t '.dob' %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= l(@form_object.applicant.date_of_birth) %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t '.nino' %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @form_object.applicant.nino %>
-        </dd>
-      </div>
-    </dl>
-  </div>
-</div>
+    <%= govuk_error_summary(@form_object) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
+
+    <%= render @client_details %>
+
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :confirm_details, @form_object.choices, :value,
                                            inline: false %>

--- a/app/views/steps/dwp/confirm_result/edit.html.erb
+++ b/app/views/steps/dwp/confirm_result/edit.html.erb
@@ -2,16 +2,19 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-   <div class="govuk-grid-column-two-thirds">
-      <%= govuk_error_summary(@form_object) %>
-   </div>
-</div>
-
-<div class="govuk-grid-row app-inverted--card app-inverted-text">
-  <div class="govuk-grid-column app-inverted-text">
-    <h1 class="govuk-heading-l app-inverted-text"><%= t '.heading' %></h1>
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
   </div>
 </div>
+
+<div class="govuk-grid-row app-inverted--card app-inverted-text govuk-!-margin-bottom-5">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l app-inverted-text govuk-!-margin-bottom-0">
+      <%= t '.heading' %>
+    </h1>
+  </div>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= step_form @form_object do |f| %>

--- a/app/views/steps/submission/shared/_date_answer.html.erb
+++ b/app/views/steps/submission/shared/_date_answer.html.erb
@@ -8,4 +8,5 @@
   end
 %>
 
-<%= render partial: 'steps/submission/shared/summary_row', locals: { row: date_answer } %>
+<%= render partial: 'steps/submission/shared/summary_row',
+           locals: { row: date_answer, editable: editable } %>

--- a/app/views/steps/submission/shared/_free_text_answer.html.erb
+++ b/app/views/steps/submission/shared/_free_text_answer.html.erb
@@ -11,4 +11,5 @@
   end
 %>
 
-<%= render partial: 'steps/submission/shared/summary_row', locals: { row: free_text_answer } %>
+<%= render partial: 'steps/submission/shared/summary_row',
+           locals: { row: free_text_answer, editable: editable } %>

--- a/app/views/steps/submission/shared/_offence_answer.html.erb
+++ b/app/views/steps/submission/shared/_offence_answer.html.erb
@@ -20,4 +20,5 @@
   <% end %>
 <% end %>
 
-<%= render partial: 'steps/submission/shared/summary_row', locals: { row: offence_answer } %>
+<%= render partial: 'steps/submission/shared/summary_row',
+           locals: { row: offence_answer, editable: editable } %>

--- a/app/views/steps/submission/shared/_section.html.erb
+++ b/app/views/steps/submission/shared/_section.html.erb
@@ -1,7 +1,9 @@
-<h2 class="govuk-heading-m">
-  <%= t(section.name, scope: 'summary.sections') %>
-</h2>
+<% unless section.headless? %>
+  <h2 class="govuk-heading-m">
+    <%= t(section.name, scope: 'summary.sections') %>
+  </h2>
+<% end %>
 
 <dl class="govuk-summary-list">
-  <%= render section.answers %>
+  <%= render section.answers, editable: section.editable? %>
 </dl>

--- a/app/views/steps/submission/shared/_summary_row.html.erb
+++ b/app/views/steps/submission/shared/_summary_row.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_actions = current_crime_application.in_progress? && row.change_link?
+  show_actions = editable && row.change_link?
 
   div_classes = ['govuk-summary-list__row']
   div_classes << 'govuk-summary-list__row--no-actions' unless show_actions

--- a/app/views/steps/submission/shared/_value_answer.html.erb
+++ b/app/views/steps/submission/shared/_value_answer.html.erb
@@ -8,4 +8,5 @@
   end
 %>
 
-<%= render partial: 'steps/submission/shared/summary_row', locals: { row: value_answer } %>
+<%= render partial: 'steps/submission/shared/summary_row',
+           locals: { row: value_answer, editable: editable } %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -41,10 +41,6 @@ en:
         edit:
           heading: Check your client’s details
           page_title: Confirm your client’s details
-          first_name: First name
-          last_name: Last name
-          dob: Date of birth
-          nino: National Insurance number
       benefit_check_result_exit:
         show:
           page_title: Use eForms for this application

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -33,7 +33,8 @@ en:
       passporting:
         question: Passporting benefit
         answers:
-          <<: *YESNO
+          'true': 'Yes'
+          'false': 'No'
       # END client details section
 
       # BEGIN contact details section

--- a/spec/presenters/summary/sections/base_section_spec.rb
+++ b/spec/presenters/summary/sections/base_section_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 describe Summary::Sections::BaseSection do
-  subject { described_class.new(crime_application) }
+  subject { described_class.new(crime_application, **arguments) }
 
-  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:crime_application) { CrimeApplication.new(status:) }
+  let(:status) { :in_progress }
+  let(:arguments) { {} }
 
   describe '#to_partial_path' do
     it 'returns the partial path' do
@@ -29,6 +31,46 @@ describe Summary::Sections::BaseSection do
 
       it 'returns true' do
         expect(subject.show?).to be(true)
+      end
+    end
+  end
+
+  describe '#editable?' do
+    context 'for an application `in_progress`' do
+      it 'returns true' do
+        expect(subject.editable?).to be(true)
+      end
+    end
+
+    context 'for an application `in_progress` but editable is overridden' do
+      let(:arguments) { { editable: false } }
+
+      it 'returns false' do
+        expect(subject.editable?).to be(false)
+      end
+    end
+
+    context 'for an application `submitted`' do
+      let(:status) { :submitted }
+
+      it 'returns false' do
+        expect(subject.editable?).to be(false)
+      end
+    end
+  end
+
+  describe '#headless?' do
+    context 'default value' do
+      it 'returns false' do
+        expect(subject.headless?).to be(false)
+      end
+    end
+
+    context 'when configured to be headless' do
+      let(:arguments) { { headless: true } }
+
+      it 'returns true' do
+        expect(subject.editable?).to be(true)
       end
     end
   end

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -20,6 +20,7 @@ describe Summary::Sections::ClientDetails do
       other_names: '',
       date_of_birth: Date.new(1999, 1, 20),
       nino: '123456',
+      passporting_benefit: true,
     )
   end
 
@@ -77,7 +78,7 @@ describe Summary::Sections::ClientDetails do
       expect(answers[5]).to be_an_instance_of(Summary::Components::ValueAnswer)
       expect(answers[5].question).to eq(:passporting)
       expect(answers[5].change_path).to be_nil
-      expect(answers[5].value).to eq(YesNoAnswer::YES)
+      expect(answers[5].value).to be(true)
     end
   end
 end

--- a/spec/requests/dwp_benefit_checker_spec.rb
+++ b/spec/requests/dwp_benefit_checker_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'DWP passporting sub journey' do
+  describe 'confirm applicant personal details page' do
+    before :all do
+      # sets up a few test records
+      app = CrimeApplication.create
+
+      Applicant.create(
+        crime_application: app,
+        first_name: 'Jane', last_name: 'Doe',
+        date_of_birth: Date.new(1990, 2, 1),
+        nino: 'AB123456A'
+      )
+    end
+
+    after :all do
+      # do not leave left overs in the test database
+      CrimeApplication.destroy_all
+    end
+
+    let(:crime_application) { CrimeApplication.first }
+
+    before do
+      get edit_steps_dwp_confirm_details_path(crime_application)
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'has a read only version of the client details summary' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Check your client’s details'
+      assert_select 'h2.govuk-heading-m', false # the summary is headless
+
+      assert_select 'dl.govuk-summary-list' do
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(1)' do
+          assert_select 'dt', 'First name'
+          assert_select 'dd', 'Jane'
+        end
+
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(2)' do
+          assert_select 'dt', 'Last name'
+          assert_select 'dd', 'Doe'
+        end
+
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(3)' do
+          assert_select 'dt', 'Other names'
+          assert_select 'dd', 'None'
+        end
+
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(4)' do
+          assert_select 'dt', 'Date of birth'
+          assert_select 'dd', '1 Feb 1990'
+        end
+
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(5)' do
+          assert_select 'dt', 'National Insurance number'
+          assert_select 'dd', 'AB123456A'
+        end
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/views/steps/submission/shared/_date_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_date_answer.html.erb_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'Rendering a summary row of type `DateAnswer`' do
-  let(:crime_application) { CrimeApplication.new(status: ApplicationStatus::IN_PROGRESS.to_s) }
-
   let(:answer) do
     Summary::Components::DateAnswer.new(
       :date_of_birth, Date.new(2008, 11, 22), change_path: '/edit'
@@ -10,11 +8,10 @@ describe 'Rendering a summary row of type `DateAnswer`' do
   end
 
   before do
-    allow(view).to receive(:current_crime_application).and_return(crime_application)
-    render answer
+    render answer, editable: true
   end
 
-  # No need to test again the application status or the change link,
+  # No need to test again the editable state or the change link,
   # as we tested it in `value_answer` and all these partials behave the same
   # because they render a common partial, where that logic resides.
 

--- a/spec/views/steps/submission/shared/_free_text_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_free_text_answer.html.erb_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'Rendering a summary row of type `FreeTextAnswer`' do
-  let(:crime_application) { CrimeApplication.new(status: ApplicationStatus::IN_PROGRESS.to_s) }
-
   let(:answer) do
     Summary::Components::FreeTextAnswer.new(
       :first_name, 'John', change_path: '/edit'
@@ -10,11 +8,10 @@ describe 'Rendering a summary row of type `FreeTextAnswer`' do
   end
 
   before do
-    allow(view).to receive(:current_crime_application).and_return(crime_application)
-    render answer
+    render answer, editable: true
   end
 
-  # No need to test again the application status or the change link,
+  # No need to test again the editable state or the change link,
   # as we tested it in `value_answer` and all these partials behave the same
   # because they render a common partial, where that logic resides.
 

--- a/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'Rendering a summary row of type `OffenceAnswer`' do
-  let(:crime_application) { CrimeApplication.new(status: ApplicationStatus::IN_PROGRESS.to_s) }
-
   let(:answer) do
     Summary::Components::OffenceAnswer.new(
       :offence_details, presented_charge, change_path: '/edit', i18n_opts: { index: 1 }
@@ -21,11 +19,10 @@ describe 'Rendering a summary row of type `OffenceAnswer`' do
   let(:offence_class) { 'Offence class' }
 
   before do
-    allow(view).to receive(:current_crime_application).and_return(crime_application)
-    render answer
+    render answer, editable: true
   end
 
-  # No need to test again the application status or the change link,
+  # No need to test again the editable state or the change link,
   # as we tested it in `value_answer` and all these partials behave the same
   # because they render a common partial, where that logic resides.
 

--- a/spec/views/steps/submission/shared/_value_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_value_answer.html.erb_spec.rb
@@ -1,21 +1,18 @@
 require 'rails_helper'
 
 describe 'Rendering a summary row of type `ValueAnswer`' do
-  let(:crime_application) { CrimeApplication.new(status:) }
-
   let(:answer) do
     Summary::Components::ValueAnswer.new(
-      :passporting, :yes, change_path:
+      :case_type, CaseType::SUMMARY_ONLY, change_path:
     )
   end
 
   before do
-    allow(view).to receive(:current_crime_application).and_return(crime_application)
-    render answer
+    render answer, editable:
   end
 
-  context 'for an `in_progress` application' do
-    let(:status) { ApplicationStatus::IN_PROGRESS.to_s }
+  context 'for editable rows' do
+    let(:editable) { true }
 
     context 'with change link' do
       let(:change_path) { '/edit' }
@@ -24,9 +21,9 @@ describe 'Rendering a summary row of type `ValueAnswer`' do
         assert_select 'div.govuk-summary-list__row--no-actions', 0
 
         assert_select 'div.govuk-summary-list__row', 1 do
-          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
-          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
-          assert_select 'dd.govuk-summary-list__actions a', text: 'Change Passporting benefit'
+          assert_select 'dt.govuk-summary-list__key', text: 'Case type'
+          assert_select 'dd.govuk-summary-list__value', text: 'Summary only'
+          assert_select 'dd.govuk-summary-list__actions a', text: 'Change Case type'
         end
       end
     end
@@ -36,24 +33,24 @@ describe 'Rendering a summary row of type `ValueAnswer`' do
 
       it 'renders the expected row' do
         assert_select 'div.govuk-summary-list__row--no-actions', 1 do
-          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
-          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dt.govuk-summary-list__key', text: 'Case type'
+          assert_select 'dd.govuk-summary-list__value', text: 'Summary only'
           assert_select 'dd.govuk-summary-list__actions', 0
         end
       end
     end
   end
 
-  context 'for a `submitted` application' do
-    let(:status) { ApplicationStatus::SUBMITTED.to_s }
+  context 'for non-editable rows' do
+    let(:editable) { false }
 
     context 'with change link' do
       let(:change_path) { '/edit' }
 
       it 'renders the expected row' do
         assert_select 'div.govuk-summary-list__row--no-actions', 1 do
-          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
-          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dt.govuk-summary-list__key', text: 'Case type'
+          assert_select 'dd.govuk-summary-list__value', text: 'Summary only'
           assert_select 'dd.govuk-summary-list__actions', 0
         end
       end
@@ -64,8 +61,8 @@ describe 'Rendering a summary row of type `ValueAnswer`' do
 
       it 'renders the expected row' do
         assert_select 'div.govuk-summary-list__row--no-actions', 1 do
-          assert_select 'dt.govuk-summary-list__key', text: 'Passporting benefit'
-          assert_select 'dd.govuk-summary-list__value', text: 'Yes'
+          assert_select 'dt.govuk-summary-list__key', text: 'Case type'
+          assert_select 'dd.govuk-summary-list__value', text: 'Summary only'
           assert_select 'dd.govuk-summary-list__actions', 0
         end
       end


### PR DESCRIPTION
## Description of change
This PR is a bit of tidy up, DRY and preparing for continuing with CRIMAP-97 (amend applications).
It looks like lots of changes but it is very minor overall. I've split this into 2 separate commits.

First thing, decouple the views from having to use the `current_crime_application` to know if the change links should show or not. Instead, make it part of the configuration of each of the sections (`editable`), and propagate this to the views as `locals`.

Same if we want to hide the header of the section. Default is false, but we can pass `headless: true` to hide the header.

This makes for more flexible "section" components so we can reuse them in other places (like in the DWP confirm applicant details page).

Also tests are simpler and do not need to have the knowledge or concept of a "crime application" record.

With these tweaks done, we can now reuse the `Summary::Sections::ClientDetails`, the same we use in the check your answers, for the DWP passporting journey too.

## Screenshots of changes (if applicable)
<img width="1032" alt="Screenshot 2022-10-28 at 15 34 14" src="https://user-images.githubusercontent.com/687910/198648968-b17391b8-7758-4d04-91b1-88d0b5d5d5de.png">
<img width="811" alt="Screenshot 2022-10-28 at 15 34 02" src="https://user-images.githubusercontent.com/687910/198648987-2b089881-64f4-41ad-b05b-b5c383417983.png">

## How to manually test the feature
Everything should keep working as before, there are no functional changes.