### PR TITLE
CRIMAP-213 Render submitted application certificate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 9fcd48b9df10b475d65f9824ce5555d94c2c11d8
+  revision: 40d92e2d3d35e65afeaabf0ff8195f24366f35e6
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct

--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -80,11 +80,19 @@ class CompletedApplicationsController < DashboardController
   end
   # :nocov:
 
-  # TODO: this will go to the document store when we have it.
-  # For now we fake it, and get it from the local DB as we are
-  # not purging applications on submission yet.
-  #
+  # FIXME: Once we have datastore working properly,
+  # clean up code that talks to local database
   def current_crime_application
-    @current_crime_application ||= CrimeApplication.not_in_progress.find_by(id: params[:id])
+    return if params[:id].blank?
+
+    @current_crime_application ||= if FeatureFlags.datastore_submission.enabled?
+                                     # :nocov:
+                                     DatastoreApi::Requests::GetApplication.new(
+                                       application_id: params[:id]
+                                     ).call
+                                     # :nocov:
+                                   else
+                                     CrimeApplication.not_in_progress.find_by(id: params[:id])
+                                   end
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,8 @@ class DashboardController < ApplicationController
   private
 
   def present_crime_application
-    @crime_application = helpers.present(current_crime_application)
+    @crime_application = helpers.present(
+      current_crime_application, CrimeApplicationPresenter
+    )
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,11 @@
 class Address < ApplicationRecord
+  ADDRESS_ATTRIBUTES = %i[
+    address_line_one
+    address_line_two
+    postcode
+    city
+    country
+  ].freeze
+
   belongs_to :person
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -7,6 +7,7 @@ class CrimeApplication < ApplicationRecord
   has_many :people, dependent: :destroy
 
   # Shortcuts through intermediate tables
+  has_one :ioj, through: :case
   has_many :addresses, through: :people
   has_many :codefendants, through: :case
 

--- a/app/models/structs/crime_application.rb
+++ b/app/models/structs/crime_application.rb
@@ -1,7 +1,0 @@
-require 'laa_crime_schemas'
-
-module Structs
-  class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
-    delegate :applicant, to: :client_details
-  end
-end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -3,7 +3,7 @@ module Summary
     attr_reader :crime_application
 
     def initialize(crime_application:)
-      @crime_application = crime_application
+      @crime_application = Adapters::BaseApplication.build(crime_application)
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -56,13 +56,11 @@ module Summary
       def full_address(address)
         return unless address
 
-        address.slice(
-          :address_line_one,
-          :address_line_two,
-          :postcode,
-          :city,
-          :country
-        ).values.compact_blank.join("\r\n")
+        # Address might not be an ActiveRecord instance, so
+        # do not rely on Rails methods like `slice`
+        address.attributes.symbolize_keys.values_at(
+          *Address::ADDRESS_ATTRIBUTES
+        ).compact_blank.join("\r\n")
       end
     end
   end

--- a/app/presenters/summary/sections/justification_for_legal_aid.rb
+++ b/app/presenters/summary/sections/justification_for_legal_aid.rb
@@ -6,7 +6,7 @@ module Summary
       end
 
       def show?
-        kase&.ioj.present? && super
+        ioj.present? && super
       end
 
       def answers
@@ -23,12 +23,8 @@ module Summary
 
       private
 
-      def kase
-        @kase ||= crime_application.case
-      end
-
       def ioj
-        @ioj ||= kase.ioj
+        @ioj ||= crime_application.ioj
       end
     end
   end

--- a/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
+++ b/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
@@ -20,15 +20,11 @@ module Summary
       private
 
       def passport_triggered?
-        kase.ioj.nil? && ioj_passport.any?
+        crime_application.ioj.nil? && kase.ioj_passport.any?
       end
 
       def kase
         @kase ||= crime_application.case
-      end
-
-      def ioj_passport
-        @ioj_passport ||= kase.ioj_passport
       end
     end
   end

--- a/app/services/adapters/base_application.rb
+++ b/app/services/adapters/base_application.rb
@@ -1,5 +1,8 @@
 module Adapters
   class BaseApplication < SimpleDelegator
+    delegate :in_progress?, :submitted?, :returned?, to: :status
+    delegate :case_type, to: :case, allow_nil: true
+
     def self.build(object)
       if object.respond_to?(:applicant)
         Adapters::DatabaseApplication
@@ -10,6 +13,10 @@ module Adapters
 
     def to_param
       id
+    end
+
+    def status
+      ApplicationStatus.new(super)
     end
 
     # Keep this wrapper method in case we retract from

--- a/app/services/adapters/database_application.rb
+++ b/app/services/adapters/database_application.rb
@@ -1,5 +1,4 @@
 module Adapters
   class DatabaseApplication < BaseApplication
-    delegate :case_type, to: :case, allow_nil: true
   end
 end

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -1,0 +1,11 @@
+module Adapters
+  module Structs
+    class Applicant < BaseStructAdapter
+      # FIXME: I think this should be included in the JSON document
+      # For now, as we don't get it from the datastore, mock it
+      def passporting_benefit
+        true
+      end
+    end
+  end
+end

--- a/app/services/adapters/structs/base_struct_adapter.rb
+++ b/app/services/adapters/structs/base_struct_adapter.rb
@@ -1,0 +1,6 @@
+module Adapters
+  module Structs
+    class BaseStructAdapter < SimpleDelegator
+    end
+  end
+end

--- a/app/services/adapters/structs/case_details.rb
+++ b/app/services/adapters/structs/case_details.rb
@@ -1,0 +1,22 @@
+module Adapters
+  module Structs
+    class CaseDetails < BaseStructAdapter
+      # TODO: finalise this in a separate PR
+      def charges
+        []
+      end
+
+      # rubocop:disable Naming/PredicateName
+      def has_codefendants
+        codefendants.any? ? YesNoAnswer::YES : YesNoAnswer::NO
+      end
+      # rubocop:enable Naming/PredicateName
+
+      # FIXME: I think this should be included in the JSON document
+      # For now, as we don't get it from the datastore, mock it
+      def ioj_passport
+        []
+      end
+    end
+  end
+end

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -1,0 +1,19 @@
+require 'laa_crime_schemas'
+
+module Adapters
+  module Structs
+    class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
+      def applicant
+        Structs::Applicant.new(client_details.applicant)
+      end
+
+      def case
+        Structs::CaseDetails.new(case_details)
+      end
+
+      def ioj
+        Structs::InterestsOfJustice.new(interests_of_justice)
+      end
+    end
+  end
+end

--- a/app/services/adapters/structs/interests_of_justice.rb
+++ b/app/services/adapters/structs/interests_of_justice.rb
@@ -1,0 +1,25 @@
+module Adapters
+  module Structs
+    class InterestsOfJustice < BaseStructAdapter
+      def initialize(collection)
+        super(collection)
+
+        collection.each do |item|
+          ioj = IojReasonType.new(item.type)
+
+          instance_variable_set(
+            :"@#{ioj.justification_field_name}", item.reason
+          )
+        end
+      end
+
+      def types
+        pluck(:type)
+      end
+
+      def [](attr_name)
+        instance_variable_get("@#{attr_name}".to_sym)
+      end
+    end
+  end
+end

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -22,11 +22,11 @@
         <div class="govuk-button-group">
           <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
                         class: 'govuk-button govuk-!-margin-right-1',
-                        data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>
+                        data: { module: 'govuk-button' } do; 'Bypass DWP'; end if current_crime_application.try(:in_progress?) %>
 
           <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
                         class: 'govuk-button govuk-!-margin-right-1',
-                        data: { module: 'govuk-button' } do; 'Mark as returned'; end if current_crime_application.submitted? %>
+                        data: { module: 'govuk-button' } do; 'Mark as returned'; end if current_crime_application.try(:submitted?) %>
 
           <%= button_to developer_tools_crime_application_path, method: :delete,
                         class: 'govuk-button govuk-button--warning',

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'laa_crime_schemas'
 
 RSpec.describe CrimeApplicationPresenter do
   subject { described_class.new(crime_application) }

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -1,18 +1,12 @@
 require 'rails_helper'
 
+# This spec is just a high level, smoke test of the sections.
+# It is not intended to test conditionality or complex rules,
+# as that is tested individually in each of the sections specs.
+#
 describe Summary::HtmlPresenter do
   subject { described_class.new(crime_application:) }
 
-  let(:crime_application) do
-    instance_double(CrimeApplication, applicant: double, case: kase)
-  end
-
-  let(:kase) { instance_double(Case, ioj:) }
-  let(:ioj) { instance_double(Ioj) }
-
-  # This test is just a high level, smoke test of the sections.
-  # It is not intended to test conditionality or complex rules,
-  # as that is tested individually in each of the sections specs.
   describe '#sections' do
     before do
       allow_any_instance_of(
@@ -20,21 +14,50 @@ describe Summary::HtmlPresenter do
       ).to receive(:show?).and_return(true)
     end
 
-    it 'has the right sections in the right order' do
-      expect(
-        subject.sections
-      ).to match_instances_array(
-        [
-          Summary::Sections::ClientDetails,
-          Summary::Sections::ContactDetails,
-          Summary::Sections::CaseDetails,
-          Summary::Sections::Offences,
-          Summary::Sections::Codefendants,
-          Summary::Sections::NextCourtHearing,
-          Summary::Sections::JustificationForLegalAid,
-          Summary::Sections::PassportJustificationForLegalAid,
-        ]
-      )
+    context 'for a database application' do
+      let(:crime_application) do
+        instance_double(CrimeApplication, applicant: double, case: double, ioj: double)
+      end
+
+      it 'has the right sections in the right order' do
+        expect(
+          subject.sections
+        ).to match_instances_array(
+          [
+            Summary::Sections::ClientDetails,
+            Summary::Sections::ContactDetails,
+            Summary::Sections::CaseDetails,
+            Summary::Sections::Offences,
+            Summary::Sections::Codefendants,
+            Summary::Sections::NextCourtHearing,
+            Summary::Sections::JustificationForLegalAid,
+            Summary::Sections::PassportJustificationForLegalAid,
+          ]
+        )
+      end
+    end
+
+    context 'for a completed application (API response)' do
+      let(:crime_application) do
+        JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      end
+
+      it 'has the right sections in the right order' do
+        expect(
+          subject.sections
+        ).to match_instances_array(
+          [
+            Summary::Sections::ClientDetails,
+            Summary::Sections::ContactDetails,
+            Summary::Sections::CaseDetails,
+            Summary::Sections::Offences,
+            Summary::Sections::Codefendants,
+            Summary::Sections::NextCourtHearing,
+            Summary::Sections::JustificationForLegalAid,
+            Summary::Sections::PassportJustificationForLegalAid,
+          ]
+        )
+      end
     end
   end
 end

--- a/spec/presenters/summary/sections/justification_for_legal_aid_spec.rb
+++ b/spec/presenters/summary/sections/justification_for_legal_aid_spec.rb
@@ -7,14 +7,7 @@ describe Summary::Sections::JustificationForLegalAid do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      case: kase,
-    )
-  end
-
-  let(:kase) do
-    instance_double(
-      Case,
-      ioj:
+      ioj: ioj,
     )
   end
 
@@ -31,27 +24,17 @@ describe Summary::Sections::JustificationForLegalAid do
   end
 
   describe '#show?' do
-    context 'when there is a case' do
-      context 'when there is no ioj' do
-        let(:ioj) { nil }
+    context 'when there is no ioj' do
+      let(:ioj) { nil }
 
-        it 'shows this section' do
-          expect(subject.show?).to be(false)
-        end
-      end
-
-      context 'when there is an ioj' do
-        it 'shows this section' do
-          expect(subject.show?).to be(true)
-        end
+      it 'shows this section' do
+        expect(subject.show?).to be(false)
       end
     end
 
-    context 'when there is no case' do
-      let(:kase) { nil }
-
-      it 'does not show this section' do
-        expect(subject.show?).to be(false)
+    context 'when there is an ioj' do
+      it 'shows this section' do
+        expect(subject.show?).to be(true)
       end
     end
   end

--- a/spec/presenters/summary/sections/passport_justification_for_legal_aid_spec.rb
+++ b/spec/presenters/summary/sections/passport_justification_for_legal_aid_spec.rb
@@ -8,6 +8,7 @@ describe Summary::Sections::PassportJustificationForLegalAid do
       CrimeApplication,
       to_param: '12345',
       case: kase,
+      ioj: ioj,
     )
   end
 
@@ -15,7 +16,6 @@ describe Summary::Sections::PassportJustificationForLegalAid do
     instance_double(
       Case,
       ioj_passport:,
-      ioj:,
     )
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'webmock/rspec'
 
+require 'laa_crime_schemas'
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::Applicant do
+  subject { described_class.new(applicant) }
+
+  let(:application_struct) do
+    Adapters::Structs::CrimeApplication.new(
+      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    )
+  end
+
+  let(:applicant) { application_struct.applicant }
+
+  describe '#first_name' do
+    it 'returns the applicant first name' do
+      expect(subject.first_name).to eq('Kit')
+    end
+  end
+
+  describe '#last_name' do
+    it 'returns the applicant first name' do
+      expect(subject.last_name).to eq('Pound')
+    end
+  end
+
+  describe '#full_name' do
+    it 'returns the applicant full name' do
+      expect(subject.full_name).to eq('Kit Pound')
+    end
+  end
+
+  # FIXME: this needs to come from the datastore
+  describe '#passporting_benefit' do
+    it 'returns true' do
+      expect(subject.passporting_benefit).to be(true)
+    end
+  end
+end

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::CaseDetails do
+  subject { described_class.new(case_details) }
+
+  let(:application_struct) do
+    Adapters::Structs::CrimeApplication.new(
+      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    )
+  end
+
+  let(:case_details) { application_struct.case }
+
+  # TODO: finalise this in a separate PR
+  describe '#charges' do
+    it 'returns an offence collection' do
+      expect(subject.charges).to eq([])
+    end
+  end
+
+  describe '#has_codefendants' do
+    before do
+      allow(case_details).to receive(:codefendants).and_return(codefendants)
+    end
+
+    context 'when there are codefendants' do
+      let(:codefendants) { [Object, Object] }
+
+      it 'returns `yes`' do
+        expect(subject.has_codefendants).to eq(YesNoAnswer::YES)
+      end
+    end
+
+    context 'when there are not codefendants' do
+      let(:codefendants) { [] }
+
+      it 'returns `no`' do
+        expect(subject.has_codefendants).to eq(YesNoAnswer::NO)
+      end
+    end
+  end
+
+  # FIXME: this needs to come from the datastore
+  describe '#ioj_passport' do
+    it 'returns the IoJ passport' do
+      expect(subject.ioj_passport).to eq([])
+    end
+  end
+end

--- a/spec/services/adapters/structs/crime_application_spec.rb
+++ b/spec/services/adapters/structs/crime_application_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::CrimeApplication do
+  subject { described_class.new(datastore_application) }
+
+  let(:datastore_application) do
+    JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+  end
+
+  describe '#applicant' do
+    it 'returns the applicant struct' do
+      expect(subject.applicant).to be_a(Adapters::Structs::Applicant)
+    end
+  end
+
+  describe '#case' do
+    it 'returns the case details struct' do
+      expect(subject.case).to be_a(Adapters::Structs::CaseDetails)
+    end
+  end
+
+  describe '#ioj' do
+    it 'returns the interests of justice struct' do
+      expect(subject.ioj).to be_a(Adapters::Structs::InterestsOfJustice)
+    end
+  end
+end

--- a/spec/services/adapters/structs/interests_of_justice_spec.rb
+++ b/spec/services/adapters/structs/interests_of_justice_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::InterestsOfJustice do
+  subject { described_class.new(ioj) }
+
+  let(:application_struct) do
+    Adapters::Structs::CrimeApplication.new(
+      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    )
+  end
+
+  let(:ioj) { application_struct.ioj }
+
+  describe '#types' do
+    it 'returns the IoJ types' do
+      expect(subject.types).to eq(['loss_of_liberty'])
+    end
+  end
+
+  describe 'justification for a given type' do
+    it 'returns the `loss_of_liberty` justification' do
+      expect(
+        subject[:loss_of_liberty_justification]
+      ).to eq('More details about loss of liberty.')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Ensure the already existing presenters we had (all under `app/presenters/summary/...`)  works also with a submitted application, as in an application coming from the Datastore and thus not persisted to Apply local DB.

It mostly works out of the box but a few tweaks were needed, because some attributes are named differently in our DB and in the datastore JSON.

To accomplish this in the most transparent way possible a few Adapters have been created in `app/services/adapters/structs/...`. The purpose of these adapters is to take the JSON from the datastore, create Struct objects (from the `laa_crime_schemas` gem) and then apply a thin layer on top of them to customise behaviour and allow for some method renames.

This is not yet completed, but in order to not make this PR too big, will leave those for another separate PR. However this is perfectly functional at the moment (assuming in the datastore there are applications conforming to the latest version of the schema).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-213

## How to manually test the feature
Ensure you are running the latest version of the datastore service locally which includes changes to the schema. You have pushed at least one properly formed application to the datastore. Enable the `datastore_submission` flag, and go to the submitted applications. You are able to render a submitted application certificate.