### PR TITLE
CRIMAP-264 Update design and copy in returned page

### DIFF
--- a/app/views/completed_applications/_return_notification.html.erb
+++ b/app/views/completed_applications/_return_notification.html.erb
@@ -7,22 +7,13 @@
   </div>
   <div class="govuk-notification-banner__content">
     <h3 class="govuk-notification-banner__heading">
-      <%= t('.heading') %>
+      <%= t('.heading', reason: t(".reasons.#{return_details.reason}", default: '')) %>
     </h3>
 
-    <p class="govuk-body">
-      <%= t('.reason', reason_type: t(return_details.reason, scope: 'shared.reason_types')) %>
-    </p>
+    <%= simple_format(return_details.details, { class: 'govuk-body' }) %>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          <%= t('.view_details') %>
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <%= simple_format(return_details.details, { class: 'govuk-body' }) %>
-      </div>
-    </details>
+    <%= button_to recreate_completed_crime_application_path, method: :put,
+                  class: 'govuk-button app-button--blue govuk-!-margin-bottom-2 app-no-print',
+                  data: { module: 'govuk-button' } do; t('.update_application'); end %>
   </div>
 </div>

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -26,13 +26,7 @@
     <% end %>
 
     <div class="govuk-!-margin-top-8 app-no-print">
-      <% if @crime_application.returned? %>
-        <%= button_to recreate_completed_crime_application_path, method: :put,
-                      class: 'govuk-button app-button--blue',
-                      data: { module: 'govuk-button' } do; t('.recreate_application'); end %>
-      <% else %>
-        <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
-      <% end %>
+      <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
     </div>
 
     <%= render @presenter.sections %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -57,7 +57,6 @@ en:
       laa_reference: "Reference number:"
       date_stamp: "Date stamp:"
       date_submitted: "Date submitted:"
-      recreate_application: Update application
       print_application: Print application
       back_to_applications: Back to all applications
       helpline:
@@ -66,9 +65,14 @@ en:
         hours: 9am to 5pm, Monday to Friday (excluding bank holidays)
     return_notification:
       title: Important
-      heading: You need to update this application
-      reason: "The application has been returned because: %{reason_type}."
-      view_details: View details
+      heading: LAA have returned this application %{reason}
+      reasons:
+        clarification_required: because further clarification is needed
+        evidence_issue: because there was an issue with the evidence that was sent
+        duplicate_application: because it is a duplicated application
+        case_concluded: because the case has already concluded
+        provider_request: at your request
+      update_application: Update application
   shared:
     dashboard_header:
       heading: Your applications
@@ -83,12 +87,6 @@ en:
         zero: Returned
         one: Returned (1)
         other: Returned (%{count})
-    reason_types:
-      clarification_required: Clarification required
-      evidence_issue: Evidence issue
-      duplicate_application: Duplicate application
-      case_concluded: Case has already concluded
-      provider_request: Provider request
     errors:
       datastore:
         unavailable:

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe 'Dashboard' do
       assert_select 'h1', 'Application for criminal legal aid certificate'
     end
 
-    it 'has appropriate CTA buttons' do
-      # There is no update button
-      assert_select 'button.govuk-button', count: 0, text: 'Update application'
-
-      # There are 2 print buttons, one above the summary, another in the bottom
+    it 'has print buttons' do
       assert_select 'a.govuk-button', count: 2, text: 'Print application'
+    end
+
+    it 'does not have an update application button' do
+      assert_select 'button.govuk-button', count: 0, text: 'Update application'
     end
 
     # rubocop:disable RSpec/ExampleLength
@@ -85,8 +85,7 @@ RSpec.describe 'Dashboard' do
 
   describe 'show an application certificate (in `returned` status)' do
     # NOTE: this is almost identical to `submitted` state, only difference
-    # is there is an `Update application` button instead of a print button,
-    # and a notification banner with the return details.
+    # is there is a notification banner with the return details and CTA button.
     # No need to test everything again.
 
     before do
@@ -106,20 +105,11 @@ RSpec.describe 'Dashboard' do
       assert_select 'div.govuk-notification-banner' do
         assert_select 'h2', 'Important'
         assert_select 'div.govuk-notification-banner__content' do
-          assert_select 'h3', 'You need to update this application'
-          assert_select 'p.govuk-body:nth-of-type(1)',
-                        'The application has been returned because: Clarification required.'
-          assert_select 'div.govuk-details__text', 'Further information regarding IoJ required'
+          assert_select 'h3', 'LAA have returned this application because further clarification is needed'
+          assert_select 'p.govuk-body', 'Further information regarding IoJ required'
+          assert_select 'button.govuk-button', count: 1, text: 'Update application'
         end
       end
-    end
-
-    it 'has appropriate CTA buttons' do
-      # There is 1 update button
-      assert_select 'button.govuk-button', count: 1, text: 'Update application'
-
-      # There is 1 print button
-      assert_select 'a.govuk-button', count: 1, text: 'Print application'
     end
 
     it 're-creates the application and renders the check your answers page' do


### PR DESCRIPTION
## Description of change
This is a follow-up PR to #265, as the final design and copy has now been decided by service designers.

There are no functional changes.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-264

Figma resubmission journey:
https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=4595%3A50120

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="747" alt="Screenshot 2023-02-03 at 15 08 09" src="https://user-images.githubusercontent.com/687910/216637545-fa23439b-a1e8-4a13-94e4-0e2a1b53915d.png">

### After changes:
<img width="735" alt="Screenshot 2023-02-03 at 15 08 24" src="https://user-images.githubusercontent.com/687910/216637561-d7b3659d-3408-4fbd-a003-a79418f8a216.png">

## How to manually test the feature
This will show in any returned application certificate.