### PR TITLE
update hint text on partner page

### DIFF
--- a/app/views/steps/client/has_partner/edit.html.erb
+++ b/app/views/steps/client/has_partner/edit.html.erb
@@ -6,7 +6,15 @@
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
         <%= f.govuk_collection_radio_buttons :client_has_partner, @form_object.choices,
-                                             :value, inline: false, legend: { tag: 'h1', size: 'xl' } %>
+                                             :value, inline: false, legend: { tag: 'h1', size: 'xl' } do %>
+          <p><%= t('.partner_definitions.intro') %></p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><%= t('.partner_definitions.definition_1') %></li>
+            <li><%= t('.partner_definitions.definition_2') %></li>
+            <li><%= t('.partner_definitions.definition_3') %></li>
+            <li><%= t('.partner_definitions.definition_4') %></li>
+          </ul>
+        <% end %>
 
         <%= f.continue_button(secondary: false) %>
     <% end %>

--- a/app/views/steps/client/has_partner/edit.html.erb
+++ b/app/views/steps/client/has_partner/edit.html.erb
@@ -4,10 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
-
     <%= step_form @form_object do |f| %>
         <%= f.govuk_collection_radio_buttons :client_has_partner, @form_object.choices,
-                                             :value, inline: true, legend: { tag: 'h1', size: 'xl' } %>
+                                             :value, inline: false, legend: { tag: 'h1', size: 'xl' } %>
 
         <%= f.continue_button(secondary: false) %>
     <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -47,7 +47,10 @@ en:
 
     hint:
       steps_client_has_partner_form:
-        client_has_partner: By partner we mean someone they are married to, in a civil partnership with, cohabit with or otherwise share finances.
+        client_has_partner_html: 'A partner is someone your client is:
+                                  <ul><li>Married to</li><li>in a civil partnership with</li>
+                                  <li>living with as if they were married or in a civil partnership</li>
+                                  <li>not permanently separated from</li></ul>'
       steps_client_details_form:
         other_names: This includes aliases, nicknames or other names your client may be known as.
         date_of_birth: For example, 27 3 2007

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -46,11 +46,6 @@ en:
         types: Why should your client get legal aid?
 
     hint:
-      steps_client_has_partner_form:
-        client_has_partner_html: 'A partner is someone your client is:
-                                  <ul><li>Married to</li><li>in a civil partnership with</li>
-                                  <li>living with as if they were married or in a civil partnership</li>
-                                  <li>not permanently separated from</li></ul>'
       steps_client_details_form:
         other_names: This includes aliases, nicknames or other names your client may be known as.
         date_of_birth: For example, 27 3 2007

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -20,6 +20,12 @@ en:
       has_partner:
         edit:
           page_title: Does your client have a partner?
+          partner_definitions:
+            intro: 'A partner is someone your client is:'
+            definition_1: married to
+            definition_2: in a civil partnership with
+            definition_3: living with as if they were married or in a civil partnership
+            definition_4: not permanently separated from<
       details:
         edit:
           page_title: Enter your client’s details

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -25,7 +25,7 @@ en:
             definition_1: married to
             definition_2: in a civil partnership with
             definition_3: living with as if they were married or in a civil partnership
-            definition_4: not permanently separated from<
+            definition_4: not permanently separated from
       details:
         edit:
           page_title: Enter your client’s details


### PR DESCRIPTION
## Description of change

Remove hint text on the partnership page and replace with a list of definitions of a partner

## Link to relevant ticket

https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-230

## Screenshots of changes (if applicable)

### Before changes:
![0 0 0 0_3000_applications_8ee35ef9-fd58-4246-b1e5-2ee4122587cf_steps_client_has_partner (1)](https://user-images.githubusercontent.com/367349/212285423-50639839-bb56-48e3-a0f4-4d4703ae0cc3.png)

### After changes:

![0 0 0 0_3000_applications_a573c49a-97fb-4444-a493-fbea111f5d9e_steps_client_has_partner (2)](https://user-images.githubusercontent.com/367349/212327001-77a08a54-21a6-46c1-b4d2-ded189cc5aed.png)

