### PR TITLE
CRIMAP-249 Scope datastore applications by office

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: c957ba1cecee3034d355639f766eac7b2fc699a1
+  revision: 3dc6e047bcbf7ccb23e22ecd5aee7a7d30251730
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct

--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -4,7 +4,7 @@ class CompletedApplicationsController < DashboardController
 
   def index
     @applications = Datastore::GetApplications.new(
-      status: status_filter, **pagination_params
+      status: status_filter, office_code: current_office_code, **pagination_params
     ).call&.page(params[:page])
   end
 
@@ -33,6 +33,14 @@ class CompletedApplicationsController < DashboardController
       page: params[:page],
       per_page: Kaminari.config.default_per_page,
     }
+  end
+
+  def status_filter
+    allowed_statuses = [
+      ApplicationStatus::SUBMITTED, ApplicationStatus::RETURNED
+    ].map(&:to_s)
+
+    allowed_statuses.include?(params[:q]) ? params[:q] : allowed_statuses.first
   end
 
   def current_crime_application

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -29,8 +29,4 @@ class CrimeApplicationsController < DashboardController
   end
 
   def confirm_destroy; end
-
-  def status_filter
-    'in_progress'
-  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,19 +2,15 @@ class DashboardController < ApplicationController
   helper_method :in_progress_count, :returned_count, :status_filter
   delegate :returned_count, to: :application_counters
 
+  private
+
   def in_progress_count
     in_progress_scope.count
   end
 
   def status_filter
-    allowed_statuses = [
-      ApplicationStatus::SUBMITTED, ApplicationStatus::RETURNED
-    ].map(&:to_s)
-
-    allowed_statuses.include?(params[:q]) ? params[:q] : allowed_statuses.first
+    ApplicationStatus::IN_PROGRESS.to_s
   end
-
-  private
 
   def in_progress_scope
     CrimeApplication.where(office_code: current_office_code)
@@ -30,6 +26,8 @@ class DashboardController < ApplicationController
   end
 
   def application_counters
-    @application_counters ||= Datastore::ApplicationCounters.new
+    @application_counters ||= Datastore::ApplicationCounters.new(
+      office_code: current_office_code
+    )
   end
 end

--- a/app/services/datastore/application_counters.rb
+++ b/app/services/datastore/application_counters.rb
@@ -3,6 +3,12 @@ module Datastore
     PER_PAGE_LIMIT = 1
     FALLBACK_COUNT = 0
 
+    attr_reader :office_code
+
+    def initialize(office_code:)
+      @office_code = office_code
+    end
+
     def returned_count
       @returned_count ||= count(ApplicationStatus::RETURNED)
     end
@@ -11,7 +17,7 @@ module Datastore
 
     def count(status)
       result = DatastoreApi::Requests::ListApplications.new(
-        status: status.to_s, per_page: PER_PAGE_LIMIT
+        status: status.to_s, office_code: office_code, per_page: PER_PAGE_LIMIT
       ).call
 
       result.pagination.fetch('total_count')

--- a/app/services/datastore/get_applications.rb
+++ b/app/services/datastore/get_applications.rb
@@ -1,18 +1,16 @@
 module Datastore
   class GetApplications
-    def initialize(status: nil, page: nil, per_page: nil, sort: nil)
+    attr_reader :status, :office_code, :pagination
+
+    def initialize(status:, office_code:, **pagination)
       @status = status
-      @page = page
-      @per_page = per_page
-      @sort = sort
+      @office_code = office_code
+      @pagination = pagination
     end
 
     def call
       result = DatastoreApi::Requests::ListApplications.new(
-        status: @status,
-        page: @page,
-        per_page: @per_page,
-        sort: @sort
+        status:, office_code:, **pagination
       ).call
 
       Kaminari.paginate_array(result, total_count: result.pagination['total_count'])

--- a/spec/services/datastore/application_counters_spec.rb
+++ b/spec/services/datastore/application_counters_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Datastore::ApplicationCounters do
-  subject { described_class.new }
+  subject { described_class.new(office_code: 'XYZ') }
+
+  let(:expected_query) do
+    { 'status' => status, 'office_code' => 'XYZ', 'per_page' => 1 }
+  end
 
   let(:datastore_result) do
     '{"pagination":{"total_count":5},"records":[]}'
@@ -9,7 +13,7 @@ RSpec.describe Datastore::ApplicationCounters do
 
   before do
     stub_request(:get, 'http://datastore-webmock/api/v2/applications')
-      .with(query: { 'status' => status, 'per_page' => 1 })
+      .with(query: expected_query)
       .to_return(body: datastore_result)
   end
 
@@ -26,7 +30,7 @@ RSpec.describe Datastore::ApplicationCounters do
 
     before do
       stub_request(:get, 'http://datastore-webmock/api/v2/applications')
-        .with(query: { 'status' => status, 'per_page' => 1 })
+        .with(query: expected_query)
         .to_raise(StandardError)
 
       allow(Sentry).to receive(:capture_exception)

--- a/spec/services/datastore/get_applications_spec.rb
+++ b/spec/services/datastore/get_applications_spec.rb
@@ -1,11 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Datastore::GetApplications do
-  subject { described_class.new(status:, per_page:, page:) }
+  subject { described_class.new(status:, office_code:, per_page:, page:) }
 
   let(:status) { 'submitted' }
+  let(:office_code) { 'XYZ' }
   let(:per_page) { 1 }
   let(:page) { 1 }
+
+  let(:expected_query) do
+    { 'status' => status, 'office_code' => office_code, 'per_page' => per_page, 'page' => page }
+  end
 
   let(:datastore_result) do
     '{"pagination":{"total_count":5},"records":[]}'
@@ -13,7 +18,7 @@ RSpec.describe Datastore::GetApplications do
 
   before do
     stub_request(:get, 'http://datastore-webmock/api/v2/applications')
-      .with(query: { 'status' => status, 'per_page' => per_page, 'page' => page, 'sort' => nil })
+      .with(query: expected_query)
       .to_return(body: datastore_result)
   end
 
@@ -26,7 +31,7 @@ RSpec.describe Datastore::GetApplications do
   context 'handling of errors' do
     before do
       stub_request(:get, 'http://datastore-webmock/api/v2/applications')
-        .with(query: { 'status' => status, 'per_page' => per_page, 'page' => page, 'sort' => nil })
+        .with(query: expected_query)
         .to_raise(StandardError)
 
       allow(Sentry).to receive(:capture_exception)


### PR DESCRIPTION
## Description of change
Similar to previous PR #234, this one will propagate the `office_code` query param to perform the scoping in the datastore API. Also the counters has been adapted.

Bumped schemas gem that includes the new `office_code` attribute.

NOTE: the filter will not have any effect until the datastore endpoint is updated to perform the scoping using this new query param.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-249

