### PR TITLE
remove status tags from applications

### DIFF
--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -1,6 +1,4 @@
 class CrimeApplicationPresenter < BasePresenter
-  DEFAULT_CLASSES = %w[govuk-tag].freeze
-
   delegate :first_name, :last_name, :date_of_birth, to: :applicant
   delegate :case_type, to: :case, allow_nil: true
 

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -1,12 +1,6 @@
 class CrimeApplicationPresenter < BasePresenter
   DEFAULT_CLASSES = %w[govuk-tag].freeze
 
-  STATUSES = {
-    'in_progress' => 'govuk-tag--blue',
-    'submitted'   => 'govuk-tag--green',
-    'returned'    => 'govuk-tag--yellow',
-  }.freeze
-
   delegate :first_name, :last_name, :date_of_birth, to: :applicant
   delegate :case_type, to: :case, allow_nil: true
 
@@ -48,17 +42,5 @@ class CrimeApplicationPresenter < BasePresenter
   # properly when there is the means to do so
   def laa_reference
     ['LAA', id[0..5]].join('-')
-  end
-
-  def status_tag
-    tag.strong class: tag_classes do
-      t!(".crime_applications.index.status.#{status}")
-    end
-  end
-
-  private
-
-  def tag_classes
-    DEFAULT_CLASSES | Array(STATUSES.fetch(status))
   end
 end

--- a/app/views/completed_applications/index.html.erb
+++ b/app/views/completed_applications/index.html.erb
@@ -22,7 +22,6 @@
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.applicant_name') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.submitted_at') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.reference') %></th>
-          <th scope="col" class="govuk-table__header"><%= t('.table_headings.status') %></th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -37,9 +36,6 @@
             </td>
             <td class="govuk-table__cell">
               <%= app.laa_reference %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= app.status_tag %>
             </td>
           </tr>
         <% end %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -22,7 +22,6 @@
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.applicant_name') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.created_at') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.reference') %></th>
-          <th scope="col" class="govuk-table__header"><%= t('.table_headings.status') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.table_headings.action') %></th>
         </tr>
       </thead>
@@ -38,9 +37,6 @@
             </td>
             <td class="govuk-table__cell">
               <%= app.laa_reference %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= app.status_tag %>
             </td>
             <td class="govuk-table__cell">
               <%= button_to confirm_destroy_crime_application_path(app), method: :get,

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -99,26 +99,5 @@ RSpec.describe CrimeApplicationPresenter do
     it 'has an LAA an reference stubbed' do
       expect(subject.laa_reference).to eq('LAA-a1234b')
     end
-
-    describe 'status tags' do
-      it 'can output an in progress tag' do
-        tag = '<strong class="govuk-tag govuk-tag--blue">In progress</strong>'
-        expect(subject.status_tag).to eq(tag)
-      end
-
-      it 'can output a submitted tag' do
-        allow(subject).to receive(:status).and_return('submitted')
-        tag = '<strong class="govuk-tag govuk-tag--green">Submitted</strong>'
-
-        expect(subject.status_tag).to eq(tag)
-      end
-
-      it 'can output a returned tag' do
-        allow(subject).to receive(:status).and_return('returned')
-        tag = '<strong class="govuk-tag govuk-tag--yellow">Returned</strong>'
-
-        expect(subject.status_tag).to eq(tag)
-      end
-    end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -197,7 +197,6 @@ RSpec.describe 'Dashboard' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
           assert_select 'button.govuk-button', count: 1, text: 'Delete'
-          assert_select 'strong.govuk-tag', count: 1, text: 'In progress'
         end
       end
 
@@ -237,7 +236,6 @@ RSpec.describe 'Dashboard' do
       assert_select 'tbody.govuk-table__body' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
-          assert_select 'strong.govuk-tag', count: 1, text: 'Submitted'
         end
       end
 
@@ -277,7 +275,6 @@ RSpec.describe 'Dashboard' do
       assert_select 'tbody.govuk-table__body' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
-          assert_select 'strong.govuk-tag', count: 1, text: 'Returned'
         end
       end
 


### PR DESCRIPTION
## Description of change

Removes status tags from the applications page as they are no longer required.
