### PR TITLE
Set a more sensible default for ENV variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -12,7 +12,9 @@ DATABASE_URL=postgresql://postgres@localhost/laa-apply-for-criminal-legal-aid
 # Local datastore endpoint
 DATASTORE_API_ROOT=http://localhost:3003
 # Local datastore API shared secret for JWT auth
-DATASTORE_API_AUTH_SECRET=
+# Value does not matter, as long as it is not blank or nil,
+# and the datastore has the same env value
+DATASTORE_API_AUTH_SECRET=foobar
 
 # Harness datastore (ask a team member for the credentials)
 # DATASTORE_API_ROOT=https://criminal-applications-datastore-harness.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change
With openssl >= 3.0.0 you need to have something in those secrets. Nil or empty string will produce an error.

With openssl < 3.0.0 a nil value will blow up but funnily enough not an empty string.

To avoid confusion and edge cases with the openssl version installed in each system, we set a default dummy value, so developers don't need to set their own in their `.local` files.
