### PR TITLE
Serialize empty collections to arrays

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 02fc72cc0ddebbb0529cd95b997d778b409110f0
+  revision: 5c20c8b705b36e04a45b692f1fc6374a7bc6804e
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct
@@ -129,27 +129,24 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    dry-container (0.11.0)
-      concurrent-ruby (~> 1.0)
-    dry-core (0.9.1)
+    dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
-    dry-inflector (0.3.0)
-    dry-logic (1.3.0)
+    dry-inflector (1.0.0)
+    dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.9, >= 0.9)
+      dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-struct (1.5.2)
-      dry-core (~> 0.9, >= 0.9)
-      dry-types (~> 1.6)
+    dry-struct (1.6.0)
+      dry-core (~> 1.0, < 2)
+      dry-types (>= 1.7, < 2)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.6.1)
+    dry-types (1.7.0)
       concurrent-ruby (~> 1.0)
-      dry-container (~> 0.3)
-      dry-core (~> 0.9, >= 0.9)
-      dry-inflector (~> 0.1, >= 0.1.2)
-      dry-logic (~> 1.3, >= 1.3)
+      dry-core (~> 1.0, < 2)
+      dry-inflector (~> 1.0, < 2)
+      dry-logic (>= 1.4, < 2)
       zeitwerk (~> 2.6)
     erb_lint (0.2.0)
       activesupport

--- a/app/serializers/submission_serializer/definitions/address.rb
+++ b/app/serializers/submission_serializer/definitions/address.rb
@@ -1,8 +1,8 @@
 module SubmissionSerializer
   module Definitions
     class Address < Definitions::BaseDefinition
-      def blank?
-        super || address_line_one.blank?
+      def present?
+        super && address_line_one.present?
       end
 
       def to_builder

--- a/app/serializers/submission_serializer/definitions/base_definition.rb
+++ b/app/serializers/submission_serializer/definitions/base_definition.rb
@@ -8,11 +8,9 @@ module SubmissionSerializer
       end
 
       def generate
-        return if blank?
-
         if respond_to?(:map)
           map { |item| self.class.generate(item) }
-        else
+        elsif present?
           to_builder.attributes!
         end
       end

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SubmissionSerializer::Application do
           'ioj_passport' => [],
           'provider_details' => {},
           'client_details' => a_hash_including('applicant'),
-          'case_details' => a_hash_including('offences', 'codefendants'),
+          'case_details' => a_hash_including('offences' => [], 'codefendants' => []),
           'interests_of_justice' => [],
         )
       )


### PR DESCRIPTION
## Description of change
Empty collections like `codefendants` (if there are no codefendants in the case) or `offences`, should be serialized as empty arrays, instead of `nil`.

Bump schemas version that makes `codefendants` a required attribute (but can be an empty array).

