### PR TITLE
Propagate legal representative details to datastore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3dc6e047bcbf7ccb23e22ecd5aee7a7d30251730
+  revision: db240a50968304bc107320703502492d062c9bee
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct

--- a/app/controllers/steps/submission/declaration_controller.rb
+++ b/app/controllers/steps/submission/declaration_controller.rb
@@ -18,13 +18,13 @@ module Steps
       private
 
       def default_values
-        first_name = current_crime_application.legal_rep_first_name.presence ||
+        first_name = current_crime_application.legal_rep_first_name ||
                      current_provider.legal_rep_first_name
 
-        last_name = current_crime_application.legal_rep_last_name.presence ||
+        last_name = current_crime_application.legal_rep_last_name ||
                     current_provider.legal_rep_last_name
 
-        telephone = current_crime_application.legal_rep_telephone.presence ||
+        telephone = current_crime_application.legal_rep_telephone ||
                     current_provider.legal_rep_telephone
 
         {

--- a/app/forms/steps/submission/declaration_form.rb
+++ b/app/forms/steps/submission/declaration_form.rb
@@ -28,8 +28,9 @@ module Steps
           attributes
         )
 
+        # Update the signed in provider settings
         record.update(
-          attributes
+          attributes.compact_blank
         )
       end
     end

--- a/app/serializers/submission_serializer/sections/provider_details.rb
+++ b/app/serializers/submission_serializer/sections/provider_details.rb
@@ -5,6 +5,9 @@ module SubmissionSerializer
         Jbuilder.new do |json|
           json.provider_details do
             json.office_code crime_application.office_code
+            json.legal_rep_first_name crime_application.legal_rep_first_name
+            json.legal_rep_last_name crime_application.legal_rep_last_name
+            json.legal_rep_telephone crime_application.legal_rep_telephone
           end
         end
       end

--- a/spec/controllers/steps/submission/declaration_controller_spec.rb
+++ b/spec/controllers/steps/submission/declaration_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Steps::Submission::DeclarationController, type: :controller do
           {
             legal_rep_first_name: 'John',
             legal_rep_last_name: 'Doe',
-            legal_rep_telephone: '123456789',
+            legal_rep_telephone: '',
           }
         end
 

--- a/spec/forms/steps/submission/declaration_form_spec.rb
+++ b/spec/forms/steps/submission/declaration_form_spec.rb
@@ -53,16 +53,41 @@ RSpec.describe Steps::Submission::DeclarationForm do
       end
 
       context 'when the details have changed' do
-        it 'saves the record' do
+        it 'saves the application record' do
+          allow(provider_record).to receive(:update).and_return(true)
+
           expect(crime_application).to receive(:update).with(
             expected_attrs
           ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+
+        it 'saves the provider settings' do
+          allow(crime_application).to receive(:update).and_return(true)
 
           expect(provider_record).to receive(:update).with(
             expected_attrs
           ).and_return(true)
 
           expect(subject.save).to be(true)
+        end
+
+        context 'when saving a draft' do
+          let(:legal_rep_telephone) { '' }
+
+          it 'saves to the provider settings attributes that are not blank' do
+            allow(crime_application).to receive(:update).and_return(true)
+
+            expect(provider_record).to receive(:update).with(
+              {
+                'legal_rep_first_name' => 'John',
+                'legal_rep_last_name' => 'Doe',
+              }
+            ).and_return(true)
+
+            expect(subject.save!).to be(true)
+          end
         end
       end
 

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe SubmissionSerializer::Application do
           'schema_version' => 1.0,
           'status' => 'submitted',
           'ioj_passport' => [],
-          'provider_details' => a_hash_including('office_code'),
+          'provider_details' => a_hash_including(
+            'office_code', 'legal_rep_first_name', 'legal_rep_last_name', 'legal_rep_telephone'
+          ),
           'client_details' => a_hash_including('applicant'),
           'case_details' => a_hash_including('offences' => [], 'codefendants' => []),
           'interests_of_justice' => [],

--- a/spec/serializers/submission_serializer/sections/provider_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/provider_details_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe SubmissionSerializer::Sections::ProviderDetails do
     instance_double(
       CrimeApplication,
       office_code: 'XYZ',
+      legal_rep_first_name: 'John',
+      legal_rep_last_name: 'Doe',
+      legal_rep_telephone: '123456789',
     )
   end
 
@@ -14,6 +17,9 @@ RSpec.describe SubmissionSerializer::Sections::ProviderDetails do
     {
       provider_details: {
         office_code: 'XYZ',
+        legal_rep_first_name: 'John',
+        legal_rep_last_name: 'Doe',
+        legal_rep_telephone: '123456789',
       }
     }.as_json
   end

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Datastore::ApplicationSubmission do
     # create all neccessary records
     app = create_test_application(
       usn: 123,
+      legal_rep_first_name: 'John',
+      legal_rep_last_name: 'Doe',
+      legal_rep_telephone: '123456789',
     )
 
     client = Applicant.create(


### PR DESCRIPTION
## Description of change
Little follow-up to previous PR #237, to add to the JSON payload of the submitted application, the legal representative details captured in the declaration page.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-224
