### PR TITLE
CRIMAP-236 Reimplement dashboard counters

### DIFF
--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -4,15 +4,6 @@ class CompletedApplicationsController < DashboardController
 
   def index
     @applications = applications_from_datastore
-
-    @in_progress_applications_count = CrimeApplication.in_progress
-                                                      .joins(:people)
-                                                      .includes(:applicant)
-                                                      .merge(Applicant.with_name)
-                                                      .count
-
-    # TODO: counter not yet coming from datastore
-    @returned_applications_count = CrimeApplication.returned.count
   end
 
   def show

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -3,15 +3,9 @@ class CrimeApplicationsController < DashboardController
                 :present_crime_application, only: [:edit, :destroy, :confirm_destroy]
 
   def index
-    # TODO: scope will change as we know more
-    @applications = CrimeApplication
-                    .in_progress
-                    .joins(:people)
-                    .includes(:applicant)
-                    .merge(Applicant.with_name)
-                    .merge(CrimeApplication.order(created_at: :desc))
-
-    @returned_applications_count = CrimeApplication.returned.count
+    @applications = in_progress_scope.merge(
+      CrimeApplication.order(created_at: :desc)
+    )
   end
 
   def create

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,9 +1,28 @@
 class DashboardController < ApplicationController
+  helper_method :in_progress_count, :submitted_count, :returned_count
+  delegate :submitted_count, :returned_count, to: :application_counters
+
+  def in_progress_count
+    in_progress_scope.count
+  end
+
   private
+
+  # TODO: filter by provider's office code
+  def in_progress_scope
+    CrimeApplication.in_progress
+                    .joins(:people)
+                    .includes(:applicant)
+                    .merge(Applicant.with_name)
+  end
 
   def present_crime_application
     @crime_application = helpers.present(
       current_crime_application, CrimeApplicationPresenter
     )
+  end
+
+  def application_counters
+    @application_counters ||= Datastore::ApplicationCounters.new
   end
 end

--- a/app/services/datastore/application_counters.rb
+++ b/app/services/datastore/application_counters.rb
@@ -1,0 +1,30 @@
+module Datastore
+  class ApplicationCounters
+    FALLBACK_COUNT = 0
+
+    def submitted_count
+      @submitted_count ||= count(ApplicationStatus::SUBMITTED)
+    end
+
+    def returned_count
+      @returned_count ||= count(ApplicationStatus::RETURNED)
+    end
+
+    private
+
+    def count(status)
+      result = DatastoreApi::Requests::ListApplications.new(
+        status: status.to_s, limit: 1
+      ).call
+
+      result.pagination.fetch('total')
+    rescue StandardError => e
+      Rails.logger.error(e)
+      Sentry.capture_exception(e)
+
+      # Fallback to `zero`, but do not blow up.
+      # As per locales, it will not show counter on the tab.
+      FALLBACK_COUNT
+    end
+  end
+end

--- a/app/views/completed_applications/index.html.erb
+++ b/app/views/completed_applications/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'shared/dashboard_header' %>
 
-<%= render partial: 'shared/subnavigation', locals: { in_progress_count: @in_progress_applications_count, returned_applications_count: @returned_applications_count } %>
+<%= render partial: 'shared/subnavigation' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'shared/dashboard_header' %>
 
-<%= render partial: 'shared/subnavigation', locals: { in_progress_count: @applications.count, returned_applications_count: @returned_applications_count } %>
+<%= render partial: 'shared/subnavigation' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -1,15 +1,21 @@
 <nav class="moj-sub-navigation" aria-label="Sub navigation">
   <ul class="moj-sub-navigation__list">
     <li class="moj-sub-navigation__item">
-      <%= link_to(t('.in_progress', count: in_progress_count), crime_applications_path, class: 'moj-sub-navigation__link', 'aria-current': ('page' if current_page?(controller: 'crime_applications', action: 'index')).to_s) %>
+      <%= link_to t('.in_progress', count: in_progress_count), crime_applications_path,
+                  class: 'moj-sub-navigation__link',
+                  'aria-current': ('page' if current_page?(controller: 'crime_applications', action: 'index')).to_s %>
     </li>
 
     <li class="moj-sub-navigation__item">
-      <%= link_to(t('.submitted'), completed_crime_applications_path, class: 'moj-sub-navigation__link', 'aria-current': ('page' if current_page?(controller: 'completed_applications', action: 'index') && params[:q] != 'returned').to_s) %>
+      <%= link_to t('.submitted', count: submitted_count), completed_crime_applications_path,
+                  class: 'moj-sub-navigation__link',
+                  'aria-current': ('page' if current_page?(controller: 'completed_applications', action: 'index') && params[:q] != 'returned').to_s %>
     </li>
 
     <li class="moj-sub-navigation__item">
-      <%= link_to(t('.returned', count: returned_applications_count), completed_crime_applications_path(q: 'returned'), class: 'moj-sub-navigation__link', 'aria-current': ('page' if current_page?(controller: 'completed_applications', action: 'index', q: 'returned')).to_s) %>
+      <%= link_to t('.returned', count: returned_count), completed_crime_applications_path(q: 'returned'),
+                  class: 'moj-sub-navigation__link',
+                  'aria-current': ('page' if current_page?(controller: 'completed_applications', action: 'index', q: 'returned')).to_s %>
     </li>
   </ul>
 </nav>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -72,7 +72,10 @@ en:
         zero: In progress
         one: In progress (1)
         other: In progress (%{count})
-      submitted: Submitted
+      submitted:
+        zero: Submitted
+        one: Submitted (1)
+        other: Submitted (%{count})
       returned:
         zero: Returned
         one: Returned (1)

--- a/spec/requests/dashboard_lists_spec.rb
+++ b/spec/requests/dashboard_lists_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe 'Dashboard' do
+  # Fixtures used to mock responses from the datastore
+  let(:application_fixture) { LaaCrimeSchemas.fixture(1.0) }
+  let(:application_fixture_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+  let(:returned_application_fixture) { LaaCrimeSchemas.fixture(1.0, name: 'application_returned') }
+  let(:pagination_fixture) { { limit: 20, total: 1, sort: 'desc', next_page_token: nil }.to_json }
+
+  before do
+    allow_any_instance_of(
+      Datastore::ApplicationCounters
+    ).to receive_messages(submitted_count: 99, returned_count: 5)
+  end
+
+  describe 'list of in progress applications' do
+    before :all do
+      # sets up a few test records
+      app1 = CrimeApplication.create(status: 'in_progress', created_at: Date.new(2022, 10, 15))
+      app2 = CrimeApplication.create
+      app3 = CrimeApplication.create
+
+      Applicant.create(crime_application: app1, first_name: 'John', last_name: 'Doe')
+      Applicant.create(crime_application: app2, first_name: '', last_name: '')
+      Applicant.create(crime_application: app3)
+    end
+
+    after :all do
+      # do not leave left overs in the test database
+      CrimeApplication.destroy_all
+    end
+
+    before do
+      get crime_applications_path
+    end
+
+    it 'contains only applications having the applicant name entered' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Your applications'
+
+      assert_select '.moj-sub-navigation__list > li:nth-child(1) > a', text: 'In progress (1)', 'aria-current': 'page'
+      assert_select '.moj-sub-navigation__list > li:nth-child(2) > a', text: 'Submitted (99)'
+      assert_select '.moj-sub-navigation__list > li:nth-child(3) > a', text: 'Returned (5)'
+
+      assert_select 'tbody.govuk-table__body' do
+        assert_select 'tr.govuk-table__row', 1 do
+          assert_select 'a', count: 1, text: 'John Doe'
+          assert_select 'td.govuk-table__cell:nth-of-type(1)', '15 Oct 2022'
+          assert_select 'td.govuk-table__cell:nth-of-type(2)', /[[:digit:]]/
+          assert_select 'td.govuk-table__cell:nth-of-type(3)' do
+            assert_select 'button.govuk-button', count: 1, text: 'Delete'
+          end
+        end
+      end
+
+      expect(response.body).not_to include('Jane Doe')
+    end
+  end
+
+  describe 'list of submitted applications' do
+    let(:collection_fixture) do
+      format(
+        '{"pagination":%<pagination_fixture>s,"records":[%<application_fixture>s]}',
+        pagination_fixture: pagination_fixture,
+        application_fixture: application_fixture.read
+      )
+    end
+
+    before do
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
+        .with(query: hash_including({ 'status' => 'submitted' }))
+        .to_return(body: collection_fixture)
+
+      get completed_crime_applications_path
+    end
+
+    it 'shows a list of submitted applications' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Your applications'
+
+      assert_select '.moj-sub-navigation__list > li:nth-child(1) > a', text: 'In progress'
+      assert_select '.moj-sub-navigation__list > li:nth-child(2) > a', text: 'Submitted (99)', 'aria-current': 'page'
+      assert_select '.moj-sub-navigation__list > li:nth-child(3) > a', text: 'Returned (5)'
+
+      assert_select 'tbody.govuk-table__body' do
+        assert_select 'tr.govuk-table__row', 1 do
+          assert_select 'a', count: 1, text: 'Kit Pound'
+        end
+        assert_select 'td.govuk-table__cell:nth-of-type(1)', '24 Oct 2022'
+        assert_select 'td.govuk-table__cell:nth-of-type(2)', '6000001'
+      end
+    end
+  end
+
+  describe 'list of returned applications' do
+    let(:collection_fixture) do
+      format(
+        '{"pagination":%<pagination_fixture>s,"records":[%<application_fixture>s]}',
+        pagination_fixture: pagination_fixture,
+        application_fixture: returned_application_fixture.read
+      )
+    end
+
+    before do
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
+        .with(query: hash_including({ 'status' => 'returned' }))
+        .to_return(body: collection_fixture)
+
+      get completed_crime_applications_path(q: 'returned')
+    end
+
+    it 'shows a list of returned applications' do
+      expect(response).to have_http_status(:success)
+
+      assert_select 'h1', 'Your applications'
+
+      assert_select '.moj-sub-navigation__list > li:nth-child(1) > a', text: 'In progress'
+      assert_select '.moj-sub-navigation__list > li:nth-child(2) > a', text: 'Submitted (99)'
+      assert_select '.moj-sub-navigation__list > li:nth-child(3) > a', text: 'Returned (5)', 'aria-current': 'page'
+
+      assert_select 'tbody.govuk-table__body' do
+        assert_select 'tr.govuk-table__row', 1 do
+          assert_select 'a', count: 1, text: 'John POTTER'
+        end
+        assert_select 'td.govuk-table__cell:nth-of-type(1)', '27 Sep 2022'
+        assert_select 'td.govuk-table__cell:nth-of-type(2)', '6000002'
+      end
+    end
+  end
+end

--- a/spec/services/datastore/application_counters_spec.rb
+++ b/spec/services/datastore/application_counters_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::ApplicationCounters do
+  subject { described_class.new }
+
+  let(:datastore_result) do
+    '{"pagination":{"total":5},"records":[]}'
+  end
+
+  before do
+    stub_request(:get, 'http://datastore-webmock/api/v1/applications')
+      .with(query: { 'status' => status, 'limit' => 1 })
+      .to_return(body: datastore_result)
+  end
+
+  describe '#submitted_count' do
+    let(:status) { 'submitted' }
+
+    it 'returns total submitted applications' do
+      expect(subject.submitted_count).to eq(5)
+    end
+  end
+
+  describe '#returned_count' do
+    let(:status) { 'returned' }
+
+    it 'returns total returned applications' do
+      expect(subject.returned_count).to eq(5)
+    end
+  end
+
+  context 'handling of errors' do
+    let(:status) { 'submitted' }
+
+    before do
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
+        .with(query: { 'status' => 'submitted', 'limit' => 1 })
+        .to_raise(StandardError)
+
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it 'reports the exception, and returns 0 count' do
+      expect(subject.submitted_count).to eq(0)
+
+      expect(Sentry).to have_received(:capture_exception).with(
+        an_instance_of(StandardError)
+      )
+    end
+  end
+end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe 'Sign in user journey' do
 
   context 'user is signed in' do
     before do
+      allow_any_instance_of(
+        Datastore::ApplicationCounters
+      ).to receive_messages(submitted_count: 99, returned_count: 5)
+
       click_button 'Sign in with LAA Portal'
     end
 


### PR DESCRIPTION
## Description of change
This adds again the counters for `returned` applications, and also additionally `submitted` applications.

Cleanup a lot of code and made it resilient so the whole dashboard will not blow up if the datastore is not available.

NOTE: I've split the `dashboard_spec` into 2, moving the tests related to the application lists to a separate file, as to avoid as much as possible conflicts with a separate open PR.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-236

## Notes for reviewer

## Screenshots of changes (if applicable)
When datastore is available:
<img width="774" alt="Screenshot 2022-12-13 at 17 56 29" src="https://user-images.githubusercontent.com/687910/207551278-49a53379-e85f-4a2f-a51b-cf4d4304a06e.png">

When datastore is not available:
<img width="737" alt="Screenshot 2022-12-13 at 17 56 48" src="https://user-images.githubusercontent.com/687910/207551360-5229bf5e-1a1e-41de-ac0b-52e2fe67d38b.png">

## How to manually test the feature
