### PR TITLE
CRIMAP-222 Reference optional MAAT ID in CYA

### DIFF
--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -22,13 +22,19 @@ module Summary
             change_path: edit_steps_case_case_type_path
           ),
 
+          # This is an optional field, depending on case type
+          # If it is an empty string (not nil), it will show as `None`
           Components::FreeTextAnswer.new(
             :previous_maat_id, kase.appeal_maat_id,
+            show: !kase.appeal_maat_id.nil?,
             change_path: edit_steps_case_case_type_path
           ),
 
+          # This is an optional field, depending on case type
+          # If it is an empty string (not nil), it will show as `None`
           Components::FreeTextAnswer.new(
             :previous_maat_id, kase.appeal_with_changes_maat_id,
+            show: !kase.appeal_with_changes_maat_id.nil?,
             change_path: edit_steps_case_case_type_path
           ),
 

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -22,9 +22,9 @@ describe Summary::Sections::CaseDetails do
     )
   end
 
-  let(:appeal_maat_id) { '' }
-  let(:appeal_with_changes_maat_id) { '' }
-  let(:appeal_with_changes_details) { '' }
+  let(:appeal_maat_id) { nil }
+  let(:appeal_with_changes_maat_id) { nil }
+  let(:appeal_with_changes_details) { nil }
 
   describe '#name' do
     it { expect(subject.name).to eq(:case_details) }
@@ -63,7 +63,7 @@ describe Summary::Sections::CaseDetails do
       expect(answers[1].value).to eq('foobar')
     end
 
-    context 'for appeal cases' do
+    context 'for appeal to crown court' do
       context 'with previous MAAT ID' do
         let(:appeal_maat_id) { '123' }
 
@@ -77,8 +77,8 @@ describe Summary::Sections::CaseDetails do
         end
       end
 
-      context 'with previous MAAT ID (financial changes)' do
-        let(:appeal_with_changes_maat_id) { '345' }
+      context 'without previous MAAT ID (field is optional)' do
+        let(:appeal_maat_id) { '' }
 
         it 'has the correct rows' do
           expect(answers.count).to eq(3)
@@ -86,13 +86,17 @@ describe Summary::Sections::CaseDetails do
           expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answers[2].question).to eq(:previous_maat_id)
           expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
-          expect(answers[2].value).to eq('345')
+          expect(answers[2].value).to eq('')
+          expect(answers[2].show).to be(true)
         end
       end
+    end
 
-      context 'with financial changes details' do
+    context 'for appeal to crown court with changes in financial circumstances' do
+      let(:appeal_with_changes_details) { 'details' }
+
+      context 'with previous MAAT ID' do
         let(:appeal_with_changes_maat_id) { '345' }
-        let(:appeal_with_changes_details) { 'details' }
 
         it 'has the correct rows' do
           expect(answers.count).to eq(4)
@@ -101,6 +105,25 @@ describe Summary::Sections::CaseDetails do
           expect(answers[2].question).to eq(:previous_maat_id)
           expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
           expect(answers[2].value).to eq('345')
+
+          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[3].question).to eq(:appeal_with_changes_details)
+          expect(answers[3].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[3].value).to eq('details')
+        end
+      end
+
+      context 'without previous MAAT ID (field is optional)' do
+        let(:appeal_with_changes_maat_id) { '' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(4)
+
+          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[2].question).to eq(:previous_maat_id)
+          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[2].value).to eq('')
+          expect(answers[2].show).to be(true)
 
           expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answers[3].question).to eq(:appeal_with_changes_details)


### PR DESCRIPTION
## Description of change
This is a small refinement to a previous PR #246 to ensure optional fields like the previous MAAT ID show as `None` in the check your answers page, if they are left blank.

This comes as confirmation from service designer that this is how it should be.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-222

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="737" alt="Screenshot 2023-01-18 at 12 08 38" src="https://user-images.githubusercontent.com/687910/213168760-ba34f4cd-7bf3-4028-aa4e-7fba44953da8.png">

## How to manually test the feature
Select different case types, with or without MAAT ID, and see how it shows in the CYA as `None` depending if it was entered or not.