### PR TITLE
Update developer tools with new return action

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: 89bb758a13361e5eac17d255f42888cb946397f9
+  revision: f0d5d0bb3a56e9708569d95513f99294586d634a
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 9e5e82e7506b691ddc7ce4566bf317c8743d26f7
+  revision: c7febd8d13df6522d19971d0a37db0095abb45b2
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
@@ -114,7 +114,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -163,7 +163,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
-    faraday (2.7.3)
+    faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -2,13 +2,7 @@
 module DeveloperTools
   class CrimeApplicationsController < ApplicationController
     def destroy
-      if current_crime_application
-        current_crime_application.destroy
-      elsif current_remote_application
-        DatastoreApi::Requests::DeleteApplication.new(
-          application_id: params[:id]
-        ).call
-      end
+      current_crime_application.destroy
 
       redirect_to crime_applications_path, flash: { success: 'Application has been deleted' }
     end
@@ -16,10 +10,17 @@ module DeveloperTools
     def mark_as_returned
       DatastoreApi::Requests::UpdateApplication.new(
         application_id: params[:id],
-        payload: { status: ApplicationStatus::RETURNED }
+        member: :return,
+        payload: {
+          return_details: {
+            reason: :provider_request,
+            details: 'Application returned through Apply developer tools.',
+          }
+        }
       ).call
 
-      redirect_to crime_applications_path, flash: { success: 'Application marked as returned' }
+      redirect_to completed_crime_applications_path(q: :returned),
+                  flash: { success: 'Application marked as returned' }
     end
 
     def bypass_dwp

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -22,13 +22,17 @@
                           data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>
           <% end %>
 
-          <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
-                        class: 'govuk-button govuk-!-margin-right-1',
-                        data: { module: 'govuk-button' } do; 'Mark as returned'; end if crime_application.submitted? %>
+          <% if crime_application.in_progress? %>
+            <%= button_to developer_tools_crime_application_path, method: :delete,
+                          class: 'govuk-button govuk-button--warning',
+                          data: { module: 'govuk-button' } do; 'Destroy'; end %>
+          <% end %>
 
-          <%= button_to developer_tools_crime_application_path, method: :delete,
-                        class: 'govuk-button govuk-button--warning',
-                        data: { module: 'govuk-button' } do; 'Destroy'; end %>
+          <% if crime_application.submitted? %>
+            <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
+                          class: 'govuk-button govuk-!-margin-right-1',
+                          data: { module: 'govuk-button' } do; 'Return application'; end %>
+          <% end %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## Description of change
Use the new v2 return endpoint to mark an application as returned from the developer tools.

When viewing a submitted application, go to the footer, developer tools, and there will be a button `Return application`.

Returned applications will show in the returned list in the dashboard.

The reason will be added in another PR.

NOTE: it requires a PR currently open in the datastore to be merged in order for the new endpoint to work.

## Screenshots of changes (if applicable)
<img width="705" alt="Screenshot 2023-01-25 at 11 05 56" src="https://user-images.githubusercontent.com/687910/214548112-d28267ad-0712-4bee-9c83-5c070fb2ed48.png">
<img width="1106" alt="Screenshot 2023-01-25 at 11 00 11" src="https://user-images.githubusercontent.com/687910/214548137-292ed15b-3c96-44d7-b3ca-fc50737a8309.png">


## How to manually test the feature
