### PR TITLE
CRIMAP-240 Adapt developer tools to datastore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: a6de65802b69e7501dbf5ce2f8dc8a2f4d2ff81c
+  revision: 1f109d882baefba339faf1510a5d76bb1535b90b
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -16,17 +16,21 @@
       </div>
 
       <% if current_crime_application %>
+        <% crime_application = present(current_crime_application, CrimeApplicationPresenter) %>
+
         <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Quick actions</h4>
         <p>Speed up some common application actions</p>
 
         <div class="govuk-button-group">
-          <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
-                        class: 'govuk-button govuk-!-margin-right-1',
-                        data: { module: 'govuk-button' } do; 'Bypass DWP'; end if current_crime_application.try(:in_progress?) %>
+          <% if crime_application.in_progress? && !crime_application.applicant&.passporting_benefit %>
+            <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
+                          class: 'govuk-button govuk-!-margin-right-1',
+                          data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>
+          <% end %>
 
           <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
                         class: 'govuk-button govuk-!-margin-right-1',
-                        data: { module: 'govuk-button' } do; 'Mark as returned'; end if current_crime_application.try(:submitted?) %>
+                        data: { module: 'govuk-button' } do; 'Mark as returned'; end if crime_application.submitted? %>
 
           <%= button_to developer_tools_crime_application_path, method: :delete,
                         class: 'govuk-button govuk-button--warning',


### PR DESCRIPTION
## Description of change
We are now using the datastore for everything post-submission of an application.

Some operations of the “developer tools“ (in the footer, intended for speed up some actions in development/demo environments) relied on local DB so these need to be tweaked to work again with the datastore.

Now, depending on the current application (in progress, or submitted) the operations will perform the expected action on the correct "database".

Please note marking a submitted application as returned will work, but there is no counter in the returned tab (it was removed couple days ago until counters are reworked, part of another ticket).

However trying to update a returned application (re-hydration) is not yet implemented so will blow up if tried.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-240

## How to manually test the feature
Play with the developer tools in both, local (in progress) applications, and remote submitted (datastore) ones. Do not delete submitted applications on staging please, only use the harness datastore or local datastore.