### PR TITLE
(test) Portal DEV integration (use SAMLmock again)

### DIFF
--- a/app/lib/laa_portal_setup.rb
+++ b/app/lib/laa_portal_setup.rb
@@ -15,7 +15,7 @@ class LaaPortalSetup
   def setup
     parse_metadata_and_merge(
       sp_entity_id: SP_ENTITY_ID,
-      idp_sso_service_binding: :post,
+      idp_sso_service_binding: :redirect,
       certificate: ENV.fetch('LAA_PORTAL_SP_CERT', nil),
       private_key: ENV.fetch('LAA_PORTAL_SP_PRIVATE_KEY', nil),
       security: {
@@ -23,6 +23,7 @@ class LaaPortalSetup
         signature_method: XMLSecurity::Document::RSA_SHA256,
         authn_requests_signed: true,
         want_assertions_signed: true,
+        want_assertions_encrypted: true,
         check_idp_cert_expiration: true,
         check_sp_cert_expiration: true,
       },

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -23,5 +23,5 @@ data:
   # corresponding certificates, if required (in `deployment.tpl` file)
   #
   # LAA_PORTAL_IDP_METADATA_URL: https://samlmock.dev.legalservices.gov.uk/metadata
-  # LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/samlmock.xml
-  LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/dev.xml
+  LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/samlmock.xml
+  # LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/dev.xml

--- a/spec/lib/laa_portal_setup_spec.rb
+++ b/spec/lib/laa_portal_setup_spec.rb
@@ -99,7 +99,7 @@ describe LaaPortalSetup do
           {
             foo: 'bar',
             sp_entity_id: 'crime-apply',
-            idp_sso_service_binding: :post,
+            idp_sso_service_binding: :redirect,
             certificate: nil,
             private_key: nil,
             security: {
@@ -107,6 +107,7 @@ describe LaaPortalSetup do
               signature_method: XMLSecurity::Document::RSA_SHA256,
               authn_requests_signed: true,
               want_assertions_signed: true,
+              want_assertions_encrypted: true,
               check_idp_cert_expiration: true,
               check_sp_cert_expiration: true,
             },


### PR DESCRIPTION
## Description of change
Follow-up to PRs #282 and #283.

Revert to use SAMLmock so staging is functional for the time being until we have a corresponding Portal staging env integration.

