### PR TITLE
CRIMAP-286 Configure logging and filtering of PII

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'faraday', '~> 2.7'
 gem 'govuk_design_system_formbuilder', '~> 3.3.0'
 gem 'jbuilder', '~> 2.11.5'
 gem 'kaminari'
+gem 'lograge'
+gem 'logstash-event'
 gem 'pg', '~> 1.4'
 gem 'puma'
 gem 'rails', '~> 7.0.3'
@@ -22,7 +24,6 @@ gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-saml', '~> 2.1.0'
 
 # Accessing soap apis
-
 gem 'savon'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,12 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    lograge (0.12.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -302,6 +308,8 @@ GEM
     regexp_parser (2.6.1)
     reline (0.3.2)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -438,6 +446,8 @@ DEPENDENCIES
   kaminari
   laa-criminal-applications-datastore-api-client!
   laa-criminal-legal-aid-schemas!
+  lograge
+  logstash-event
   mail (< 2.8.0)
   omniauth-rails_csrf_protection
   omniauth-saml (~> 2.1.0)

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,5 +5,22 @@
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
-  :SAMLResponse, :Signature, :SigAlg, :KeyInfo
+  :SAMLResponse, :Signature, :SigAlg, :KeyInfo,
+  # Attributes relating to an application
+  # It does partial matching (i.e. `telephone_number` is covered by `phone`)
+  :first_name,
+  :last_name,
+  :other_names,
+  :date_of_birth,
+  :nino,
+  :address_line,
+  :postcode,
+  :email,
+  :phone,
+  :urn,
+  :maat_id,
+  :reason,
+  :description,
+  :justification,
+  :appeal_with_changes_details,
 ]

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,32 @@
+Rails.application.configure do
+  config.lograge.enabled = Rails.env.production?
+
+  config.lograge.base_controller_class = 'ActionController::Base'
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+
+  config.lograge.ignore_actions = %w[
+    HealthcheckController#show
+    HealthcheckController#ping
+  ]
+
+  config.lograge.custom_options = lambda do |event|
+    request = event.payload[:request]
+
+    {
+      process_id: Process.pid,
+      host: request.host,
+      request_id: request.request_id,
+      user_agent: request.user_agent,
+      params: request.params.except(
+        *%w[controller action format id]
+      ),
+    }.compact_blank
+  end
+
+  config.lograge.custom_payload do |controller|
+    {
+      provider_id: controller.current_provider.to_param,
+    }
+  end
+end


### PR DESCRIPTION
## Description of change
Logs to stdout so other systems can route these logs to final destinations for viewing and long-term archival. For example this is needed to see the logs in Kibana.

Also, added PII parameters to the filter. These are also used by Sentry when reporting exceptions.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-286

## How to manually test the feature
On local environments this new log stream to stdout can seen and tested by running the app in production mode, or by using docker-compose.
In our k8s namespaces, logs will output to stdout and can be accessed in Kibana.