### PR TITLE
Remove unused secret ref from deployment

### DIFF
--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -60,8 +60,6 @@ spec:
               name: configmap-staging
           - secretRef:
               name: secrets-staging
-          - secretRef:
-              name: portal-certificates-staging
         env:
           #
           # secrets created by `certificates.yml`


### PR DESCRIPTION
## Description of change
We are not using these portal secrets anymore as a consequence of previous PR #273. Forgot to clean up this.
