### PR TITLE
Add additional secretRef to deployment template

### DIFF
--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -60,6 +60,8 @@ spec:
               name: configmap-staging
           - secretRef:
               name: secrets-staging
+          - secretRef:
+              name: portal-certificates-staging
         env:
           # secrets created by terraform
           - name: DATABASE_URL


### PR DESCRIPTION
## Description of change
Follow-up to previous PR #267.

The new secrets (portal certificates) are created but if we don't specify them in the deployment template, they are not being picked up 🤦‍♂️ 