### PR TITLE
Pagination proof of concept (dynamodb)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: 4cb57fd31c118e153565e9c33e9c67c1be351ab1
+  revision: d2f682817a96b32af08288a0f0a50a17782172f8
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)

--- a/app/presenters/infinite_pagination.rb
+++ b/app/presenters/infinite_pagination.rb
@@ -1,0 +1,53 @@
+# FIXME: implement tests if we decide to go with DynamoDB.
+# This will not be neccessary if we decide to go with Postgres, as then
+# we can use traditional pagination and there are good gems for that.
+# :nocov:
+class InfinitePagination < BasePresenter
+  def initialize(pagination:, params:)
+    @unfiltered_params = params
+
+    super(
+      pagination
+    )
+  end
+
+  def to_partial_path
+    'shared/infinite_pagination'.freeze
+  end
+
+  def show?
+    total > limit
+  end
+
+  def total_pages
+    (total / limit.to_f).ceil
+  end
+
+  def current_page
+    index = params[:p].to_i
+    index += 1 if index.zero?
+
+    [index, total_pages].min
+  end
+
+  def next_page
+    current_page + 1
+  end
+
+  def next_page_params
+    params.merge(page_token: next_page_token, p: next_page)
+  end
+
+  def start_page_params
+    params.except(:page_token, :p)
+  end
+
+  private
+
+  def params
+    @unfiltered_params.permit(
+      :q, :p, :limit, :sort, :page_token
+    )
+  end
+end
+# :nocov:

--- a/app/views/completed_applications/index.html.erb
+++ b/app/views/completed_applications/index.html.erb
@@ -41,5 +41,7 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= render @paginator if @paginator %>
   </div>
 </div>

--- a/app/views/shared/_infinite_pagination.html.erb
+++ b/app/views/shared/_infinite_pagination.html.erb
@@ -1,0 +1,41 @@
+<%
+  total_pages  = infinite_pagination.total_pages
+  current_page = infinite_pagination.current_page
+
+  next_page_url  = completed_crime_applications_path(infinite_pagination.next_page_params)
+  first_page_url = completed_crime_applications_path(infinite_pagination.start_page_params)
+%>
+
+<% if infinite_pagination.show? %>
+  <nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+    <% if current_page >= total_pages %>
+      <div class="govuk-pagination__prev">
+        <%= link_to first_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state', rel: 'prev' do %>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
+               height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+          </svg>
+          <span class="govuk-pagination__link-title"><%= t('.start_link') %></span><span class="govuk-visually-hidden">:</span>
+          <span class="govuk-pagination__link-label">
+            <%= t('.page_counter', current_page: 1, total_pages: total_pages) %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if current_page < total_pages %>
+      <div class="govuk-pagination__next">
+        <%= link_to next_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state', rel: 'next' do %>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg"
+               height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+          <span class="govuk-pagination__link-title"><%= t('.next_link') %></span><span class="govuk-visually-hidden">:</span>
+          <span class="govuk-pagination__link-label">
+            <%= t('.page_counter', current_page:, total_pages:) %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+  </nav>
+<% end %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -69,12 +69,16 @@ en:
         hours: 9am to 5pm, Monday to Friday (excluding bank holidays)
   shared:
     subnavigation:
-        in_progress:
-          zero: In progress
-          one: In progress (1)
-          other: In progress (%{count})
-        submitted: Submitted
-        returned:
-          zero: Returned
-          one: Returned (1)
-          other: Returned (%{count})
+      in_progress:
+        zero: In progress
+        one: In progress (1)
+        other: In progress (%{count})
+      submitted: Submitted
+      returned:
+        zero: Returned
+        one: Returned (1)
+        other: Returned (%{count})
+    infinite_pagination:
+      start_link: Start
+      next_link: Next
+      page_counter: "%{current_page} of %{total_pages}"


### PR DESCRIPTION
## Description of change
A limitation of DynamoDB is the pagination is not like a traditional pagination where you have pointers to each page through an offset and a limit.

Pagination with DynamoDB is really an "infinite scroll" pagination where you just get a "token" based on the last record returned in the previous page, so you can pass this token in the next request and continue loading records where you left.

This means you can only advance forwards, and not go to a specific page, just the immediate next page to the one you are.

There are ways to get back to the previous page if you track the previous token as query params, but that is all, only current page, previous and next are supported, the moment you go backwards more than 1 page, you don't have a previous token anymore.

This PoC is a limited version of a pagination, where user can advance through pages, and they can't go back, unless they reach the last page in which case a "< Start" link shows to go back to page 1.

It is done a bit quick and dirty to get the sense and idea. I'm not sure if pagination might be a deal breaker to _not_ use dynamodb (along with probably in the near future complex filters and sort columns)...

## Link to relevant ticket
Partially related to this ticket:
https://dsdmoj.atlassian.net/browse/CRIMAP-212

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1142" alt="Screenshot 2022-11-17 at 12 23 42" src="https://user-images.githubusercontent.com/687910/202445602-cbbd714e-0899-4905-a433-c31655e3b536.png">
<img width="1082" alt="Screenshot 2022-11-17 at 12 23 51" src="https://user-images.githubusercontent.com/687910/202445609-552a8858-4c7d-4c45-866b-8c84f946a4b1.png">
<img width="1089" alt="Screenshot 2022-11-17 at 12 23 57" src="https://user-images.githubusercontent.com/687910/202445611-d5952e62-528c-4164-a9a2-4840d4bd57c2.png">

## How to manually test the feature
Pre-requirement: you have the datastore up and running locally. Checkout the branch, ensure you have the `datastore_submission` feature flag enabled in `local`, and then have some submitted applications to your local datastore.

Go to the dashboard, go to the `submitted` tab, and then in the URL reduce the returned records per page with query param: `limit=2` for instance. That will return 2 applications per page, and if you have more than 2 applications you should see the pagination in the bottom.