### PR TITLE
Show office list on sign in if no office is selected

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -13,11 +13,7 @@ module Providers
     private
 
     def after_sign_in_path_for(_)
-      if current_provider.multiple_offices?
-        edit_steps_provider_confirm_office_path
-      else
-        crime_applications_path
-      end
+      ProviderOfficeRouter.call(current_provider)
     end
 
     def after_omniauth_failure_path_for(_)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -28,13 +28,16 @@ class Provider < ApplicationRecord
 
     private
 
-    # If `selected_office_code` is nil or unknown, it defaults
-    # to the first office code from the returned ones.
+    # If `selected_office_code` is nil or unknown, and there is
+    # only one office returned, it defaults to that office.
+    # If there are more offices, the provider will choose one.
     def ensure_default_office(record)
       return if record.office_codes.include?(record.selected_office_code)
 
       record.update(
-        selected_office_code: record.office_codes.first
+        selected_office_code: (
+          record.office_codes.first unless record.multiple_offices?
+        )
       )
     end
   end

--- a/app/services/provider_office_router.rb
+++ b/app/services/provider_office_router.rb
@@ -1,0 +1,23 @@
+class ProviderOfficeRouter
+  include Rails.application.routes.url_helpers
+
+  attr_reader :provider
+
+  def initialize(provider)
+    @provider = provider
+  end
+
+  def self.call(provider)
+    new(provider).path
+  end
+
+  def path
+    if provider.selected_office_code.blank?
+      edit_steps_provider_select_office_path
+    elsif provider.multiple_offices?
+      edit_steps_provider_confirm_office_path
+    else
+      crime_applications_path
+    end
+  end
+end

--- a/app/views/steps/provider/confirm_office/edit.html.erb
+++ b/app/views/steps/provider/confirm_office/edit.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% step_header(path: root_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/provider/select_office/edit.html.erb
+++ b/app/views/steps/provider/select_office/edit.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% step_header(path: edit_steps_provider_confirm_office_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/requests/dashboard_lists_spec.rb
+++ b/spec/requests/dashboard_lists_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe 'Dashboard' do
     allow_any_instance_of(
       Datastore::ApplicationCounters
     ).to receive_messages(returned_count: 5)
+
+    # Assume we have a signed in Provider,
+    # with a selected office account
+    allow_any_instance_of(
+      Provider
+    ).to receive(:selected_office_code).and_return('1A123B')
   end
 
   describe 'list of in progress applications' do
@@ -79,7 +85,7 @@ RSpec.describe 'Dashboard' do
 
     before do
       stub_request(:get, 'http://datastore-webmock/api/v2/applications')
-        .with(query: hash_including({ 'status' => 'submitted' }))
+        .with(query: hash_including({ 'status' => 'submitted', 'office_code' => '1A123B' }))
         .to_return(body: collection_fixture)
 
       get completed_crime_applications_path
@@ -131,7 +137,7 @@ RSpec.describe 'Dashboard' do
 
     before do
       stub_request(:get, 'http://datastore-webmock/api/v2/applications')
-        .with(query: hash_including({ 'status' => 'returned' }))
+        .with(query: hash_including({ 'status' => 'returned', 'office_code' => '1A123B' }))
         .to_return(body: collection_fixture)
 
       get completed_crime_applications_path(q: 'returned')

--- a/spec/services/provider_office_router_spec.rb
+++ b/spec/services/provider_office_router_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ProviderOfficeRouter do
+  include Rails.application.routes.url_helpers
+
+  subject { described_class.call(provider) }
+
+  let(:provider) { Provider.new(office_codes:, selected_office_code:) }
+  let(:office_codes) { %w[ABC XYZ] }
+  let(:selected_office_code) { nil }
+
+  describe 'redirect path' do
+    context 'when there is no selected office' do
+      it { expect(subject).to eq(edit_steps_provider_select_office_path) }
+    end
+
+    context 'when there is a selected office' do
+      let(:selected_office_code) { 'ABC' }
+
+      context 'and there are multiple offices' do
+        it { expect(subject).to eq(edit_steps_provider_confirm_office_path) }
+      end
+
+      context 'and there is only one office' do
+        let(:office_codes) { %w[ABC] }
+
+        it { expect(subject).to eq(crime_applications_path) }
+      end
+    end
+  end
+end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe 'Sign in user journey' do
 
   context 'user is signed in, has multiple accounts' do
     before do
+      allow_any_instance_of(
+        Provider
+      ).to receive(:selected_office_code).and_return('1A123B')
+
       click_button 'Sign in with LAA Portal'
     end
 


### PR DESCRIPTION
## Description of change
This is a refinement on top of previous PR #233.

When a provider signs in for the first time, if they have multiple offices, we don't set a default one, instead we show them a list of offices for them to select. Subsequents signs in will present them the office confirmation page in case they want to change their selection.

If they only have one office, then we default to that one as before, and do not show them the office selection or confirmation pages.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-41
