### PR TITLE
Add granularity to `FeatureFlags` for test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,13 @@ Set a new feature flag in the `config/settings.yml` under the heading `feature_f
 feature_flags:
   your_new_feature:
     local: true
+    test: false
     staging: true
     production: false
 ```
+
+If not declared, `local` and `test` environments will default to `true` (feature flag enabled).  
+Any other envs, if not explicitly declared, will default to `false` (for instance `staging` or `production`).
 
 To check if a feature is enabled / disabled and run code accordingly, use:
 

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -10,17 +10,30 @@ class FeatureFlags
   attr_reader :config, :env_name
 
   class EnabledFeature
+    ENV_DEFAULTS = {
+      HostEnv::LOCAL => true,
+      HostEnv::TEST  => true,
+    }.freeze
+
     def initialize(config, env_name)
       @env_config = config
       @env_name = env_name
     end
 
     def enabled?
-      @env_config.fetch(@env_name, false)
+      @env_config.fetch(
+        @env_name, default_for(@env_name)
+      )
     end
 
     def disabled?
       !enabled?
+    end
+
+    private
+
+    def default_for(env)
+      ENV_DEFAULTS.fetch(env, false)
     end
   end
 

--- a/app/lib/host_env.rb
+++ b/app/lib/host_env.rb
@@ -2,6 +2,7 @@ module HostEnv
   # Update if more environments are needed
   NAMED_ENVIRONMENTS = [
     LOCAL = 'local'.freeze,
+    TEST = 'test'.freeze,
     STAGING = 'staging'.freeze,
     PRODUCTION = 'production'.freeze,
   ].freeze
@@ -10,7 +11,8 @@ module HostEnv
     NAMED_ENVIRONMENTS.each { |name| delegate "#{name}?", to: :inquiry }
 
     def env_name
-      return LOCAL if Rails.env.development? || Rails.env.test?
+      return TEST  if Rails.env.test?
+      return LOCAL if Rails.env.development?
 
       ENV.fetch('ENV_NAME')
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,7 @@ feature_flags:
     production: false
   datastore_submission:
     local: false # if `true`, ensure the datastore service is running locally
+    test: false # enable once we start writing tests for the feature
     staging: false
     production: false
 

--- a/spec/controllers/completed_applications_controller_spec.rb
+++ b/spec/controllers/completed_applications_controller_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe CompletedApplicationsController, type: :controller do
       allow(
         ApplicationAmendment
       ).to receive(:new).with(crime_application).and_return(amend_service)
-
-      # While we figure out if this is a sensible approach or not,
-      # we have the datastore submission behind a feature flag, and
-      # we are not investing time on tests for code that will surely
-      # change completely. Stub the feature flag to return `false`.
-      allow(
-        FeatureFlags
-      ).to receive(:datastore_submission).and_return(double(enabled?: false))
     end
 
     it 'triggers the amendment of an application' do

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -5,15 +5,16 @@ describe HostEnv do
     context 'local development rails environment' do
       before do
         allow(Rails.env).to receive(:development?).and_return(true)
+        allow(Rails.env).to receive(:test?).and_return(false)
       end
 
-      describe 'HostEnv.staging?' do
+      describe '.staging?' do
         it 'returns false' do
           expect(described_class.staging?).to be false
         end
       end
 
-      describe 'HostEnv.production?' do
+      describe '.production?' do
         it 'returns false' do
           expect(described_class.production?).to be false
         end
@@ -24,10 +25,16 @@ describe HostEnv do
           expect(described_class.local?).to be true
         end
       end
+
+      describe '.test?' do
+        it 'returns false' do
+          expect(described_class.test?).to be false
+        end
+      end
     end
 
     context 'local test rails environment' do
-      describe 'HostEnv.staging?' do
+      describe '.staging?' do
         it 'returns false' do
           expect(described_class.staging?).to be false
         end
@@ -40,8 +47,14 @@ describe HostEnv do
       end
 
       describe '.local?' do
+        it 'returns false' do
+          expect(described_class.local?).to be false
+        end
+      end
+
+      describe '.test?' do
         it 'returns true' do
-          expect(described_class.local?).to be true
+          expect(described_class.test?).to be true
         end
       end
     end

--- a/spec/services/application_submission_spec.rb
+++ b/spec/services/application_submission_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe ApplicationSubmission do
 
   before do
     allow(crime_application).to receive(:update!).and_return(true)
-
-    # While we figure out if this is a sensible approach or not,
-    # we have the datastore submission behind a feature flag, and
-    # we are not investing time on tests for code that will surely
-    # change completely. Stub the feature flag to return `false`.
-    allow(
-      FeatureFlags
-    ).to receive(:datastore_submission).and_return(double(enabled?: false))
   end
 
   describe '#call' do


### PR DESCRIPTION
## Description of change
As we develop some code behind feature flags, like right now the datastore integration, we might not want yet to go ahead and write detailed tests for it.

One way to handle this was to use, for instance:

```ruby
allow(
  FeatureFlags
).to receive(:datastore_submission).and_return(double(enabled?: false))
```

But when you have many places where the feature flag might trigger, adding this to every single test (and then remember to remove it, etc.) can be tiresome.

Adding some granularity to the `HostEnv` and `FeatureFlags` mechanism to treat the `test` environment as any other environment so we can turn on/off features will make this hopefully a bit easier.

By default, local and test envs, if not explicitly declared on the feature flags configuration, will be turned on. To disable just declare the env.

## How to manually test the feature
Everything should continue working as it is now. `FeatureFlags ` introduce more granularity on the `test` environment.