### PR TITLE
Locking alpine image to version 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine
+FROM ruby:3.1.2-alpine3.15
 MAINTAINER LAA Crime Apply Team
 
 RUN apk --no-cache add --virtual build-deps \


### PR DESCRIPTION
## Description of change
It seems there have been some regression or breaking change starting with 3.16 (published 2 days ago).

Will investigate further, but for now this unblocks the deploys.

