### PR TITLE
CRIMAP-97 Amend returned application

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -49,8 +49,17 @@
   }
 }
 
+$app-blue-button-colour: govuk-colour("blue");
+.app-button--blue {
+  background-color: $app-blue-button-colour;
+  box-shadow: 0 $button-shadow-size 0 govuk-shade($app-blue-button-colour, 60%);
+
+  &:hover {
+    background-color: govuk-shade($app-blue-button-colour, 20%);
+  }
+}
+
 // style accessible autocomplete
 .autocomplete__wrapper * {
   @include govuk-typography-common();
 }
-

--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -27,6 +27,13 @@ class CompletedApplicationsController < DashboardController
     )
   end
 
+  def amend
+    ApplicationAmendment.new(current_crime_application).call
+
+    # Redirect to check your answers (review) page
+    redirect_to edit_steps_submission_review_path(current_crime_application)
+  end
+
   private
 
   # TODO: this will go to the document store when we have it.

--- a/app/services/application_amendment.rb
+++ b/app/services/application_amendment.rb
@@ -1,0 +1,25 @@
+class ApplicationAmendment
+  attr_reader :crime_application
+
+  def initialize(crime_application)
+    @crime_application = crime_application
+  end
+
+  # TODO: for now we don't really know how the amendment will work,
+  # this is just a mock, and for now we just mark an application as
+  # `in_progress`, to re-enable the steps journey.
+  #
+  # Presumably, the act of "amending" an application will mean
+  # creating a "copy" of the last submitted version, with a
+  # reference to it (`parent_id`). To be decided.
+  #
+  def call
+    crime_application.update!(
+      status: ApplicationStatus::IN_PROGRESS.value,
+      # we reset some values
+      navigation_stack: [],
+      declaration_signed: nil,
+      submitted_at: nil,
+    )
+  end
+end

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -48,7 +48,13 @@
     </div>
 
     <div class="govuk-button-group app-no-print">
-      <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+      <% if @crime_application.returned? %>
+        <%= button_to amend_completed_crime_application_path, method: :put,
+                      class: 'govuk-button app-button--blue',
+                      data: { module: 'govuk-button' } do; t('.amend_application'); end %>
+      <% else %>
+        <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+      <% end %>
     </div>
 
     <%= render @presenter.sections %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -48,6 +48,7 @@ en:
       laa_reference: "LAA reference:"
       date_stamp: "Date stamp:"
       date_submitted: "Date submitted:"
+      amend_application: Update application
       print_application: Print application
       back_to_applications: Back to all applications
       helpline:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
     scope :completed, as: :completed, controller: :completed_applications do
       get :index, on: :collection
       get :show, on: :member
+      put :amend, on: :member
     end
   end
 

--- a/spec/controllers/completed_applications_controller_spec.rb
+++ b/spec/controllers/completed_applications_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe CompletedApplicationsController, type: :controller do
+  describe '#amend' do
+    let(:crime_application) { CrimeApplication.create(status: :returned) }
+    let(:amend_service) { instance_double(ApplicationAmendment) }
+
+    before do
+      allow(
+        ApplicationAmendment
+      ).to receive(:new).with(crime_application).and_return(amend_service)
+    end
+
+    it 'triggers the amendment of an application' do
+      expect(amend_service).to receive(:call)
+
+      put :amend, params: { id: crime_application.id }
+
+      expect(response).to redirect_to(edit_steps_submission_review_path(crime_application))
+    end
+  end
+end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Dashboard' do
     end
   end
 
-  describe 'show an application certificate (once an application is completed)' do
+  describe 'show an application certificate (in `submitted` status)' do
     before :all do
       # sets up a test record
       app = CrimeApplication.create(
@@ -39,6 +39,14 @@ RSpec.describe 'Dashboard' do
       expect(response).to have_http_status(:success)
 
       assert_select 'h1', 'Application for criminal legal aid certificate'
+    end
+
+    it 'has appropriate CTA buttons' do
+      # There is no update button
+      assert_select 'button.govuk-button', count: 0, text: 'Update application'
+
+      # There are 2 print buttons, one above the summary, another in the bottom
+      assert_select 'a.govuk-button', count: 2, text: 'Print application'
     end
 
     it 'has the application details' do
@@ -73,6 +81,43 @@ RSpec.describe 'Dashboard' do
           assert_select 'dd:nth-of-type(1)', 'Doe'
         end
       end
+    end
+  end
+
+  # NOTE: this is almost identical to `submitted` state, only difference
+  # is there is an `Update application` button instead of a print button.
+  # No need to test everything again.
+  describe 'show an application certificate (in `returned` status)' do
+    before :all do
+      # sets up a test record
+      CrimeApplication.create(
+        status: :returned,
+        date_stamp: Date.new(2022, 12, 25),
+        submitted_at: Date.new(2022, 12, 31),
+      )
+    end
+
+    after :all do
+      CrimeApplication.destroy_all
+    end
+
+    before do
+      app = CrimeApplication.returned.first
+      get completed_crime_application_path(app)
+    end
+
+    it 'renders the certificate page' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Application for criminal legal aid certificate'
+    end
+
+    it 'has appropriate CTA buttons' do
+      # There is 1 update button
+      assert_select 'button.govuk-button', count: 1, text: 'Update application'
+
+      # There is 1 print button
+      assert_select 'a.govuk-button', count: 1, text: 'Print application'
     end
   end
 

--- a/spec/services/application_amendment_spec.rb
+++ b/spec/services/application_amendment_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationAmendment do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+    )
+  end
+
+  before do
+    allow(crime_application).to receive(:update!).and_return(true)
+  end
+
+  describe '#call' do
+    it 'marks the application as `in_progress`' do
+      expect(
+        crime_application
+      ).to receive(:update!).with(
+        status: :in_progress,
+        navigation_stack: [],
+        declaration_signed: nil,
+        submitted_at: nil,
+      )
+
+      expect(subject.call).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Follow-up to previous preparation PRs, this one implements a barebones "amend" action, with a button in the certificate page so the provider can put back an application into "editable" mode (`in_progress`) and make changes in order to submit again the application.

Note: there are so many implementation details we are still missing that is not worth it taking this further until we have perhaps the document store.

For now is a bit smoke and mirrors but it serve the purpose of getting an idea how the user experience will look like and we can test this with providers.

I'm awaiting confirmation regarding some of the time stamps on the application, if we have to keep the originals or reset on re-submission. I think we might have to introduce a `parent_id` at some point, it will keep track of previously submitted applications to create kind of a history of all amendments, but didn't want to add that DB attribute until we have more clarification.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-97

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="700" alt="Screenshot 2022-10-31 at 11 43 30" src="https://user-images.githubusercontent.com/687910/199000298-1485710a-0fae-4296-bc84-6408ca9b46f2.png">


## How to manually test the feature
To "fake" a returned application, access a submitted application certificate (URL is `/completed/applications/{uuid}`) and then in the developer tools in the footer click the button `Mark as returned`. This will take you back to the dashboard and you will see a returned application.

Access again its certificate page (same URL as before) and there should be a blue "Update application" button. Clicking this button will set the application back into `in_progress` status and take you to the Check your answers where you can change anything and progress all the way to the end to sign the declaration and submit again the application.