### PR TITLE
CRIMAP-253 Confirm item deletion with flash alert

### DIFF
--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -33,7 +33,7 @@ module Steps
         @form_object.save!
         redirect_to edit_crime_application_path(current_crime_application)
       elsif @form_object.save
-        redirect_to decision_tree_class.new(@form_object, as: opts.fetch(:as)).destination
+        redirect_to decision_tree_class.new(@form_object, as: opts.fetch(:as)).destination, flash: opts[:flash]
       else
         render opts.fetch(:render, :edit)
       end

--- a/app/controllers/steps/case/charges_controller.rb
+++ b/app/controllers/steps/case/charges_controller.rb
@@ -9,7 +9,7 @@ module Steps
 
       def update
         update_and_advance(
-          ChargesForm, record: charge_record, as: step_name
+          ChargesForm, record: charge_record, as: step_name, flash: flash_msg
         )
       end
 
@@ -42,6 +42,10 @@ module Steps
         else
           :charges
         end
+      end
+
+      def flash_msg
+        { success: t('.edit.deleted_flash') } if step_name.eql?(:delete_offence_date)
       end
 
       def charge_record

--- a/app/controllers/steps/case/codefendants_controller.rb
+++ b/app/controllers/steps/case/codefendants_controller.rb
@@ -8,7 +8,9 @@ module Steps
       end
 
       def update
-        update_and_advance(CodefendantsForm, as: step_name)
+        update_and_advance(
+          CodefendantsForm, as: step_name, flash: flash_msg
+        )
       end
 
       private
@@ -21,6 +23,10 @@ module Steps
         else
           :codefendants_finished
         end
+      end
+
+      def flash_msg
+        { success: t('.edit.deleted_flash') } if step_name.eql?(:delete_codefendant)
       end
 
       def additional_permitted_params

--- a/app/views/steps/case/codefendants/edit.html.erb
+++ b/app/views/steps/case/codefendants/edit.html.erb
@@ -3,13 +3,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.fields_for :codefendants do |c| %>
-        <%= c.govuk_fieldset legend: { text: t('.codefendant_legend', index: c.index + 1) }, id: "codefendant_#{c.index + 1}" do %>
+        <% index = c.index + 1 %>
+
+        <%= c.govuk_fieldset legend: { text: t('.codefendant_legend', index:) }, id: "codefendant_#{index}" do %>
           <%= c.govuk_text_field :first_name, label: { text: t("helpers.label.#{f.object_name}.first_name") },
                                  autocomplete: 'off', width: 'three-quarters' %>
 
@@ -25,7 +29,7 @@
                                                  class: 'govuk-fieldset__legend',
                                                } %>
 
-          <%= c.button t('.remove_button'), type: :submit, value: '1', name: c.field_name(:_destroy, index: nil),
+          <%= c.button t('.remove_button', index:), type: :submit, value: '1', name: c.field_name(:_destroy, index: nil),
                        class: %w[govuk-button govuk-button--warning],
                        data: { module: 'govuk-button' } if @form_object.show_destroy? %>
         <% end %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -119,6 +119,7 @@ en:
           offence_dates_fieldset_legend: Offence dates
           add_button: Add another date
           remove_button: Remove date %{index}
+          deleted_flash: The offence date has been deleted
         confirm_destroy:
           page_title: Delete offence confirmation
           heading: Are you sure you want to delete this offence?
@@ -145,7 +146,8 @@ en:
           heading: Enter the details of any co-defendants in the case
           codefendant_legend: Co-defendant %{index}
           add_button: Add another co-defendant
-          remove_button: Remove co-defendant
+          remove_button: Remove co-defendant %{index}
+          deleted_flash: The co-defendant has been deleted
       hearing_details:
         edit:
           page_title: Next hearing court details

--- a/spec/controllers/steps/case/charges_controller_spec.rb
+++ b/spec/controllers/steps/case/charges_controller_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Steps::Case::ChargesController, type: :controller do
         ).to receive(:update_and_advance).with(
           form_class,
           record: charge_record,
-          as: :add_offence_date
+          as: :add_offence_date,
+          flash: nil
         )
       end
     end
@@ -60,7 +61,8 @@ RSpec.describe Steps::Case::ChargesController, type: :controller do
         ).to receive(:update_and_advance).with(
           form_class,
           record: charge_record,
-          as: :delete_offence_date
+          as: :delete_offence_date,
+          flash: { success: 'The offence date has been deleted' }
         )
       end
     end

--- a/spec/controllers/steps/case/codefendants_controller_spec.rb
+++ b/spec/controllers/steps/case/codefendants_controller_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Steps::Case::CodefendantsController, type: :controller do
         it 'has the expected step name' do
           expect(
             subject
-          ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :add_codefendant)
+          ).to receive(:update_and_advance).with(
+            Steps::Case::CodefendantsForm, as: :add_codefendant, flash: nil
+          )
 
           put :update, params: { id: existing_case, add_codefendant: '' }
         end
@@ -28,7 +30,10 @@ RSpec.describe Steps::Case::CodefendantsController, type: :controller do
         it 'has the expected step name' do
           expect(
             subject
-          ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :delete_codefendant)
+          ).to receive(:update_and_advance).with(
+            Steps::Case::CodefendantsForm, as: :delete_codefendant,
+            flash: { success: 'The co-defendant has been deleted' }
+          )
 
           put :update, params: { :id => existing_case, form_class_params_name => codefendant_attributes }
         end
@@ -38,7 +43,9 @@ RSpec.describe Steps::Case::CodefendantsController, type: :controller do
         it 'has the expected step name' do
           expect(
             subject
-          ).to receive(:update_and_advance).with(Steps::Case::CodefendantsForm, as: :codefendants_finished)
+          ).to receive(:update_and_advance).with(
+            Steps::Case::CodefendantsForm, as: :codefendants_finished, flash: nil
+          )
 
           put :update, params: { id: existing_case, foo: { bar: '1' } }
         end


### PR DESCRIPTION
## Description of change
On the back of some recent accessibility conversations, it was raised the suggestion to show a notification when an item, from a list of multiple items, is deleted, so screen readers can read it aloud.

Made possible by extending the `#update_and_advance` method to support a new `flash` kwarg, so this can be used in other steps to show a flash when advancing to next step.

This applies to the co-defendants page (removing an existing co-defendant) and to the offences page (removing an existing offence date).

Additionally and to be consistent with Offences, the co-defendant "Remove" buttons are also numbered, as required for accessibility reasons.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-253

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="794" alt="Screenshot 2023-01-12 at 18 00 13" src="https://user-images.githubusercontent.com/687910/212296604-7673e387-881b-45fa-b783-969ee8c46971.png">
<img width="728" alt="Screenshot 2023-01-13 at 10 19 34" src="https://user-images.githubusercontent.com/687910/212296607-6692b1c0-8bc6-4b1c-aa97-9850774406b2.png">

## How to manually test the feature
Add more than 1 co-defendant or more than 1 offence date, and then delete any of those. It should redirect back to the same page with a flash alert.