### PR TITLE
Remove dev api gem + config for it

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,5 +9,3 @@ DATABASE_URL=postgresql://postgres@localhost/laa-apply-for-criminal-legal-aid
 # Datastore (local) endpoint
 DATASTORE_API_ROOT=http://localhost:3003
 
-# uncomment if using puma-dev
-# CRIME_APPLY_HOST=laa-apply-for-criminal-legal-aid.test

--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,6 @@ gem 'sentry-ruby'
 
 gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', tag: 'v0.2.0'
 
-# Temporary utitily to add a data api to apply.
-gem 'laa_crime_apply_dev_api', github: 'ministryofjustice/laa-crime-apply-dev-api',
-ref: '506d72ced64e96ee3e82369ef73b95e56bfa72e8'
-
 gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,16 +6,6 @@ GIT
     hmcts_common_platform (0.1.0)
 
 GIT
-  remote: https://github.com/ministryofjustice/laa-crime-apply-dev-api.git
-  revision: 506d72ced64e96ee3e82369ef73b95e56bfa72e8
-  ref: 506d72ced64e96ee3e82369ef73b95e56bfa72e8
-  specs:
-    laa_crime_apply_dev_api (0.2.0)
-      dry-schema (>= 1.10)
-      jbuilder (>= 2.11)
-      rails (>= 7.0)
-
-GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
   revision: a6de65802b69e7501dbf5ce2f8dc8a2f4d2ff81c
   specs:
@@ -139,27 +129,15 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    dry-configurable (0.16.1)
-      dry-core (~> 0.6)
-      zeitwerk (~> 2.6)
     dry-container (0.11.0)
       concurrent-ruby (~> 1.0)
     dry-core (0.9.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-inflector (0.3.0)
-    dry-initializer (3.1.1)
     dry-logic (1.3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.9, >= 0.9)
-      zeitwerk (~> 2.6)
-    dry-schema (1.11.3)
-      concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.16, >= 0.16)
-      dry-core (~> 0.9, >= 0.9)
-      dry-initializer (~> 3.0)
-      dry-logic (~> 1.3)
-      dry-types (~> 1.6)
       zeitwerk (~> 2.6)
     dry-struct (1.5.2)
       dry-core (~> 0.9, >= 0.9)
@@ -204,9 +182,6 @@ GEM
     io-console (0.5.11)
     irb (1.4.2)
       reline (>= 0.3.0)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     json (2.6.2)
     json-schema (3.0.0)
       addressable (>= 2.8)
@@ -389,7 +364,6 @@ DEPENDENCIES
   importmap-rails
   laa-criminal-applications-datastore-api-client!
   laa-criminal-legal-aid-schemas!
-  laa_crime_apply_dev_api!
   pg (~> 1.4)
   pry
   puma

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,10 +67,4 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-
-
-  # Allow a host to be set in development
-  if ENV.fetch("CRIME_APPLY_HOST", false)
-    config.hosts << ENV['CRIME_APPLY_HOST']
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,9 +108,6 @@ Rails.application.routes.draw do
   # catch-all route
   # :nocov:
   match '*path', to: 'errors#not_found', via: :all, constraints:
-    lambda { |request|
-      not_dev_api_request = !request.url['api/applications']
-      Rails.env.production? && not_dev_api_request
-    }
+    lambda { |_request| !Rails.application.config.consider_all_requests_local }
   # :nocov:
 end


### PR DESCRIPTION
## Description of change
Now that we have the client API and can set up the datastore locally, there is no need for the direct dev-api gem so this PR removes it from apply.

## Link to relevant ticket
n/a