### PR TITLE
CRIMAP-267 Better handling of application statuses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: f0d5d0bb3a56e9708569d95513f99294586d634a
+  revision: edddba0959c9b71655aa4349c38548a9d5aa18b0
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: c7febd8d13df6522d19971d0a37db0095abb45b2
+  revision: 2530eda6f3b1c89bfa7f18230bba684b6d6e3419
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   add_flash_types :success
 
   def current_crime_application
-    @current_crime_application ||= CrimeApplication.find_by(id: params[:id])
+    @current_crime_application ||= CrimeApplication.find_by(id: application_id)
   end
   helper_method :current_crime_application
 
@@ -30,5 +30,9 @@ class ApplicationController < ActionController::Base
     @crime_application = helpers.present(
       current_crime_application, CrimeApplicationPresenter
     )
+  end
+
+  def application_id
+    params[:id]
   end
 end

--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -5,7 +5,7 @@ class CompletedApplicationsController < DashboardController
                 :present_crime_application, only: [:show]
 
   def index
-    @applications = Datastore::GetApplications.new(
+    @applications = Datastore::ListApplications.new(
       filtering: filtering_params, sorting: sorting_params, pagination: pagination_params
     ).call&.page(params[:page])
   end

--- a/app/controllers/concerns/datastore_application_consumer.rb
+++ b/app/controllers/concerns/datastore_application_consumer.rb
@@ -4,10 +4,8 @@ module DatastoreApplicationConsumer
   private
 
   def current_crime_application
-    return if params[:id].blank?
+    return if application_id.blank?
 
-    @current_crime_application ||= DatastoreApi::Requests::GetApplication.new(
-      application_id: params[:id]
-    ).call
+    @current_crime_application ||= Datastore::GetApplication.new(application_id).call
   end
 end

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -9,7 +9,7 @@ module DeveloperTools
 
     def mark_as_returned
       DatastoreApi::Requests::UpdateApplication.new(
-        application_id: params[:id],
+        application_id: application_id,
         member: :return,
         payload: {
           return_details: {
@@ -40,12 +40,6 @@ module DeveloperTools
     end
 
     private
-
-    def current_remote_application
-      @current_remote_application ||= DatastoreApi::Requests::GetApplication.new(
-        application_id: params[:id]
-      ).call
-    end
 
     def crime_application
       @crime_application ||= current_crime_application || initialize_crime_application(

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -11,8 +11,7 @@ class CrimeApplication < ApplicationRecord
   has_many :addresses, through: :people
   has_many :codefendants, through: :case
 
-  enum status: ApplicationStatus.enum_values,
-       _default: ApplicationStatus.enum_values[:in_progress]
+  enum status: ApplicationStatus.enum_values
 
   alias_attribute :reference, :usn
 

--- a/app/presenters/crime_application_presenter.rb
+++ b/app/presenters/crime_application_presenter.rb
@@ -21,18 +21,16 @@ class CrimeApplicationPresenter < BasePresenter
     applicant.present?
   end
 
+  # This is used in the task list (applications in progress)
+  #
   # - If case type is “date stampable”, we use the date stamp value
-  # - If case type is non “date stampable”, and the application is submitted,
-  #   we use the submission date as the date stamp
+  # - If case type is non “date stampable”, we just return `nil`
+  #
+  # We have to check if it is date stampable, instead of blindly
+  # using `date_stamp` value, as provider might change case types
   #
   def interim_date_stamp
-    date = if date_stampable?
-             date_stamp
-           elsif submitted?
-             submitted_at
-           end
-
-    l(date, format: :datetime) if date
+    l(date_stamp, format: :datetime) if date_stampable? && date_stamp.present?
   end
 
   def date_stampable?

--- a/app/presenters/tasks/declaration.rb
+++ b/app/presenters/tasks/declaration.rb
@@ -16,8 +16,10 @@ module Tasks
       !!crime_application.legal_rep_first_name
     end
 
+    # `in_progress` applications will never have this task
+    # marked as completed, as the completion means submitting it
     def completed?
-      crime_application.submitted?
+      false
     end
   end
 end

--- a/app/services/adapters/base_application.rb
+++ b/app/services/adapters/base_application.rb
@@ -1,6 +1,6 @@
 module Adapters
   class BaseApplication < SimpleDelegator
-    delegate :in_progress?, :submitted?, :returned?, to: :status
+    delegate(*ApplicationStatus::INQUIRY_METHODS, to: :status)
     delegate :case_type, to: :case, allow_nil: true
 
     def self.build(object)

--- a/app/services/datastore/get_application.rb
+++ b/app/services/datastore/get_application.rb
@@ -21,7 +21,7 @@ module Datastore
     private
 
     def superseded?(app)
-      ApplicationStatus.new(app.fetch('status')).superseded?
+      ApplicationStatus.new(app.status).superseded?
     end
   end
 end

--- a/app/services/datastore/get_application.rb
+++ b/app/services/datastore/get_application.rb
@@ -1,0 +1,27 @@
+module Datastore
+  class GetApplication
+    attr_reader :application_id
+
+    def initialize(application_id)
+      @application_id = application_id
+    end
+
+    def call
+      app = DatastoreApi::Requests::GetApplication.new(
+        application_id:
+      ).call
+
+      raise DatastoreApi::Errors::NotFoundError if superseded?(app)
+
+      app
+    rescue DatastoreApi::Errors::NotFoundError
+      raise Errors::ApplicationNotFound
+    end
+
+    private
+
+    def superseded?(app)
+      ApplicationStatus.new(app.fetch('status')).superseded?
+    end
+  end
+end

--- a/app/services/datastore/list_applications.rb
+++ b/app/services/datastore/list_applications.rb
@@ -1,5 +1,5 @@
 module Datastore
-  class GetApplications
+  class ListApplications
     attr_reader :filtering, :sorting, :pagination
 
     def initialize(filtering:, sorting:, pagination:)

--- a/app/value_objects/application_status.rb
+++ b/app/value_objects/application_status.rb
@@ -3,9 +3,14 @@ class ApplicationStatus < ValueObject
     IN_PROGRESS = new(:in_progress),
     SUBMITTED   = new(:submitted),
     RETURNED    = new(:returned),
+    SUPERSEDED  = new(:superseded),
+  ].freeze
+
+  LOCALLY_PERSISTED_STATUSES = [
+    IN_PROGRESS,
   ].freeze
 
   def self.enum_values
-    values.to_h { |value| [value.to_sym, value.to_s] }
+    LOCALLY_PERSISTED_STATUSES.map(&:value).index_with(&:to_s)
   end
 end

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -21,13 +21,19 @@ class ValueObject
   end
 
   class << self
+    # Define inquiry methods for each value in the value object,
+    # i.e. `#coffee?` returns true for value `:coffee`, false for `:tea`
     def inherited(subclass)
-      TracePoint.trace(:end) do
-        # Define inquiry methods for each value in the value object,
-        # i.e. `#coffee?` returns true for value `:coffee`, false for `:tea`
+      TracePoint.trace(:end) do |trace|
         # :nocov:
-        subclass.values.each do |value|
-          define_method("#{value}?") { value.eql?(self) }
+        if subclass == trace.self
+          subclass.const_set(
+            :INQUIRY_METHODS, subclass.values.map { |value| "#{value}?".to_sym }
+          )
+
+          subclass.values.each do |value|
+            subclass.define_method("#{value}?") { value.eql?(self) }
+          end
         end
         # :nocov:
       end

--- a/db/migrate/20230130161415_set_default_application_status.rb
+++ b/db/migrate/20230130161415_set_default_application_status.rb
@@ -1,0 +1,5 @@
+class SetDefaultApplicationStatus < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :crime_applications, :status, :in_progress
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_111219) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_30_161415) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -68,7 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_111219) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "client_has_partner"
-    t.string "status"
+    t.string "status", default: "in_progress"
     t.datetime "date_stamp"
     t.datetime "submitted_at"
     t.serial "usn", null: false

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe CrimeApplication, type: :model do
         described_class.statuses
       ).to eq(
         'in_progress' => 'in_progress',
-        'submitted' => 'submitted',
-        'returned' => 'returned',
       )
     end
   end

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -35,16 +35,16 @@ RSpec.describe CrimeApplicationPresenter do
   end
 
   describe '#interim_date_stamp' do
+    before do
+      allow(subject).to receive(:date_stamp).and_return(date_stamp)
+    end
+
+    let(:date_stamp) { DateTime.new(2022, 2, 1) }
+
     context 'when a case is date stampable' do
       let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
-      before do
-        allow(subject).to receive(:date_stamp).and_return(date_stamp)
-      end
-
       context 'and it has a date_stamp' do
-        let(:date_stamp) { DateTime.new(2022, 2, 1) }
-
         it { expect(subject.interim_date_stamp).to eq('1 February 2022 12:00am') }
       end
 
@@ -56,22 +56,14 @@ RSpec.describe CrimeApplicationPresenter do
     end
 
     context 'when a case is not date stampable' do
-      let(:case_type) { CaseType::INDICTABLE.to_s }
-
-      context 'and the application is submitted' do
-        let(:crime_application) do
-          CrimeApplication.new(status: :submitted, submitted_at: DateTime.new(2022, 2, 15))
-        end
-
-        it 'uses the `submitted_at` date as the date stamp' do
-          expect(subject.interim_date_stamp).to eq('15 February 2022 12:00am')
-        end
+      context 'and a date_stamp was set previously' do
+        it { expect(subject.interim_date_stamp).to be_nil }
       end
 
-      context 'and the application is not yet submitted' do
-        it 'returns nil' do
-          expect(subject.interim_date_stamp).to be_nil
-        end
+      context 'and a date_stamp was not set' do
+        let(:date_stamp) { nil }
+
+        it { expect(subject.interim_date_stamp).to be_nil }
       end
     end
   end

--- a/spec/presenters/summary/sections/base_section_spec.rb
+++ b/spec/presenters/summary/sections/base_section_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 describe Summary::Sections::BaseSection do
   subject { described_class.new(crime_application, **arguments) }
 
-  let(:crime_application) { CrimeApplication.new(status:) }
-  let(:status) { :in_progress }
+  let(:crime_application) { CrimeApplication.new }
   let(:arguments) { {} }
 
   describe '#to_partial_path' do
@@ -50,8 +49,10 @@ describe Summary::Sections::BaseSection do
       end
     end
 
-    context 'for an application `submitted`' do
-      let(:status) { :submitted }
+    context 'for an application other than `in_progress`' do
+      let(:crime_application) do
+        Adapters::BaseApplication.build(build_struct_application)
+      end
 
       it 'returns false' do
         expect(subject.editable?).to be(false)

--- a/spec/presenters/tasks/declaration_spec.rb
+++ b/spec/presenters/tasks/declaration_spec.rb
@@ -6,12 +6,10 @@ RSpec.describe Tasks::Declaration do
   let(:crime_application) do
     CrimeApplication.new(
       legal_rep_first_name:,
-      status:,
     )
   end
 
   let(:legal_rep_first_name) { nil }
-  let(:status) { ApplicationStatus::IN_PROGRESS.to_s }
 
   before do
     allow(crime_application).to receive(:id).and_return('12345')
@@ -66,14 +64,6 @@ RSpec.describe Tasks::Declaration do
   end
 
   describe '#completed?' do
-    context 'when application is submitted' do
-      let(:status) { ApplicationStatus::SUBMITTED.to_s }
-
-      it { expect(subject.completed?).to be(true) }
-    end
-
-    context 'when application is in_progress' do
-      it { expect(subject.completed?).to be(false) }
-    end
+    it { expect(subject.completed?).to be(false) }
   end
 end

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe Adapters::Structs::Applicant do
   subject { application_struct.applicant }
 
-  let(:application_struct) do
-    Adapters::Structs::CrimeApplication.new(
-      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
-    )
-  end
+  let(:application_struct) { build_struct_application }
 
   describe '#first_name' do
     it 'returns the applicant first name' do

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe Adapters::Structs::CaseDetails do
   subject { application_struct.case }
 
-  let(:application_struct) do
-    Adapters::Structs::CrimeApplication.new(
-      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
-    )
-  end
+  let(:application_struct) { build_struct_application }
 
   describe '#charges' do
     it 'returns a charges collection' do

--- a/spec/services/adapters/structs/crime_application_spec.rb
+++ b/spec/services/adapters/structs/crime_application_spec.rb
@@ -1,11 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Adapters::Structs::CrimeApplication do
-  subject { described_class.new(datastore_application) }
-
-  let(:datastore_application) do
-    JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
-  end
+  subject { build_struct_application }
 
   describe '#applicant' do
     it 'returns the applicant struct' do

--- a/spec/services/adapters/structs/interests_of_justice_spec.rb
+++ b/spec/services/adapters/structs/interests_of_justice_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe Adapters::Structs::InterestsOfJustice do
   subject { application_struct.ioj }
 
-  let(:application_struct) do
-    Adapters::Structs::CrimeApplication.new(
-      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
-    )
-  end
+  let(:application_struct) { build_struct_application }
 
   describe '#types' do
     it 'returns the IoJ types' do

--- a/spec/services/datastore/get_application_spec.rb
+++ b/spec/services/datastore/get_application_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::GetApplication do
+  subject { described_class.new('12345') }
+
+  let(:endpoint) { 'http://datastore-webmock/api/v2/applications/12345' }
+  let(:datastore_result) { '{"status":"submitted"}' }
+
+  before do
+    stub_request(:get, endpoint).to_return(body: datastore_result)
+  end
+
+  describe '#call' do
+    it 'returns the application' do
+      expect(subject.call).to be_a(DatastoreApi::Responses::ApplicationResult)
+    end
+
+    context 'for a superseded application' do
+      let(:datastore_result) { '{"status":"superseded"}' }
+
+      it 'raises `ApplicationNotFound`' do
+        expect { subject.call }.to raise_exception(Errors::ApplicationNotFound)
+      end
+    end
+  end
+
+  context 'handling of errors' do
+    before do
+      stub_request(:get, endpoint).to_raise(error)
+    end
+
+    context 'for not found errors' do
+      let(:error) { DatastoreApi::Errors::NotFoundError }
+
+      it 're-raises as `ApplicationNotFound`' do
+        expect { subject.call }.to raise_exception(Errors::ApplicationNotFound)
+      end
+    end
+
+    context 'for other kind of errors' do
+      let(:error) { StandardError }
+
+      it 'lets the exception bubble up' do
+        expect { subject.call }.to raise_exception(StandardError)
+      end
+    end
+  end
+end

--- a/spec/services/datastore/list_applications_spec.rb
+++ b/spec/services/datastore/list_applications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Datastore::GetApplications do
+RSpec.describe Datastore::ListApplications do
   subject { described_class.new(filtering:, sorting:, pagination:) }
 
   let(:filtering) do

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -6,4 +6,10 @@ module FactoryHelpers
       { office_code: TEST_OFFICE_CODE }.merge(attributes)
     )
   end
+
+  def build_struct_application(fixture_name: 'application')
+    Adapters::Structs::CrimeApplication.new(
+      JSON.parse(LaaCrimeSchemas.fixture(1.0, name: fixture_name).read)
+    )
+  end
 end

--- a/spec/value_objects/application_status_spec.rb
+++ b/spec/value_objects/application_status_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe ApplicationStatus do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w[in_progress submitted returned]
+        %w[in_progress submitted returned superseded]
       )
     end
   end
 
   describe '.enum_values' do
-    it 'returns a map of values, used as an enum definition' do
+    it 'returns a map of values, used as the `status` enum definition' do
       expect(
         described_class.enum_values
-      ).to eq({ in_progress: 'in_progress', submitted: 'submitted', returned: 'returned' })
+      ).to eq({ in_progress: 'in_progress' })
     end
   end
 end

--- a/spec/value_objects/value_object_spec.rb
+++ b/spec/value_objects/value_object_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-Fruit = Class.new(ValueObject) do
-  const_set(:VALUES, [new(:apple), new(:banana)])
-end
-
 RSpec.describe ValueObject do
   subject { described_class.new(value) }
 
@@ -77,15 +73,21 @@ RSpec.describe ValueObject do
   end
 
   describe 'inquiry methods' do
-    let(:fruit_one) { Fruit.new(:apple) }
-    let(:fruit_two) { Fruit.new(:banana) }
+    let(:yes_answer) { YesNoAnswer.new(:yes) }
+    let(:no_answer)  { YesNoAnswer.new(:no) }
+
+    it 'has a constant with the inquiry methods' do
+      expect(
+        YesNoAnswer::INQUIRY_METHODS
+      ).to match_array(%i[yes? no?])
+    end
 
     it 'defines inquiry methods for each of the values' do
-      expect(fruit_one.apple?).to be(true)
-      expect(fruit_one.banana?).to be(false)
+      expect(yes_answer.yes?).to be(true)
+      expect(yes_answer.no?).to be(false)
 
-      expect(fruit_two.apple?).to be(false)
-      expect(fruit_two.banana?).to be(true)
+      expect(no_answer.yes?).to be(false)
+      expect(no_answer.no?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Description of change
This is mostly a refactor and tidy up of some code that no longer makes sense because we only have in progress applications locally, and anything else is remote (datastore).

Previously, we had still a few coupling of the `status` values to locally persisted records, this is no longer the case.

To be extremely explicit, the `enum` in the `CrimeApplication` model now only support `in_progress` values so it forbids trying to persist to local DB a record in any other status (to limit mistakes).

Implement (similar to the others we already had) a `Datastore::GetApplication` service object that encapsulates the call to the API and handling of errors (including not found).

Awaiting confirmation from service designer on what to do with `superseded` applications, but for now, and for the sake of this code, I'm treating them as "not found" which means showing a "nice" error page to the user (this is an existing error page).

Finally, fixed a bug in the `ValueObject` superclass where inquiry methods were polluting other value object subclasses namespace.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-267

## Notes for reviewer

## Screenshots of changes (if applicable)

## How to manually test the feature
Everything should behave as before, but datastore applications not found (fake an UUID in the URL, for instance) will produce as expected a human not found error page. Same (for now, unless decided otherwise) for superseded applications.