### PR TITLE
Use the post-processed and filtered params hash

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
       host: request.host,
       request_id: request.request_id,
       user_agent: request.user_agent,
-      params: request.params.except(
+      params: request.filtered_parameters.except(
         *%w[controller action format id]
       ),
     }.compact_blank


### PR DESCRIPTION
## Description of change
This should read `filtered_parameters` instead of `params`. Which is why I added the params to the `config/initializers/filter_parameter_logging.rb` file in previous PR #280 :facepalm

