### PR TITLE
CRIMAP-264 Show return details in certificate page

### DIFF
--- a/app/views/completed_applications/_return_notification.html.erb
+++ b/app/views/completed_applications/_return_notification.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title"
+     data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      <%= t('.title') %>
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <h3 class="govuk-notification-banner__heading">
+      <%= t('.heading') %>
+    </h3>
+
+    <p class="govuk-body">
+      <%= t('.reason', reason_type: t(return_details.reason, scope: 'shared.reason_types')) %>
+    </p>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          <%= t('.view_details') %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%= simple_format(return_details.details, { class: 'govuk-body' }) %>
+      </div>
+    </details>
+  </div>
+</div>

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -7,7 +7,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'return_notification',
+               locals: { return_details: @crime_application.return_details } if @crime_application.returned? %>
+
     <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
+
     <dl class="govuk-summary-list govuk-summary-list--no-border app-summary-list--compact">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -64,6 +64,11 @@ en:
         intro: If you need to withdraw or update this application before it has been processed by the LAA, contact the criminal applications helpline.
         phone: 'Telephone: 0300 200 2020'
         hours: 9am to 5pm, Monday to Friday (excluding bank holidays)
+    return_notification:
+      title: Important
+      heading: You need to update this application
+      reason: "The application has been returned because: %{reason_type}."
+      view_details: View details
   shared:
     dashboard_header:
       heading: Your applications
@@ -78,6 +83,12 @@ en:
         zero: Returned
         one: Returned (1)
         other: Returned (%{count})
+    reason_types:
+      clarification_required: Clarification required
+      evidence_issue: Evidence issue
+      duplicate_application: Duplicate application
+      case_concluded: Case has already concluded
+      provider_request: Provider request
     errors:
       datastore:
         unavailable:

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe 'Dashboard' do
 
   describe 'show an application certificate (in `returned` status)' do
     # NOTE: this is almost identical to `submitted` state, only difference
-    # is there is an `Update application` button instead of a print button.
+    # is there is an `Update application` button instead of a print button,
+    # and a notification banner with the return details.
     # No need to test everything again.
 
     before do
@@ -89,6 +90,18 @@ RSpec.describe 'Dashboard' do
       expect(response).to have_http_status(:success)
 
       assert_select 'h1', 'Application for criminal legal aid certificate'
+    end
+
+    it 'has a notification banner with the return details' do
+      assert_select 'div.govuk-notification-banner' do
+        assert_select 'h2', 'Important'
+        assert_select 'div.govuk-notification-banner__content' do
+          assert_select 'h3', 'You need to update this application'
+          assert_select 'p.govuk-body:nth-of-type(1)',
+                        'The application has been returned because: Clarification required.'
+          assert_select 'div.govuk-details__text', 'Further information regarding IoJ required'
+        end
+      end
     end
 
     it 'has appropriate CTA buttons' do


### PR DESCRIPTION
## Description of change
NOTE: design and copy is still under discussion with service designers but will be some similar incarnation to what is being implemented here.

When an application is returned, rendering its certificate page will show a notification banner in the top of the page with the return details. These details come from the datastore.

There is a separate ticket to redesign the application overview details (reference number, date stamp, date submitted...)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-264

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="764" alt="Screenshot 2023-01-25 at 12 58 43" src="https://user-images.githubusercontent.com/687910/214569775-a3137888-e7af-4f4c-8768-d5c57cf5e60e.png">
<img width="769" alt="Screenshot 2023-01-25 at 12 58 58" src="https://user-images.githubusercontent.com/687910/214569789-15a993f6-8298-4fcc-ad8a-da91a551eaa2.png">

## How to manually test the feature
Mark an application as returned, and go to its certificate page in the dashboard. It requires latest version of the datastore running locally (or use harness).