### PR TITLE
CRIMAP-239 Implement returned applications parent_id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 65f7b0b1f9807181fe48eb7a50ab657081c74bf0
+  revision: 9e5e82e7506b691ddc7ce4566bf317c8743d26f7
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,4 +25,10 @@ class ApplicationController < ActionController::Base
       yield(crime_application) if block
     end
   end
+
+  def present_crime_application
+    @crime_application = helpers.present(
+      current_crime_application, CrimeApplicationPresenter
+    )
+  end
 end

--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -1,4 +1,6 @@
 class CompletedApplicationsController < DashboardController
+  include DatastoreApplicationConsumer
+
   before_action :check_crime_application_presence,
                 :present_crime_application, only: [:show]
 
@@ -49,13 +51,5 @@ class CompletedApplicationsController < DashboardController
     ].map(&:to_s)
 
     allowed_statuses.include?(params[:q]) ? params[:q] : allowed_statuses.first
-  end
-
-  def current_crime_application
-    return if params[:id].blank?
-
-    @current_crime_application ||= DatastoreApi::Requests::GetApplication.new(
-      application_id: params[:id]
-    ).call
   end
 end

--- a/app/controllers/concerns/datastore_application_consumer.rb
+++ b/app/controllers/concerns/datastore_application_consumer.rb
@@ -1,0 +1,13 @@
+module DatastoreApplicationConsumer
+  extend ActiveSupport::Concern
+
+  private
+
+  def current_crime_application
+    return if params[:id].blank?
+
+    @current_crime_application ||= DatastoreApi::Requests::GetApplication.new(
+      application_id: params[:id]
+    ).call
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -19,12 +19,6 @@ class DashboardController < ApplicationController
                     .merge(Applicant.with_name)
   end
 
-  def present_crime_application
-    @crime_application = helpers.present(
-      current_crime_application, CrimeApplicationPresenter
-    )
-  end
-
   def application_counters
     @application_counters ||= Datastore::ApplicationCounters.new(
       office_code: current_office_code

--- a/app/controllers/steps/submission/confirmation_controller.rb
+++ b/app/controllers/steps/submission/confirmation_controller.rb
@@ -1,22 +1,14 @@
 module Steps
   module Submission
     class ConfirmationController < Steps::SubmissionStepController
-      # This action is special, as soon we will not have
-      # a DB record after the application is submitted.
-      # Ensure there is nothing in the view using the DB.
-      #
-      skip_before_action :check_crime_application_presence,
-                         :update_navigation_stack
+      include DatastoreApplicationConsumer
 
-      def show
-        @reference = reference_param
-      end
+      skip_before_action :update_navigation_stack
 
-      private
+      before_action :check_crime_application_presence,
+                    :present_crime_application, only: [:show]
 
-      def reference_param
-        params[:reference].to_i
-      end
+      def show; end
     end
   end
 end

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -5,6 +5,10 @@ class CrimeApplicationPresenter < BasePresenter
     )
   end
 
+  def resubmission?
+    parent_id.present?
+  end
+
   def applicant_dob
     l(applicant.date_of_birth)
   end

--- a/app/serializers/submission_serializer/sections/application_details.rb
+++ b/app/serializers/submission_serializer/sections/application_details.rb
@@ -5,6 +5,7 @@ module SubmissionSerializer
       def to_builder
         Jbuilder.new do |json|
           json.id crime_application.id
+          json.parent_id crime_application.parent_id
           json.schema_version 1.0
           json.reference crime_application.reference
           json.created_at crime_application.created_at

--- a/app/services/adapters/base_application.rb
+++ b/app/services/adapters/base_application.rb
@@ -18,11 +18,5 @@ module Adapters
     def status
       ApplicationStatus.new(super)
     end
-
-    # Keep this wrapper method in case we retract from
-    # using sequence USN to use any other ID/reference
-    def laa_reference
-      reference
-    end
   end
 end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -12,6 +12,7 @@ module Datastore
 
       crime_application.update!(
         client_has_partner: YesNoAnswer::NO,
+        parent_id: parent.id,
         date_stamp: parent.date_stamp,
         ioj_passport: parent.ioj_passport,
         applicant: applicant,

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -14,11 +14,8 @@ module Decisions
     private
 
     def submit_application
-      # Get it before we purge the local DB record
-      reference = current_crime_application.usn
-
       if Datastore::ApplicationSubmission.new(current_crime_application).call
-        show(:confirmation, reference:)
+        show(:confirmation)
       else
         edit(:failure)
       end

--- a/app/views/completed_applications/index.html.erb
+++ b/app/views/completed_applications/index.html.erb
@@ -40,7 +40,7 @@
                 <%= l(app.submitted_at) %>
               </td>
               <td class="govuk-table__cell">
-                <%= app.laa_reference %>
+                <%= app.reference %>
               </td>
             </tr>
           <% end %>

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -14,7 +14,7 @@
           <%= t('.laa_reference') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @crime_application.laa_reference %>
+          <%= @crime_application.reference %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -24,7 +24,7 @@
         <%= t('.aside.reference') %>
       </h3>
       <p class="govuk-body">
-        <%= @crime_application.laa_reference %>
+        <%= @crime_application.reference %>
       </p>
 
       <% if @crime_application.applicant? %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -39,7 +39,7 @@
                 <%= l(app.created_at) %>
               </td>
               <td class="govuk-table__cell">
-                <%= app.laa_reference %>
+                <%= app.reference %>
               </td>
               <td class="govuk-table__cell">
                 <%= button_to confirm_destroy_crime_application_path(app), method: :get,

--- a/app/views/steps/submission/confirmation/show.en.html.erb
+++ b/app/views/steps/submission/confirmation/show.en.html.erb
@@ -5,12 +5,16 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-6">
       <h1 class="govuk-panel__title">
-        Application complete
+        <% if @crime_application.resubmission? %>
+          Application updated
+        <% else %>
+          Application complete
+        <% end %>
       </h1>
       <div class="govuk-panel__body">
         Your reference number<br>
         <strong>
-          <%= @reference %>
+          <%= @crime_application.reference %>
         </strong>
       </div>
     </div>

--- a/db/migrate/20230123111219_add_parent_id_to_applications.rb
+++ b/db/migrate/20230123111219_add_parent_id_to_applications.rb
@@ -1,0 +1,5 @@
+class AddParentIdToApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :parent_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_19_163611) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_23_111219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_19_163611) do
     t.string "ioj_passport", default: [], null: false, array: true
     t.string "office_code"
     t.jsonb "provider_details", default: {}, null: false
+    t.uuid "parent_id"
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end

--- a/spec/controllers/steps/submission/confirmation_controller_spec.rb
+++ b/spec/controllers/steps/submission/confirmation_controller_spec.rb
@@ -2,22 +2,23 @@ require 'rails_helper'
 
 RSpec.describe Steps::Submission::ConfirmationController, type: :controller do
   describe 'confirmation page' do
-    it 'responds with HTTP success' do
-      get :show, params: { id: 'uuid', reference: '123' }
-      expect(response).to be_successful
+    let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+    let(:application_fixture) { LaaCrimeSchemas.fixture(1.0) }
 
-      reference = controller.instance_variable_get(:@reference)
-
-      expect(reference).to eq(123)
+    before do
+      stub_request(:get, "http://datastore-webmock/api/v2/applications/#{application_id}")
+        .to_return(body: application_fixture)
     end
 
-    it 'sanitises the reference' do
-      get :show, params: { id: 'uuid', reference: "'<script>alert('boom!');</script>'" }
+    it 'responds with HTTP success' do
+      get :show, params: { id: application_id }
       expect(response).to be_successful
 
-      reference = controller.instance_variable_get(:@reference)
+      crime_app = controller.instance_variable_get(:@crime_application)
 
-      expect(reference).to eq(0)
+      expect(crime_app).not_to be_nil
+      expect(crime_app.reference).to eq(6_000_001)
+      expect(crime_app.resubmission?).to be(false)
     end
   end
 end

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe CrimeApplicationPresenter do
     end
 
     it 'has a reference number' do
-      expect(subject.laa_reference).to eq(123)
+      expect(subject.reference).to eq(123)
     end
   end
 
-  describe 'for a completed application (API response)' do
+  describe 'for a submitted application (API response)' do
     subject { described_class.new(datastore_application) }
 
     let(:datastore_application) do
@@ -129,9 +129,9 @@ RSpec.describe CrimeApplicationPresenter do
       end
     end
 
-    describe '#laa_reference' do
+    describe '#reference' do
       it 'returns the reference number' do
-        expect(subject.laa_reference).to eq(6_000_001)
+        expect(subject.reference).to eq(6_000_001)
       end
     end
   end

--- a/spec/serializers/submission_serializer/sections/application_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/application_details_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
     instance_double(
       CrimeApplication,
       id: 'uuid',
+      parent_id: nil,
       reference: 6_000_001,
       created_at: created_at,
       submitted_at: submitted_at,
@@ -22,11 +23,12 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
   let(:json_output) do
     {
       id: 'uuid',
+      parent_id: nil,
+      schema_version: 1.0,
       reference: 6_000_001,
       created_at: created_at,
       submitted_at: submitted_at,
       date_stamp: date_stamp,
-      schema_version: 1.0,
       ioj_passport: ['on_case_type'],
     }.as_json
   end

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Datastore::ApplicationRehydration do
         crime_application
       ).to receive(:update!).with(
         client_has_partner: YesNoAnswer::NO,
+        parent_id: '47a93336-7da6-48ec-b139-808ddd555a41',
         date_stamp: an_instance_of(DateTime),
         ioj_passport: an_instance_of(Array),
         applicant: an_instance_of(Applicant),

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Decisions::SubmissionDecisionTree do
 
   let(:crime_application) do
     instance_double(
-      CrimeApplication, id: 'uuid', usn: 123,
+      CrimeApplication,
+      id: 'uuid',
     )
   end
 
@@ -51,7 +52,7 @@ RSpec.describe Decisions::SubmissionDecisionTree do
       context 'when the submission was successful' do
         let(:submission_success) { true }
 
-        it { is_expected.to have_destination(:confirmation, :show, id: crime_application, reference: 123) }
+        it { is_expected.to have_destination(:confirmation, :show, id: crime_application) }
       end
 
       context 'when the submission was unsuccessful' do


### PR DESCRIPTION
## Description of change
The PR is a bit large with a changes in some other files as I took the opportunity to refactor some of the old code we had (from the time when the applications were still not purged in the local DB).

On rehydration of returned applications, persist the UUID of the returned application as `parent_id` in the new, in_progress, application, so by the time it is submitted we can propagate this to the datastore.

This `parent_id` can then be used to know things like:
- it is a resubmission (as first-time submissions will have this attribute to nil)
- what application (submitted, persisted in the datastore) this new resubmission was originated from
- link all resubmissions together for a given USN and perform diffs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-239
https://dsdmoj.atlassian.net/browse/CRIMAP-184

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="725" alt="Screenshot 2023-01-23 at 13 27 12" src="https://user-images.githubusercontent.com/687910/214051310-e3e57c5d-43a1-4217-bd77-f2f3a4189e97.png">

## How to manually test the feature
Rehydrate a returned application and resubmit the application. It will propagate the original application UUID as `parent_id` in the JSON payload, and also in the confirmation page, instead of "Application complete" it should read "Application updated" as per designs.