### PR TITLE
change location of guard clause for updating provider details

### DIFF
--- a/app/forms/steps/submission/declaration_form.rb
+++ b/app/forms/steps/submission/declaration_form.rb
@@ -22,11 +22,11 @@ module Steps
       private
 
       def persist!
-        return true unless changed?
-
         crime_application.update(
           attributes
         )
+
+        return true unless changed?
 
         # Update the signed in provider settings
         record.update(

--- a/spec/forms/steps/submission/declaration_form_spec.rb
+++ b/spec/forms/steps/submission/declaration_form_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Steps::Submission::DeclarationForm do
         let(:rep_details_attrs) { expected_attrs }
 
         it 'does not save the record but returns true' do
-          expect(crime_application).not_to receive(:update)
+          expect(crime_application).to receive(:update)
           expect(provider_record).not_to receive(:update)
           expect(subject.save).to be(true)
         end


### PR DESCRIPTION
## Description of change

Fixes a bug that was stopping users submitting applications

## Link to relevant ticket

https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-250

## Notes for reviewer

### Before changes:

Users were only able to submit an application if they changed the legal representative details on the declaration page

### After changes:

Users should be able to submit applications without changing the legal representative details

## How to manually test the feature

Submit multiple applications without changing the legal representative details
