### PR TITLE
CRIMAP-204 Change the ref number format

### DIFF
--- a/app/controllers/steps/submission/confirmation_controller.rb
+++ b/app/controllers/steps/submission/confirmation_controller.rb
@@ -14,9 +14,8 @@ module Steps
 
       private
 
-      # Strip non alphanumeric chars, as a precaution, leave dashes
       def reference_param
-        params[:reference].gsub(/[^[[:alnum:]]-]/, '')
+        params[:reference].to_i
       end
     end
   end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -36,9 +36,9 @@ class CrimeApplicationPresenter < BasePresenter
     CaseType.new(case_type.to_s).date_stampable?
   end
 
-  # this is stubbed for now will implement
-  # properly when there is the means to do so
+  # Keep this wrapper method in case we retract from
+  # using sequence USN to use any other ID/reference
   def laa_reference
-    ['LAA', id[0..5]].join('-')
+    usn
   end
 end

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -57,7 +57,7 @@ en:
     show:
       page_title: Application certificate
       heading: Application for criminal legal aid certificate
-      laa_reference: "LAA reference:"
+      laa_reference: "Reference number:"
       date_stamp: "Date stamp:"
       date_submitted: "Date submitted:"
       amend_application: Update application

--- a/spec/controllers/steps/submission/confirmation_controller_spec.rb
+++ b/spec/controllers/steps/submission/confirmation_controller_spec.rb
@@ -3,21 +3,21 @@ require 'rails_helper'
 RSpec.describe Steps::Submission::ConfirmationController, type: :controller do
   describe 'confirmation page' do
     it 'responds with HTTP success' do
-      get :show, params: { id: '123-uuid-567', reference: 'LAA-123456' }
+      get :show, params: { id: 'uuid', reference: '123' }
       expect(response).to be_successful
 
       reference = controller.instance_variable_get(:@reference)
 
-      expect(reference).to eq('LAA-123456')
+      expect(reference).to eq(123)
     end
 
     it 'sanitises the reference' do
-      get :show, params: { id: '123-uuid-567', reference: "'<script>alert('boom!');</script>'" }
+      get :show, params: { id: 'uuid', reference: "'<script>alert('boom!');</script>'" }
       expect(response).to be_successful
 
       reference = controller.instance_variable_get(:@reference)
 
-      expect(reference).to eq('scriptalertboomscript')
+      expect(reference).to eq(0)
     end
   end
 end

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CrimeApplicationPresenter do
     CrimeApplication.new(
       id: 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
       created_at: DateTime.new(2022, 1, 12),
+      usn: 123,
     )
   end
 
@@ -96,8 +97,8 @@ RSpec.describe CrimeApplicationPresenter do
       expect(subject.start_date).to eq('12 Jan 2022')
     end
 
-    it 'has an LAA an reference stubbed' do
-      expect(subject.laa_reference).to eq('LAA-a1234b')
+    it 'has a reference number' do
+      expect(subject.laa_reference).to eq(123)
     end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe 'Dashboard' do
     it 'has the application details' do
       assert_select 'dl.govuk-summary-list:nth-of-type(1)' do
         assert_select 'div.govuk-summary-list__row:nth-of-type(1)' do
-          assert_select 'dt:nth-of-type(1)', 'LAA reference:'
-          assert_select 'dd:nth-of-type(1)', /^LAA-[[:alnum:]]{6}$/
+          assert_select 'dt:nth-of-type(1)', 'Reference number:'
+          assert_select 'dd:nth-of-type(1)', /[[:digit:]]/
         end
         assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
           assert_select 'dt:nth-of-type(1)', 'Date stamp:'
@@ -150,7 +150,7 @@ RSpec.describe 'Dashboard' do
       # aside details
       assert_select 'div.govuk-grid-column-one-third aside', 1 do
         assert_select 'h3:nth-of-type(1)', 'Reference number'
-        assert_select 'p:nth-of-type(1)', /^LAA-[[:alnum:]]{6}$/
+        assert_select 'p:nth-of-type(1)', /[[:digit:]]/
 
         assert_select 'h3:nth-of-type(2)', 'First name'
         assert_select 'p:nth-of-type(2)', 'Jane'

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe Decisions::SubmissionDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
-  let(:crime_application) { instance_double(CrimeApplication, id: '123456789') }
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication, id: 'uuid', usn: 123,
+    )
+  end
 
   before do
     allow(
@@ -42,7 +46,7 @@ RSpec.describe Decisions::SubmissionDecisionTree do
     end
 
     context 'has correct next step' do
-      it { is_expected.to have_destination(:confirmation, :show, id: crime_application, reference: 'LAA-123456') }
+      it { is_expected.to have_destination(:confirmation, :show, id: crime_application, reference: 123) }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Follow-up to PR #173, to start showing to the provider on the views the USN.

I've not changed the name of the method (`#laa_reference`) in the presenter as to make it easier to move from using USN to any other ID/ref in the future if we need to.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-204

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1103" alt="Screenshot 2022-11-14 at 16 10 58" src="https://user-images.githubusercontent.com/687910/201709078-d1e206c1-d336-4854-9866-6332873c8e19.png">
