### PR TITLE
CRIMAP-213 Show offences in submitted certificate

### DIFF
--- a/app/services/adapters/structs/base_struct_adapter.rb
+++ b/app/services/adapters/structs/base_struct_adapter.rb
@@ -1,6 +1,11 @@
 module Adapters
   module Structs
     class BaseStructAdapter < SimpleDelegator
+      NIL_UUID = '00000000-0000-0000-0000-000000000000'.freeze
+
+      def to_param
+        NIL_UUID
+      end
     end
   end
 end

--- a/app/services/adapters/structs/case_details.rb
+++ b/app/services/adapters/structs/case_details.rb
@@ -1,9 +1,8 @@
 module Adapters
   module Structs
     class CaseDetails < BaseStructAdapter
-      # TODO: finalise this in a separate PR
       def charges
-        []
+        offences.map { |struct| Structs::Charge.new(struct) }
       end
 
       # rubocop:disable Naming/PredicateName

--- a/app/services/adapters/structs/charge.rb
+++ b/app/services/adapters/structs/charge.rb
@@ -1,0 +1,27 @@
+module Adapters
+  module Structs
+    class Charge < BaseStructAdapter
+      # {
+      #   "name": "Attempt robbery",
+      #   "offence_class": "Class C",
+      #   "dates": ["2020-05-11", "2020-08-11"]
+      # }
+      def initialize(offence_struct)
+        @dates = offence_struct.dates
+
+        super(
+          ::Charge.new(offence_name: offence_struct.name)
+        )
+      end
+
+      def offence_dates
+        @dates.map { |date| { date: } }
+      end
+
+      # For a datastore application, this is always true
+      def complete?
+        true
+      end
+    end
+  end
+end

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe Adapters::Structs::CaseDetails do
 
   let(:case_details) { application_struct.case }
 
-  # TODO: finalise this in a separate PR
   describe '#charges' do
-    it 'returns an offence collection' do
-      expect(subject.charges).to eq([])
+    it 'returns a charges collection' do
+      expect(subject.charges).to all(be_an(Adapters::Structs::Charge))
     end
   end
 

--- a/spec/services/adapters/structs/charge_spec.rb
+++ b/spec/services/adapters/structs/charge_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::Charge do
+  subject { application_struct.case.charges.first }
+
+  let(:application_struct) do
+    Adapters::Structs::CrimeApplication.new(
+      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    )
+  end
+
+  describe '#to_param' do
+    it 'has a nil UUID, as it is not used or needed' do
+      expect(subject.to_param).to eq(Adapters::Structs::BaseStructAdapter::NIL_UUID)
+    end
+  end
+
+  describe 'delegated class' do
+    it 'is a `Charge` ActiveRecord model' do
+      expect(subject.__getobj__).to be_a(::Charge)
+    end
+  end
+
+  describe '#offence' do
+    it 'returns the offence value object' do
+      expect(subject.offence).to be_an(::Offence)
+    end
+  end
+
+  describe '#offence_dates' do
+    it 'returns the mapped dates' do
+      expect(
+        subject.offence_dates
+      ).to match_array([{ date: kind_of(Date) }, { date: kind_of(Date) }])
+    end
+  end
+
+  describe '#complete?' do
+    it 'returns always true' do
+      expect(subject.complete?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Follow-up to previous PR #196 to finalise the `offences` section.

Because the way the presenters work internally to present the offences class, etc. in the different parts of the service (offences basket, check your answers, certificate page) there is a bit more of complexity in the "thin adapter layer", as we want to reuse our "Charge" model and not to re-implement most of it.

Also, charges in our database might not be "completed" (lacking some details like the name or the dates) but those coming from the datastore can be assumed to be completed as they fulfilled the JSON schema already.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-213

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="804" alt="Screenshot 2022-11-28 at 13 13 22" src="https://user-images.githubusercontent.com/687910/204287398-f4b7300c-d47b-4ca6-8cc5-63fc6327ed53.png">

## How to manually test the feature
Offences should just show on the certificate page as long as they are present in the JSON coming from the datastore.