### PR TITLE
CRIMAP-40 Confirm office account on sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,9 +20,4 @@ class ApplicationController < ActionController::Base
       yield(crime_application) if block
     end
   end
-
-  # Where we take the user after sign in
-  def signed_in_root_path(_)
-    crime_applications_path
-  end
 end

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -12,6 +12,14 @@ module Providers
 
     private
 
+    def after_sign_in_path_for(_)
+      if current_provider.multiple_offices?
+        edit_steps_provider_confirm_office_path
+      else
+        crime_applications_path
+      end
+    end
+
     def after_omniauth_failure_path_for(_)
       new_provider_session_path
     end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,6 +8,10 @@ class Provider < ApplicationRecord
     uid
   end
 
+  def multiple_offices?
+    office_codes.size > 1
+  end
+
   class << self
     def from_omniauth(auth)
       find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Provider, type: :model do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      uid: 'test-user',
+      office_codes: office_codes,
+    }
+  end
+
+  let(:office_codes) { %w[A1 B2 C3] }
+
+  describe '#display_name' do
+    it { expect(subject.display_name).to eq('test-user') }
+  end
+
+  describe '#multiple_offices?' do
+    context 'provider has more than 1 office account' do
+      it { expect(subject.multiple_offices?).to be(true) }
+    end
+
+    context 'provider has only 1 office account' do
+      let(:office_codes) { %w[A1] }
+
+      it { expect(subject.multiple_offices?).to be(false) }
+    end
+  end
+end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'Sign in user journey' do
   end
 
   before do
+    allow_any_instance_of(
+      Datastore::ApplicationCounters
+    ).to receive_messages(returned_count: 5)
+
     visit '/'
     click_on 'Start now'
   end
@@ -23,12 +27,8 @@ RSpec.describe 'Sign in user journey' do
     end
   end
 
-  context 'user is signed in' do
+  context 'user is signed in, has multiple accounts' do
     before do
-      allow_any_instance_of(
-        Datastore::ApplicationCounters
-      ).to receive_messages(returned_count: 5)
-
       click_button 'Sign in with LAA Portal'
     end
 
@@ -60,6 +60,20 @@ RSpec.describe 'Sign in user journey' do
 
       expect(current_url).to match(root_path)
       expect(page).not_to have_css('nav.govuk-header__navigation')
+    end
+  end
+
+  context 'user is signed in, only has one account' do
+    before do
+      allow_any_instance_of(
+        Provider
+      ).to receive(:office_codes).and_return(['A1'])
+
+      click_button 'Sign in with LAA Portal'
+    end
+
+    it 'authenticates the user and redirects to the dashboard' do
+      expect(current_url).to match(crime_applications_path)
     end
   end
 end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -32,7 +32,20 @@ RSpec.describe 'Sign in user journey' do
       click_button 'Sign in with LAA Portal'
     end
 
-    it 'authenticates the user and redirect to the dashboard' do
+    it 'authenticates the user and redirects to the office account confirmation page' do
+      expect(current_url).to match(edit_steps_provider_confirm_office_path)
+      expect(page).to have_content('Is 1A123B your office account number?')
+
+      choose('No, another office is handling this application')
+      click_button 'Save and continue'
+
+      expect(current_url).to match(edit_steps_provider_select_office_path)
+
+      expect(page).to have_css('.govuk-radios__label', text: '1A123B')
+      expect(page).to have_css('.govuk-radios__label', text: '2A555X')
+
+      choose('2A555X')
+      click_button 'Save and continue'
       expect(current_url).to match(crime_applications_path)
     end
 


### PR DESCRIPTION
## Description of change
Wiring up the previous work.

If the provider has more than 1 office account, show the confirmation page (implemented in previous PR #231 and #232) upon signing in.

If provider has only 1 account, do not show this page, and take them directly to the dashboard.

The selected account will persist across logins, but the provider will be asked again to confirm, in case they want to change it.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-40

## How to manually test the feature
The mock has more than one account so it will show these pages. If using a provider account with only 1 account, it will not show.