### PR TITLE
CRIMAP-222 Add missing MAAT ID info to CYA

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ecb302f7456eb9839f63ff76774aaa33967ad4ab
+  revision: ee9096e0bafa444f9ac999ed8e9580a62461fbe4
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -9,6 +9,7 @@ module Summary
         kase.present? && super
       end
 
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
         [
           Components::FreeTextAnswer.new(
@@ -20,8 +21,24 @@ module Summary
             :case_type, kase.case_type,
             change_path: edit_steps_case_case_type_path
           ),
+
+          Components::FreeTextAnswer.new(
+            :previous_maat_id, kase.appeal_maat_id,
+            change_path: edit_steps_case_case_type_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :previous_maat_id, kase.appeal_with_changes_maat_id,
+            change_path: edit_steps_case_case_type_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :appeal_with_changes_details, kase.appeal_with_changes_details,
+            change_path: edit_steps_case_case_type_path
+          ),
         ].select(&:show?)
       end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       private
 

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -28,7 +28,7 @@ module Summary
           ),
 
           Components::FreeTextAnswer.new(
-            :telephone_number, applicant.telephone_number,
+            :telephone_number, applicant.telephone_number, show: true,
             change_path: edit_steps_client_contact_details_path
           ),
         ].select(&:show?)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -66,7 +66,6 @@ en:
         steps/client/contact_details_form:
           attributes:
             telephone_number:
-              blank: Enter a UK telephone number
               invalid: Enter a telephone number in the correct format
             correspondence_address_type:
               inclusion: Select a correspondence address

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -52,6 +52,7 @@ en:
           other_address: Somewhere else
       telephone_number:
         question: UK telephone number
+        absence_answer: *absence_none
       # END contact details section
 
       # BEGIN case details section
@@ -68,6 +69,11 @@ en:
           committal: Committal for sentence
           appeal_to_crown_court: Appeal to crown court
           appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
+      previous_maat_id:
+        question: Previous MAAT ID
+        absence_answer: *absence_none
+      appeal_with_changes_details:
+        question: Change details
       # END case details section
 
       # BEGIN offences section

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -16,8 +16,15 @@ describe Summary::Sections::CaseDetails do
       Case,
       urn: 'xyz',
       case_type: 'foobar',
+      appeal_maat_id: appeal_maat_id,
+      appeal_with_changes_maat_id: appeal_with_changes_maat_id,
+      appeal_with_changes_details: appeal_with_changes_details,
     )
   end
+
+  let(:appeal_maat_id) { '' }
+  let(:appeal_with_changes_maat_id) { '' }
+  let(:appeal_with_changes_details) { '' }
 
   describe '#name' do
     it { expect(subject.name).to eq(:case_details) }
@@ -54,6 +61,53 @@ describe Summary::Sections::CaseDetails do
       expect(answers[1].question).to eq(:case_type)
       expect(answers[1].change_path).to match('applications/12345/steps/case/case_type')
       expect(answers[1].value).to eq('foobar')
+    end
+
+    context 'for appeal cases' do
+      context 'with previous MAAT ID' do
+        let(:appeal_maat_id) { '123' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(3)
+
+          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[2].question).to eq(:previous_maat_id)
+          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[2].value).to eq('123')
+        end
+      end
+
+      context 'with previous MAAT ID (financial changes)' do
+        let(:appeal_with_changes_maat_id) { '345' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(3)
+
+          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[2].question).to eq(:previous_maat_id)
+          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[2].value).to eq('345')
+        end
+      end
+
+      context 'with financial changes details' do
+        let(:appeal_with_changes_maat_id) { '345' }
+        let(:appeal_with_changes_details) { 'details' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(4)
+
+          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[2].question).to eq(:previous_maat_id)
+          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[2].value).to eq('345')
+
+          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[3].question).to eq(:appeal_with_changes_details)
+          expect(answers[3].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[3].value).to eq('details')
+        end
+      end
     end
   end
 end

--- a/spec/presenters/summary/sections/contact_details_spec.rb
+++ b/spec/presenters/summary/sections/contact_details_spec.rb
@@ -14,13 +14,14 @@ describe Summary::Sections::ContactDetails do
   let(:applicant) do
     instance_double(
       Applicant,
-      home_address: home_address,
-      correspondence_address: correspondence_address,
-      correspondence_address_type: correspondence_address_type,
-      telephone_number: '123456789',
+      home_address:,
+      correspondence_address:,
+      correspondence_address_type:,
+      telephone_number:,
     )
   end
 
+  let(:telephone_number) { '123456789' }
   let(:correspondence_address_type) { CorrespondenceType::OTHER_ADDRESS.to_s }
 
   let(:home_address) do
@@ -121,6 +122,17 @@ describe Summary::Sections::ContactDetails do
         expect(answers[1].value).to eq('providers_office_address')
 
         expect(answers[2].question).to eq(:telephone_number)
+      end
+    end
+
+    context 'when there is no telephone number' do
+      let(:telephone_number) { '' }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(4)
+
+        expect(answers[3].question).to eq(:telephone_number)
+        expect(answers[3].value).to eq('')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Add previous MAAT ID and financial change details (depending on case type selection) to the Check your answers page.

Additionally and on the back of recent PR #244 that made the applicant telephone number optional, update the CYA to show `None` if the telephone is left blank so the provider is aware of this. Same as we do with other optional fields.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-222

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2023-01-12 at 16 33 33](https://user-images.githubusercontent.com/687910/212131545-690dc653-5ee9-470d-a159-2ad18ebcbb79.png)

### After changes:
![Screenshot 2023-01-12 at 16 33 09](https://user-images.githubusercontent.com/687910/212131623-2369f255-0bc5-44c2-9910-96fa45af9556.png)

<img width="751" alt="Screenshot 2023-01-12 at 16 43 49" src="https://user-images.githubusercontent.com/687910/212132195-3d900d7b-3560-4191-b559-24cb2102e96f.png">

## How to manually test the feature
