### PR TITLE
Prepare Apply to use datastore JWT auth

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,13 +9,16 @@ DATABASE_URL=postgresql://postgres@localhost/laa-apply-for-criminal-legal-aid
 # Choose your preferred datastore method.
 # Locally running datastore service (recommended way) or remote harness (shared with others).
 #
-# Local datastore (no credentials)
+# Local datastore endpoint
 # DATASTORE_API_ROOT=http://localhost:3003
 
 # Harness datastore (ask a team member for the credentials)
 # DATASTORE_API_ROOT=https://criminal-applications-datastore-harness.apps.live.cloud-platform.service.justice.gov.uk
 # DATASTORE_AUTH_USERNAME=
 # DATASTORE_AUTH_PASSWORD=
+
+# Local datastore API shared secret for JWT auth
+DATASTORE_API_AUTH_SECRET=
 
 # LAA Portal SAML authentication metadata endpoint
 # or path to a locally-stored metadata file, one or the other

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,11 @@ gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', 
 gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
+# Gem is not published to rubygems. If published, then we will not need this,
+# as it can be loaded via the `datastore-api-client` gem instead
+gem 'simple-jwt-auth',
+    github: 'ministryofjustice/simple-jwt-auth'
+
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: edddba0959c9b71655aa4349c38548a9d5aa18b0
+  revision: d6926f1b19a8642022a68fb84659e23f8371eae1
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)
@@ -19,6 +19,14 @@ GIT
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
       json-schema (~> 3.0.0)
+
+GIT
+  remote: https://github.com/ministryofjustice/simple-jwt-auth.git
+  revision: 174ad91cd1d9ba13e990ab98be2e9db21dc8b625
+  specs:
+    simple-jwt-auth (0.0.1)
+      json
+      jwt
 
 GEM
   remote: https://rubygems.org/
@@ -201,6 +209,7 @@ GEM
     json (2.6.3)
     json-schema (3.0.0)
       addressable (>= 2.8)
+    jwt (2.7.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -449,6 +458,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
+  simple-jwt-auth!
   simplecov
   sprockets-rails
   uk_postcode

--- a/config/initializers/datastore_client.rb
+++ b/config/initializers/datastore_client.rb
@@ -5,6 +5,8 @@ DatastoreApi.configure do |config|
   config.api_path = '/api/v2'
 
   # Basic auth is only needed on staging
+  # To be replaced with `jwt` auth soon
+  config.auth_type = :basic
   config.basic_auth_username = ENV.fetch('DATASTORE_AUTH_USERNAME', nil)
   config.basic_auth_password = ENV.fetch('DATASTORE_AUTH_PASSWORD', nil)
 

--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -1,0 +1,12 @@
+require 'simple_jwt_auth'
+
+# If DatastoreApi `auth_type` is set to `jwt` then this
+# configuration will be used to generate the auth tokens
+#
+SimpleJwtAuth.configure do |config|
+  config.issuer = 'crime-apply'
+
+  config.secrets_config = {
+    config.issuer => ENV.fetch('DATASTORE_API_AUTH_SECRET', nil)
+  }
+end

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -82,3 +82,8 @@ spec:
               secretKeyRef:
                 name: rds-instance
                 key: url
+          - name: DATASTORE_API_AUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: datastore-api-auth-secret
+                key: secret


### PR DESCRIPTION
## Description of change
Merging this will not enable JWT or change any functionality on Apply, as it is not enabled yet (to enable, change `config.auth_type = :jwt`).

Once enabled, the datastore API client will make use of a little middleware introduced in the `simple-jwt-auth` gem to generate and send a JWT bearer token.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-273

## Notes for reviewer
If wanted to test locally, a corresponding PR has been raised in the datastore repo, in order to have an end to end, locally-testable demo.
