### PR TITLE
CRIMAP-121 Propagate provider email address

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,10 @@ RSpec/Rails/InferredSpecType:
 Metrics/MethodLength:
   Max: 12
 
+# To be tweaked until we find the right balance
+Metrics/AbcSize:
+  Max: 18
+
 # https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ee9096e0bafa444f9ac999ed8e9580a62461fbe4
+  revision: 65f7b0b1f9807181fe48eb7a50ab657081c74bf0
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/forms/steps/submission/declaration_form.rb
+++ b/app/forms/steps/submission/declaration_form.rb
@@ -23,7 +23,9 @@ module Steps
 
       def persist!
         crime_application.update(
-          attributes
+          attributes.merge(
+            additional_attributes
+          )
         )
 
         return true unless changed?
@@ -32,6 +34,12 @@ module Steps
         record.update(
           attributes.compact_blank
         )
+      end
+
+      # Any other non user-editable attributes required
+      # before the final submission
+      def additional_attributes
+        { provider_email: record.email }
       end
     end
   end

--- a/app/lib/laa_portal_setup.rb
+++ b/app/lib/laa_portal_setup.rb
@@ -35,7 +35,7 @@ class LaaPortalSetup
       provider: 'saml',
       uid: 'test-user',
       info: {
-        email: 'test@example.com',
+        email: 'provider@example.com',
         roles: 'CCR_CCRGradeA1,CCLF_BillManager',
         office_codes: '1A123B,2A555X',
       }

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -15,4 +15,10 @@ class CrimeApplication < ApplicationRecord
        _default: ApplicationStatus.enum_values[:in_progress]
 
   alias_attribute :reference, :usn
+
+  store_accessor :provider_details,
+                 :provider_email,
+                 :legal_rep_first_name,
+                 :legal_rep_last_name,
+                 :legal_rep_telephone
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,4 +1,8 @@
 class Provider < ApplicationRecord
+  # TODO: temporary measure until we integrate properly
+  # with LAA Portal (current SAML mock lacks email)
+  FALLBACK_EMAIL = 'provider@example.com'.freeze
+
   devise :lockable, :timeoutable, :trackable,
          :omniauthable, omniauth_providers: %i[saml]
 
@@ -20,7 +24,7 @@ class Provider < ApplicationRecord
     def from_omniauth(auth)
       find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|
         record.update(
-          email: auth.info.email,
+          email: auth.info.email.presence || FALLBACK_EMAIL,
           description: auth.info.description,
           roles: auth.info.roles.split(','),
           office_codes: auth.info.office_codes.split(','),

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -6,7 +6,6 @@ module Summary
       @crime_application = Adapters::BaseApplication.build(crime_application)
     end
 
-    # rubocop:disable Metrics/AbcSize
     def sections
       [
         Sections::ClientDetails.new(crime_application),
@@ -19,6 +18,5 @@ module Summary
         Sections::PassportJustificationForLegalAid.new(crime_application),
       ].select(&:show?)
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/serializers/submission_serializer/sections/application_details.rb
+++ b/app/serializers/submission_serializer/sections/application_details.rb
@@ -10,7 +10,6 @@ module SubmissionSerializer
           json.created_at crime_application.created_at
           json.submitted_at crime_application.submitted_at
           json.date_stamp crime_application.date_stamp
-          json.status crime_application.status
           json.ioj_passport crime_application.ioj_passport
         end
       end

--- a/app/serializers/submission_serializer/sections/provider_details.rb
+++ b/app/serializers/submission_serializer/sections/provider_details.rb
@@ -5,6 +5,7 @@ module SubmissionSerializer
         Jbuilder.new do |json|
           json.provider_details do
             json.office_code crime_application.office_code
+            json.provider_email crime_application.provider_email
             json.legal_rep_first_name crime_application.legal_rep_first_name
             json.legal_rep_last_name crime_application.legal_rep_last_name
             json.legal_rep_telephone crime_application.legal_rep_telephone

--- a/app/services/datastore/application_submission.rb
+++ b/app/services/datastore/application_submission.rb
@@ -12,10 +12,9 @@ module Datastore
       date_stamp = crime_application.date_stamp || submitted_at
 
       CrimeApplication.transaction do
-        crime_application.update!(
-          status: ApplicationStatus::SUBMITTED.value,
-          submitted_at: submitted_at,
-          date_stamp: date_stamp,
+        crime_application.assign_attributes(
+          submitted_at:,
+          date_stamp:,
         )
 
         DatastoreApi::Requests::CreateApplication.new(

--- a/db/migrate/20230119163611_add_provider_details_to_application.rb
+++ b/db/migrate/20230119163611_add_provider_details_to_application.rb
@@ -1,0 +1,9 @@
+class AddProviderDetailsToApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :provider_details, :jsonb, null: false, default: {}
+
+    remove_column :crime_applications, :legal_rep_first_name, :string
+    remove_column :crime_applications, :legal_rep_last_name, :string
+    remove_column :crime_applications, :legal_rep_telephone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_10_130424) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_19_163611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,9 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_10_130424) do
     t.serial "usn", null: false
     t.string "ioj_passport", default: [], null: false, array: true
     t.string "office_code"
-    t.string "legal_rep_first_name"
-    t.string "legal_rep_last_name"
-    t.string "legal_rep_telephone"
+    t.jsonb "provider_details", default: {}, null: false
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end

--- a/spec/forms/steps/submission/declaration_form_spec.rb
+++ b/spec/forms/steps/submission/declaration_form_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe Steps::Submission::DeclarationForm do
   end
 
   let(:legal_rep_telephone) { '123456789' }
-  let(:provider_record) { Provider.new(rep_details_attrs) }
+  let(:provider_record) { Provider.new(provider_attrs.merge(rep_details_attrs)) }
   let(:crime_application) { instance_double(CrimeApplication) }
 
+  let(:provider_attrs) { { email: 'provider@example.com' } }
   let(:rep_details_attrs) { {} }
 
   describe '#save' do
@@ -57,7 +58,7 @@ RSpec.describe Steps::Submission::DeclarationForm do
           allow(provider_record).to receive(:update).and_return(true)
 
           expect(crime_application).to receive(:update).with(
-            expected_attrs
+            expected_attrs.merge(provider_email: 'provider@example.com')
           ).and_return(true)
 
           expect(subject.save).to be(true)
@@ -94,7 +95,7 @@ RSpec.describe Steps::Submission::DeclarationForm do
       context 'when the details have not changed' do
         let(:rep_details_attrs) { expected_attrs }
 
-        it 'does not save the record but returns true' do
+        it 'saves the record, but not the provider settings, and returns true' do
           expect(crime_application).to receive(:update)
           expect(provider_record).not_to receive(:update)
           expect(subject.save).to be(true)

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Application do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) { CrimeApplication.new(status: :submitted) }
+  let(:crime_application) { CrimeApplication.new }
 
   describe '#sections' do
     before do
@@ -47,11 +47,8 @@ RSpec.describe SubmissionSerializer::Application do
       ).to match(
         a_hash_including(
           'schema_version' => 1.0,
-          'status' => 'submitted',
           'ioj_passport' => [],
-          'provider_details' => a_hash_including(
-            'office_code', 'legal_rep_first_name', 'legal_rep_last_name', 'legal_rep_telephone'
-          ),
+          'provider_details' => be_a(Hash),
           'client_details' => a_hash_including('applicant'),
           'case_details' => a_hash_including('offences' => [], 'codefendants' => []),
           'interests_of_justice' => [],

--- a/spec/serializers/submission_serializer/sections/application_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/application_details_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
       created_at: created_at,
       submitted_at: submitted_at,
       date_stamp: date_stamp,
-      status: 'submitted',
       ioj_passport: ['on_case_type'],
     )
   end
@@ -28,7 +27,6 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
       submitted_at: submitted_at,
       date_stamp: date_stamp,
       schema_version: 1.0,
-      status: 'submitted',
       ioj_passport: ['on_case_type'],
     }.as_json
   end

--- a/spec/serializers/submission_serializer/sections/provider_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/provider_details_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SubmissionSerializer::Sections::ProviderDetails do
     instance_double(
       CrimeApplication,
       office_code: 'XYZ',
+      provider_email: 'foo@bar.com',
       legal_rep_first_name: 'John',
       legal_rep_last_name: 'Doe',
       legal_rep_telephone: '123456789',
@@ -17,6 +18,7 @@ RSpec.describe SubmissionSerializer::Sections::ProviderDetails do
     {
       provider_details: {
         office_code: 'XYZ',
+        provider_email: 'foo@bar.com',
         legal_rep_first_name: 'John',
         legal_rep_last_name: 'Doe',
         legal_rep_telephone: '123456789',

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Datastore::ApplicationSubmission do
     # create all neccessary records
     app = create_test_application(
       usn: 123,
+      provider_email: 'foo@bar.com',
       legal_rep_first_name: 'John',
       legal_rep_last_name: 'Doe',
       legal_rep_telephone: '123456789',
@@ -97,11 +98,12 @@ RSpec.describe Datastore::ApplicationSubmission do
     end
 
     context 'when `date_stamp` attribute is `nil`' do
-      it 'marks the application as submitted, setting the `date_stamp` to the submission date' do
+      it 'sets the `date_stamp` as the value of the submission date' do
         expect(
           crime_application
-        ).to receive(:update!).with(
-          status: :submitted, submitted_at: submitted_date, date_stamp: submitted_date
+        ).to receive(:assign_attributes).with(
+          submitted_at: submitted_date,
+          date_stamp: submitted_date,
         )
 
         expect(subject.call).to be(true)
@@ -115,11 +117,12 @@ RSpec.describe Datastore::ApplicationSubmission do
         allow(crime_application).to receive(:date_stamp).and_return(date_stamp)
       end
 
-      it 'marks the application as submitted, do not change the `date_stamp`' do
+      it 'does not change the `date_stamp` value' do
         expect(
           crime_application
-        ).to receive(:update!).with(
-          status: :submitted, submitted_at: submitted_date, date_stamp: date_stamp
+        ).to receive(:assign_attributes).with(
+          submitted_at: submitted_date,
+          date_stamp: date_stamp,
         )
 
         expect(subject.call).to be(true)


### PR DESCRIPTION
## Description of change
On submission, the currently signed in provider email address gets injected into the application to be propagated to the datastore along with the already existing legal representative attributes.

NOTE: on staging we are currently using a somehow lacking SAML mock, which does not return to us any email address. In the interim until we properly integrate with LAA Portal staging environment, a fallback email will be used, just so the schema validates the payload.

Additionally, and as recently discussed, Apply will stop sending a `status` attribute when submitting applications to the datastore. This attribute is redundant on submissions and the datastore was already setting the status to `submitted` anyways.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-121

## How to manually test the feature
Submitted applications (if testing locally, requires a datastore running latest version of the schemas gem) will contain the provider email address (inside the `provider_details` attribute). Also, submissions from Apply will not send to the datastore the `status` attribute anymore.