### PR TITLE
Show the submitted_at date in dashboard

### DIFF
--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -8,10 +8,6 @@ class CrimeApplicationPresenter < BasePresenter
     id
   end
 
-  def start_date
-    l(created_at)
-  end
-
   def applicant_dob
     l(date_of_birth)
   end

--- a/app/views/completed_applications/index.html.erb
+++ b/app/views/completed_applications/index.html.erb
@@ -32,7 +32,7 @@
                           class: 'govuk-link--no-visited-state' %>
             </th>
             <td class="govuk-table__cell">
-              <%= app.start_date %>
+              <%= l(app.submitted_at) %>
             </td>
             <td class="govuk-table__cell">
               <%= app.laa_reference %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -33,7 +33,7 @@
                           class: 'govuk-link--no-visited-state' %>
             </th>
             <td class="govuk-table__cell">
-              <%= app.start_date %>
+              <%= l(app.created_at) %>
             </td>
             <td class="govuk-table__cell">
               <%= app.laa_reference %>

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -99,10 +99,6 @@ RSpec.describe CrimeApplicationPresenter do
       expect(subject.applicant_dob).to eq('1 Feb 1990')
     end
 
-    it 'can output the subject start date in the correct format' do
-      expect(subject.start_date).to eq('12 Jan 2022')
-    end
-
     it 'has a reference number' do
       expect(subject.laa_reference).to eq(123)
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Dashboard' do
   describe 'list of applications' do
     before :all do
       # sets up a few test records
-      app1 = CrimeApplication.create(status: 'in_progress')
+      app1 = CrimeApplication.create(status: 'in_progress', created_at: Date.new(2022, 10, 15))
       app2 = CrimeApplication.create
       app3 = CrimeApplication.create
 
@@ -196,7 +196,11 @@ RSpec.describe 'Dashboard' do
       assert_select 'tbody.govuk-table__body' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
-          assert_select 'button.govuk-button', count: 1, text: 'Delete'
+          assert_select 'td.govuk-table__cell:nth-of-type(1)', '15 Oct 2022'
+          assert_select 'td.govuk-table__cell:nth-of-type(2)', /[[:digit:]]/
+          assert_select 'td.govuk-table__cell:nth-of-type(3)' do
+            assert_select 'button.govuk-button', count: 1, text: 'Delete'
+          end
         end
       end
 
@@ -207,7 +211,7 @@ RSpec.describe 'Dashboard' do
   describe 'list of submitted applications' do
     before :all do
       # sets up a few test records
-      app1 = CrimeApplication.create(status: 'submitted')
+      app1 = CrimeApplication.create(status: 'submitted', submitted_at: Date.new(2021, 12, 31))
       app2 = CrimeApplication.create
       app3 = CrimeApplication.create
 
@@ -237,6 +241,8 @@ RSpec.describe 'Dashboard' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
         end
+        assert_select 'td.govuk-table__cell:nth-of-type(1)', '31 Dec 2021'
+        assert_select 'td.govuk-table__cell:nth-of-type(2)', /[[:digit:]]/
       end
 
       expect(response.body).not_to include('Jane Doe')
@@ -246,7 +252,7 @@ RSpec.describe 'Dashboard' do
   describe 'list of returned applications' do
     before :all do
       # sets up a few test records
-      app1 = CrimeApplication.create(status: 'returned')
+      app1 = CrimeApplication.create(status: 'returned', submitted_at: Date.new(2021, 12, 31))
       app2 = CrimeApplication.create
       app3 = CrimeApplication.create
 
@@ -276,6 +282,8 @@ RSpec.describe 'Dashboard' do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John Doe'
         end
+        assert_select 'td.govuk-table__cell:nth-of-type(1)', '31 Dec 2021'
+        assert_select 'td.govuk-table__cell:nth-of-type(2)', /[[:digit:]]/
       end
 
       expect(response.body).not_to include('Jane Doe')


### PR DESCRIPTION
## Description of change
In the submitted and returned tabs, we were showing the `start_date` (created_at). It should be the `submitted_at` (at least for now, this requirement may change in the future).

Added some additional assertions to the spec to test these dates in the dashboard tables.

## Screenshots of changes (if applicable)
<img width="1056" alt="Screenshot 2022-11-17 at 08 58 54" src="https://user-images.githubusercontent.com/687910/202401830-ba6b1a51-b213-4f5b-8b8c-a16235a748c5.png">

## How to manually test the feature
The dates that show in the dashboard for submitted and returned applications are the "submitted_at" date, and is sorted DESC.