### PR TITLE
CRIMAP-41 Select office code from a list

### DIFF
--- a/app/controllers/steps/provider/select_office_controller.rb
+++ b/app/controllers/steps/provider/select_office_controller.rb
@@ -1,0 +1,17 @@
+module Steps
+  module Provider
+    class SelectOfficeController < Steps::ProviderStepController
+      def edit
+        @form_object = SelectOfficeForm.new(
+          record: current_provider
+        )
+      end
+
+      def update
+        update_and_advance(
+          SelectOfficeForm, record: current_provider, as: :select_office
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/provider/select_office_form.rb
+++ b/app/forms/steps/provider/select_office_form.rb
@@ -1,0 +1,20 @@
+module Steps
+  module Provider
+    class SelectOfficeForm < Steps::BaseFormObject
+      attribute :office_code, :string
+      validates :office_code, inclusion: { in: :choices }
+
+      def choices
+        record.office_codes
+      end
+
+      private
+
+      def persist!
+        record.update(
+          selected_office_code: office_code
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/provider_decision_tree.rb
+++ b/app/services/decisions/provider_decision_tree.rb
@@ -3,11 +3,26 @@ module Decisions
     def destination
       case step_name
       when :confirm_office
-        # TODO: update when we have next step
-        show('/home', action: :index)
+        after_confirm_office
+      when :select_office
+        dashboard_url
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
+    end
+
+    private
+
+    def after_confirm_office
+      if form_object.is_current_office.yes?
+        dashboard_url
+      else
+        edit(:select_office)
+      end
+    end
+
+    def dashboard_url
+      show('/crime_applications', action: :index)
     end
   end
 end

--- a/app/views/steps/provider/confirm_office/edit.html.erb
+++ b/app/views/steps/provider/confirm_office/edit.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% step_header(path: root_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/provider/select_office/edit.html.erb
+++ b/app/views/steps/provider/select_office/edit.html.erb
@@ -1,0 +1,16 @@
+<% title t('.page_title') %>
+<% step_header(path: edit_steps_provider_confirm_office_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :office_code, @form_object.choices,
+                                           :to_s, :to_s, inline: false,
+                                           legend: { tag: 'h1', size: 'xl' } %>
+
+      <%= f.continue_button(secondary: false) %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,1 +1,0 @@
-I18n.load_path = I18n.load_path + Dir[File.expand_path('config/locales') + '/**/*.yml']

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -2,12 +2,13 @@
 
 # NOTE: many of devise default locales are not used in our current
 # implementation. I've cleaned many of these.
+# Empty quotes will make Devise not show that flash message.
 #
 ---
 en:
   devise:
     failure:
-      already_authenticated: "You are already signed in."
+      already_authenticated: ""
       locked: "Your account is locked."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in before continuing."
@@ -15,6 +16,6 @@ en:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
     sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
+      signed_in: ""
+      signed_out: ""
+      already_signed_out: ""

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -34,6 +34,10 @@ en:
           attributes:
             is_current_office:
               inclusion: Select yes if this is your office account number
+        steps/provider/select_office_form:
+          attributes:
+            office_code:
+              inclusion: Select an office account number from the list
         steps/client/has_partner_form:
           attributes:
             client_has_partner:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -17,6 +17,8 @@ en:
       try_again: Try again
 
     legend:
+      steps_provider_select_office_form:
+        office_code: Select your office account number
       steps_client_has_partner_form:
         client_has_partner: Does your client have a partner?
       steps_client_details_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -9,6 +9,9 @@ en:
         edit:
           page_title: Confirm office account number
           current_office_legend: Is %{office_code} your office account number?
+      select_office:
+        edit:
+          page_title: Select office account number
 
     client:
       has_partner:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   namespace :steps do
     namespace :provider do
       edit_step :confirm_office
+      edit_step :select_office
     end
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       RAILS_SERVE_STATIC_FILES: "1"
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
+      OMNIAUTH_TEST_MODE: "true"
     ports:
       - "3000:3000"
     depends_on:

--- a/spec/controllers/steps/provider/select_office_controller_spec.rb
+++ b/spec/controllers/steps/provider/select_office_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Provider::SelectOfficeController, type: :controller do
+  let(:provider) { Provider.new }
+
+  before do
+    allow(controller).to receive(:current_provider).and_return(provider)
+  end
+
+  describe '#edit' do
+    it 'responds with HTTP success' do
+      get :edit
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#update' do
+    let(:form_class) { Steps::Provider::SelectOfficeForm }
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) do
+      { form_class_params_name => { foo: 'bar' } }
+    end
+
+    before do
+      allow(form_class).to receive(:new).and_return(form_object)
+    end
+
+    context 'when the form saves successfully' do
+      before do
+        expect(form_object).to receive(:save).and_return(true)
+      end
+
+      let(:decision_tree) { instance_double(Decisions::ProviderDecisionTree, destination: '/expected_destination') }
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(Decisions::ProviderDecisionTree).to receive(:new).and_return(decision_tree)
+
+        put :update, params: expected_params
+
+        expect(response).to have_http_status(:redirect)
+        expect(subject).to redirect_to('/expected_destination')
+      end
+    end
+
+    context 'when the form fails to save' do
+      before do
+        expect(form_object).to receive(:save).and_return(false)
+      end
+
+      it 'renders the question page again' do
+        put :update, params: expected_params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/provider/select_office_form_spec.rb
+++ b/spec/forms/steps/provider/select_office_form_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Provider::SelectOfficeForm do
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      record: provider_record,
+      office_code: office_code,
+    }
+  end
+
+  let(:office_code) { nil }
+  let(:provider_record) do
+    instance_double(Provider, office_codes: %w[1A123B 2A555X])
+  end
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq(%w[1A123B 2A555X])
+    end
+  end
+
+  describe '#save' do
+    context 'when `office_code` is not provided' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:office_code, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `office_code` is not valid' do
+      let(:is_current_office) { 'XYZ321' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:office_code, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when form is valid' do
+      let(:office_code) { '1A123B' }
+
+      it 'saves the record' do
+        expect(provider_record).to receive(:update).with(
+          { selected_office_code: office_code }
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/decisions/provider_decision_tree_spec.rb
+++ b/spec/services/decisions/provider_decision_tree_spec.rb
@@ -12,11 +12,28 @@ RSpec.describe Decisions::ProviderDecisionTree do
   it_behaves_like 'a decision tree'
 
   context 'when the step is `confirm_office`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', is_current_office:) }
     let(:step_name) { :confirm_office }
 
+    context 'and answer is `yes`' do
+      let(:is_current_office) { YesNoAnswer::YES }
+
+      it { is_expected.to have_destination('/crime_applications', :index, id: nil) }
+    end
+
+    context 'and answer is `no`' do
+      let(:is_current_office) { YesNoAnswer::NO }
+
+      it { is_expected.to have_destination(:select_office, :edit, id: nil) }
+    end
+  end
+
+  context 'when the step is `select_office`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :select_office }
+
     context 'has correct next step' do
-      it { is_expected.to have_destination('/home', :index, id: nil) }
+      it { is_expected.to have_destination('/crime_applications', :index, id: nil) }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Follow-up to PR #231.

Allows the provider to select the office account number from a list. This will persist the selected code to the provider's setting so we don't have to ask again until next login.

Still not integrated in the wider journey, this will come as a separate PR.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-41

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="838" alt="Screenshot 2022-12-19 at 15 23 42" src="https://user-images.githubusercontent.com/687910/208460710-f8c418f3-2f7a-4558-a57f-1a6ee1941d07.png">

## How to manually test the feature
Like the other step, in order to test this one, go to `/steps/provider/select_office` manually.