### PR TITLE
Add a simple system test for the auth flow

### DIFF
--- a/app/lib/laa_portal_setup.rb
+++ b/app/lib/laa_portal_setup.rb
@@ -35,13 +35,8 @@ class LaaPortalSetup
       info: {
         name: 'test-user',
         email: 'test@example.com',
-      },
-      extra: {
-        raw_info: {
-          USER_EMAIL: 'test@example.com',
-          LAA_APP_ROLES: ['CCR_CCRGradeA1'],
-          LAA_ACCOUNTS: ['1A123B'],
-        }
+        roles: ['CCR_CCRGradeA1'],
+        office_codes: ['1A123B'],
       }
     )
   end

--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -5,7 +5,7 @@
       <li class="govuk-header__navigation-item">
         <%= link_to t('.your_applications'), crime_applications_path, class: 'govuk-header__link' %>
       </li>
-      <li class="govuk-header__navigation-item">
+      <li class="govuk-header__navigation-item app-header__auth-user">
         <%= current_user.name %>
       </li>
       <li class="govuk-header__navigation-item">

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,9 @@ RSpec.configure do |config|
   # For specific scenarios, the user can be "signed off".
   config.before(:each, type: :controller) { sign_in }
   config.before(:all, type: :request) { get saml_authorize_callback_path }
+
+  # Use the faster rack test by default for system specs
+  config.before(:each, type: :system) { driven_by :rack_test }
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,8 @@
+# Allow connections to webdriver urls
+#
+driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
+
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: driver_urls,
+)

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Sign in user journey' do
+  before do
+    visit '/'
+    click_on 'Start now'
+  end
+
+  context 'user is not signed in' do
+    it 'redirects to the unauthorized page' do
+      expect(current_url).to match('/errors/unauthorized')
+      expect(page).to have_content('Access restricted')
+    end
+  end
+
+  context 'user is signed in' do
+    before do
+      click_button 'Sign in with LAA Portal'
+    end
+
+    it 'authenticates the user and redirect to the dashboard' do
+      expect(current_url).to match(crime_applications_path)
+    end
+
+    it 'renders the user menu in the header' do
+      expect(page).to have_css('nav.govuk-header__navigation')
+      expect(page).to have_css('.app-header__auth-user', text: 'test-user')
+      expect(page).to have_button('Sign out')
+    end
+
+    it 'on sign out it redirects to the home' do
+      click_button 'Sign out'
+
+      expect(current_url).to match(root_path)
+      expect(page).not_to have_css('nav.govuk-header__navigation')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This is just using Omniauth in test mode with a mocked auth response, but at least covers a bit of the user-flow that is more difficult to test through unit tests or request tests.
