### PR TITLE
CRIMAP-98 Print application certificate

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,21 @@
+// Print specific overrides.
+// Currently this is only used in the application certificate page.
+//
+@media print {
+  header,
+  footer,
+  .govuk-phase-banner,
+  .govuk-back-link,
+  .app-no-print {
+    display: none;
+  }
+
+  main {
+    padding: 0 !important;
+    margin: 3em !important;
+
+    .govuk-grid-column-two-thirds {
+      width: 100% !important;
+    }
+  }
+}

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -1,6 +1,10 @@
 <% title t('.page_title') %>
 <% step_header(path: :back) %>
 
+<% content_for(:head) do %>
+  <%= stylesheet_link_tag 'print', media: 'print' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
@@ -43,11 +47,13 @@
       </p>
     </div>
 
-    <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+    <div class="govuk-button-group app-no-print">
+      <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+    </div>
 
     <%= render @presenter.sections %>
 
-    <div class="govuk-button-group govuk-!-margin-top-8">
+    <div class="govuk-button-group govuk-!-margin-top-8 app-no-print">
       <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
       <%= link_button t('.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
     </div>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,1 +1,6 @@
 Rails.application.config.dartsass.build_options << " --quiet-deps"
+
+Rails.application.config.dartsass.builds = {
+  'application.scss' => 'application.css',
+  'print.scss'       => 'print.css',
+}


### PR DESCRIPTION
## Description of change
Apply a basic print stylesheet in the application certificate page, to remove superfluous visual elements like the header or footer, when printing the page.

The printing can be invoked through the "Print application" button (but this will only work with javascript enabled) or just by going to the browser menubar and selecting "File - Print".

We can tweak the print stylesheet if required, but for now it looks good enough. Also, in the future, this might be superseded by a PDF download (probably post-MVP as it is not a very high priority right now).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-98

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="942" alt="Screenshot 2022-10-31 at 14 11 28" src="https://user-images.githubusercontent.com/687910/199029508-0b47bcfd-02c0-44b0-a714-77adda68206d.png">

## How to manually test the feature
Important: after checking out this branch, stop the server, run `rails assets:clobber` and then `bin/dev` to ensure the styles are properly compiled.
Go to a certificate page, and click the "Print application" button. Or use the browser menu or shortcut to print.
The page should render without header, footer, and other distractions.