### PR TITLE
Use Dockerfile multi-stage builds and update deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,9 +16,8 @@ vendor/bundle/
 .github
 
 .byebug_history
-/coverage/*
-tags
-.ctags_exclude
+coverage/
+.git-crypt/
 
 # Ignore master key for decrypting credentials
 config/master.key

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install packages with yarn
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Precompile assets
         run: bin/rails assets:precompile


### PR DESCRIPTION
## Description of change
Although currently our docker image is quite contained in size, and it is fast enough to build, some gains can be obtained (and make it easier to expand in the future) by using multi-stage builds.

Removed a few build deps that it seems were not necessary, at least in my local tests, but until a full deployment is done I can't be certain for sure. Worst case scenario we need to add them back.

Additionally, the Alpine image has been bumped to the latest one, 3.16

Results for `time docker build --no-cache .`

```
Original Dockerfile

non-cached build
time - 1:01
size - 877MB

Improved Dockerfile (multi-stage)

non-cached build
time - 0:48
size - 597MB
```