### PR TITLE
CRIMAP-223 Fix duplicated IoJ copy

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -150,7 +150,7 @@ en:
           question_of_law: A substantial question of law may be involved (whether arising from legislation, judicial authority or other source of law).
           understanding: They may not be able to understand the court proceedings or present their own case.
           witness_tracing: Witnesses may need to be traced or interviewed on their behalf.
-          expert_examination: Witnesses may need to be traced or interviewed on their behalf.
+          expert_examination: The proceedings may involve expert cross-examination of a prosecution witness (whether an expert or not).
           interest_of_another: It is in the interests of another person (such as the person making a complaint or other witness) that they are represented.
           other: Other
       steps_submission_declaration_form:


### PR DESCRIPTION
## Description of change
Expert examination IOJ was using same copy as Witness tracing.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-223

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="651" alt="Screenshot 2022-11-30 at 15 17 45" src="https://user-images.githubusercontent.com/687910/204836707-296884ad-c3db-4872-b48a-2619e819479b.png">

## How to manually test the feature
