### PR TITLE
Rename case type maat details DB fields

### DIFF
--- a/app/forms/steps/case/case_type_form.rb
+++ b/app/forms/steps/case/case_type_form.rb
@@ -5,16 +5,16 @@ module Steps
       has_one_association :case
 
       attribute :case_type, :value_object, source: CaseType
-      attribute :cc_appeal_maat_id, :string
-      attribute :cc_appeal_fin_change_maat_id, :string
-      attribute :cc_appeal_fin_change_details, :string
+      attribute :appeal_maat_id, :string
+      attribute :appeal_with_changes_maat_id, :string
+      attribute :appeal_with_changes_details, :string
 
       validates :case_type,
                 inclusion: { in: :choices }
 
-      validates :cc_appeal_fin_change_details,
+      validates :appeal_with_changes_details,
                 presence: true,
-                if: -> { case_type&.appeal_to_crown_court_with_changes? }
+                if: -> { appeal_with_changes? }
 
       def choices
         CaseType.values
@@ -28,22 +28,18 @@ module Steps
 
       def attributes_to_reset
         {
-          'cc_appeal_maat_id' => appeal_maat_id,
-          'cc_appeal_fin_change_maat_id' => appeal_fin_change_maat_id,
-          'cc_appeal_fin_change_details' => appeal_fin_change_details
+          'appeal_maat_id' => (appeal_maat_id if appeal?),
+          'appeal_with_changes_maat_id' => (appeal_with_changes_maat_id if appeal_with_changes?),
+          'appeal_with_changes_details' => (appeal_with_changes_details if appeal_with_changes?),
         }
       end
 
-      def appeal_maat_id
-        case_type.appeal_to_crown_court? ? cc_appeal_maat_id : nil
+      def appeal?
+        case_type&.appeal_to_crown_court?
       end
 
-      def appeal_fin_change_maat_id
-        case_type.appeal_to_crown_court_with_changes? ? cc_appeal_fin_change_maat_id : nil
-      end
-
-      def appeal_fin_change_details
-        case_type.appeal_to_crown_court_with_changes? ? cc_appeal_fin_change_details : nil
+      def appeal_with_changes?
+        case_type&.appeal_to_crown_court_with_changes?
       end
     end
   end

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -11,14 +11,14 @@
           <% if choice == CaseType::APPEAL_TO_CROWN_COURT %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :cc_appeal_maat_id, width: 'one-third', autocomplete: 'off' %>
+              <%= f.govuk_text_field :appeal_maat_id, width: 'one-third', autocomplete: 'off' %>
             <% end %>
 
           <% elsif choice == CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES %>
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :cc_appeal_fin_change_maat_id, width: 'one-third', autocomplete: 'off' %>
-              <%= f.govuk_text_area :cc_appeal_fin_change_details %>
+              <%= f.govuk_text_field :appeal_with_changes_maat_id, width: 'one-third', autocomplete: 'off' %>
+              <%= f.govuk_text_area :appeal_with_changes_details %>
             <% end %>
 
           <% else %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -91,7 +91,7 @@ en:
           attributes:
             case_type:
               inclusion: Select a case type
-            cc_appeal_fin_change_details:
+            appeal_with_changes_details:
               blank: Add the details of what has changed
               present: Details of what has changed are required for Appeal to Crown Court with changes to financial circumstances only
         steps/case/has_codefendants_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -116,9 +116,9 @@ en:
           committal: Committal for sentence
           appeal_to_crown_court: Appeal to crown court
           appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
-        cc_appeal_maat_id: Previous MAAT ID (optional)
-        cc_appeal_fin_change_maat_id: Previous MAAT ID (optional)
-        cc_appeal_fin_change_details: Enter the details of what has changed
+        appeal_maat_id: Previous MAAT ID (optional)
+        appeal_with_changes_maat_id: Previous MAAT ID (optional)
+        appeal_with_changes_details: Enter the details of what has changed
       steps_case_charges_form:
         offence_name: Offence name
       steps_case_charges_summary_form:

--- a/db/migrate/20221123104634_rename_case_appeal_fields.rb
+++ b/db/migrate/20221123104634_rename_case_appeal_fields.rb
@@ -1,0 +1,7 @@
+class RenameCaseAppealFields < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :cases, :cc_appeal_maat_id, :appeal_maat_id
+    rename_column :cases, :cc_appeal_fin_change_maat_id, :appeal_with_changes_maat_id
+    rename_column :cases, :cc_appeal_fin_change_details, :appeal_with_changes_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_22_170409) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_23_104634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -36,9 +36,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_170409) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "case_type"
-    t.string "cc_appeal_maat_id"
-    t.string "cc_appeal_fin_change_maat_id"
-    t.text "cc_appeal_fin_change_details"
+    t.string "appeal_maat_id"
+    t.string "appeal_with_changes_maat_id"
+    t.text "appeal_with_changes_details"
     t.string "has_codefendants"
     t.string "hearing_court_name"
     t.date "hearing_date"

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Steps::Case::CaseTypeForm do
   let(:arguments) do
     {
       crime_application:,
-    case_type:,
-    cc_appeal_maat_id:,
-    cc_appeal_fin_change_maat_id:,
-    cc_appeal_fin_change_details:
+      case_type:,
+      appeal_maat_id:,
+      appeal_with_changes_maat_id:,
+      appeal_with_changes_details:
     }
   end
 
@@ -19,9 +19,9 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
   let(:kase) { Case.new }
   let(:case_type) { nil }
-  let(:cc_appeal_maat_id) { nil }
-  let(:cc_appeal_fin_change_maat_id) { nil }
-  let(:cc_appeal_fin_change_details) { nil }
+  let(:appeal_maat_id) { nil }
+  let(:appeal_with_changes_maat_id) { nil }
+  let(:appeal_with_changes_details) { nil }
 
   describe '#save' do
     context 'when `case_type` is blank' do
@@ -53,25 +53,25 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
       context 'when non-appeal case type' do
         context 'with a previous MAAT ID' do
-          let(:cc_appeal_maat_id) { '123456' }
-          let(:cc_appeal_fin_change_maat_id) { '234567' }
+          let(:appeal_maat_id) { '123456' }
+          let(:appeal_with_changes_maat_id) { '234567' }
 
           it { is_expected.to be_valid }
 
           it 'can make MAAT ID fields nil if case types do not require them' do
             attributes = form.send(:attributes_to_reset)
-            expect(attributes['cc_appeal_maat_id']).to be_nil
-            expect(attributes['cc_appeal_fin_change_maat_id']).to be_nil
+            expect(attributes['appeal_maat_id']).to be_nil
+            expect(attributes['appeal_with_changes_maat_id']).to be_nil
           end
         end
 
         context 'with details of a change of financial circumstances' do
-          let(:cc_appeal_fin_change_details) { 'These are the details' }
+          let(:appeal_with_changes_details) { 'These are the details' }
 
           it 'can financial change details nil if case type doesnt require it' do
             attributes = form.send(:attributes_to_reset)
             expect(form).to be_valid
-            expect(attributes['cc_appeal_fin_change_details']).to be_nil
+            expect(attributes['appeal_with_changes_details']).to be_nil
           end
         end
       end
@@ -79,13 +79,13 @@ RSpec.describe Steps::Case::CaseTypeForm do
       context 'when Appeal to crown court' do
         context 'with a previous MAAT ID' do
           let(:case_type) { 'appeal_to_crown_court' }
-          let(:cc_appeal_maat_id) { '123456' }
+          let(:appeal_maat_id) { '123456' }
 
           it 'is valid' do
             expect(form).to be_valid
             expect(
               form.errors.of_kind?(
-                :cc_appeal_maat_id,
+                :appeal_maat_id,
                 :present
               )
             ).to be(false)
@@ -93,7 +93,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
           it 'cannot reset MAAT IDs as the are relevant to this case type' do
             attributes = form.send(:attributes_to_reset)
-            expect(attributes['cc_appeal_maat_id']).to eq(cc_appeal_maat_id)
+            expect(attributes['appeal_maat_id']).to eq(appeal_maat_id)
           end
         end
 
@@ -104,7 +104,7 @@ RSpec.describe Steps::Case::CaseTypeForm do
             expect(form).to be_valid
             expect(
               form.errors.of_kind?(
-                :cc_appeal_maat_id,
+                :appeal_maat_id,
                 :present
               )
             ).to be(false)
@@ -115,14 +115,14 @@ RSpec.describe Steps::Case::CaseTypeForm do
       context 'when Appeal to crown court with changes in financial circumstances' do
         context 'with details of what has changed' do
           let(:case_type) { 'appeal_to_crown_court_with_changes' }
-          let(:cc_appeal_fin_change_maat_id) { '123456' }
-          let(:cc_appeal_fin_change_details) { 'These are the details' }
+          let(:appeal_with_changes_maat_id) { '123456' }
+          let(:appeal_with_changes_details) { 'These are the details' }
 
           it 'is valid' do
             expect(form).to be_valid
             expect(
               form.errors.of_kind?(
-                :cc_appeal_fin_change_details,
+                :appeal_with_changes_details,
                 :present
               )
             ).to be(false)
@@ -130,24 +130,24 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
           it 'cannot reset MAAT IDs as the are relevant to this case type' do
             attributes = form.send(:attributes_to_reset)
-            expect(attributes['cc_appeal_fin_change_maat_id']).to eq(cc_appeal_fin_change_maat_id)
+            expect(attributes['appeal_with_changes_maat_id']).to eq(appeal_with_changes_maat_id)
           end
 
           it 'cannot reset change details as the are relevant to this case type' do
             attributes = form.send(:attributes_to_reset)
-            expect(attributes['cc_appeal_fin_change_details']).to eq(cc_appeal_fin_change_details)
+            expect(attributes['appeal_with_changes_details']).to eq(appeal_with_changes_details)
           end
         end
 
         context 'with no details of what has changed' do
           let(:case_type) { 'appeal_to_crown_court_with_changes' }
-          let(:cc_appeal_maat_id) { '123456' }
+          let(:appeal_maat_id) { '123456' }
 
           it 'is invalid' do
             expect(form).not_to be_valid
             expect(
               form.errors.of_kind?(
-                :cc_appeal_fin_change_details,
+                :appeal_with_changes_details,
                 :blank
               )
             ).to be(true)
@@ -163,9 +163,9 @@ RSpec.describe Steps::Case::CaseTypeForm do
                       association_name: :case,
                       expected_attributes: {
                         'case_type' => CaseType::INDICTABLE,
-                        'cc_appeal_maat_id' => nil,
-                        'cc_appeal_fin_change_maat_id' => nil,
-                        'cc_appeal_fin_change_details' => nil
+                        'appeal_maat_id' => nil,
+                        'appeal_with_changes_maat_id' => nil,
+                        'appeal_with_changes_details' => nil
                       }
     end
   end


### PR DESCRIPTION
## Description of change
For consistency with the schemas and the previous renaming of case types in PR #188.

## How to manually test the feature
Functionally everything should be the same.