### PR TITLE
Another pagination proof of concept (dynamodb)

### DIFF
--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -30,7 +30,7 @@ class CompletedApplicationsController < DashboardController
 
   private
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def applications_from_datastore
     if FeatureFlags.datastore_submission.enabled?
       # :nocov:
@@ -38,10 +38,17 @@ class CompletedApplicationsController < DashboardController
         status: status_filter, **pagination_params
       ).call
 
-      @paginator = InfinitePagination.new(
-        pagination: result.pagination,
-        params: params,
-      )
+      @paginator = if params[:v] == '1'
+                     InfinitePagination.new(
+                       pagination: result.pagination,
+                       params: params,
+                     )
+                   else
+                     InfinitePaginationV2.new(
+                       pagination: result.pagination,
+                       params: params,
+                     )
+                   end
 
       result
       # :nocov:
@@ -53,7 +60,7 @@ class CompletedApplicationsController < DashboardController
         .merge(CrimeApplication.order(submitted_at: :desc))
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def status_filter
     allowed_statuses = [

--- a/app/presenters/infinite_pagination.rb
+++ b/app/presenters/infinite_pagination.rb
@@ -46,7 +46,7 @@ class InfinitePagination < BasePresenter
 
   def params
     @unfiltered_params.permit(
-      :q, :p, :limit, :sort, :page_token
+      :v, :q, :p, :limit, :sort, :page_token
     )
   end
 end

--- a/app/presenters/infinite_pagination_v2.rb
+++ b/app/presenters/infinite_pagination_v2.rb
@@ -1,0 +1,77 @@
+# FIXME: implement tests if we decide to go with DynamoDB.
+# This will not be neccessary if we decide to go with Postgres, as then
+# we can use traditional pagination and there are good gems for that.
+# :nocov:
+class InfinitePaginationV2 < BasePresenter
+  def initialize(pagination:, params:)
+    @unfiltered_params = params
+
+    super(
+      pagination
+    )
+  end
+
+  def to_partial_path
+    'shared/infinite_pagination_v2'.freeze
+  end
+
+  def show?
+    total > limit
+  end
+
+  def total_pages
+    (total / limit.to_f).ceil
+  end
+
+  def current_page
+    index = params[:p].to_i
+    index += 1 if index.zero?
+
+    [index, total_pages].min
+  end
+
+  def aria_current
+    current_page == params[:p] ? 'page' : nil
+  end
+
+  def next_page
+    current_page + 1
+  end
+
+  def prev_page
+    if previous_page_token.present?
+      [current_page - 1, 1].max
+    else
+      1 # always first page once we lack prev pointer
+    end
+  end
+
+  def current_page_token
+    params[:page_token]
+  end
+
+  def previous_page_token
+    params[:previous_page_token]
+  end
+
+  def next_page_params
+    params.merge(page_token: next_page_token, previous_page_token: current_page_token, p: next_page)
+  end
+
+  def previous_page_params
+    params.except(:previous_page_token).merge(page_token: previous_page_token, p: prev_page)
+  end
+
+  def start_page_params
+    params.except(:page_token, :previous_page_token, :p)
+  end
+
+  private
+
+  def params
+    @unfiltered_params.permit(
+      :v, :q, :p, :limit, :sort, :page_token, :previous_page_token
+    )
+  end
+end
+# :nocov:

--- a/app/views/shared/_infinite_pagination_v2.html.erb
+++ b/app/views/shared/_infinite_pagination_v2.html.erb
@@ -1,0 +1,84 @@
+<%
+  total_pages  = infinite_pagination_v2.total_pages
+  current_page = infinite_pagination_v2.current_page
+  aria_current = infinite_pagination_v2.aria_current
+
+  next_page = infinite_pagination_v2.next_page
+  prev_page = infinite_pagination_v2.prev_page
+
+  first_page_url = completed_crime_applications_path(infinite_pagination_v2.start_page_params)
+  next_page_url  = completed_crime_applications_path(infinite_pagination_v2.next_page_params)
+  prev_page_url  = completed_crime_applications_path(infinite_pagination_v2.previous_page_params)
+%>
+
+<% if infinite_pagination_v2.show? %>
+  <nav class="govuk-pagination" role="navigation" aria-label="results">
+    <% if current_page > 1 %>
+      <div class="govuk-pagination__prev">
+        <%= link_to prev_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state', rel: 'prev' do %>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
+               height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+          </svg>
+          <span class="govuk-pagination__link-title"><%= t('.previous_link') %></span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <ul class="govuk-pagination__list">
+      <% if current_page > 3 %>
+        <li class="govuk-pagination__item">
+          <%= link_to first_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state',
+                      aria: { label: t('.aria_page', page: 1), current: aria_current } do %>
+            <%= 1 %>
+          <% end %>
+        </li>
+
+        <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
+
+        <% if prev_page > 1 %>
+          <li class="govuk-pagination__item">
+            <%= link_to prev_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state',
+                        aria: { label: t('.aria_page', page: prev_page), current: aria_current } do %>
+              <%= prev_page %>
+            <% end %>
+          </li>
+        <% end %>
+      <% elsif current_page > 1 %>
+        <li class="govuk-pagination__item">
+          <%= link_to prev_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state',
+                      aria: { label: t('.aria_page', page: prev_page), current: aria_current } do %>
+            <%= prev_page %>
+          <% end %>
+        </li>
+      <% end %>
+
+      <li class="govuk-pagination__item govuk-pagination__item--current">
+        <%= link_to '#', class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state',
+                    aria: { label: t('.aria_page', page: current_page), current: aria_current } do %>
+          <%= current_page %>
+        <% end %>
+      </li>
+      <% if current_page < total_pages %>
+        <li class="govuk-pagination__item">
+          <%= link_to next_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state',
+                      aria: { label: t('.aria_page', page: next_page), current: aria_current } do %>
+            <%= next_page %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+
+    <% if current_page < total_pages %>
+      <div class="govuk-pagination__next">
+        <%= link_to next_page_url, class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state', rel: 'next' do %>
+          <span class="govuk-pagination__link-title"><%= t('.next_link') %></span>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg"
+               height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+        <% end %>
+      </div>
+    <% end %>
+  </nav>
+<% end %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -82,3 +82,7 @@ en:
       start_link: Start
       next_link: Next
       page_counter: "%{current_page} of %{total_pages}"
+    infinite_pagination_v2:
+      previous_link: Previous
+      next_link: Next
+      aria_page: Page %{page}


### PR DESCRIPTION
## Description of change
This is another kind of pagination, as a follow up to PR #184.

This one is a bit more complex on the markup side (probably a fair amount of DRY and tidy up can be done, but this is a quick PoC), but may be more useful to users.

This one allows to always move, from the page you are in, one page forward and one page backwards, however when going backwards only the immediate previous page can be accessed.

The benefit of this pagination is that it is "almost" like a traditional pagination, and has visual feedback of which page you are in, which is the next one, and which is the previous one. When there are no more previous pages (because of dynamo limitation) we show page 1.

## Screenshots of changes (if applicable)
<img width="1079" alt="Screenshot 2022-11-18 at 11 10 57" src="https://user-images.githubusercontent.com/687910/202692320-d69b8f10-71ff-4fb1-9085-643dd1502d65.png">
<img width="1090" alt="Screenshot 2022-11-18 at 11 11 03" src="https://user-images.githubusercontent.com/687910/202692328-05195d31-4726-4966-980f-6c668803e088.png">
<img width="1092" alt="Screenshot 2022-11-18 at 11 11 09" src="https://user-images.githubusercontent.com/687910/202692329-218d692d-1015-4182-9db9-0b92f14afd5c.png">
<img width="1088" alt="Screenshot 2022-11-18 at 11 11 13" src="https://user-images.githubusercontent.com/687910/202692330-f6537bd0-c9c1-47e9-bfb6-b41565c0edb2.png">
<img width="1111" alt="Screenshot 2022-11-18 at 11 11 18" src="https://user-images.githubusercontent.com/687910/202692334-ebf21915-6766-4c90-8303-e4fe2141375f.png">
<img width="1108" alt="Screenshot 2022-11-18 at 11 11 24" src="https://user-images.githubusercontent.com/687910/202692336-4309bc66-4d22-4df3-8bc3-1d3d6fcd2ada.png">


## How to manually test the feature
Same as previous PR, but now you can choose which pagination to use with the query param `v`, so `v=1` is version 1 (previous paginator), and `v=2` (or not param at all) is version 2 (this paginator).