### PR TITLE
Protect against offences without class

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -10,6 +10,9 @@ class Charge < ApplicationRecord
   composed_of :offence, mapping: %i[offence_name name],
               constructor: :find_by_name, allow_nil: true
 
+  delegate :offence_class, :offence_type,
+           to: :offence, allow_nil: true
+
   def complete?
     offence_name.present? && offence_dates.pluck(:date).any?
   end

--- a/app/serializers/submission_serializer/definitions/offence.rb
+++ b/app/serializers/submission_serializer/definitions/offence.rb
@@ -3,8 +3,8 @@ module SubmissionSerializer
     class Offence < Definitions::BaseDefinition
       def to_builder
         Jbuilder.new do |json|
-          json.name offence.name
-          json.offence_class offence.offence_class
+          json.name offence_name
+          json.offence_class offence_class
           json.dates offence_dates.pluck(:date)
         end
       end

--- a/spec/serializers/submission_serializer/sections/case_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/case_details_spec.rb
@@ -15,18 +15,15 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
       appeal_with_changes_details: 'appeal changes',
       hearing_court_name: 'Court',
       hearing_date: hearing_date,
-      charges: [charge],
+      charges: [charge1, charge2],
       codefendants: [codefendant],
     )
   end
 
   let(:hearing_date) { DateTime.new(2023, 3, 2) }
 
-  let(:charge) do
-    Charge.new(
-      offence_name: 'Common assault',
-    )
-  end
+  let(:charge1) { Charge.new(offence_name: 'Common assault') }
+  let(:charge2) { Charge.new(offence_name: 'An unlisted offence') }
 
   let(:codefendant) do
     Codefendant.new(
@@ -51,7 +48,12 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
             name: 'Common assault',
             offence_class: 'H',
             dates: %w[Date1 Date2],
-          }
+          },
+          {
+            name: 'An unlisted offence',
+            offence_class: nil,
+            dates: %w[Date1],
+          },
         ],
         codefendants: [
           {
@@ -65,7 +67,8 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
   end
 
   before do
-    allow(charge).to receive(:offence_dates).and_return([{ date: 'Date1' }, { date: 'Date2' }])
+    allow(charge1).to receive(:offence_dates).and_return([{ date: 'Date1' }, { date: 'Date2' }])
+    allow(charge2).to receive(:offence_dates).and_return([{ date: 'Date1' }])
   end
 
   describe '#generate' do


### PR DESCRIPTION
## Description of change
Some unlisted offences may be entered manually, without selecting an existing offence from the dropdown.

These offences will not have a class.

The `charge` serializer was failing for unlisted offences.

## How to manually test the feature
Enter some manual (not listed in the dropdown) offences and submit the application. Should not fail.