### PR TITLE
CRIMAP-204 Add USN sequence (serial) DB attribute

### DIFF
--- a/app/lib/usn_seq_helper.rb
+++ b/app/lib/usn_seq_helper.rb
@@ -1,3 +1,4 @@
+# :nocov:
 class UsnSeqHelper
   # More details about USN, the sequence start, etc:
   # https://dsdmoj.atlassian.net/wiki/spaces/CRIMAP/pages/4210524301/USN
@@ -53,7 +54,7 @@ class UsnSeqHelper
     end
 
     def restart_sequence
-      puts "Restarting USN sequence with #{seq_start}..."
+      Rails.logger.info "Restarting USN sequence with #{seq_start}..."
 
       ActiveRecord::Base.connection.execute(
         "ALTER SEQUENCE IF EXISTS public.#{USN_SEQUENCE_NAME} RESTART WITH #{seq_start}"
@@ -63,7 +64,8 @@ class UsnSeqHelper
     private
 
     def seq_start
-      ENV.fetch('USN_SEQ_START', USN_SEQUENCE_START)
+      ENV.fetch('USN_SEQ_START', USN_SEQUENCE_START).to_i
     end
   end
 end
+# :nocov:

--- a/app/lib/usn_seq_helper.rb
+++ b/app/lib/usn_seq_helper.rb
@@ -1,0 +1,69 @@
+class UsnSeqHelper
+  # More details about USN, the sequence start, etc:
+  # https://dsdmoj.atlassian.net/wiki/spaces/CRIMAP/pages/4210524301/USN
+
+  USN_SEQUENCE_NAME  = 'crime_applications_usn_seq'.freeze
+  USN_SEQUENCE_START = 6_000_000
+
+  class << self
+    # Sequence configuration is not be captured in the `schema.rb`.
+    # The alternative to this would be to stop using `schema.rb`
+    # and move towards using `structure.sql` instead.
+    #
+    # But even with `structure.sql`, there are some gotchas to
+    # bear in mind:
+    #
+    # When reconstructing the database from the `schema.rb` (or
+    # `structure.sql`) by doing `db:schema:load`, `db:prepare`
+    # or `db:setup`, the sequence will be reset back to 1.
+    #
+    # If the database setup is done with a 2-steps approach,
+    # first `db:create` and then `db:migrate`, then the migration
+    # will configure the sequence to start back at 6_000_000.
+    #
+    # In both scenarios, this might not be desirable.
+    # If using this helper, the `USN_SEQ_START` env variable can
+    # be used to override the default sequence start.
+    #
+    # In production, once we have real data, I can't foresee a
+    # scenario where we would be doing any of the above. If we
+    # are doing so, it means we are starting fresh, with no DB.
+    # Also note, that doing `db:prepare` on an existing DB will
+    # not recreate it. Prepare runs setup if database does not
+    # exist, or runs migrations if it does.
+    #
+    # In case of catastrophic failure of the database or
+    # corruption of data, we would have to restore from a backup
+    # at a point in time, which would reset everything back to
+    # how it was at that moment, including the sequence numbering
+    # whatever that is by then (i.e. 6_789_567).
+    #
+    def create_sequence
+      ActiveRecord::Base.connection.execute(
+        "CREATE SEQUENCE IF NOT EXISTS #{USN_SEQUENCE_NAME} AS integer START WITH #{seq_start}"
+      )
+    end
+
+    def drop_sequence
+      raise 'The Rails environment is running in production mode!' if Rails.env.production?
+
+      ActiveRecord::Base.connection.execute(
+        "DROP SEQUENCE IF EXISTS #{USN_SEQUENCE_NAME}"
+      )
+    end
+
+    def restart_sequence
+      puts "Restarting USN sequence with #{seq_start}..."
+
+      ActiveRecord::Base.connection.execute(
+        "ALTER SEQUENCE IF EXISTS public.#{USN_SEQUENCE_NAME} RESTART WITH #{seq_start}"
+      )
+    end
+
+    private
+
+    def seq_start
+      ENV.fetch('USN_SEQ_START', USN_SEQUENCE_START)
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,52 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "8046755f7c588acdd693d8bacdedd11071aae2d899d7e43ab061461d60c86ed6",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/lib/usn_seq_helper.rb",
+      "line": 59,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"ALTER SEQUENCE IF EXISTS public.#{\"crime_applications_usn_seq\"} RESTART WITH #{seq_start}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "UsnSeqHelper",
+        "method": "restart_sequence"
+      },
+      "user_input": "seq_start",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "f526fe183df1efa4935c92739b663b43bdbc67c977fa1bad7b61bcb6b41f4fd1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/lib/usn_seq_helper.rb",
+      "line": 43,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"CREATE SEQUENCE IF NOT EXISTS #{\"crime_applications_usn_seq\"} AS integer START WITH #{seq_start}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "UsnSeqHelper",
+        "method": "create_sequence"
+      },
+      "user_input": "seq_start",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    }
+  ],
+  "updated": "2022-11-09 15:04:45 +0000",
+  "brakeman_version": "5.3.1"
+}

--- a/db/migrate/20221108112731_add_usn_attribute.rb
+++ b/db/migrate/20221108112731_add_usn_attribute.rb
@@ -1,0 +1,17 @@
+class AddUsnAttribute < ActiveRecord::Migration[7.0]
+  def up
+    UsnSeqHelper.create_sequence
+
+    add_column :crime_applications, :usn, :integer, null: false,
+               default: -> { "nextval('#{UsnSeqHelper::USN_SEQUENCE_NAME}')" }
+
+    add_index :crime_applications, :usn, unique: true
+  end
+
+  # On rollback, we do not remove the sequence on purpose!
+  # This is a precaution so worst case scenario we don't
+  # end up with re-used USNs.
+  def down
+    remove_column :crime_applications, :usn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_25_110320) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_08_112731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -72,6 +72,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_25_110320) do
     t.datetime "date_stamp"
     t.boolean "declaration_signed"
     t.datetime "submitted_at"
+    t.serial "usn", null: false
+    t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
 
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
This will be later on used to replace our current (mocked) LAA reference.

This PR only adds the sequence and attribute, along with a looong comment explaining some gotchas.

Upon migrate, any existing applications in the DB will see their `usn` attribute populated based on the sequence, starting at `6_000_000`

But this attribute is not yet used anywhere. A separate PR will be raise to replace the LAA reference with this USN.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-204
https://dsdmoj.atlassian.net/wiki/spaces/CRIMAP/pages/4210524301/USN

## How to manually test the feature
Checkout, run the migration, open a console and do:

```ruby
> a = CrimeApplication.create
> a.reload
> a.usn
=> 6000001

> b = CrimeApplication.create
> b.reload
> b.usn
=> 6000002

> b.usn = a.usn
=> 6000001
> b.save # raises ActiveRecord::RecordNotUnique

> b.usn = nil
> b.save # raises ActiveRecord::NotNullViolation
```

Some other considerations:

- Resetting your DB (`db:reset`) performs a `db:drop` and a `db:setup`, which recreates the database from their schema. The schema does not capture the sequence start, so sequence will start with 1.
- Performing a `db:prepare` on a non-existing DB will have the same effect.
- Doing a rollback on the sequence migration (`20221108112731_add_usn_attribute`) and then up, will not reset the sequence as it is not deleted on rollback and is not created (as it already exists) on migrate up.
- Dropping your DB and running all migrations to recreate it will set the sequence back at `6_000_000`.

Note many of these problems are not specific to a sequence. This is how Rails migrations (using `schema.rb` or in many cases also `structure.sql`) works. If we were using incremental PK on the `id` attribute, this same would happen. A reset of the database or drop, etc. would reset back the sequence to 0 and all record IDs would start at 1 again.

In our local envs this is not a big issue. And in production, once the database has been created and initialised with the schema/structure, and records start to be created, if the DB suffers catastrophic failure we would need to restore from backup, which includes the sequence.