### PR TITLE
CRIMAP-213 Refactor and show IoJ passported in certificate page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 40d92e2d3d35e65afeaabf0ff8195f24366f35e6
+  revision: 2d674da813a0d2b14dc15a1581afad540c5060de
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct

--- a/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
+++ b/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
@@ -5,10 +5,6 @@ module Summary
         :passport_justification_for_legal_aid
       end
 
-      def show?
-        kase.present? && super
-      end
-
       def answers
         [
           Components::ValueAnswer.new(
@@ -20,11 +16,7 @@ module Summary
       private
 
       def passport_triggered?
-        crime_application.ioj.nil? && kase.ioj_passport.any?
-      end
-
-      def kase
-        @kase ||= crime_application.case
+        crime_application.ioj.blank? && crime_application.ioj_passport.any?
       end
     end
   end

--- a/app/presenters/tasks/ioj.rb
+++ b/app/presenters/tasks/ioj.rb
@@ -13,13 +13,13 @@ module Tasks
     end
 
     def in_progress?
-      crime_application.case.ioj_passport.any? ||
-        crime_application.case.ioj.present?
+      crime_application.ioj_passport.any? ||
+        crime_application.ioj.present?
     end
 
     def completed?
-      crime_application.case.ioj_passport.any? ||
-        crime_application.case.ioj.types.any?
+      crime_application.ioj_passport.any? ||
+        crime_application.ioj.types.any?
     end
   end
 end

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -1,8 +1,9 @@
 module Adapters
   module Structs
     class Applicant < BaseStructAdapter
-      # FIXME: I think this should be included in the JSON document
-      # For now, as we don't get it from the datastore, mock it
+      # NOTE: for MVP this is always true, as we are doing
+      # screening of applicants with DWP. This will change
+      # post-MVP but we don't know yet how exactly.
       def passporting_benefit
         true
       end

--- a/app/services/adapters/structs/case_details.rb
+++ b/app/services/adapters/structs/case_details.rb
@@ -10,12 +10,6 @@ module Adapters
         codefendants.any? ? YesNoAnswer::YES : YesNoAnswer::NO
       end
       # rubocop:enable Naming/PredicateName
-
-      # FIXME: I think this should be included in the JSON document
-      # For now, as we don't get it from the datastore, mock it
-      def ioj_passport
-        []
-      end
     end
   end
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -82,7 +82,7 @@ module Decisions
     end
 
     def after_hearing_details
-      if IojPassporter.new(form_object.crime_application.applicant, form_object.case).call
+      if IojPassporter.new(current_crime_application).call
         edit(:ioj_passport)
       else
         edit(:ioj)

--- a/db/migrate/20221128154645_move_ioj_passport_field_to_application.rb
+++ b/db/migrate/20221128154645_move_ioj_passport_field_to_application.rb
@@ -1,0 +1,6 @@
+class MoveIojPassportFieldToApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :ioj_passport, :string, array: true, default: [], null: false
+    remove_column :cases, :ioj_passport, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_23_104634) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_154645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -42,7 +42,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_23_104634) do
     t.string "has_codefendants"
     t.string "hearing_court_name"
     t.date "hearing_date"
-    t.string "ioj_passport", default: [], array: true
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 
@@ -74,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_23_104634) do
     t.boolean "declaration_signed"
     t.datetime "submitted_at"
     t.serial "usn", null: false
+    t.string "ioj_passport", default: [], null: false, array: true
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
 

--- a/spec/presenters/summary/sections/passport_justification_for_legal_aid_spec.rb
+++ b/spec/presenters/summary/sections/passport_justification_for_legal_aid_spec.rb
@@ -7,15 +7,8 @@ describe Summary::Sections::PassportJustificationForLegalAid do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      case: kase,
+      ioj_passport: ioj_passport,
       ioj: ioj,
-    )
-  end
-
-  let(:kase) do
-    instance_double(
-      Case,
-      ioj_passport:,
     )
   end
 
@@ -27,37 +20,27 @@ describe Summary::Sections::PassportJustificationForLegalAid do
   end
 
   describe '#show?' do
-    context 'when there is a case' do
-      context 'when there is an ioj present' do
-        let(:ioj) { 'foo' }
+    context 'when there is an ioj present' do
+      let(:ioj) { 'foo' }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+
+    context 'when there is no ioj present' do
+      context 'when there is no ioj passport' do
+        let(:ioj_passport) { [] }
 
         it 'does not show this section' do
           expect(subject.show?).to be(false)
         end
       end
 
-      context 'when there is no ioj present' do
-        context 'when there is no ioj passport' do
-          let(:ioj_passport) { [] }
-
-          it 'does not show this section' do
-            expect(subject.show?).to be(false)
-          end
+      context 'when there is an ioj passport' do
+        it 'shows this section' do
+          expect(subject.show?).to be(true)
         end
-
-        context 'when there is an ioj passport' do
-          it 'shows this section' do
-            expect(subject.show?).to be(true)
-          end
-        end
-      end
-    end
-
-    context 'when there is no case' do
-      let(:kase) { nil }
-
-      it 'does not show this section' do
-        expect(subject.show?).to be(false)
       end
     end
   end

--- a/spec/presenters/tasks/ioj_spec.rb
+++ b/spec/presenters/tasks/ioj_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Tasks::Ioj do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      case: kase
+      ioj_passport: ioj_passport,
+      ioj: ioj,
     )
   end
 
-  let(:kase) { instance_double(Case, ioj:, ioj_passport:) }
   let(:ioj) { instance_double(Ioj, types: ioj_types) }
   let(:ioj_types) { [] }
   let(:ioj_passport) { [] }
@@ -24,7 +24,6 @@ RSpec.describe Tasks::Ioj do
     allow(
       subject
     ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details_fulfilled)
-    allow(kase).to receive(:ioj_passport).and_return(ioj_passport)
   end
 
   describe '#path' do

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe Adapters::Structs::Applicant do
     end
   end
 
-  # FIXME: this needs to come from the datastore
   describe '#passporting_benefit' do
-    it 'returns true' do
+    it 'returns always true for MVP' do
       expect(subject.passporting_benefit).to be(true)
     end
   end

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -38,11 +38,4 @@ RSpec.describe Adapters::Structs::CaseDetails do
       end
     end
   end
-
-  # FIXME: this needs to come from the datastore
-  describe '#ioj_passport' do
-    it 'returns the IoJ passport' do
-      expect(subject.ioj_passport).to eq([])
-    end
-  end
 end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -15,13 +15,8 @@ RSpec.describe Decisions::CaseDecisionTree do
       form_object
     ).to receive(:crime_application).and_return(crime_application)
 
-    allow(
-      form_object
-    ).to receive(:case).and_return(kase)
-
     allow(crime_application).to receive(:update).and_return(true)
     allow(crime_application).to receive(:date_stamp).and_return(nil)
-    allow(kase).to receive(:update).and_return(true)
   end
 
   it_behaves_like 'a decision tree'
@@ -249,18 +244,18 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :hearing_details }
 
-    context 'and the applicant is over 18' do
-      before do
-        allow_any_instance_of(IojPassporter).to receive(:call).and_return(false)
-      end
+    before do
+      allow_any_instance_of(IojPassporter).to receive(:call).and_return(ioj_passported)
+    end
+
+    context 'and the IoJ passporter was not triggered' do
+      let(:ioj_passported) { false }
 
       it { is_expected.to have_destination(:ioj, :edit, id: crime_application) }
     end
 
-    context 'and the applicant is under 18' do
-      before do
-        allow_any_instance_of(IojPassporter).to receive(:call).and_return(true)
-      end
+    context 'and the IoJ passporter was triggered' do
+      let(:ioj_passported) { true }
 
       it { is_expected.to have_destination(:ioj_passport, :edit, id: crime_application) }
     end

--- a/spec/services/ioj_passporter_spec.rb
+++ b/spec/services/ioj_passporter_spec.rb
@@ -1,32 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe IojPassporter do
-  subject { described_class.new(applicant, kase) }
+  subject { described_class.new(crime_application) }
 
-  let(:kase) { instance_double(Case) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
   let(:applicant) { instance_double(Applicant, date_of_birth: applicant_dob) }
   let(:applicant_dob) { nil }
 
   before do
-    allow(kase).to receive(:update)
-    allow(kase).to receive(:ioj_passport).and_return([])
+    allow(crime_application).to receive(:update)
+    allow(crime_application).to receive(:ioj_passport).and_return([])
   end
 
   describe '#call' do
     context 'when applicant is over 18' do
-      let(:applicant_dob) { Date.new(1990, 1, 1) }
+      let(:applicant_dob) { 19.years.ago }
 
-      it 'does not add a passported type to the case ioj' do
-        expect(kase).to receive(:update).with({ ioj_passport: [] })
+      it 'does not add a passported type to the array' do
+        expect(crime_application).to receive(:update).with({ ioj_passport: [] })
         subject.call
       end
     end
 
     context 'when applicant is under 18' do
-      let(:applicant_dob) { Time.zone.today }
+      let(:applicant_dob) { 17.years.ago }
 
-      it 'adds a passported type to the case ioj' do
-        expect(kase).to receive(:update).with({ ioj_passport: ['on_age_under18'] })
+      it 'adds a passported type to the array' do
+        expect(crime_application).to receive(:update).with({ ioj_passport: [IojPassportType::ON_AGE_UNDER18.to_s] })
         subject.call
       end
     end


### PR DESCRIPTION
## Description of change
This is I believe the final bit of information we have to read from the datastore application and be able to render in the certificate page.

I've moved the DB attribute from the `case` to the `crime_application` table as it is something that applies globally to the "application" as a whole.

It also makes the code much simpler and I've been able to cleanup quite a lot and refactor some additional code in the task list page, and check your answers page.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-213

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="800" alt="Screenshot 2022-11-28 at 17 14 46" src="https://user-images.githubusercontent.com/687910/204340200-1bd35f35-e812-4a95-9ba8-8539e08eefba.png">

## How to manually test the feature
In order to test this, make sure to be running latest code in the datastore and submit an application containing the attributes:

```json
"ioj_passport": ["on_age_under18"],
"interests_of_justice": null
```