### PR TITLE
Add settings mechanism, similar to `FeatureFlags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ FeatureFlags.your_new_feature.disabled?
 ```
 
 
+## Settings
+
+Similar to feature flags, the application can have settings. The same file `config/settings.yml` is used to define 
+settings, and these are not environment-aware. If your setting is supposed to change depending on the 
+environment (staging / production for example) then it probably belongs in the kubernetes `config_map` instead.
+
+To read a setting, use:
+
+```ruby
+Settings.setting_name
+```
+
+
 ## Kubernetes deployment
 
 ### To provision infrastructure

--- a/app/lib/settings.rb
+++ b/app/lib/settings.rb
@@ -1,0 +1,33 @@
+# Retrieve global settings and configuration.
+#
+# usage (for e.g. `session_timeout_minutes`):
+#
+#   Settings.session_timeout_minutes
+#
+class Settings
+  include Singleton
+
+  attr_reader :config
+
+  def initialize
+    @config = YAML.load_file(
+      Rails.root.join('config/settings.yml')
+    ).fetch('settings', {}).with_indifferent_access.freeze
+  end
+
+  class << self
+    delegate :method_missing, :respond_to?, to: :instance
+  end
+
+  def method_missing(name, *args)
+    if config.key?(name)
+      config.fetch(name)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(name, _include_private = false)
+    config.key?(name) || super
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,3 +3,9 @@ feature_flags:
     local: true
     staging: true
     production: false
+
+# NOTE: consider if the setting you are adding here
+# should belong in the k8s `config_map`, which is
+# usually the case if it varies per environment.
+settings:
+  session_timeout_minutes: 60 # not used yet, just an example

--- a/spec/lib/settings_spec.rb
+++ b/spec/lib/settings_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe Settings do
+  before do
+    # override whatever is in the settings file with these settings
+    # so that tests are predictable
+    allow(
+      described_class.instance
+    ).to receive(:config).and_return(
+      { my_test_setting: 'hello' }.with_indifferent_access
+    )
+  end
+
+  describe 'reading settings' do
+    it { expect(described_class.my_test_setting).to eq('hello') }
+  end
+
+  describe 'handling of method_missing' do
+    context 'a setting defined in the config' do
+      it 'responds true' do
+        expect(described_class.respond_to?(:my_test_setting)).to be(true)
+      end
+    end
+
+    context 'a method defined on the superclass' do
+      it 'responds true' do
+        expect(described_class.respond_to?(:object_id)).to be(true)
+      end
+    end
+
+    context 'unknown setting' do
+      it 'responds false' do
+        expect(described_class.respond_to?(:not_a_real_setting)).to be(false)
+      end
+
+      it 'raises an exception' do
+        expect { described_class.not_a_real_setting }.to raise_exception(NoMethodError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
We had `FeatureFlags` in the application already, and back at the time we talked about having a similar approach for general settings, those not requiring to change between environments.

These settings are added sometimes to the `application.rb` file and then retrieved with `Rails.configuration.x.whatever` but I think it is cleaner to have them in a separate file not relying on Rails.

The file is the same used for the feature flags too, so all is kept in the same place for easy tweaking.
