### PR TITLE
CRIMAP-40 Confirm office account number

### DIFF
--- a/app/controllers/steps/provider/confirm_office_controller.rb
+++ b/app/controllers/steps/provider/confirm_office_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Provider
+    class ConfirmOfficeController < Steps::ProviderStepController
+      def edit
+        @form_object = ConfirmOfficeForm.new
+      end
+
+      def update
+        update_and_advance(ConfirmOfficeForm, as: :confirm_office)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/provider_step_controller.rb
+++ b/app/controllers/steps/provider_step_controller.rb
@@ -1,0 +1,12 @@
+module Steps
+  class ProviderStepController < BaseStepController
+    skip_before_action :check_crime_application_presence,
+                       :update_navigation_stack
+
+    private
+
+    def decision_tree_class
+      Decisions::ProviderDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/provider/confirm_office_form.rb
+++ b/app/forms/steps/provider/confirm_office_form.rb
@@ -1,0 +1,18 @@
+module Steps
+  module Provider
+    class ConfirmOfficeForm < Steps::BaseFormObject
+      attribute :is_current_office, :value_object, source: YesNoAnswer
+      validates :is_current_office, inclusion: { in: :choices }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        true
+      end
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -2,18 +2,36 @@ class Provider < ApplicationRecord
   devise :lockable, :timeoutable, :trackable,
          :omniauthable, omniauth_providers: %i[saml]
 
-  def self.from_omniauth(auth)
-    find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|
-      record.update(
-        email: auth.info.email,
-        description: auth.info.description,
-        roles: auth.info.roles.split(','),
-        office_codes: auth.info.office_codes.split(','),
-      )
-    end
-  end
+  store_accessor :settings, :selected_office_code
 
   def display_name
     uid
+  end
+
+  class << self
+    def from_omniauth(auth)
+      find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|
+        record.update(
+          email: auth.info.email,
+          description: auth.info.description,
+          roles: auth.info.roles.split(','),
+          office_codes: auth.info.office_codes.split(','),
+        )
+
+        ensure_default_office(record)
+      end
+    end
+
+    private
+
+    # If `selected_office_code` is nil or unknown, it defaults
+    # to the first office code from the returned ones.
+    def ensure_default_office(record)
+      return if record.office_codes.include?(record.selected_office_code)
+
+      record.update(
+        selected_office_code: record.office_codes.first
+      )
+    end
   end
 end

--- a/app/services/decisions/provider_decision_tree.rb
+++ b/app/services/decisions/provider_decision_tree.rb
@@ -1,0 +1,13 @@
+module Decisions
+  class ProviderDecisionTree < BaseDecisionTree
+    def destination
+      case step_name
+      when :confirm_office
+        # TODO: update when we have next step
+        show('/home', action: :index)
+      else
+        raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+  end
+end

--- a/app/views/steps/provider/confirm_office/edit.html.erb
+++ b/app/views/steps/provider/confirm_office/edit.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :is_current_office, @form_object.choices, :value, inline: false,
+                                           legend: {
+                                             tag: 'h1', size: 'xl',
+                                             text: t('.current_office_legend',
+                                                     office_code: current_provider.selected_office_code)
+                                           } %>
+
+      <%= f.continue_button(secondary: false) %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -30,6 +30,10 @@ en:
   activemodel:
     errors:
       models:
+        steps/provider/confirm_office_form:
+          attributes:
+            is_current_office:
+              inclusion: Select yes if this is your office account number
         steps/client/has_partner_form:
           attributes:
             client_has_partner:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -77,6 +77,10 @@ en:
         other_justification: *ioj_justification_hint
 
     label:
+      steps_provider_confirm_office_form:
+        is_current_office_options:
+          'yes': 'Yes'
+          'no': 'No, another office is handling this application'
       steps_client_has_partner_form:
         client_has_partner_options: *YESNO
       steps_client_details_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -4,6 +4,12 @@ en:
     shared:
       offence_class: Class %{class}
 
+    provider:
+      confirm_office:
+        edit:
+          page_title: Confirm office account number
+          current_office_legend: Is %{office_code} your office account number?
+
     client:
       has_partner:
         edit:
@@ -31,7 +37,7 @@ en:
         edit:
           page_title: Client’s contact details
           heading: Enter your client’s contact details
-    
+
     dwp:
       confirm_result:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :steps do
+    namespace :provider do
+      edit_step :confirm_office
+    end
+  end
+
   scope 'applications/:id' do
     namespace :steps do
       namespace :client do

--- a/spec/controllers/steps/provider/confirm_office_controller_spec.rb
+++ b/spec/controllers/steps/provider/confirm_office_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Provider::ConfirmOfficeController, type: :controller do
+  describe '#edit' do
+    it 'responds with HTTP success' do
+      get :edit
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#update' do
+    let(:form_class) { Steps::Provider::ConfirmOfficeForm }
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) { { form_class_params_name => { foo: 'bar' } } }
+
+    before do
+      allow(form_class).to receive(:new).and_return(form_object)
+    end
+
+    context 'when the form saves successfully' do
+      before do
+        expect(form_object).to receive(:save).and_return(true)
+      end
+
+      let(:decision_tree) do
+        instance_double(Decisions::ProviderDecisionTree, destination: '/expected_destination')
+      end
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(Decisions::ProviderDecisionTree).to receive(:new).and_return(decision_tree)
+
+        put :update, params: expected_params
+
+        expect(response).to have_http_status(:redirect)
+        expect(subject).to redirect_to('/expected_destination')
+      end
+    end
+
+    context 'when the form fails to save' do
+      before do
+        expect(form_object).to receive(:save).and_return(false)
+      end
+
+      it 'renders the question page again' do
+        put :update, params: expected_params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/provider/confirm_office_form_spec.rb
+++ b/spec/forms/steps/provider/confirm_office_form_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Provider::ConfirmOfficeForm do
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    { is_current_office: }
+  end
+
+  let(:is_current_office) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `is_current_office` is not provided' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:is_current_office, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `is_current_office` is not valid' do
+      let(:is_current_office) { 'maybe' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:is_current_office, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when form is valid' do
+      let(:is_current_office) { 'yes' }
+
+      it 'returns true' do
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/decisions/provider_decision_tree_spec.rb
+++ b/spec/services/decisions/provider_decision_tree_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Decisions::ProviderDecisionTree do
+  subject { described_class.new(form_object, as: step_name) }
+
+  before do
+    allow(
+      form_object
+    ).to receive(:crime_application).and_return(nil)
+  end
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `confirm_office`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :confirm_office }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination('/home', :index, id: nil) }
+    end
+  end
+end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Sign in user journey' do
+  # Do not leave left overs, as this test will persist
+  # a mock provider to the database
+  before(:all) do
+    Provider.destroy_all
+  end
+
+  after(:all) do
+    Provider.destroy_all
+  end
+
   before do
     visit '/'
     click_on 'Start now'


### PR DESCRIPTION
## Description of change
First part of the provider's office account selection.

Currently this is not yet hooked to the general flow. That will come in a separate PR.

Usual controller, form object, decision tree, etc. New `provider` namespace and decision tree to separate concerns. Only difference here is that at any point in these steps we will have a `current_crime_application` as these steps come before the creation of the application.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-40

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="833" alt="Screenshot 2022-12-19 at 12 23 41" src="https://user-images.githubusercontent.com/687910/208427802-edd97cb7-fb16-4304-9d50-067646774f60.png">


## How to manually test the feature
For now, the only way to test this is to be signed in and access the URL directly: `/steps/provider/confirm_office`