### PR TITLE
Fix for `mail` gem latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem 'puma'
 gem 'rails', '~> 7.0.3'
 gem 'uk_postcode'
 
+# Temporarily until 2.8.1 is released
+# https://github.com/mikel/mail/issues/1541
+gem 'mail', '< 2.8.0'
+
 # Authentication
 gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-saml', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,11 +201,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -400,6 +397,7 @@ DEPENDENCIES
   kaminari
   laa-criminal-applications-datastore-api-client!
   laa-criminal-legal-aid-schemas!
+  mail (< 2.8.0)
   omniauth-rails_csrf_protection
   omniauth-saml (~> 2.1.0)
   pg (~> 1.4)


### PR DESCRIPTION
## Description of change
There seems to be some issues with latest version of this gem, which was bumped in previous PR #223.

Locking its version temporarily until 2.8.1 is released.

