### PR TITLE
CRIMAP-232 Show date ranges if entered

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -14,6 +14,14 @@ class Charge < ApplicationRecord
            to: :offence, allow_nil: true
 
   def complete?
-    offence_name.present? && offence_dates.pluck(:date_from).any?
+    offence_name.present? && valid_dates?
+  end
+
+  # NOTE: we use `pluck` in several places instead of ActiveRecord,
+  # as to make these methods compatible with JSON responses received
+  # from the datastore (submitted applications).
+  def valid_dates?
+    dates = offence_dates.pluck(:date_from)
+    dates.any? && dates.all?
   end
 end

--- a/app/presenters/charge_presenter.rb
+++ b/app/presenters/charge_presenter.rb
@@ -7,6 +7,8 @@ class ChargePresenter < BasePresenter
   end
 
   def offence_dates
-    super.pluck(:date_from).compact
+    return [] unless valid_dates?
+
+    super.pluck(:date_from, :date_to)
   end
 end

--- a/app/services/adapters/structs/charge.rb
+++ b/app/services/adapters/structs/charge.rb
@@ -14,13 +14,17 @@ module Adapters
         )
       end
 
-      # TODO: update once the JSON schema has been changed
       def offence_dates
-        @dates.map { |date| { date_from: date } }
+        @dates.map { |date_from, date_to| { date_from:, date_to: } }
       end
 
-      # For a datastore application, this is always true
+      # For a submitted datastore application, following methods
+      # are assumed to be always true (schema is enforced).
       def complete?
+        true
+      end
+
+      def valid_dates?
         true
       end
     end

--- a/app/views/steps/shared/_charge.html.erb
+++ b/app/views/steps/shared/_charge.html.erb
@@ -13,9 +13,9 @@
   </p>
 <% end %>
 
-<% charge.offence_dates.each do |date| %>
+<% charge.offence_dates.each do |date_from, date_to| %>
   <p class="govuk-body govuk-!-margin-bottom-0">
-    <%= l(date) %>
+    <%= date_to ? [l(date_from), l(date_to)].join(' – ') : l(date_from) %>
   </p>
 <% end %>
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Charge, type: :model do
 
     context 'for an offence with name and dates' do
       let(:offence_name) { 'Foobar' }
-      let(:offence_dates) { [{ date_from: 'date' }, { date_from: nil }] }
+      let(:offence_dates) { [{ date_from: 'date1' }, { date_from: 'date2' }] }
 
       it 'returns true' do
         expect(subject.complete?).to be(true)
@@ -55,7 +55,16 @@ RSpec.describe Charge, type: :model do
 
     context 'for an offence with name but no dates' do
       let(:offence_name) { 'Foobar' }
-      let(:offence_dates) { [{ date_from: nil }] }
+      let(:offence_dates) { [] }
+
+      it 'returns false' do
+        expect(subject.complete?).to be(false)
+      end
+    end
+
+    context 'for an offence with name but some `date_from` missing' do
+      let(:offence_name) { 'Foobar' }
+      let(:offence_dates) { [{ date_from: 'date' }, { date_from: nil, date_to: 'date' }] }
 
       it 'returns false' do
         expect(subject.complete?).to be(false)

--- a/spec/requests/charges_summary_spec.rb
+++ b/spec/requests/charges_summary_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe 'Charges/offences summary page' do
     app = CrimeApplication.create
     kase = Case.create(crime_application: app)
 
-    kase.charges.create!(
-      offence_name: 'Robbery',
-      offence_dates_attributes: { id: nil, date_from: Date.new(1990, 2, 1) }
+    charge = kase.charges.create!(offence_name: 'Robbery')
+    charge.offence_dates.first.update(
+      date_from: Date.new(1990, 2, 1), date_to: Date.new(1990, 2, 5)
     )
   end
 
@@ -33,7 +33,7 @@ RSpec.describe 'Charges/offences summary page' do
         assert_select 'div.govuk-summary-list__row', 1 do
           assert_select 'dd.govuk-summary-list__value p:nth-of-type(1)', count: 1, text: 'Robbery'
           assert_select 'dd.govuk-summary-list__value p:nth-of-type(2)', count: 1, text: 'Class C or B'
-          assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '1 Feb 1990'
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '1 Feb 1990 – 5 Feb 1990'
 
           assert_select 'dd.govuk-summary-list__actions:nth-of-type(1) a', count: 1, text: 'Change offence'
           assert_select 'dd.govuk-summary-list__actions:nth-of-type(2) a', count: 1, text: 'Remove offence'
@@ -55,7 +55,7 @@ RSpec.describe 'Charges/offences summary page' do
         assert_select 'div.govuk-summary-list__row', 1 do
           assert_select 'dd.govuk-summary-list__value p:nth-of-type(1)', count: 1, text: 'Robbery'
           assert_select 'dd.govuk-summary-list__value p:nth-of-type(2)', count: 1, text: 'Class C or B'
-          assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '1 Feb 1990'
+          assert_select 'dd.govuk-summary-list__value p:nth-of-type(3)', count: 1, text: '1 Feb 1990 – 5 Feb 1990'
 
           assert_select 'dd.govuk-summary-list__actions', count: 0
         end

--- a/spec/services/adapters/structs/charge_spec.rb
+++ b/spec/services/adapters/structs/charge_spec.rb
@@ -31,13 +31,21 @@ RSpec.describe Adapters::Structs::Charge do
     it 'returns the mapped dates' do
       expect(
         subject.offence_dates
-      ).to match_array([{ date_from: kind_of(Date) }, { date_from: kind_of(Date) }])
+      ).to match_array(
+        [{ date_from: kind_of(Date), date_to: nil }, { date_from: kind_of(Date), date_to: nil }]
+      )
     end
   end
 
   describe '#complete?' do
     it 'returns always true' do
       expect(subject.complete?).to be(true)
+    end
+  end
+
+  describe '#valid_dates?' do
+    it 'returns always true' do
+      expect(subject.valid_dates?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Description of change
This PR builds up upon previous one #242 to show in the different views the date ranges when there are any, or just the `date_from` if there is no range.

It prepares the path to update the schema and start submitting ranges to the datastore, which will be done separated in another PR.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-232

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="739" alt="Screenshot 2023-01-11 at 14 49 47" src="https://user-images.githubusercontent.com/687910/211837081-48ee23aa-7a68-4372-9c67-6f778864bd1f.png">

## How to manually test the feature
Add offences with different combinations of single date or range dates, and see how they show in the charges summary page, and the check your answer page.