### PR TITLE
Force omniauth test mode on staging for now

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -15,7 +15,7 @@ class ErrorsController < ApplicationController
   end
 
   def unauthorized
-    respond_with_status(:ok)
+    respond_with_status(:forbidden)
   end
 
   def unhandled

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -10,5 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   # Datastore endpoint for staging
   DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
-  # LAA Portal metadata endpoint (for now, we use the dev mock)
+  # LAA Portal metadata endpoint
+  # (not accessible from inside CP it seems, using test mode for now)
   LAA_PORTAL_IDP_METADATA_URL: https://samlmock.dev.legalservices.gov.uk/metadata
+  OMNIAUTH_TEST_MODE: true

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Error pages' do
   context 'unauthorized' do
     it 'renders the expected page and has expected status code' do
       get '/errors/unauthorized'
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:forbidden)
     end
 
     context 'when the sign in fails' do


### PR DESCRIPTION
## Description of change
The metadata endpoint to configure the SAML requests is not accessible from inside the CP, so for now, disabling it so staging can be used as normally.
