### PR TITLE
Fix config map value

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -13,4 +13,4 @@ data:
   # LAA Portal metadata endpoint
   # (not accessible from inside CP it seems, using test mode for now)
   LAA_PORTAL_IDP_METADATA_URL: https://samlmock.dev.legalservices.gov.uk/metadata
-  OMNIAUTH_TEST_MODE: true
+  OMNIAUTH_TEST_MODE: "true"


### PR DESCRIPTION
It seems `true` value needs to be quoted. Oh well.
