### PR TITLE
Submit to datastore new offence ranges

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,9 +14,9 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: db240a50968304bc107320703502492d062c9bee
+  revision: ecb302f7456eb9839f63ff76774aaa33967ad4ab
   specs:
-    laa-criminal-legal-aid-schemas (0.1.0)
+    laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/app/serializers/submission_serializer/definitions/offence.rb
+++ b/app/serializers/submission_serializer/definitions/offence.rb
@@ -5,7 +5,9 @@ module SubmissionSerializer
         Jbuilder.new do |json|
           json.name offence_name
           json.offence_class offence_class
-          json.dates offence_dates.pluck(:date_from)
+          json.dates do
+            json.merge! offence_dates.as_json(only: [:date_from, :date_to])
+          end
         end
       end
     end

--- a/app/services/adapters/structs/charge.rb
+++ b/app/services/adapters/structs/charge.rb
@@ -4,7 +4,10 @@ module Adapters
       # {
       #   "name": "Attempt robbery",
       #   "offence_class": "Class C",
-      #   "dates": ["2020-05-11", "2020-08-11"]
+      #   "dates": [
+      #     { "date_from": "2020-05-11", "date_to": "2020-05-12" },
+      #     { "date_from": "2020-08-11", "date_to": null }
+      #   ]
       # }
       def initialize(offence_struct)
         @dates = offence_struct.dates
@@ -15,7 +18,7 @@ module Adapters
       end
 
       def offence_dates
-        @dates.map { |date_from, date_to| { date_from:, date_to: } }
+        @dates.map { |obj| { date_from: obj.date_from, date_to: obj.date_to } }
       end
 
       # For a submitted datastore application, following methods

--- a/spec/serializers/submission_serializer/definitions/offence_spec.rb
+++ b/spec/serializers/submission_serializer/definitions/offence_spec.rb
@@ -13,19 +13,32 @@ RSpec.describe SubmissionSerializer::Definitions::Offence do
       {
         name: 'Common assault',
         offence_class: 'H',
-        dates: %w[Date1 Date2],
+        dates: [
+          { date_from: 'date_from_1', date_to: 'date_to_1' }, { date_from: 'date_from_2', date_to: nil }
+        ],
       },
       {
         name: 'An unlisted offence',
         offence_class: nil,
-        dates: %w[Date1],
+        dates: [
+          { date_from: 'date_from_1', date_to: nil }
+        ]
       },
     ].as_json
   end
 
   before do
-    allow(charge1).to receive(:offence_dates).and_return([{ date_from: 'Date1' }, { date_from: 'Date2' }])
-    allow(charge2).to receive(:offence_dates).and_return([{ date_from: 'Date1' }])
+    allow(charge1).to receive(:offence_dates).and_return(
+      [
+        { date_from: 'date_from_1', date_to: 'date_to_1' },
+        { date_from: 'date_from_2', date_to: nil }
+      ]
+    )
+    allow(charge2).to receive(:offence_dates).and_return(
+      [
+        { date_from: 'date_from_1', date_to: nil }
+      ]
+    )
   end
 
   describe '#generate' do

--- a/spec/services/adapters/structs/charge_spec.rb
+++ b/spec/services/adapters/structs/charge_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Adapters::Structs::Charge do
       expect(
         subject.offence_dates
       ).to match_array(
-        [{ date_from: kind_of(Date), date_to: nil }, { date_from: kind_of(Date), date_to: nil }]
+        [{ date_from: kind_of(Date), date_to: kind_of(Date) }, { date_from: kind_of(Date), date_to: nil }]
       )
     end
   end


### PR DESCRIPTION
## Description of change
Final follow up to previous PRs.

This uses the updated schema, to push the new ranges format for offence dates.

However sadly old submitted applications can't be read once this is merged. An SQL migration can be run to update those applications or maybe is time to wipe out the datastore and start fresh.

NOTE: the schemas gem is not yet updated in the datastore. Merge this PR after that is done.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-251

## Notes for reviewer

## How to manually test the feature
New applications are able to be submitted with date ranges in the offences, once the datastore start using the new schema.