### PR TITLE
CRIMAP-235 Spike SAML authentication

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,3 +16,8 @@ DATABASE_URL=postgresql://postgres@localhost/laa-apply-for-criminal-legal-aid
 # DATASTORE_API_ROOT=https://criminal-applications-datastore-harness.apps.live.cloud-platform.service.justice.gov.uk
 # DATASTORE_AUTH_USERNAME=
 # DATASTORE_AUTH_PASSWORD=
+
+# LAA Portal SAML authentication metadata endpoint
+LAA_PORTAL_IDP_METADATA_URL=https://samlmock.dev.legalservices.gov.uk/metadata
+# Set to true to bypass authentication (a mock will be used)
+OMNIAUTH_TEST_MODE=true

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,17 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby File.read('.ruby-version').chomp
 
 gem 'faraday', '~> 2.4'
+gem 'govuk_design_system_formbuilder', '~> 3.1.0'
 gem 'jbuilder', '~> 2.11.5'
 gem 'pg', '~> 1.4'
 gem 'puma'
 gem 'rails', '~> 7.0.3'
 gem 'uk_postcode'
 
-gem 'govuk_design_system_formbuilder', '~> 3.1.0'
+# Authentication
+gem 'omniauth-rails_csrf_protection'
+gem 'omniauth-saml', '~> 2.1.0'
+gem 'warden'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
@@ -57,6 +61,7 @@ group :test do
   gem 'rubocop-rspec', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
+  gem 'warden-rspec-rails' # if we move to Devise, we don't need this
   gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
       activesupport (>= 6.1)
       html-attributes-utils (~> 0.9, >= 0.9.2)
     hashdiff (1.0.1)
+    hashie (5.0.0)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
     i18n (1.12.0)
@@ -209,6 +210,16 @@ GEM
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    omniauth (2.1.0)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth-saml (2.1.0)
+      omniauth (~> 2.0)
+      ruby-saml (~> 1.12)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -221,6 +232,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.1)
     rack (2.2.4)
+    rack-protection (3.0.4)
+      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4)
@@ -294,6 +307,9 @@ GEM
     rubocop-rspec (2.13.2)
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
+    ruby-saml (1.14.0)
+      nokogiri (>= 1.10.5)
+      rexml
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -326,6 +342,9 @@ GEM
       concurrent-ruby (~> 1.0)
     uk_postcode (2.1.8)
     unicode-display_width (2.3.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
+    warden-rspec-rails (0.3.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -365,6 +384,8 @@ DEPENDENCIES
   jbuilder (~> 2.11.5)
   laa-criminal-applications-datastore-api-client!
   laa-criminal-legal-aid-schemas!
+  omniauth-rails_csrf_protection
+  omniauth-saml (~> 2.1.0)
   pg (~> 1.4)
   pry
   puma
@@ -380,6 +401,8 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   uk_postcode
+  warden
+  warden-rspec-rails
   web-console
   webdrivers
   webmock

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -1,6 +1,26 @@
 // App-specific custom styles and overrides
 // Please use BEM convention: http://getbem.com/naming/
 //
+@mixin app-button-reset {
+  padding: 0;
+  margin: 0;
+  border: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  box-sizing: unset;
+  background-color: transparent;
+}
+
+.app-header__auth-link {
+  // 1. Remove any button styling
+  @include app-button-reset;
+
+  // 2. Apply header link styling
+  @include govuk-font($size: 16, $weight: bold);
+  white-space: nowrap;
+}
+
 .app-dashboard-table {
   .govuk-table__header,
   .govuk-table__cell {

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,6 @@
 class AboutController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def privacy; end
   def contact; end
   def feedback; end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include ErrorHandling
+  include AuthHandling
   include StepsHelper
 
   add_flash_types :success

--- a/app/controllers/concerns/auth_handling.rb
+++ b/app/controllers/concerns/auth_handling.rb
@@ -1,0 +1,26 @@
+module AuthHandling
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_action :authenticate_user!
+    helper_method :warden, :signed_in?, :current_user
+  end
+
+  def signed_in?
+    !current_user.nil?
+  end
+
+  def current_user
+    warden.user
+  end
+
+  def warden
+    request.env['warden']
+  end
+
+  protected
+
+  def authenticate_user!
+    warden.authenticate!
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,6 @@
 class ErrorsController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token,
+                     :authenticate_user!
 
   def invalid_session
     respond_with_status(:ok)
@@ -11,6 +12,10 @@ class ErrorsController < ApplicationController
 
   def not_found
     respond_with_status(:not_found)
+  end
+
+  def unauthorized
+    respond_with_status(:ok)
   end
 
   def unhandled

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,5 @@
 class HomeController < ApplicationController
-  def index; end
+  skip_before_action :authenticate_user!
 
-  # Just for demo purposes, to be removed
-  def selected_yes; end
-  def selected_no; end
+  def index; end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,4 +12,8 @@ class SessionsController < ApplicationController
     warden.logout
     redirect_to root_path
   end
+
+  def failure
+    redirect_to root_path, flash: { notice: t('errors.omniauth.signin_failure') }
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,15 @@
 class SessionsController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_before_action :verify_authenticity_token, only: [:create]
+
+  # This is the callback endpoint
+  def create
+    authenticate_user!
+    redirect_to crime_applications_path
+  end
+
   def destroy
-    reset_session
+    warden.logout
     redirect_to root_path
   end
 end

--- a/app/lib/laa_portal_setup.rb
+++ b/app/lib/laa_portal_setup.rb
@@ -1,0 +1,105 @@
+class LaaPortalSetup
+  class AuthSetupError < StandardError; end
+
+  def initialize(env)
+    @env = env
+    @request = ActionDispatch::Request.new(env)
+  end
+
+  def self.call(env)
+    return if OmniAuth.config.test_mode
+
+    new(env).setup
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def setup
+    parse_metadata_and_merge(
+      sp_entity_id: 'crime-apply',
+      security: {
+        authn_requests_signed: true,
+        want_assertions_signed: true,
+      },
+      request_attributes: {},
+      attribute_statements: {
+        email: ['USER_EMAIL'],
+        roles: ['LAA_APP_ROLES'],
+        office_codes: ['LAA_ACCOUNTS'],
+      }
+    )
+  rescue StandardError => e
+    raise AuthSetupError, e
+  end
+
+  # :nocov:
+  def self.mock_auth
+    OmniAuth::AuthHash.new(
+      provider: 'saml',
+      uid: 'test-uid',
+      info: {
+        name: 'test-user',
+        email: 'test@example.com',
+      },
+      extra: {
+        raw_info: {
+          USER_EMAIL: 'test@example.com',
+          LAA_APP_ROLES: ['CCR_CCRGradeA1'],
+          LAA_ACCOUNTS: ['1A123B'],
+        }
+      }
+    )
+  end
+  # :nocov:
+  # rubocop:enable Metrics/MethodLength
+
+  private
+
+  def parse_metadata_and_merge(config = {})
+    @env['omniauth.strategy'].options.merge!(
+      metadata_config.merge(config)
+    )
+  end
+
+  # An explicit timeout is set, as the gem parser does not have one,
+  # which means it hangs for a very long time if URL is not reachable.
+  def metadata_config
+    Timeout.timeout(3) do
+      OneLogin::RubySaml::IdpMetadataParser.new.parse_remote_to_hash(metadata_url)
+    end
+  rescue StandardError => e
+    if e.is_a?(Timeout::Error)
+      e = StandardError.new(
+        "Execution expired parsing remote metadata: `#{metadata_url}`"
+      )
+    end
+
+    Rails.logger.error(e)
+    Sentry.capture_exception(e)
+
+    raise(e) # re-raise exception
+  end
+
+  def metadata_url
+    ENV.fetch('LAA_PORTAL_IDP_METADATA_URL')
+  end
+
+  # This is a middleware class used to catch exceptions
+  # during the strategy `setup` phase, like metadata timeouts.
+  # :nocov:
+  class AuthSetupErrorCatcher
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    rescue LaaPortalSetup::AuthSetupError => e
+      flash = ActionDispatch::Flash::FlashHash.new(notice: e.message)
+
+      Rack::Request.new(env).session['flash'] = flash.to_session_value
+
+      [302, { 'Location' => '/' }, []]
+    end
+  end
+  # :nocov:
+end

--- a/app/lib/warden/strategies/laa_portal_strategy.rb
+++ b/app/lib/warden/strategies/laa_portal_strategy.rb
@@ -1,0 +1,43 @@
+module Warden
+  module Strategies
+    class LaaPortalStrategy < ::Warden::Strategies::Base
+      def authenticate!
+        if auth_env
+          success!(user_details)
+        else
+          fail!
+        end
+      end
+
+      private
+
+      def auth_env
+        request.env['omniauth.auth']
+      end
+
+      def user_details
+        attrs = auth_env.info
+
+        # These are `nil` when using samlmock.dev, so filling with something
+        attrs.name  ||= auth_env.uid
+        attrs.email ||= auth_env.uid
+
+        attrs
+      end
+    end
+  end
+
+  class UnauthorizedController < ActionController::Metal
+    include ActionController::Redirecting
+    include Rails.application.routes.url_helpers
+
+    def self.call(env)
+      @respond ||= action(:respond)
+      @respond.call(env)
+    end
+
+    def respond
+      redirect_to unauthorized_errors_path
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,0 +1,12 @@
+class Provider
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
+  attribute :email, :string
+  attribute :first_name, :string
+  attribute :last_name, :string
+
+  attribute :roles, array: true, default: -> { [] }
+  attribute :office_codes, array: true, default: -> { [] }
+end

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+
+    <%= button_to saml_authorize_path, method: :post,
+                  class: 'govuk-button govuk-!-margin-top-2',
+                  data: { module: 'govuk-button' } do; t('.sign_in_button'); end %>
+  </div>
+</div>

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -2,6 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+
     <h1 class="govuk-heading-xl">
       <%= service_name %>
     </h1>

--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -1,0 +1,16 @@
+<% if signed_in? %>
+  <nav aria-label="Menu" class="govuk-header__navigation">
+    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
+    <ul id="navigation" class="govuk-header__navigation-list">
+      <li class="govuk-header__navigation-item">
+        <%= link_to t('.your_applications'), crime_applications_path, class: 'govuk-header__link' %>
+      </li>
+      <li class="govuk-header__navigation-item">
+        <%= current_user.name %>
+      </li>
+      <li class="govuk-header__navigation-item">
+        <%= button_to t('.sign_out'), logout_path, method: :delete, class: 'govuk-header__link app-header__auth-link' %>
+      </li>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
               class: 'govuk-header__link govuk-header__service-name', id: 'header-service-name' %>
 <% end %>
 
+<% content_for(:header_navigation) do %>
+  <% render partial: 'layouts/header_navigation' %>
+<% end %>
+
 <% content_for(:phase_banner) do %>
   <% render partial: 'layouts/phase_banner' %>
 <% end %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -52,6 +52,7 @@
 
     <div class="govuk-header__content">
       <%= yield(:service_name) %>
+      <%= yield(:header_navigation) %>
     </div>
   </div>
 </header>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -1,16 +1,15 @@
 <% flash.each do |type, msg| %>
-  <% if type == 'success' %>
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          <%= t('flash.success.title') %>
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">
-          <%= msg %>
-        </p>
-      </div>
+  <div class="govuk-notification-banner govuk-notification-banner--<%= type %>" role="alert"
+       aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        <%= t(:title, scope: "flash.#{type}") %>
+      </h2>
     </div>
-  <% end %>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        <%= msg %>
+      </p>
+    </div>
+  </div>
 <% end %>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
+  :SAMLResponse, :Signature, :SigAlg, :KeyInfo
 ]

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,12 +4,10 @@ require 'laa_portal_setup'
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :saml, setup: LaaPortalSetup
 
+  on_failure { |env| SessionsController.action(:failure).call(env) }
+
   configure do |config|
     config.add_mock(:saml, LaaPortalSetup.mock_auth)
     config.test_mode = Rails.env.test? || ENV.fetch('OMNIAUTH_TEST_MODE', 'false').inquiry.true?
   end
 end
-
-Rails.application.config.middleware.insert_before(
-  OmniAuth::Builder, LaaPortalSetup::AuthSetupErrorCatcher
-)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,15 @@
+require 'omniauth'
+require 'laa_portal_setup'
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :saml, setup: LaaPortalSetup
+
+  configure do |config|
+    config.add_mock(:saml, LaaPortalSetup.mock_auth)
+    config.test_mode = Rails.env.test? || ENV.fetch('OMNIAUTH_TEST_MODE', 'false').inquiry.true?
+  end
+end
+
+Rails.application.config.middleware.insert_before(
+  OmniAuth::Builder, LaaPortalSetup::AuthSetupErrorCatcher
+)

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,0 +1,15 @@
+require 'warden/strategies/laa_portal_strategy'
+
+Warden::Strategies.add(
+  :laa_portal, Warden::Strategies::LaaPortalStrategy
+)
+
+Rails.application.config.middleware.insert_after(ActionDispatch::Flash, Warden::Manager) do |manager|
+  manager.default_scope = :user
+  manager.scope_defaults :user, strategies: [:laa_portal]
+
+  manager.failure_app = Warden::UnauthorizedController
+
+  manager.serialize_into_session(:user) { |user| user.as_json }
+  manager.serialize_from_session(:user) { |session_data| Provider.new(session_data) }
+end

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -10,3 +10,5 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   # Datastore endpoint for staging
   DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
+  # LAA Portal metadata endpoint (for now, we use the dev mock)
+  LAA_PORTAL_IDP_METADATA_URL: https://samlmock.dev.legalservices.gov.uk/metadata

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,14 @@ en:
   flash:
     success:
       title: Success
+    notice:
+      title: Notice
+
+  layouts:
+    header_navigation:
+      your_applications: Your applications
+      sign_in: Sign in
+      sign_out: Sign out
 
   support:
     array:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -3,6 +3,10 @@ en:
   errors:
     format: "%{message}"
     page_title_prefix: "Error: "
+
+    omniauth:
+      signin_failure: There was a problem signing you in
+
     error_summary:
       heading: There is a problem on this page
     invalid_session:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -20,6 +20,11 @@ en:
       page_title: Unexpected error
       heading: Sorry, something went wrong with our service
       lead_text: You can go back and retry, or start again.
+    unauthorized:
+      page_title: Unauthorized
+      heading: Access restricted
+      lead_text: This page requires you to be signed in to LAA Portal. You will be redirected back to this service after you sign in.
+      sign_in_button: Sign in with LAA Portal
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,15 @@ Rails.application.routes.draw do
     get :application_not_found
     get :invalid_session
     get :unhandled
+    get :unauthorized
     get :not_found
   end
 
-  resource :session, only: [:destroy] do
-  end
+  # Omniauth SAML
+  post 'auth/saml', as: :saml_authorize
+  post 'auth/saml/callback', to: 'sessions#create', as: :saml_authorize_callback
+  get 'auth/saml/callback', to: 'sessions#create', constraints: -> (_) { OmniAuth.config.test_mode }
+  delete 'logout', to: 'sessions#destroy'
 
   namespace :developer_tools, constraints: -> (_) { FeatureFlags.developer_tools.enabled? } do
     resources :crime_applications, only: [:update, :destroy], path: 'applications' do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
   describe '#destroy' do
-    it 'resets the session' do
-      expect(subject).to receive(:reset_session)
+    it 'logs out the user' do
+      expect(warden).to receive(:logout)
       delete :destroy
     end
 

--- a/spec/controllers/steps/dummy_step_controller_spec.rb
+++ b/spec/controllers/steps/dummy_step_controller_spec.rb
@@ -8,14 +8,39 @@ end
 
 RSpec.describe DummyStepController, type: :controller do
   before do
-    Rails.application.routes.draw do
-      get '/dummy_step/:id' => 'dummy_step#show'
-      root to: 'dummy_root#index'
+    Rails.application.routes.append do
+      get '/dummy_step/:id', to: 'dummy_step#show'
+      get '/dummy_step/:id/edit', to: 'dummy_step#edit'
+      put '/dummy_step/:id', to: 'dummy_step#update'
     end
+    Rails.application.reload_routes!
   end
 
-  after do
-    Rails.application.reload_routes!
+  describe 'authenticate_user!' do
+    before do
+      sign_out
+    end
+
+    describe '#show' do
+      it 'redirects to the unauthorized error page' do
+        get :show, params: { id: '12345' }
+        expect(response).to redirect_to(unauthorized_errors_path)
+      end
+    end
+
+    describe '#edit' do
+      it 'redirects to the unauthorized error page' do
+        get :edit, params: { id: '12345' }
+        expect(response).to redirect_to(unauthorized_errors_path)
+      end
+    end
+
+    describe '#update' do
+      it 'redirects to the unauthorized error page' do
+        put :update, params: { id: '12345' }
+        expect(response).to redirect_to(unauthorized_errors_path)
+      end
+    end
   end
 
   describe 'navigation stack' do

--- a/spec/lib/laa_portal_setup_spec.rb
+++ b/spec/lib/laa_portal_setup_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe LaaPortalSetup do
+  subject { described_class.call(env) }
+
+  let(:env) do
+    { 'omniauth.strategy' => double(options: {}) }
+  end
+
+  before do
+    allow(Sentry).to receive(:capture_exception)
+    allow(OmniAuth.config).to receive(:test_mode).and_return(false)
+  end
+
+  describe '.setup' do
+    context 'when no metadata endpoint is declared' do
+      it 'raises an exception' do
+        expect { subject }.to raise_exception(
+          LaaPortalSetup::AuthSetupError, /key not found: "LAA_PORTAL_IDP_METADATA_URL"/
+        )
+
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(KeyError)
+        )
+      end
+    end
+
+    context 'when metadata endpoint times out' do
+      before do
+        allow(ENV).to receive(:fetch).with('LAA_PORTAL_IDP_METADATA_URL').and_return('url')
+
+        allow_any_instance_of(
+          OneLogin::RubySaml::IdpMetadataParser
+        ).to receive(:parse_remote_to_hash).and_raise(Timeout::Error)
+      end
+
+      it 'raises an exception' do
+        expect { subject }.to raise_exception(
+          LaaPortalSetup::AuthSetupError, /Execution expired parsing remote metadata: `url`/
+        )
+
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(StandardError)
+        )
+      end
+    end
+
+    context 'when metadata endpoint can be retrieved and parsed' do
+      let(:metadata_url) { 'http://saml-metadata-endpoint' }
+      let(:metadata_result) { { foo: 'bar' } }
+
+      before do
+        allow(ENV).to receive(:fetch).with('LAA_PORTAL_IDP_METADATA_URL').and_return(metadata_url)
+
+        allow_any_instance_of(
+          OneLogin::RubySaml::IdpMetadataParser
+        ).to receive(:parse_remote_to_hash).with(metadata_url).and_return(metadata_result)
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'merges the configuration into the `omniauth.strategy`' do
+        expect(
+          subject
+        ).to eq(
+          {
+            foo: 'bar',
+            sp_entity_id: 'crime-apply',
+            security: {
+              authn_requests_signed: true,
+              want_assertions_signed: true
+            },
+            request_attributes: {},
+            attribute_statements: {
+              email: ['USER_EMAIL'],
+              roles: ['LAA_APP_ROLES'],
+              office_codes: ['LAA_ACCOUNTS']
+            }
+          }
+        )
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+  end
+end

--- a/spec/lib/laa_portal_setup_spec.rb
+++ b/spec/lib/laa_portal_setup_spec.rb
@@ -16,7 +16,7 @@ describe LaaPortalSetup do
     context 'when no metadata endpoint is declared' do
       it 'raises an exception' do
         expect { subject }.to raise_exception(
-          LaaPortalSetup::AuthSetupError, /key not found: "LAA_PORTAL_IDP_METADATA_URL"/
+          KeyError, /key not found: "LAA_PORTAL_IDP_METADATA_URL"/
         )
 
         expect(Sentry).to have_received(:capture_exception).with(
@@ -36,7 +36,7 @@ describe LaaPortalSetup do
 
       it 'raises an exception' do
         expect { subject }.to raise_exception(
-          LaaPortalSetup::AuthSetupError, /Execution expired parsing remote metadata: `url`/
+          StandardError, /Execution expired parsing remote metadata: `url`/
         )
 
         expect(Sentry).to have_received(:capture_exception).with(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,11 +34,19 @@ RSpec.configure do |config|
 
   config.include ActiveSupport::Testing::TimeHelpers
 
+  config.include(Warden::Test::ControllerHelpers, type: :controller)
+  config.include(AuthenticationHelpers, type: :controller)
+
   config.include(ViewSpecHelpers, type: :helper)
   config.include(ViewSpecHelpers, type: :view)
 
   config.before(:each, type: :helper) { initialize_view_helpers(helper) }
   config.before(:each, type: :view) { initialize_view_helpers(view) }
+
+  # As a default, we assume a user is signed in all controllers.
+  # For specific scenarios, the user can be "signed off".
+  config.before(:each, type: :controller) { sign_in }
+  config.before(:all, type: :request) { get saml_authorize_callback_path }
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -28,4 +28,11 @@ RSpec.describe 'Error pages' do
       expect(response).to have_http_status(:internal_server_error)
     end
   end
+
+  context 'unauthorized' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/unauthorized'
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -34,5 +34,17 @@ RSpec.describe 'Error pages' do
       get '/errors/unauthorized'
       expect(response).to have_http_status(:ok)
     end
+
+    context 'when the sign in fails' do
+      before do
+        allow(OmniAuth.config).to receive(:test_mode).and_return(false)
+        allow_any_instance_of(LaaPortalSetup).to receive(:setup).and_raise(StandardError)
+      end
+
+      it 'redirects to the home' do
+        post saml_authorize_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,11 @@
+module AuthenticationHelpers
+  def sign_in(provider = double('provider'))
+    login_as(provider)
+    allow(controller).to receive(:current_user).and_return(provider)
+  end
+
+  def sign_out
+    logout
+    allow(controller).to receive(:current_user).and_return(nil)
+  end
+end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    OmniAuth.configure do |omniauth_config|
+      omniauth_config.logger = Rails.logger
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Basic SAML auth against LAA Portal (for now using a mock they've deployed that clearly is lacking some stuff).

Using Omniauth with Warden. Not using Devise just yet as it might not be necessary and also I wanted to focus this spike/code on the actual SAML strategy and IdP metadata, and not so much on the handling of the users (aka providers), if these have to be persisted to DB or not, etc.

Clearly some kinks to iron out, error messages and such... Also currently not using certificate for the metadata, we probably need that for any environment other than the mock.

NOTE: on localhost "real" SAML auth is disabled. So if you check out the branch, you are using out of the box a mock.

Define `OMNIAUTH_TEST_MODE=false` in your `.env.development.local` (and restart server) to perform real calls to the IdP.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-235

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1025" alt="Screenshot 2022-12-08 at 13 42 17" src="https://user-images.githubusercontent.com/687910/206461422-e79ce53a-5884-4209-88cc-0db9a3f7b472.png">
<img width="1041" alt="Screenshot 2022-12-08 at 13 42 42" src="https://user-images.githubusercontent.com/687910/206461432-6c825b0e-4858-4699-a7bd-139edc8b7fe8.png">
<img width="1041" alt="Screenshot 2022-12-08 at 15 08 45" src="https://user-images.githubusercontent.com/687910/206481976-ffaf60a8-e470-46a0-891f-41d4f33a2a50.png">


## How to manually test the feature
