### PR TITLE
add provider details to certificate page

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -6,6 +6,7 @@ module Summary
       @crime_application = Adapters::BaseApplication.build(crime_application)
     end
 
+    # rubocop:disable Metrics/AbcSize
     def sections
       [
         Sections::ClientDetails.new(crime_application),
@@ -16,7 +17,9 @@ module Summary
         Sections::NextCourtHearing.new(crime_application),
         Sections::JustificationForLegalAid.new(crime_application),
         Sections::PassportJustificationForLegalAid.new(crime_application),
+        Sections::LegalRepresentativeDetails.new(crime_application),
       ].select(&:show?)
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/presenters/summary/sections/legal_representative_details.rb
+++ b/app/presenters/summary/sections/legal_representative_details.rb
@@ -1,0 +1,45 @@
+module Summary
+  module Sections
+    class LegalRepresentativeDetails < Sections::BaseSection
+      def name
+        :legal_representative_details
+      end
+
+      def show?
+        provider_details.present? && super
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def answers
+        [
+          Components::FreeTextAnswer.new(
+            :office_code, provider_details.office_code,
+          ),
+
+          Components::FreeTextAnswer.new(
+            :provider_email, provider_details.provider_email,
+          ),
+
+          Components::FreeTextAnswer.new(
+            :legal_rep_first_name, provider_details.legal_rep_first_name,
+          ),
+
+          Components::FreeTextAnswer.new(
+            :legal_rep_last_name, provider_details.legal_rep_last_name,
+          ),
+
+          Components::FreeTextAnswer.new(
+            :legal_rep_telephone, provider_details.legal_rep_telephone, show: true,
+          ),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def provider_details
+        @provider_details ||= crime_application.provider_details
+      end
+    end
+  end
+end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -17,6 +17,7 @@ en:
       next_court_hearing: Next court hearing
       justification_for_legal_aid: Justification for legal aid
       passport_justification_for_legal_aid: Justification for legal aid
+      legal_representative_details: Legal representative details
 
     questions:
       # BEGIN client details section
@@ -127,3 +128,16 @@ en:
         answers: 
           'true': Details provided do not require further justification for legal aid
       # END passport justification for legal aid section
+
+      # BEGIN legal representative details section
+      office_code:
+        question: Office account number
+      provider_email:
+        question: Email address
+      legal_rep_first_name:
+        question: First name
+      legal_rep_last_name:
+        question: Last name
+      legal_rep_telephone:
+        question: Telephone
+      # END legal representative details section

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -16,7 +16,7 @@ describe Summary::HtmlPresenter do
 
     context 'for a database application' do
       let(:crime_application) do
-        instance_double(CrimeApplication, applicant: double, case: double, ioj: double)
+        instance_double(CrimeApplication, applicant: double, case: double, ioj: double, provider_details: nil)
       end
 
       it 'has the right sections in the right order' do
@@ -55,6 +55,7 @@ describe Summary::HtmlPresenter do
             Summary::Sections::NextCourtHearing,
             Summary::Sections::JustificationForLegalAid,
             Summary::Sections::PassportJustificationForLegalAid,
+            Summary::Sections::LegalRepresentativeDetails,
           ]
         )
       end


### PR DESCRIPTION
## Description of change

Add legal representative details to the certificate page

## Link to relevant ticket

https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-257

## Notes for reviewer

## Screenshots of changes (if applicable)

![0 0 0 0_3000_completed_applications_2a86cf90-d0e7-419b-9d82-25cc1f9dabd0](https://user-images.githubusercontent.com/367349/215450591-f78ccba2-9946-4b54-9396-19106298449e.png)

## How to manually test the feature

Submit an application and check the completed application page. Legal representative details should be at the bottom of the page.