### PR TITLE
CRIMAP-39 Add proper content to home page

### DIFF
--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -40,7 +40,8 @@ module StepsHelper
     end
   end
 
-  def link_button(name, href, options = {})
+  # rubocop:disable Metrics/MethodLength
+  def link_button(name, href, options = {}, &block)
     html_options = {
       class: 'govuk-button', role: 'button', draggable: false, data: { module: 'govuk-button' },
     }.merge(options) do |_key, old_value, new_value|
@@ -53,6 +54,13 @@ module StepsHelper
       end
     end
 
-    link_to name, href, html_options
+    if block
+      link_to href, html_options do
+        yield(block)
+      end
+    else
+      link_to name, href, html_options
+    end
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -1,0 +1,38 @@
+<% title '' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= service_name %>
+    </h1>
+
+    <p class="govuk-body">
+      Use this service to apply for criminal legal aid.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Before you start
+    </h3>
+
+    <p class="govuk-body">
+      You can only use this service to apply for an ongoing case where your client:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>does not have a partner</li>
+      <li>has a National Insurance number</li>
+      <li>receives a passporting benefit, including Universal Credit</li>
+    </ul>
+
+    <p class="govuk-body">
+      Use <%= link_to 'eForms', Settings.eforms_url %> for all other applications.
+    </p>
+
+    <!-- NOTE: temporarily until we implement LAA Portal Login, this button goes to the dashboard-->
+    <%= link_button nil, crime_applications_path, class: 'govuk-button--start govuk-!-margin-top-4' do %>
+      Start now
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    <% end %>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,0 @@
-<% title '' %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Hello world!
-    </h1>
-  </div>
-</div>

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -12,7 +12,7 @@
     </ul>
 
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <%= link_button 'Apply in eForms', 'https://portal.legalservices.gov.uk', class: 'app-button--m app-button--inverted' %>
+      <%= link_button 'Apply in eForms', Settings.eforms_url, class: 'app-button--m app-button--inverted' %>
     </div>
 
     <%= link_to 'Back to all applications', crime_applications_path, class: 'app-link--inverted govuk-!-font-size-19' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,4 +12,5 @@ feature_flags:
 # should belong in the k8s `config_map`, which is
 # usually the case if it varies per environment.
 settings:
+  eforms_url: https://portal.legalservices.gov.uk
   session_timeout_minutes: 60 # not used yet, just an example

--- a/spec/helpers/steps_helper_spec.rb
+++ b/spec/helpers/steps_helper_spec.rb
@@ -140,5 +140,13 @@ data: { module: 'govuk-button', ga_category: 'category', ga_label: 'label' })
         'data-ga-category="category" data-ga-label="label" href="/">Continue</a>'
       )
     end
+
+    it 'supports block for content' do
+      expect(
+        helper.link_button(nil, root_path, draggable: true) { 'Drag this' }
+      ).to eq(
+        '<a class="govuk-button" role="button" draggable="true" data-module="govuk-button" href="/">Drag this</a>'
+      )
+    end
   end
 end


### PR DESCRIPTION
## Description of change
In preparation for user test sessions, make the homepage more similar to what eventually will be (once we have post-login journey).

Note the view is localised, as is heavy on content, with no dynamic/complex components.

The `start button` will go to the dashboard, this is the same as going to the `developer tools` and clicking "your applications", but is better for user testing, as providers might get confused what this developer tools is about.

Once we have the Portal Login, the start button in reality will go to the selection of office account number. But we can't implement that yet.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-39
https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=2711%3A7235&t=QN4uBvORzji6zsjO-4

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1057" alt="Screenshot 2022-11-15 at 11 44 45" src="https://user-images.githubusercontent.com/687910/201921000-76bcede4-853e-49e5-a843-d9b08f7b48bc.png">

### After changes:
<img width="917" alt="Screenshot 2022-11-15 at 12 35 28" src="https://user-images.githubusercontent.com/687910/201921078-e6eaa5fc-7be5-4f08-82c5-e97ec0a16196.png">
