### PR TITLE
Tweak certificate page helpline copy

### DIFF
--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -36,18 +36,20 @@
       </div>
     </dl>
 
-    <div class="govuk-inset-text govuk-!-margin-bottom-8">
-      <p class="govuk-body">
-        <%= t('.helpline.intro') %>
-      </p>
-      <p class="govuk-body">
-        <%= t('.helpline.phone') %>
-        <br>
-        <%= t('.helpline.hours') %>
-      </p>
-    </div>
+    <% unless @crime_application.returned? %>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">
+          <%= t('.helpline.intro') %>
+        </p>
+        <p class="govuk-body">
+          <%= t('.helpline.phone') %>
+          <br>
+          <%= t('.helpline.hours') %>
+        </p>
+      </div>
+    <% end %>
 
-    <div class="govuk-button-group app-no-print">
+    <div class="govuk-!-margin-top-8 app-no-print">
       <% if @crime_application.returned? %>
         <%= button_to amend_completed_crime_application_path, method: :put,
                       class: 'govuk-button app-button--blue',

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -64,9 +64,9 @@ en:
       print_application: Print application
       back_to_applications: Back to all applications
       helpline:
-        intro: If you need to withdraw or update this application, contact the criminal applications helpline.
+        intro: If you need to withdraw or update this application before it has been processed by the LAA, contact the criminal applications helpline.
         phone: 'Telephone: 0300 200 2020'
-        hours: 9am to 5pm, Monday to Friday (excluding bank holidays).
+        hours: 9am to 5pm, Monday to Friday (excluding bank holidays)
   shared:
     subnavigation:
         in_progress:


### PR DESCRIPTION
## Description of change
As per latest designs.

The helpline details will not show on returned applications as per designer decision.

## Screenshots of changes (if applicable)
<img width="872" alt="Screenshot 2022-11-02 at 10 21 43" src="https://user-images.githubusercontent.com/687910/199465529-b840225b-96e9-466c-9276-e3fca0165c49.png">
<img width="810" alt="Screenshot 2022-11-02 at 10 21 56" src="https://user-images.githubusercontent.com/687910/199465539-5b964c7e-52ad-4834-92b3-dd8db4755f2d.png">
