### PR TITLE
CRIMAP-244 Retry application submission failures

### DIFF
--- a/app/controllers/concerns/steps/no_op_advance_step.rb
+++ b/app/controllers/concerns/steps/no_op_advance_step.rb
@@ -1,0 +1,25 @@
+module Steps
+  module NoOpAdvanceStep
+    extend ActiveSupport::Concern
+
+    def edit
+      @form_object = Steps::Shared::NoOpForm.build(
+        current_crime_application
+      )
+    end
+
+    def update
+      update_and_advance(
+        Steps::Shared::NoOpForm, as: advance_as
+      )
+    end
+
+    private
+
+    # :nocov:
+    def advance_as
+      raise 'implement in controllers using this concern'
+    end
+    # :nocov:
+  end
+end

--- a/app/controllers/steps/submission/failure_controller.rb
+++ b/app/controllers/steps/submission/failure_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Submission
+    class FailureController < Steps::SubmissionStepController
+      include Steps::NoOpAdvanceStep
+
+      private
+
+      def advance_as
+        :submission_retry
+      end
+    end
+  end
+end

--- a/app/forms/steps/shared/no_op_form.rb
+++ b/app/forms/steps/shared/no_op_form.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Shared
+    class NoOpForm < Steps::BaseFormObject
+      # NOTE: steps using this form do not persist anything to DB.
+      # It is only used to advance in the decision tree.
+      # Normally used through the `Steps::NoOpAdvanceStep` concern.
+      #
+      def persist!
+        true
+      end
+    end
+  end
+end

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -4,7 +4,7 @@ module Decisions
       case step_name
       when :review
         edit(:declaration)
-      when :declaration
+      when :declaration, :submission_retry
         submit_application
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
@@ -20,9 +20,7 @@ module Decisions
       if ApplicationSubmission.new(current_crime_application).call
         show(:confirmation, reference:)
       else
-        # TODO: we need a more user-friendly unhappy path
-        # for when the submission or datastore fail
-        show('/errors', action: :unhandled, id: nil)
+        edit(:failure)
       end
     end
   end

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -48,7 +48,7 @@
         <%= f.govuk_check_box :declaration_signed, 1, 0, multiple: false, link_errors: true %>
       <% end %>
 
-      <%= f.continue_button %>
+      <%= f.continue_button(primary: :save_and_submit) %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/submission/failure/edit.html.erb
+++ b/app/views/steps/submission/failure/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading')%>
+    </h1>
+
+    <p class="govuk-body">
+      <%= t('.lead_text') %>
+    </p>
+    <p class="govuk-body">
+      <%= t('.info_text') %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      <%= t('.contact_helpline_html', helpline_url: about_contact_path) %>
+    </p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.continue_button(primary: :try_again, secondary: nil) %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= link_to t('.back_to_applications'), crime_applications_path %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -12,7 +12,9 @@ en:
     submit:
       save_and_continue: Save and continue
       save_and_come_back_later: Save and come back later
+      save_and_submit: Save and submit application
       find_address: Find address
+      try_again: Try again
 
     legend:
       steps_client_has_partner_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -160,3 +160,11 @@ en:
           page_title: Application submitted
           view_application: View completed application
           back_to_applications: Back to all applications
+      failure:
+        edit:
+          page_title: Application submission failed
+          heading: Sorry, there is a problem with the service
+          lead_text: We cannot connect to our database. This means you cannot submit applications in progress, or view returned and submitted applications.
+          info_text: We have saved your latest application in progress.
+          contact_helpline_html: <a href="%{helpline_url}">Contact the criminal applications helpline</a> if you need to get an update on submitted applications.
+          back_to_applications: Back to all applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
       namespace :submission do
         edit_step :review
         edit_step :declaration
+        edit_step :failure
         show_step :confirmation
       end
     end

--- a/spec/controllers/steps/submission/failure_controller_spec.rb
+++ b/spec/controllers/steps/submission/failure_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::FailureController, type: :controller do
+  it_behaves_like 'a no-op advance step controller', :submission_retry, Decisions::SubmissionDecisionTree
+end

--- a/spec/forms/steps/shared/no_op_form_spec.rb
+++ b/spec/forms/steps/shared/no_op_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Shared::NoOpForm do
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    { crime_application: }
+  end
+
+  let(:crime_application) do
+    instance_double(CrimeApplication)
+  end
+
+  describe '#save' do
+    it 'does not perform any operation, it only returns true' do
+      expect(subject.save).to be(true)
+    end
+  end
+end

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -57,8 +57,18 @@ RSpec.describe Decisions::SubmissionDecisionTree do
       context 'when the submission was unsuccessful' do
         let(:submission_success) { false }
 
-        it { is_expected.to have_destination('/errors', :unhandled, id: nil) }
+        it { is_expected.to have_destination(:failure, :edit, id: crime_application) }
       end
+    end
+  end
+
+  context 'when the step is `submission_retry`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :submission_retry }
+
+    it 'retries the submission of the application' do
+      expect(subject).to receive(:submit_application)
+      subject.destination
     end
   end
 end


### PR DESCRIPTION
## Description of change
This builds on the back of some previous work we had to handle submission errors, but we were redirecting the user to a generic "unhandled error" page.

Now we have a proper design and content for this error page, and also as per service designer, the `Try again` button will re-try the submission, without taking the user back to the `declaration` page.

The user can keep re-trying as many times as they want, or click `back` link to go to the declaration page, or `Back to all applications` to go to the dashboard.

Also as part of this, a minor copy change to the declaration primary button was done, as per ticket CRIMAP-242.

NOTE: I've introduced a `Steps::NoOpAdvanceStep` concern as well as a `NoOpForm` to be used in controllers that don't persist anything, and are only used to control flow by "advancing". I will raise a separate PR to use this in a few other places to DRY code.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-244
https://dsdmoj.atlassian.net/browse/CRIMAP-242

## Notes for reviewer
The `contact helpline` link goes to the footer contact page, which at the moment is just a placeholder with no content. There are separate tickets to review content of footer pages, etc.

## Screenshots of changes (if applicable)
<img width="752" alt="Screenshot 2022-12-13 at 11 34 13" src="https://user-images.githubusercontent.com/687910/207311237-4fe14302-cd48-4b0b-8c26-c45f20350965.png">
<img width="769" alt="Screenshot 2022-12-13 at 11 34 03" src="https://user-images.githubusercontent.com/687910/207311269-cc8663f5-5f7a-466a-afd6-e3966eb3cf6f.png">

## How to manually test the feature
Shut down the local datastore to force erroring. Go all the way to the declaration page, see the primary button label has changed. Submit the application. It will fail, and will allow to retry, etc.