### PR TITLE
CRIMAP-224 Collect legal rep details in declaration page

### DIFF
--- a/app/controllers/steps/submission/declaration_controller.rb
+++ b/app/controllers/steps/submission/declaration_controller.rb
@@ -2,13 +2,36 @@ module Steps
   module Submission
     class DeclarationController < Steps::SubmissionStepController
       def edit
-        @form_object = DeclarationForm.build(
-          current_crime_application
+        @form_object = DeclarationForm.new(
+          record: current_provider,
+          crime_application: current_crime_application,
+          **default_values
         )
       end
 
       def update
-        update_and_advance(DeclarationForm, as: :declaration)
+        update_and_advance(
+          DeclarationForm, record: current_provider, as: :declaration
+        )
+      end
+
+      private
+
+      def default_values
+        first_name = current_crime_application.legal_rep_first_name.presence ||
+                     current_provider.legal_rep_first_name
+
+        last_name = current_crime_application.legal_rep_last_name.presence ||
+                    current_provider.legal_rep_last_name
+
+        telephone = current_crime_application.legal_rep_telephone.presence ||
+                    current_provider.legal_rep_telephone
+
+        {
+          legal_rep_first_name: first_name,
+          legal_rep_last_name: last_name,
+          legal_rep_telephone: telephone,
+        }
       end
     end
   end

--- a/app/forms/steps/submission/declaration_form.rb
+++ b/app/forms/steps/submission/declaration_form.rb
@@ -1,13 +1,34 @@
 module Steps
   module Submission
     class DeclarationForm < Steps::BaseFormObject
-      attribute :declaration_signed, :boolean
-      validates :declaration_signed, presence: true
+      attribute :legal_rep_first_name, :string
+      attribute :legal_rep_last_name, :string
+      attribute :legal_rep_telephone, :string
+
+      # Very basic validation to allow numeric and common telephone number symbols
+      TEL_REGEXP = /\A[0-9#+()-.]{7,18}\Z/
+
+      validates :legal_rep_first_name,
+                :legal_rep_last_name,
+                :legal_rep_telephone, presence: true
+
+      validates :legal_rep_telephone,
+                format: { with: TEL_REGEXP }
+
+      def legal_rep_telephone=(str)
+        super(str.delete(' ')) if str
+      end
 
       private
 
       def persist!
+        return true unless changed?
+
         crime_application.update(
+          attributes
+        )
+
+        record.update(
           attributes
         )
       end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -2,7 +2,11 @@ class Provider < ApplicationRecord
   devise :lockable, :timeoutable, :trackable,
          :omniauthable, omniauth_providers: %i[saml]
 
-  store_accessor :settings, :selected_office_code
+  store_accessor :settings,
+                 :selected_office_code,
+                 :legal_rep_first_name,
+                 :legal_rep_last_name,
+                 :legal_rep_telephone
 
   def display_name
     uid

--- a/app/presenters/tasks/declaration.rb
+++ b/app/presenters/tasks/declaration.rb
@@ -12,13 +12,12 @@ module Tasks
       fulfilled?(Ioj)
     end
 
-    # Once the Ioj task is fulfilled, this is always true
     def in_progress?
-      true
+      !!crime_application.legal_rep_first_name
     end
 
     def completed?
-      !!crime_application.declaration_signed
+      crime_application.submitted?
     end
   end
 end

--- a/app/presenters/tasks/review.rb
+++ b/app/presenters/tasks/review.rb
@@ -18,7 +18,9 @@ module Tasks
     end
 
     def completed?
-      fulfilled?(Declaration)
+      crime_application.values_at(
+        :legal_rep_first_name, :legal_rep_last_name, :legal_rep_telephone
+      ).any?
     end
   end
 end

--- a/app/services/datastore/application_amendment.rb
+++ b/app/services/datastore/application_amendment.rb
@@ -19,7 +19,6 @@ module Datastore
         status: ApplicationStatus::IN_PROGRESS.value,
         # we reset some values
         navigation_stack: [],
-        declaration_signed: nil,
         submitted_at: nil,
       )
     end

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -9,15 +9,7 @@
       Confirm the following and submit application
     </h1>
 
-    <p class="govuk-body">You agree that:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>you’ve obtained a signed declaration from my client</li>
-      <li>you’ve provided correct and complete information in this application</li>
-      <li>you’ll share a copy of the completed application with my client</li>
-    </ul>
-
-    <p class="govuk-body govuk-!-margin-top-8">Your client agrees that:</p>
+    <p class="govuk-body">Your client agrees that:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed Hitchcock, Jones and King to represent them</li>
@@ -30,7 +22,7 @@
       <li>they’ll report any changes to their financial situation immediately</li>
     </ul>
 
-    <div class="govuk-warning-text">
+    <div class="govuk-warning-text govuk-!-margin-bottom-0">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
@@ -43,9 +35,19 @@
       </strong>
     </div>
 
+    <p class="govuk-body">You agree that:</p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+      <li>you’ve obtained a signed declaration from your client</li>
+      <li>you’ve provided correct and complete information in this application</li>
+      <li>you’ll share a copy of the completed application with your client</li>
+    </ul>
+
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_check_boxes_fieldset :declaration_signed, multiple: false, legend: { hidden: true } do %>
-        <%= f.govuk_check_box :declaration_signed, 1, 0, multiple: false, link_errors: true %>
+      <%= f.govuk_fieldset legend: { text: t('.legal_representative_legend') } do %>
+        <%= f.govuk_text_field :legal_rep_first_name, autocomplete: 'off', width: 'three-quarters' %>
+        <%= f.govuk_text_field :legal_rep_last_name, autocomplete: 'off', width: 'three-quarters' %>
+        <%= f.govuk_text_field :legal_rep_telephone, autocomplete: 'off', width: 'three-quarters' %>
       <% end %>
 
       <%= f.continue_button(primary: :save_and_submit) %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -193,5 +193,10 @@ en:
               blank: Enter more detail
         steps/submission/declaration_form:
           attributes:
-            declaration_signed:
-              blank: You must confirm that the information on this page is correct in order to submit the application
+            legal_rep_first_name:
+              blank: Enter a first name
+            legal_rep_last_name:
+              blank: Enter a last name
+            legal_rep_telephone:
+              blank: Enter a telephone number
+              invalid: Enter a telephone number in the correct format

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -43,8 +43,6 @@ en:
         hearing_date: Date of next hearing
       steps_case_ioj_form:
         types: Why should your client get legal aid?
-      steps_submission_declaration_form:
-        declaration_signed: Confirm and submit application
 
     hint:
       steps_client_has_partner_form:
@@ -77,6 +75,8 @@ en:
         expert_examination_justification: *ioj_justification_hint
         interest_of_another_justification: *ioj_justification_hint
         other_justification: *ioj_justification_hint
+      steps_submission_declaration_form:
+        legal_rep_telephone: For example, 01632 960 001 or +44 808 157 0192
 
     label:
       steps_provider_confirm_office_form:
@@ -162,5 +162,6 @@ en:
           interest_of_another: It is in the interests of another person (such as the person making a complaint or other witness) that they are represented.
           other: Other
       steps_submission_declaration_form:
-        declaration_signed_options:
-          '1': I, the instructed legal representative, confirm the above is correct.
+        legal_rep_first_name: First name
+        legal_rep_last_name: Last name
+        legal_rep_telephone: Telephone number

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -164,6 +164,7 @@ en:
       declaration:
         edit:
           page_title: Declaration
+          legal_representative_legend: Legal representative
       confirmation:
         show:
           page_title: Application submitted

--- a/db/migrate/20221222105156_remove_declaration_signed_field.rb
+++ b/db/migrate/20221222105156_remove_declaration_signed_field.rb
@@ -1,0 +1,5 @@
+class RemoveDeclarationSignedField < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :crime_applications, :declaration_signed, :boolean
+  end
+end

--- a/db/migrate/20221222105608_add_legal_representative_fields.rb
+++ b/db/migrate/20221222105608_add_legal_representative_fields.rb
@@ -1,0 +1,7 @@
+class AddLegalRepresentativeFields < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :legal_rep_first_name, :string
+    add_column :crime_applications, :legal_rep_last_name, :string
+    add_column :crime_applications, :legal_rep_telephone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_20_114547) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_22_105608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -70,11 +70,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_20_114547) do
     t.string "client_has_partner"
     t.string "status"
     t.datetime "date_stamp"
-    t.boolean "declaration_signed"
     t.datetime "submitted_at"
     t.serial "usn", null: false
     t.string "ioj_passport", default: [], null: false, array: true
     t.string "office_code"
+    t.string "legal_rep_first_name"
+    t.string "legal_rep_last_name"
+    t.string "legal_rep_telephone"
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end

--- a/spec/controllers/steps/submission/declaration_controller_spec.rb
+++ b/spec/controllers/steps/submission/declaration_controller_spec.rb
@@ -1,6 +1,138 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Submission::DeclarationController, type: :controller do
-  it_behaves_like 'a generic step controller', Steps::Submission::DeclarationForm, Decisions::SubmissionDecisionTree
-  it_behaves_like 'a step that can be drafted', Steps::Submission::DeclarationForm
+  let(:form_class) { Steps::Submission::DeclarationForm }
+  let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+
+  let(:provider) { Provider.new }
+
+  before do
+    allow(controller).to receive(:current_provider).and_return(provider)
+  end
+
+  describe '#edit' do
+    context 'when application is not found' do
+      before do
+        # Needed because some specs that include these examples stub current_crime_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_crime_application).and_return(nil)
+      end
+
+      it 'redirects to the application not found error page' do
+        get :edit, params: { id: '12345' }
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when application is found' do
+      let(:existing_case) { CrimeApplication.create(legal_rep_attrs) }
+
+      context 'when application has existing legal rep details' do
+        let(:legal_rep_attrs) do
+          {
+            legal_rep_first_name: 'John',
+            legal_rep_last_name: 'Doe',
+            legal_rep_telephone: '123456789',
+          }
+        end
+
+        it 'uses the application details' do
+          expect(
+            form_class
+          ).to receive(:new).with(
+            record: provider,
+            crime_application: existing_case,
+            **legal_rep_attrs
+          )
+
+          get :edit, params: { id: existing_case }
+          expect(response).to be_successful
+        end
+      end
+
+      context 'when application has no legal rep details' do
+        let(:legal_rep_attrs) { {} }
+        let(:provider_settings) do
+          {
+            legal_rep_first_name: 'Jane',
+            legal_rep_last_name: 'Doe',
+            legal_rep_telephone: '999999999',
+          }
+        end
+
+        let(:provider) { Provider.new(provider_settings) }
+
+        it 'uses the provider details' do
+          expect(
+            form_class
+          ).to receive(:new).with(
+            record: provider,
+            crime_application: existing_case,
+            **provider_settings
+          )
+
+          get :edit, params: { id: existing_case }
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) do
+      { :id => existing_case, form_class_params_name => { foo: 'bar' } }
+    end
+
+    context 'when application is not found' do
+      let(:existing_case) { '12345' }
+
+      before do
+        # Needed because some specs that include these examples stub current_crime_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_crime_application).and_return(nil)
+      end
+
+      it 'redirects to the application not found error page' do
+        put :update, params: expected_params
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when an application in progress is found' do
+      let(:existing_case) { CrimeApplication.create }
+
+      before do
+        allow(form_class).to receive(:new).and_return(form_object)
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          expect(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) { instance_double(Decisions::SubmissionDecisionTree, destination: '/expected_destination') }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(Decisions::SubmissionDecisionTree).to receive(:new).and_return(decision_tree)
+
+          put :update, params: expected_params
+
+          expect(response).to have_http_status(:redirect)
+          expect(subject).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          expect(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the question page again' do
+          put :update, params: expected_params, session: { crime_application_id: existing_case.id }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
 end

--- a/spec/forms/steps/submission/declaration_form_spec.rb
+++ b/spec/forms/steps/submission/declaration_form_spec.rb
@@ -5,34 +5,76 @@ RSpec.describe Steps::Submission::DeclarationForm do
 
   let(:arguments) do
     {
-      crime_application:,
-      declaration_signed:,
+      record: provider_record,
+      crime_application: crime_application,
+      legal_rep_first_name: 'John',
+      legal_rep_last_name: 'Doe',
+      legal_rep_telephone: legal_rep_telephone,
     }
   end
 
+  let(:legal_rep_telephone) { '123456789' }
+  let(:provider_record) { Provider.new(rep_details_attrs) }
   let(:crime_application) { instance_double(CrimeApplication) }
-  let(:declaration_signed) { '1' }
 
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:declaration_signed) }
-
-    context 'when checkbox is not ticked' do
-      let(:declaration_signed) { '0' }
-
-      it 'has a validation error on the field' do
-        expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:declaration_signed, :blank)).to be(true)
-      end
-    end
-  end
+  let(:rep_details_attrs) { {} }
 
   describe '#save' do
-    it 'saves the record' do
-      expect(crime_application).to receive(:update).with(
-        { 'declaration_signed' => true }
-      ).and_return(true)
+    context 'validations' do
+      it { is_expected.to validate_presence_of(:legal_rep_first_name) }
+      it { is_expected.to validate_presence_of(:legal_rep_last_name) }
+      it { is_expected.to validate_presence_of(:legal_rep_telephone) }
 
-      expect(subject.save).to be(true)
+      context 'when `legal_rep_telephone` contains letters' do
+        let(:legal_rep_telephone) { 'not a telephone_number' }
+
+        it 'has a validation error on the field' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:legal_rep_telephone, :invalid)).to be(true)
+        end
+      end
+
+      context 'when `legal_rep_telephone` is valid' do
+        let(:legal_rep_telephone) { '(+44) 55-55.555 #22' }
+
+        it 'removes spaces from input' do
+          expect(subject.legal_rep_telephone).to eq('(+44)55-55.555#22')
+        end
+      end
+    end
+
+    context 'when validations pass' do
+      let(:expected_attrs) do
+        {
+          'legal_rep_first_name' => 'John',
+          'legal_rep_last_name' => 'Doe',
+          'legal_rep_telephone' => '123456789',
+        }
+      end
+
+      context 'when the details have changed' do
+        it 'saves the record' do
+          expect(crime_application).to receive(:update).with(
+            expected_attrs
+          ).and_return(true)
+
+          expect(provider_record).to receive(:update).with(
+            expected_attrs
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when the details have not changed' do
+        let(:rep_details_attrs) { expected_attrs }
+
+        it 'does not save the record but returns true' do
+          expect(crime_application).not_to receive(:update)
+          expect(provider_record).not_to receive(:update)
+          expect(subject.save).to be(true)
+        end
+      end
     end
   end
 end

--- a/spec/presenters/tasks/declaration_spec.rb
+++ b/spec/presenters/tasks/declaration_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe Tasks::Declaration do
   subject { described_class.new(crime_application:) }
 
   let(:crime_application) do
-    instance_double(
-      CrimeApplication,
-      to_param: '12345',
-      declaration_signed: declaration_signed,
+    CrimeApplication.new(
+      legal_rep_first_name:,
+      status:,
     )
   end
 
-  let(:declaration_signed) { nil }
+  let(:legal_rep_first_name) { nil }
+  let(:status) { ApplicationStatus::IN_PROGRESS.to_s }
+
+  before do
+    allow(crime_application).to receive(:id).and_return('12345')
+  end
 
   describe '#path' do
     it { expect(subject.path).to eq('/applications/12345/steps/submission/declaration') }
@@ -44,17 +48,31 @@ RSpec.describe Tasks::Declaration do
   end
 
   describe '#in_progress?' do
-    it { expect(subject.in_progress?).to be(true) }
+    context 'when the `legal_rep_first_name` is nil' do
+      it { expect(subject.in_progress?).to be(false) }
+    end
+
+    context 'when the `legal_rep_first_name` is blank' do
+      let(:legal_rep_first_name) { '' }
+
+      it { expect(subject.in_progress?).to be(true) }
+    end
+
+    context 'when the `legal_rep_first_name` has some value' do
+      let(:legal_rep_first_name) { 'John' }
+
+      it { expect(subject.in_progress?).to be(true) }
+    end
   end
 
   describe '#completed?' do
-    context 'when we have signed the declaration' do
-      let(:declaration_signed) { true }
+    context 'when application is submitted' do
+      let(:status) { ApplicationStatus::SUBMITTED.to_s }
 
       it { expect(subject.completed?).to be(true) }
     end
 
-    context 'when we have not signed yet the declaration' do
+    context 'when application is in_progress' do
       it { expect(subject.completed?).to be(false) }
     end
   end

--- a/spec/presenters/tasks/review_spec.rb
+++ b/spec/presenters/tasks/review_spec.rb
@@ -4,10 +4,19 @@ RSpec.describe Tasks::Review do
   subject { described_class.new(crime_application:) }
 
   let(:crime_application) do
-    instance_double(
-      CrimeApplication,
-      to_param: '12345',
+    CrimeApplication.new(
+      legal_rep_first_name:,
+      legal_rep_last_name:,
+      legal_rep_telephone:,
     )
+  end
+
+  let(:legal_rep_first_name) { nil }
+  let(:legal_rep_last_name) { nil }
+  let(:legal_rep_telephone) { nil }
+
+  before do
+    allow(crime_application).to receive(:id).and_return('12345')
   end
 
   describe '#path' do
@@ -45,23 +54,13 @@ RSpec.describe Tasks::Review do
   end
 
   describe '#completed?' do
-    # We assume the completeness of the Declaration here, as
-    # their statuses are tested in its own spec, no need to repeat
-    before do
-      allow(
-        subject
-      ).to receive(:fulfilled?).with(Tasks::Declaration).and_return(declaration_fulfilled)
-    end
-
-    context 'when the Declaration task has been completed' do
-      let(:declaration_fulfilled) { true }
+    context 'when the Declaration task has some value' do
+      let(:legal_rep_first_name) { 'John' }
 
       it { expect(subject.completed?).to be(true) }
     end
 
-    context 'when the Declaration task has not been completed yet' do
-      let(:declaration_fulfilled) { false }
-
+    context 'when the Declaration task has no values yet' do
       it { expect(subject.completed?).to be(false) }
     end
   end

--- a/spec/services/datastore/application_amendment_spec.rb
+++ b/spec/services/datastore/application_amendment_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Datastore::ApplicationAmendment do
       ).to receive(:update!).with(
         status: :in_progress,
         navigation_stack: [],
-        declaration_signed: nil,
         submitted_at: nil,
       )
 

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Datastore::ApplicationSubmission do
     # create all neccessary records
     app = create_test_application(
       usn: 123,
-      client_has_partner: 'no',
-      declaration_signed: true,
     )
 
     client = Applicant.create(


### PR DESCRIPTION
## Description of change
Adapt the existing declaration page to collect the legal representative details, who is the one signing the declaration.

Removed the previous "check box" as it is no longer used.

These legal rep details are also stored as "settings" of the currently signed in provider, so next time they get to a declaration page on a new application, these details get pre-populated.

If any of the details are changed in a declaration page, the settings are also updated, and will have effect on new applications (not existing ones).

NOTE: integration with the datastore will be done in a separate PR.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-224

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="781" alt="Screenshot 2022-12-22 at 13 48 21" src="https://user-images.githubusercontent.com/687910/209148063-ef004269-8c44-4093-af7a-68c1490df28b.png">

## How to manually test the feature
Go all the way to the declaration. It will be blank the first time, and then for new applications it will pre-populate with previous values. Validation is in place too.