### PR TITLE
CRIMAP-232 Add date ranges in offences page

### DIFF
--- a/app/forms/steps/case/offence_date_fieldset_form.rb
+++ b/app/forms/steps/case/offence_date_fieldset_form.rb
@@ -3,13 +3,25 @@ module Steps
     class OffenceDateFieldsetForm < Steps::BaseFormObject
       attribute :_destroy, :boolean
       attribute :id, :string
-      attribute :date, :multiparam_date
+      attribute :date_from, :multiparam_date
+      attribute :date_to, :multiparam_date
 
-      validates :date, presence: true, multiparam_date: true
+      validates :date_from, presence: true, multiparam_date: true
+      validates :date_to, multiparam_date: true
+
+      validate :date_from_before_date_to
 
       # Needed for `#fields_for` to render the uuids as hidden fields
       def persisted?
         id.present?
+      end
+
+      private
+
+      def date_from_before_date_to
+        return unless date_from.is_a?(Date) && date_to.is_a?(Date)
+
+        errors.add(:date_to, :before_date_from) if date_to < date_from
       end
     end
   end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -14,6 +14,6 @@ class Charge < ApplicationRecord
            to: :offence, allow_nil: true
 
   def complete?
-    offence_name.present? && offence_dates.pluck(:date).any?
+    offence_name.present? && offence_dates.pluck(:date_from).any?
   end
 end

--- a/app/presenters/charge_presenter.rb
+++ b/app/presenters/charge_presenter.rb
@@ -7,6 +7,6 @@ class ChargePresenter < BasePresenter
   end
 
   def offence_dates
-    super.pluck(:date).compact
+    super.pluck(:date_from).compact
   end
 end

--- a/app/presenters/summary/components/offence_answer.rb
+++ b/app/presenters/summary/components/offence_answer.rb
@@ -4,11 +4,8 @@ module Summary
       # This component receives as `value` a presented `charge`
       delegate :offence_name,
                :offence_class,
-               :offence_dates, to: :value
-
-      def value?
-        super && value.complete?
-      end
+               :offence_dates,
+               :complete?, to: :value
 
       def to_partial_path
         'steps/submission/shared/offence_answer'

--- a/app/serializers/submission_serializer/definitions/offence.rb
+++ b/app/serializers/submission_serializer/definitions/offence.rb
@@ -5,7 +5,7 @@ module SubmissionSerializer
         Jbuilder.new do |json|
           json.name offence_name
           json.offence_class offence_class
-          json.dates offence_dates.pluck(:date)
+          json.dates offence_dates.pluck(:date_from)
         end
       end
     end

--- a/app/services/adapters/structs/charge.rb
+++ b/app/services/adapters/structs/charge.rb
@@ -14,8 +14,9 @@ module Adapters
         )
       end
 
+      # TODO: update once the JSON schema has been changed
       def offence_dates
-        @dates.map { |date| { date: } }
+        @dates.map { |date| { date_from: date } }
       end
 
       # For a datastore application, this is always true

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -103,7 +103,7 @@ module Decisions
     end
 
     def blank_date_required?
-      current_charge.offence_dates.map(&:date).exclude?(nil)
+      current_charge.offence_dates.map(&:date_from).exclude?(nil)
     end
   end
 end

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -24,14 +24,19 @@
 
       <%= f.govuk_fieldset legend: { text: t('.offence_dates_fieldset_legend') } do %>
         <%= f.fields_for :offence_dates do |od| %>
-          <%= od.govuk_date_field :date, maxlength_enabled: true,
+          <%= od.govuk_date_field :date_from, maxlength_enabled: true,
                                   legend: {
-                                    text: t("helpers.legend.#{f.object_name}.date", index: od.index + 1),
-                                    hidden: true
+                                    text: t("helpers.legend.#{f.object_name}.date_from", count: od.index + 1),
+                                    size: 's'
+                                  } %>
+
+          <%= od.govuk_date_field :date_to, maxlength_enabled: true,
+                                  legend: {
+                                    text: t("helpers.legend.#{f.object_name}.date_to", count: od.index + 1),
+                                    size: 's'
                                   },
                                   hint: {
-                                    text: t("helpers.hint.#{f.object_name}.date"),
-                                    hidden: !od.index.zero?
+                                    text: t("helpers.hint.#{f.object_name}.date_to")
                                   } %>
 
           <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -24,22 +24,24 @@
 
       <%= f.govuk_fieldset legend: { text: t('.offence_dates_fieldset_legend') } do %>
         <%= f.fields_for :offence_dates do |od| %>
+          <% index = od.index + 1 %>
+
           <%= od.govuk_date_field :date_from, maxlength_enabled: true,
                                   legend: {
-                                    text: t("helpers.legend.#{f.object_name}.date_from", count: od.index + 1),
+                                    text: t("helpers.legend.#{f.object_name}.date_from", index:),
                                     size: 's'
                                   } %>
 
           <%= od.govuk_date_field :date_to, maxlength_enabled: true,
                                   legend: {
-                                    text: t("helpers.legend.#{f.object_name}.date_to", count: od.index + 1),
+                                    text: t("helpers.legend.#{f.object_name}.date_to", index:),
                                     size: 's'
                                   },
                                   hint: {
                                     text: t("helpers.hint.#{f.object_name}.date_to")
                                   } %>
 
-          <%= od.button t('.remove_button'), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
+          <%= od.button t('.remove_button', index:), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
                         class: %w[govuk-button govuk-button--warning],
                         data: { module: 'govuk-button' } if @form_object.show_destroy? %>
         <% end %>

--- a/app/views/steps/case/charges_summary/_offence_details.html.erb
+++ b/app/views/steps/case/charges_summary/_offence_details.html.erb
@@ -1,26 +1,6 @@
 <div class="govuk-summary-list__row">
   <dd class="govuk-summary-list__value">
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <%= charge.offence_name %>
-    </p>
-
-    <% if charge.offence_class %>
-      <p class="govuk-caption-m govuk-!-margin-bottom-2 govuk-!-margin-top-0">
-        <%= charge.offence_class %>
-      </p>
-    <% end %>
-
-    <% charge.offence_dates.each do |date| %>
-      <p class="govuk-body govuk-!-margin-bottom-0">
-        <%= l(date) %>
-      </p>
-    <% end %>
-
-    <% unless charge.complete? %>
-      <strong class="moj-badge moj-badge--red">
-        <%= t('.incomplete_tag') %>
-      </strong>
-    <% end %>
+    <%= render partial: 'steps/shared/charge', locals: { charge: } %>
   </dd>
 
   <% if show_actions %>

--- a/app/views/steps/shared/_charge.html.erb
+++ b/app/views/steps/shared/_charge.html.erb
@@ -1,0 +1,26 @@
+<%#
+  This partial is shared between the `offences summary` page
+  and the `check your answers` page.
+%>
+
+<p class="govuk-body govuk-!-margin-bottom-1">
+  <%= charge.offence_name.presence || t('.unknown_name') %>
+</p>
+
+<% if charge.offence_class %>
+  <p class="govuk-caption-m govuk-!-margin-bottom-2 govuk-!-margin-top-0">
+    <%= charge.offence_class %>
+  </p>
+<% end %>
+
+<% charge.offence_dates.each do |date| %>
+  <p class="govuk-body govuk-!-margin-bottom-0">
+    <%= l(date) %>
+  </p>
+<% end %>
+
+<% unless charge.complete? %>
+  <strong class="moj-badge moj-badge--red">
+    <%= t('.incomplete_tag') %>
+  </strong>
+<% end %>

--- a/app/views/steps/submission/shared/_offence_answer.html.erb
+++ b/app/views/steps/submission/shared/_offence_answer.html.erb
@@ -5,25 +5,7 @@
 %>
 
 <% content_for(:row_answer, flush: true) do %>
-  <p class="govuk-body govuk-!-margin-bottom-1">
-    <%= offence_answer.offence_name || t("summary.questions.#{offence_answer.question}.unknown_name") %>
-  </p>
-
-  <p class="govuk-caption-m">
-    <%= offence_answer.offence_class || t("summary.questions.#{offence_answer.question}.unknown_class") %>
-  </p>
-
-  <% offence_answer.offence_dates.map do |date| %>
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      <%= l(date) %>
-    </p>
-  <% end %>
-
-  <% unless offence_answer.complete? %>
-    <strong class="moj-badge moj-badge--red">
-      <%= t("summary.questions.#{offence_answer.question}.incomplete_tag") %>
-    </strong>
-  <% end %>
+  <%= render partial: 'steps/shared/charge', locals: { charge: offence_answer } %>
 <% end %>
 
 <%= render partial: 'steps/submission/shared/summary_row',

--- a/app/views/steps/submission/shared/_offence_answer.html.erb
+++ b/app/views/steps/submission/shared/_offence_answer.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for(:row_answer, flush: true) do %>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    <%= offence_answer.offence_name %>
+    <%= offence_answer.offence_name || t("summary.questions.#{offence_answer.question}.unknown_name") %>
   </p>
 
   <p class="govuk-caption-m">
@@ -17,6 +17,12 @@
     <p class="govuk-body govuk-!-margin-bottom-0">
       <%= l(date) %>
     </p>
+  <% end %>
+
+  <% unless offence_answer.complete? %>
+    <strong class="moj-badge moj-badge--red">
+      <%= t("summary.questions.#{offence_answer.question}.incomplete_tag") %>
+    </strong>
   <% end %>
 <% end %>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -138,23 +138,39 @@ en:
               missing_details: You must complete all offence details in order to proceed
         steps/case/offence_date_fieldset_form:
           attributes:
-            date:
-              blank: Offence date cannot be blank
-              invalid: Enter a valid date
+            date_from:
+              blank: Offence start date cannot be blank
+              invalid: Enter a valid start date
               invalid_day: Enter a valid day
               invalid_month: Enter a valid month
               invalid_year: Enter a valid year
               year_too_early: Date is too far in the past
-              future_not_allowed: Offence date cannot be in the future
+              future_not_allowed: Offence start date cannot be in the future
+            date_to:
+              invalid: Enter a valid end date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date is too far in the past
+              future_not_allowed: Offence end date cannot be in the future
+              before_date_from: Offence end date cannot be before start date
           summary:
-            date:
-              blank: Offence dates cannot be blank
+            date_from:
+              blank: Offence start date cannot be blank
               invalid: Enter a valid date
               invalid_day: Enter a valid day
               invalid_month: Enter a valid month
               invalid_year: Enter a valid year
               year_too_early: Date is too far in the past
-              future_not_allowed: Offence dates cannot be in the future
+              future_not_allowed: Offence start date cannot be in the future
+            date_to:
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date is too far in the past
+              future_not_allowed: Offence end date cannot be in the future
+              before_date_from: Offence end date cannot be before start date
         steps/case/hearing_details_form:
           attributes:
             hearing_court_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -32,7 +32,14 @@ en:
       steps_case_case_type_form:
         case_type: What is the case type?
       steps_case_charges_form:
-        date: Offence date %{index}
+        date_from:
+          zero: Start date
+          one: Start date
+          other: Start date %{count}
+        date_to:
+          zero: End date (optional)
+          one: End date (optional)
+          other: End date %{count} (optional)
       steps_case_charges_summary_form:
         add_offence: Do you want to add another offence?
       steps_case_has_codefendants_form:
@@ -60,7 +67,7 @@ en:
         urn: For example, ‘12 AB 3456789’.
       steps_case_charges_form:
         offence_name: For example, robbery
-        date: For example, 12 11 2007
+        date_to: Leave blank if the offence happened on a single date
       steps_case_hearing_details_form:
         hearing_court_name: For example, Cardiff Crown Court
         hearing_date: For example, 27 3 2024

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -32,14 +32,8 @@ en:
       steps_case_case_type_form:
         case_type: What is the case type?
       steps_case_charges_form:
-        date_from:
-          zero: Start date
-          one: Start date
-          other: Start date %{count}
-        date_to:
-          zero: End date (optional)
-          one: End date (optional)
-          other: End date %{count} (optional)
+        date_from: Start date %{index}
+        date_to: End date %{index} (optional)
       steps_case_charges_summary_form:
         add_offence: Do you want to add another offence?
       steps_case_has_codefendants_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -115,7 +115,7 @@ en:
           heading: What has your client been charged with?
           offence_dates_fieldset_legend: Offence dates
           add_button: Add another date
-          remove_button: Remove date
+          remove_button: Remove date %{index}
         confirm_destroy:
           page_title: Delete offence confirmation
           heading: Are you sure you want to delete this offence?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -3,6 +3,9 @@ en:
   steps:
     shared:
       offence_class: Class %{class}
+      charge:
+        unknown_name: Name not entered
+        incomplete_tag: Incomplete
 
     provider:
       confirm_office:
@@ -131,7 +134,6 @@ en:
             one: You have added %{count} offence
             other: You have added %{count} offences
         offence_details:
-          incomplete_tag: Incomplete
           change_link_html: Change <span class="govuk-visually-hidden">offence</span>
           remove_link_html: Remove <span class="govuk-visually-hidden">offence</span>
       has_codefendants:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -73,9 +73,6 @@ en:
       # BEGIN offences section
       offence_details:
         question: "Offence %{index}"
-        unknown_name: Name not entered
-        unknown_class: Class not specified
-        incomplete_tag: Incomplete
       # END offences section
 
       # BEGIN codefendants section

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -73,7 +73,9 @@ en:
       # BEGIN offences section
       offence_details:
         question: "Offence %{index}"
+        unknown_name: Name not entered
         unknown_class: Class not specified
+        incomplete_tag: Incomplete
       # END offences section
 
       # BEGIN codefendants section

--- a/db/migrate/20230110130424_add_range_to_offence_dates.rb
+++ b/db/migrate/20230110130424_add_range_to_offence_dates.rb
@@ -1,0 +1,8 @@
+class AddRangeToOffenceDates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :offence_dates, :date_from, :date
+    add_column :offence_dates, :date_to, :date
+
+    remove_column :offence_dates, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_22_105608) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_10_130424) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -103,7 +103,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_22_105608) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "charge_id", null: false
-    t.date "date"
+    t.date "date_from"
+    t.date "date_to"
     t.index ["charge_id"], name: "index_offence_dates_on_charge_id"
   end
 

--- a/spec/forms/steps/case/charges_form_spec.rb
+++ b/spec/forms/steps/case/charges_form_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Steps::Case::ChargesForm do
   let(:offence_name) { 'Robbery' }
   let(:offence_dates_attributes) do
     {
-      '0' => { 'date(3i)' => '03', 'date(2i)' => '11', 'date(1i)' => '2000' },
-     '1' => { 'date(3i)' => '11', 'date(2i)' => '07', 'date(1i)' => '2010' },
-     '2' => { 'date(3i)' => '10', 'date(2i)' => '02', 'date(1i)' => '2009' }
+      '0' => { 'date_from(3i)' => '03', 'date_from(2i)' => '11', 'date_from(1i)' => '2000' },
+      '1' => { 'date_from(3i)' => '11', 'date_from(2i)' => '07', 'date_from(1i)' => '2010' },
+      '2' => { 'date_from(3i)' => '10', 'date_from(2i)' => '02', 'date_from(1i)' => '2009' }
     }
   end
 
@@ -29,8 +29,11 @@ RSpec.describe Steps::Case::ChargesForm do
     context 'offence dates' do
       let(:offence_dates_attributes) do
         {
-          '0' => { 'date(3i)' => '03', 'date(2i)' => '11', 'date(1i)' => '3000' },
-          '1' => { 'date(3i)' => '', 'date(2i)' => '', 'date(1i)' => '' },
+          '0' => {
+            'date_from(3i)' => '03', 'date_from(2i)' => '11', 'date_from(1i)' => '3000',
+            'date_to(3i)' => '03', 'date_to(2i)' => '11', 'date_to(1i)' => '2022'
+          },
+          '1' => { 'date_from(3i)' => '', 'date_from(2i)' => '', 'date_from(1i)' => '' },
         }
       end
 
@@ -40,16 +43,20 @@ RSpec.describe Steps::Case::ChargesForm do
 
       it 'sets the errors with their index' do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?('offence_dates-attributes[0].date', :future_not_allowed)).to be(true)
 
-        expect(subject.errors.messages_for('offence_dates-attributes[0].date').first).to eq(
-          'Offence dates cannot be in the future'
+        expect(subject.errors.of_kind?('offence_dates-attributes[0].date_from', :future_not_allowed)).to be(true)
+        expect(subject.errors.messages_for('offence_dates-attributes[0].date_from').first).to eq(
+          'Offence start date cannot be in the future'
         )
 
-        expect(subject.errors.of_kind?('offence_dates-attributes[1].date', :blank)).to be(true)
+        expect(subject.errors.of_kind?('offence_dates-attributes[0].date_to', :before_date_from)).to be(true)
+        expect(subject.errors.messages_for('offence_dates-attributes[0].date_to').first).to eq(
+          'Offence end date cannot be before start date'
+        )
 
-        expect(subject.errors.messages_for('offence_dates-attributes[1].date').first).to eq(
-          'Offence dates cannot be blank'
+        expect(subject.errors.of_kind?('offence_dates-attributes[1].date_from', :blank)).to be(true)
+        expect(subject.errors.messages_for('offence_dates-attributes[1].date_from').first).to eq(
+          'Offence start date cannot be blank'
         )
       end
     end
@@ -62,8 +69,8 @@ RSpec.describe Steps::Case::ChargesForm do
 
         let(:offence_dates) do
           [
-            OffenceDate.new(date: Date.new(2000, 11, 3)),
-            OffenceDate.new(date: Date.new(2009, 5, 1))
+            OffenceDate.new(date_from: Date.new(2000, 11, 3)),
+            OffenceDate.new(date_from: Date.new(2009, 5, 1))
           ]
         end
 
@@ -73,16 +80,16 @@ RSpec.describe Steps::Case::ChargesForm do
           {
             '0' => {
               'id' => offence_dates[0].id.to_s,
-              'date(3i)' => '03',
-              'date(2i)' => '11',
-              'date(1i)' => '2000',
+              'date_from(3i)' => '03',
+              'date_from(2i)' => '11',
+              'date_from(1i)' => '2000',
               '_destroy' => '1'
             },
             '1' => {
               'id' => offence_dates[1].id.to_s,
-              'date(3i)' => '01',
-              'date(2i)' => '05',
-              'date(1i)' => '2009'
+              'date_from(3i)' => '01',
+              'date_from(2i)' => '05',
+              'date_from(1i)' => '2009'
             }
           }
         end
@@ -123,7 +130,7 @@ RSpec.describe Steps::Case::ChargesForm do
     context 'if there are fewer than two offence dates' do
       let(:offence_dates_attributes) do
         {
-          '0' => { 'date(3i)' => '03', 'date(2i)' => '11', 'date(1i)' => '2000' },
+          '0' => { 'date_from(3i)' => '03', 'date_from(2i)' => '11', 'date_from(1i)' => '2000' },
         }
       end
 
@@ -135,8 +142,8 @@ RSpec.describe Steps::Case::ChargesForm do
     context 'if there two or more offence dates' do
       let(:offence_dates_attributes) do
         {
-          '0' => { 'date(3i)' => '03', 'date(2i)' => '11', 'date(1i)' => '2000' },
-          '1' => { 'date(3i)' => '11', 'date(2i)' => '07', 'date(1i)' => '2010' }
+          '0' => { 'date_from(3i)' => '03', 'date_from(2i)' => '11', 'date_from(1i)' => '2000' },
+          '1' => { 'date_from(3i)' => '11', 'date_from(2i)' => '07', 'date_from(1i)' => '2010' }
         }
       end
 

--- a/spec/forms/steps/case/offence_date_fieldset_form_spec.rb
+++ b/spec/forms/steps/case/offence_date_fieldset_form_spec.rb
@@ -5,16 +5,42 @@ RSpec.describe Steps::Case::OffenceDateFieldsetForm do
 
   let(:arguments) do
     {
-      crime_application: crime_application,
-      record: OffenceDate.new(date: '02, 07, 2020'),
-      id: record_id
+      id: record_id,
+      date_from: record.date_from,
+      date_to: record.date_to,
     }
   end
 
+  let(:record) { OffenceDate.new(date_from: Date.new(2020, 7, 2)) }
   let(:record_id) { '123456' }
   let(:crime_application) { instance_double(CrimeApplication) }
 
-  # TODO: validations
+  describe 'validations' do
+    describe '#date_from' do
+      it { is_expected.to validate_presence_of(:date_from) }
+
+      it_behaves_like 'a multiparam date validation',
+                      attribute_name: :date_from
+    end
+
+    describe '#date_to' do
+      it { is_expected.not_to validate_presence_of(:date_to) }
+
+      it_behaves_like 'a multiparam date validation',
+                      attribute_name: :date_to
+    end
+
+    context '`date_to` is before `date_from`' do
+      let(:record) do
+        OffenceDate.new(date_from: Date.new(2020, 7, 18), date_to: Date.new(2020, 7, 2))
+      end
+
+      it 'has a validation error on the `date_to` field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.added?(:date_to, :before_date_from)).to be(true)
+      end
+    end
+  end
 
   describe '#persisted?' do
     context 'when form has an id' do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -37,25 +37,25 @@ RSpec.describe Charge, type: :model do
 
     context 'for an offence with name and dates' do
       let(:offence_name) { 'Foobar' }
-      let(:offence_dates) { [{ date: 'date' }, { date: nil }] }
+      let(:offence_dates) { [{ date_from: 'date' }, { date_from: nil }] }
 
       it 'returns true' do
         expect(subject.complete?).to be(true)
       end
     end
 
-    context 'for an offence with no name and dates' do
+    context 'for an offence with dates but no name' do
       let(:offence_name) { '' }
-      let(:offence_dates) { [{ date: 'date' }, { date: nil }] }
+      let(:offence_dates) { [{ date_from: 'date' }, { date_from: nil }] }
 
-      it 'returns true' do
+      it 'returns false' do
         expect(subject.complete?).to be(false)
       end
     end
 
     context 'for an offence with name but no dates' do
       let(:offence_name) { 'Foobar' }
-      let(:offence_dates) { [{ date: nil }] }
+      let(:offence_dates) { [{ date_from: nil }] }
 
       it 'returns false' do
         expect(subject.complete?).to be(false)
@@ -64,7 +64,7 @@ RSpec.describe Charge, type: :model do
 
     context 'for an offence with no name and no dates' do
       let(:offence_name) { '' }
-      let(:offence_dates) { [{ date: nil }] }
+      let(:offence_dates) { [{ date_from: nil }] }
 
       it 'returns false' do
         expect(subject.complete?).to be(false)

--- a/spec/presenters/summary/components/offence_answer_spec.rb
+++ b/spec/presenters/summary/components/offence_answer_spec.rb
@@ -12,21 +12,6 @@ describe Summary::Components::OffenceAnswer do
     end
   end
 
-  describe '#value?' do
-    it 'calls `#complete?` on the value' do
-      expect(value).to receive(:complete?)
-      subject.value?
-    end
-
-    context 'when there is no value' do
-      let(:value) { nil }
-
-      it 'returns false' do
-        expect(subject.value?).to be(false)
-      end
-    end
-  end
-
   describe 'methods delegation' do
     it 'delegates `offence_name`' do
       expect(value).to receive(:offence_name)
@@ -41,6 +26,11 @@ describe Summary::Components::OffenceAnswer do
     it 'delegates `offence_dates`' do
       expect(value).to receive(:offence_dates)
       subject.offence_dates
+    end
+
+    it 'delegates `complete?`' do
+      expect(value).to receive(:complete?)
+      subject.complete?
     end
   end
 end

--- a/spec/presenters/summary/sections/offences_spec.rb
+++ b/spec/presenters/summary/sections/offences_spec.rb
@@ -25,12 +25,6 @@ describe Summary::Sections::Offences do
     )
   end
 
-  let(:complete) { true }
-
-  before do
-    allow(charge).to receive(:complete?).and_return(complete)
-  end
-
   describe '#name' do
     it { expect(subject.name).to eq(:offences) }
   end
@@ -62,14 +56,6 @@ describe Summary::Sections::Offences do
       expect(answers[0].change_path).to match('applications/12345/steps/case/charges/321')
       expect(answers[0].value).to be_an_instance_of(ChargePresenter)
       expect(answers[0].i18n_opts).to eq({ index: 1 })
-    end
-
-    context 'when the charge is not complete' do
-      let(:complete) { false }
-
-      it 'does not show the row' do
-        expect(answers.count).to eq(0)
-      end
     end
   end
 end

--- a/spec/requests/charges_summary_spec.rb
+++ b/spec/requests/charges_summary_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Charges/offences summary page' do
 
     kase.charges.create!(
       offence_name: 'Robbery',
-      offence_dates_attributes: { id: nil, date: Date.new(1990, 2, 1) }
+      offence_dates_attributes: { id: nil, date_from: Date.new(1990, 2, 1) }
     )
   end
 

--- a/spec/serializers/submission_serializer/definitions/offence_spec.rb
+++ b/spec/serializers/submission_serializer/definitions/offence_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe SubmissionSerializer::Definitions::Offence do
   end
 
   before do
-    allow(charge1).to receive(:offence_dates).and_return([{ date: 'Date1' }, { date: 'Date2' }])
-    allow(charge2).to receive(:offence_dates).and_return([{ date: 'Date1' }])
+    allow(charge1).to receive(:offence_dates).and_return([{ date_from: 'Date1' }, { date_from: 'Date2' }])
+    allow(charge2).to receive(:offence_dates).and_return([{ date_from: 'Date1' }])
   end
 
   describe '#generate' do

--- a/spec/services/adapters/structs/charge_spec.rb
+++ b/spec/services/adapters/structs/charge_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Adapters::Structs::Charge do
     it 'returns the mapped dates' do
       expect(
         subject.offence_dates
-      ).to match_array([{ date: kind_of(Date) }, { date: kind_of(Date) }])
+      ).to match_array([{ date_from: kind_of(Date) }, { date_from: kind_of(Date) }])
     end
   end
 

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Datastore::ApplicationSubmission do
     Charge.create(
       case: kase,
       offence_name: 'Robbery',
-      offence_dates: [OffenceDate.new(date: '01-02-2000')]
+      offence_dates: [OffenceDate.new(date_from: '01-02-2000')]
     )
 
     # An incomplete charge (no dates), on purpose

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Decisions::CaseDecisionTree do
   context 'when the step is `add_offence_date`' do
     context 'has correct next step' do
       let(:step_name) { :add_offence_date }
-      let(:offence_dates) { [OffenceDate.new(date: '01, 02, 2000')] }
+      let(:offence_dates) { [OffenceDate.new(date_from: '01, 02, 2000')] }
       let(:charge) { Charge.new(id: '20', offence_dates: offence_dates) }
       let(:form_object) { double('FormObject', case: kase, record: charge) }
 

--- a/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
@@ -50,8 +50,8 @@ describe 'Rendering a summary row of type `OffenceAnswer`' do
   context 'when the offence has no class' do
     let(:offence_class) { nil }
 
-    it 'shows a placeholder copy' do
-      assert_select 'dd.govuk-summary-list__value p.govuk-caption-m', 'Class not specified'
+    it 'skips the class paragraph' do
+      assert_select 'dd.govuk-summary-list__value p.govuk-caption-m', false
     end
   end
 

--- a/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_offence_answer.html.erb_spec.rb
@@ -10,12 +10,15 @@ describe 'Rendering a summary row of type `OffenceAnswer`' do
   let(:presented_charge) do
     double(
       'PresentedCharge',
-      offence_name: 'My offence name',
+      offence_name: offence_name,
       offence_class: offence_class,
       offence_dates: [Date.new(2000, 11, 3)],
+      complete?: complete,
     )
   end
 
+  let(:complete) { true }
+  let(:offence_name) { 'My offence name' }
   let(:offence_class) { 'Offence class' }
 
   before do
@@ -36,11 +39,27 @@ describe 'Rendering a summary row of type `OffenceAnswer`' do
     end
   end
 
+  context 'when the offence has no name' do
+    let(:offence_name) { nil }
+
+    it 'shows a placeholder copy' do
+      assert_select 'dd.govuk-summary-list__value p:nth-of-type(1)', 'Name not entered'
+    end
+  end
+
   context 'when the offence has no class' do
     let(:offence_class) { nil }
 
     it 'shows a placeholder copy' do
       assert_select 'dd.govuk-summary-list__value p.govuk-caption-m', 'Class not specified'
+    end
+  end
+
+  context 'when the offence is incomplete' do
+    let(:complete) { false }
+
+    it 'shows an incomplete tag' do
+      assert_select 'dd.govuk-summary-list__value strong.moj-badge--red', 'Incomplete'
     end
   end
 end


### PR DESCRIPTION
## Description of change
A new requirement is needed to allow adding date ranges, with a start and end date, being the end date optional, to the current offences page.

Figma designs (still some open questions to be addressed in follow-up PRs): https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=3328%3A27560&t=NqyXwuhArytsMxws-4

Note this PR looks like a lot of changes but it is mostly the removal of the old `date` attribute and replacement with a `date_from` (and `date_to` still not used in many places).

To maintain compatibility as much as possible, existing submitted applications will continue rendering the certificate page. Also, applications will keep submitting a "dates" array with just the `date_from` until the schema is changed in a follow-up PR.

NOTE: locally stored applications (not submitted) will need to be updated to add the `date_from`. I didn't create a migration as don't think is a big problem, but what I did was surface in the Check your answers page if an offence is incomplete, similar to what we already do in the charges summary page.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-232

## Notes for reviewer
First of at least 2 or 3 PRs. More to come.

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2023-01-10 at 17 03 45](https://user-images.githubusercontent.com/687910/211616800-ab9bdced-a392-433b-9ed4-5ea1bd321121.png)

### After changes:
<img width="575" alt="Screenshot 2023-01-11 at 09 24 37" src="https://user-images.githubusercontent.com/687910/211768203-2d4a1050-a822-4546-adfd-2c8bd567f849.png">

Existing in progress applications (not submitted), that had offences added, will show as incomplete in the Check your answers page as a result of this work:
<img width="797" alt="Screenshot 2023-01-10 at 17 10 53" src="https://user-images.githubusercontent.com/687910/211617523-4fd8a702-e4dc-4325-88f5-446cb6d550be.png">

## How to manually test the feature
Start a new application and go to the offences page. You should be able to add start/end dates. End date is optional. Validation is implemented. End date can't be before start date.
You are able to submit the application, but behind the scenes the datastore continues using just 1 date (date_from), not yet date_to which will be added next. Schema is not yet updated.