### PR TITLE
Update code to work with latest schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: d2f682817a96b32af08288a0f0a50a17782172f8
+  revision: a6de65802b69e7501dbf5ce2f8dc8a2f4d2ff81c
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -49,6 +49,7 @@ module DeveloperTools
         record.update(
           first_name: record.first_name || 'Test',
           last_name: surname,
+          other_names: '',
           date_of_birth: details[:dob],
           has_nino: YesNoAnswer::YES,
           nino: details[:nino],

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -12,4 +12,6 @@ class CrimeApplication < ApplicationRecord
 
   enum status: ApplicationStatus.enum_values,
        _default: ApplicationStatus.enum_values[:in_progress]
+
+  alias_attribute :reference, :usn
 end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -1,11 +1,8 @@
 class CrimeApplicationPresenter < BasePresenter
-  delegate :first_name, :last_name, :date_of_birth, to: :applicant
-  delegate :case_type, to: :case, allow_nil: true
-
-  # To build RESTful urls with route helpers, even
-  # for applications coming from the datastore
-  def to_param
-    id
+  def initialize(object)
+    super(
+      Adapters::BaseApplication.build(object)
+    )
   end
 
   def applicant_dob
@@ -36,11 +33,5 @@ class CrimeApplicationPresenter < BasePresenter
 
   def date_stampable?
     CaseType.new(case_type.to_s).date_stampable?
-  end
-
-  # Keep this wrapper method in case we retract from
-  # using sequence USN to use any other ID/reference
-  def laa_reference
-    usn
   end
 end

--- a/app/presenters/infinite_pagination.rb
+++ b/app/presenters/infinite_pagination.rb
@@ -6,9 +6,11 @@ class InfinitePagination < BasePresenter
   def initialize(pagination:, params:)
     @unfiltered_params = params
 
+    # rubocop:disable Style/OpenStructUse
     super(
-      pagination
+      OpenStruct.new(pagination)
     )
+    # rubocop:enable Style/OpenStructUse
   end
 
   def to_partial_path

--- a/app/presenters/infinite_pagination_v2.rb
+++ b/app/presenters/infinite_pagination_v2.rb
@@ -6,9 +6,11 @@ class InfinitePaginationV2 < BasePresenter
   def initialize(pagination:, params:)
     @unfiltered_params = params
 
+    # rubocop:disable Style/OpenStructUse
     super(
-      pagination
+      OpenStruct.new(pagination)
     )
+    # rubocop:enable Style/OpenStructUse
   end
 
   def to_partial_path

--- a/app/services/adapters/base_application.rb
+++ b/app/services/adapters/base_application.rb
@@ -1,0 +1,28 @@
+module Adapters
+  class BaseApplication < SimpleDelegator
+    # NOTE: eventually it will be best not to rely on any delegation
+    # and declare explicitly all the attributes and where they come from
+    # in each adapter. Leaving this for now tho.
+    #
+    delegate :first_name, :last_name, :date_of_birth, to: :applicant
+    delegate :case_type, to: :case, allow_nil: true
+
+    def self.build(object)
+      if object.respond_to?(:applicant)
+        Adapters::DatabaseApplication
+      else
+        Adapters::JsonApplication
+      end.new(object)
+    end
+
+    def to_param
+      self['id']
+    end
+
+    # Keep this wrapper method in case we retract from
+    # using sequence USN to use any other ID/reference
+    def laa_reference
+      self['reference']
+    end
+  end
+end

--- a/app/services/adapters/database_application.rb
+++ b/app/services/adapters/database_application.rb
@@ -1,0 +1,4 @@
+module Adapters
+  class DatabaseApplication < BaseApplication
+  end
+end

--- a/app/services/adapters/json_application.rb
+++ b/app/services/adapters/json_application.rb
@@ -1,0 +1,16 @@
+module Adapters
+  class JsonApplication < BaseApplication
+    ApplicantStruct = Struct.new(:first_name, :last_name, keyword_init: true)
+
+    def submitted_at
+      DateTime.iso8601(self['submitted_at'])
+    end
+
+    def applicant
+      ApplicantStruct.new(
+        first_name: dig('client_details', 'applicant', 'first_name'),
+        last_name: dig('client_details', 'applicant', 'last_name'),
+      )
+    end
+  end
+end

--- a/app/services/application_submission.rb
+++ b/app/services/application_submission.rb
@@ -37,13 +37,17 @@ class ApplicationSubmission
   # What we want eventually is a proper adapter to transform
   # the application record into the expected JSON document,
   # conforming to the agreed schema.
+  # https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas
   # :nocov:
   def application_payload
     crime_application.as_json(
-      only: [:id, :usn, :status, :created_at, :submitted_at, :date_stamp]
+      only: [:id, :status, :created_at, :submitted_at, :date_stamp]
     ).merge(
-      client_details: crime_application.applicant.as_json,
-      schema_version: 1.0,
+      client_details: {
+        applicant: crime_application.applicant.as_json
+      },
+      reference: crime_application.usn,
+      schema_version: 0.1,
     )
   end
   # :nocov:

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -15,9 +15,7 @@ module Decisions
 
     def submit_application
       # Get it before we purge the local DB record
-      reference = CrimeApplicationPresenter.new(
-        current_crime_application
-      ).laa_reference
+      reference = current_crime_application.usn
 
       # TODO: this potentially will purge the record soon
       ApplicationSubmission.new(current_crime_application).call

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -103,4 +103,46 @@ RSpec.describe CrimeApplicationPresenter do
       expect(subject.laa_reference).to eq(123)
     end
   end
+
+  describe 'for a completed application (API response)' do
+    subject { described_class.new(datastore_application) }
+
+    let(:datastore_application) do
+      {
+        'id' => 'a1234bcd-5dfb-4180-ae5e-91b0fbef468d',
+        'reference' => 123,
+        'submitted_at' => '2022-11-21T12:00:28.000+00:00',
+        'client_details' => {
+          'applicant' => {
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+          }
+        }
+      }
+    end
+
+    describe '#to_param' do
+      it 'returns the ID of the application' do
+        expect(subject.to_param).to eq('a1234bcd-5dfb-4180-ae5e-91b0fbef468d')
+      end
+    end
+
+    describe '#applicant_name' do
+      it 'returns the full name of the applicant' do
+        expect(subject.applicant_name).to eq('John Doe')
+      end
+    end
+
+    describe '#submitted_at' do
+      it 'parses the string into a DateTime object' do
+        expect(subject.submitted_at).to be_a(DateTime)
+      end
+    end
+
+    describe '#laa_reference' do
+      it 'returns the reference number' do
+        expect(subject.laa_reference).to eq(123)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Now that we've started to validate the JSON payload against the schema on the datastore, some of the code was outdated. Also the JSON responses have changed so we need to adapt some of the proof of concept code we had (like the paginators).

In addition, the presenters need to work with both, DB applications and JSON applications. I've started some work on this front but is far from perfect and definitely kind of ugly.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-210

## How to manually test the feature
After checking out this branch, remove all existing applications in your local datastore as most likely these will be in an old format (or none at all) and may cause issues.
One way to do this, is with the rake task `rake dynamo:destroy_all` (in the datastore directory).
New submitted applications will conform to the basic schema.