### PR TITLE
Unify case types across app and schemas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 52178cea9a43128a08cb8e3756b723bc60e92880
+  revision: d21abe2ef05a5fd9084cc96fdfabe95340405583
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct
@@ -181,7 +181,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.11.0)
-    faraday (2.6.0)
+    faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
@@ -370,7 +370,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -14,7 +14,7 @@ module Steps
 
       validates :cc_appeal_fin_change_details,
                 presence: true,
-                if: -> { case_type&.cc_appeal_fin_change? }
+                if: -> { case_type&.appeal_to_crown_court_with_changes? }
 
       def choices
         CaseType.values
@@ -35,15 +35,15 @@ module Steps
       end
 
       def appeal_maat_id
-        case_type.cc_appeal? ? cc_appeal_maat_id : nil
+        case_type.appeal_to_crown_court? ? cc_appeal_maat_id : nil
       end
 
       def appeal_fin_change_maat_id
-        case_type.cc_appeal_fin_change? ? cc_appeal_fin_change_maat_id : nil
+        case_type.appeal_to_crown_court_with_changes? ? cc_appeal_fin_change_maat_id : nil
       end
 
       def appeal_fin_change_details
-        case_type.cc_appeal_fin_change? ? cc_appeal_fin_change_details : nil
+        case_type.appeal_to_crown_court_with_changes? ? cc_appeal_fin_change_details : nil
       end
     end
   end

--- a/app/models/structs/crime_application.rb
+++ b/app/models/structs/crime_application.rb
@@ -1,0 +1,7 @@
+require 'laa_crime_schemas'
+
+module Structs
+  class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
+    delegate :applicant, to: :client_details
+  end
+end

--- a/app/services/adapters/json_application.rb
+++ b/app/services/adapters/json_application.rb
@@ -1,12 +1,8 @@
-require 'laa_crime_schemas'
-
 module Adapters
   class JsonApplication < BaseApplication
-    delegate :applicant, to: :client_details
-
     def initialize(payload)
       super(
-        LaaCrimeSchemas::Structs::CrimeApplication.new(payload)
+        Structs::CrimeApplication.new(payload)
       )
     end
   end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -3,18 +3,18 @@ class CaseType < ValueObject
     SUMMARY_ONLY = new(:summary_only),
     EITHER_WAY = new(:either_way),
     INDICTABLE = new(:indictable),
-    ALREADY_CC_TRIAL = new(:already_cc_trial),
+    ALREADY_IN_CROWN_COURT = new(:already_in_crown_court),
     COMMITTAL = new(:committal),
-    CC_APPEAL = new(:cc_appeal),
-    CC_APPEAL_FIN_CHANGE = new(:cc_appeal_fin_change)
+    APPEAL_TO_CROWN_COURT = new(:appeal_to_crown_court),
+    APPEAL_TO_CROWN_COURT_WITH_CHANGES = new(:appeal_to_crown_court_with_changes),
   ].freeze
 
   DATE_STAMPABLE = [
     SUMMARY_ONLY,
     EITHER_WAY,
     COMMITTAL,
-    CC_APPEAL,
-    CC_APPEAL_FIN_CHANGE,
+    APPEAL_TO_CROWN_COURT,
+    APPEAL_TO_CROWN_COURT_WITH_CHANGES,
   ].freeze
 
   def date_stampable?

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -8,13 +8,13 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset(:case_type, legend: { tag: 'h1', size: 'xl' }) do %>
         <% @form_object.choices.each_with_index do |choice, index| %>
-          <% if choice.value == :cc_appeal %>
+          <% if choice == CaseType::APPEAL_TO_CROWN_COURT %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
               <%= f.govuk_text_field :cc_appeal_maat_id, width: 'one-third', autocomplete: 'off' %>
             <% end %>
 
-          <% elsif choice.value == :cc_appeal_fin_change %>
+          <% elsif choice == CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
               <%= f.govuk_text_field :cc_appeal_fin_change_maat_id, width: 'one-third', autocomplete: 'off' %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -112,10 +112,10 @@ en:
           summary_only: Summary only
           either_way: Either way
           indictable: Indictable
-          already_cc_trial: Trial already in crown court
+          already_in_crown_court: Trial already in crown court
           committal: Committal for sentence
-          cc_appeal: Appeal to crown court
-          cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances
+          appeal_to_crown_court: Appeal to crown court
+          appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
         cc_appeal_maat_id: Previous MAAT ID (optional)
         cc_appeal_fin_change_maat_id: Previous MAAT ID (optional)
         cc_appeal_fin_change_details: Enter the details of what has changed

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -64,10 +64,10 @@ en:
           summary_only: Summary only
           either_way: Either way
           indictable: Indictable
-          already_cc_trial: Trial already in crown court
+          already_in_crown_court: Trial already in crown court
           committal: Committal for sentence
-          cc_appeal: Appeal to crown court
-          cc_appeal_fin_change: Appeal to crown court with changes in financial circumstances
+          appeal_to_crown_court: Appeal to crown court
+          appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
       # END case details section
 
       # BEGIN offences section

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
       context 'when Appeal to crown court' do
         context 'with a previous MAAT ID' do
-          let(:case_type) { 'cc_appeal' }
+          let(:case_type) { 'appeal_to_crown_court' }
           let(:cc_appeal_maat_id) { '123456' }
 
           it 'is valid' do
@@ -98,7 +98,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
         end
 
         context 'without a previous MAAT ID' do
-          let(:case_type) { 'cc_appeal' }
+          let(:case_type) { 'appeal_to_crown_court' }
 
           it 'is also valid' do
             expect(form).to be_valid
@@ -114,7 +114,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
       context 'when Appeal to crown court with changes in financial circumstances' do
         context 'with details of what has changed' do
-          let(:case_type) { 'cc_appeal_fin_change' }
+          let(:case_type) { 'appeal_to_crown_court_with_changes' }
           let(:cc_appeal_fin_change_maat_id) { '123456' }
           let(:cc_appeal_fin_change_details) { 'These are the details' }
 
@@ -140,7 +140,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
         end
 
         context 'with no details of what has changed' do
-          let(:case_type) { 'cc_appeal_fin_change' }
+          let(:case_type) { 'appeal_to_crown_court_with_changes' }
           let(:cc_appeal_maat_id) { '123456' }
 
           it 'is invalid' do

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe CaseType do
           summary_only
           either_way
           indictable
-          already_cc_trial
+          already_in_crown_court
           committal
-          cc_appeal
-          cc_appeal_fin_change
+          appeal_to_crown_court
+          appeal_to_crown_court_with_changes
         ]
       )
     end
@@ -28,8 +28,8 @@ RSpec.describe CaseType do
           summary_only
           either_way
           committal
-          cc_appeal
-          cc_appeal_fin_change
+          appeal_to_crown_court
+          appeal_to_crown_court_with_changes
         ]
       )
     end


### PR DESCRIPTION
## Description of change
Also bump the version of the schemas gem, and use it through inheritance instead of directly instantiating the gem class, to allow for more flexibility.

NOTE: important, as some case types values has been changed, if in your local DB you have applications created with the old names, they might start to blow up.
Quickest solution is to delete from your local DB the offending applications.