### PR TITLE
CRIMAP-254 Avoid error message repetition

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -136,40 +136,35 @@ en:
               inclusion: Select yes if you want to add another offence
               missing_details: You must complete all offence details in order to proceed
         steps/case/offence_date_fieldset_form:
+          shared_date_errors: &shared_date_errors
+            blank: Date cannot be blank
+            invalid: Enter a valid date
+            invalid_day: Enter a valid day
+            invalid_month: Enter a valid month
+            invalid_year: Enter a valid year
+            year_too_early: Date is too far in the past
+            future_not_allowed: Date cannot be in the future
+            before_date_from: End date cannot be before start date
           attributes:
-            date_from:
-              blank: Offence start date cannot be blank
-              invalid: Enter a valid start date
-              invalid_day: Enter a valid day
-              invalid_month: Enter a valid month
-              invalid_year: Enter a valid year
-              year_too_early: Date is too far in the past
-              future_not_allowed: Offence start date cannot be in the future
-            date_to:
-              invalid: Enter a valid end date
-              invalid_day: Enter a valid day
-              invalid_month: Enter a valid month
-              invalid_year: Enter a valid year
-              year_too_early: Date is too far in the past
-              future_not_allowed: Offence end date cannot be in the future
-              before_date_from: Offence end date cannot be before start date
+            date_from: *shared_date_errors
+            date_to: *shared_date_errors
           summary:
             date_from:
-              blank: Offence start date cannot be blank
-              invalid: Enter a valid date
-              invalid_day: Enter a valid day
-              invalid_month: Enter a valid month
-              invalid_year: Enter a valid year
-              year_too_early: Date is too far in the past
-              future_not_allowed: Offence start date cannot be in the future
+              blank: Start date %{index} cannot be blank
+              invalid: Enter a valid start date %{index}
+              invalid_day: Enter a valid start date %{index} day
+              invalid_month: Enter a valid start date %{index} month
+              invalid_year: Enter a valid start date %{index} year
+              year_too_early: Start date %{index} is too far in the past
+              future_not_allowed: Start date %{index} cannot be in the future
             date_to:
-              invalid: Enter a valid date
-              invalid_day: Enter a valid day
-              invalid_month: Enter a valid month
-              invalid_year: Enter a valid year
-              year_too_early: Date is too far in the past
-              future_not_allowed: Offence end date cannot be in the future
-              before_date_from: Offence end date cannot be before start date
+              invalid: Enter a valid end date %{index}
+              invalid_day: Enter a valid end date %{index} day
+              invalid_month: Enter a valid end date %{index} month
+              invalid_year: Enter a valid end date %{index} year
+              year_too_early: End date %{index} is too far in the past
+              future_not_allowed: End date %{index} cannot be in the future
+              before_date_from: End date %{index} cannot be before start date %{index}
         steps/case/hearing_details_form:
           attributes:
             hearing_court_name:
@@ -185,27 +180,27 @@ en:
         steps/case/ioj_form:
           attributes:
             types:
-              invalid: Select a criteria
+              invalid: Select why your client should get legal aid
             loss_of_liberty_justification:
-              blank: Enter more detail
+              blank: Enter details on why it is likely they will lose their liberty if any matter in the proceedings is decided against them
             suspended_sentence_justification:
-              blank: Enter more detail
+              blank: Enter details on why they have been given a sentence that is suspended or non-custodial
             loss_of_livelihood_justification:
-              blank: Enter more detail
+              blank: Enter details on why it is likely they will lose their livelihood
             reputation_justification:
-              blank: Enter more detail
+              blank: Enter details on why it is likely they will suffer serious damage to their reputation
             question_of_law_justification:
-              blank: Enter more detail
+              blank: Enter details on why a substantial question of law may be involved
             understanding_justification:
-              blank: Enter more detail
+              blank: Enter details on why they may not be able to understand the court proceedings or present their own case
             witness_tracing_justification:
-              blank: Enter more detail
+              blank: Enter details on why witnesses may need to be traced or interviewed
             expert_examination_justification:
-              blank: Enter more detail
+              blank: Enter details on why the proceedings may involve expert cross-examination of a prosecution witness
             interest_of_another_justification:
-              blank: Enter more detail
+              blank: Enter details on why it is in the interest of another person that your client is represented
             other_justification:
-              blank: Enter more detail
+              blank: Enter details on why your client should get legal aid
         steps/submission/declaration_form:
           attributes:
             legal_rep_first_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -59,7 +59,7 @@ en:
       steps_case_urn_form:
         urn: For example, ‘12 AB 3456789’.
       steps_case_charges_form:
-        offence_name: For example, robbery
+        offence_name: Add one offence at a time, for example, robbery. You can add more later.
         date_to: Leave blank if the offence happened on a single date
       steps_case_hearing_details_form:
         hearing_court_name: For example, Cardiff Crown Court
@@ -128,7 +128,7 @@ en:
         appeal_with_changes_maat_id: Previous MAAT ID (optional)
         appeal_with_changes_details: Enter the details of what has changed
       steps_case_charges_form:
-        offence_name: Offence name
+        offence_name: Offence
       steps_case_charges_summary_form:
         add_offence_options: *YESNO
       steps_case_has_codefendants_form:
@@ -151,15 +151,15 @@ en:
         interest_of_another_justification: Interest of another justification
         other_justification: Other justification
         types_options:
-          loss_of_liberty: It is likely that they will lose their liberty if any matter in the proceedings is decided against them.
-          suspended_sentence: They have been given a sentence that is suspended or non-custodial. If they break this, the court may be able to deal with them for the original offence.
-          loss_of_livelihood: It is likely that they will lose their livelihood.
-          reputation: It is likely that they will suffer serious damage to their reputation.
-          question_of_law: A substantial question of law may be involved (whether arising from legislation, judicial authority or other source of law).
-          understanding: They may not be able to understand the court proceedings or present their own case.
-          witness_tracing: Witnesses may need to be traced or interviewed on their behalf.
-          expert_examination: The proceedings may involve expert cross-examination of a prosecution witness (whether an expert or not).
-          interest_of_another: It is in the interests of another person (such as the person making a complaint or other witness) that they are represented.
+          loss_of_liberty: It is likely that they will lose their liberty if any matter in the proceedings is decided against them
+          suspended_sentence: They have been given a sentence that is suspended or non-custodial. If they break this, the court may be able to deal with them for the original offence
+          loss_of_livelihood: It is likely that they will lose their livelihood
+          reputation: It is likely that they will suffer serious damage to their reputation
+          question_of_law: A substantial question of law may be involved (whether arising from legislation, judicial authority or other source of law)
+          understanding: They may not be able to understand the court proceedings or present their own case
+          witness_tracing: Witnesses may need to be traced or interviewed on their behalf
+          expert_examination: The proceedings may involve expert cross-examination of a prosecution witness (whether an expert or not)
+          interest_of_another: It is in the interests of another person (such as the person making a complaint or other witness) that they are represented
           other: Other
       steps_submission_declaration_form:
         legal_rep_first_name: First name

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -129,7 +129,7 @@ en:
         edit:
           page_title: What has your client been charged with?
           heading: What has your client been charged with?
-          offence_dates_fieldset_legend: Offence dates
+          offence_dates_fieldset_legend: When did the offence happen?
           add_button: Add another date
           remove_button: Remove date %{index}
           deleted_flash: The offence date has been deleted

--- a/spec/forms/steps/case/charges_form_spec.rb
+++ b/spec/forms/steps/case/charges_form_spec.rb
@@ -46,17 +46,17 @@ RSpec.describe Steps::Case::ChargesForm do
 
         expect(subject.errors.of_kind?('offence_dates-attributes[0].date_from', :future_not_allowed)).to be(true)
         expect(subject.errors.messages_for('offence_dates-attributes[0].date_from').first).to eq(
-          'Offence start date cannot be in the future'
+          'Start date 1 cannot be in the future'
         )
 
         expect(subject.errors.of_kind?('offence_dates-attributes[0].date_to', :before_date_from)).to be(true)
         expect(subject.errors.messages_for('offence_dates-attributes[0].date_to').first).to eq(
-          'Offence end date cannot be before start date'
+          'End date 1 cannot be before start date 1'
         )
 
         expect(subject.errors.of_kind?('offence_dates-attributes[1].date_from', :blank)).to be(true)
         expect(subject.errors.messages_for('offence_dates-attributes[1].date_from').first).to eq(
-          'Offence start date cannot be blank'
+          'Start date 2 cannot be blank'
         )
       end
     end


### PR DESCRIPTION
## Description of change
As a preparation for an accessibility audit, we must try to avoid repetition of error messages (in summary) when in a page there are more than "1 thing of the same".

For instance, in the interests of justice page, when more than one justification text area was left blank, the error summary was repeating "Enter more detail" multiple times. This is no good.

Tweaked these and other minor changes in Offences page (hint texts, labels, etc.) after suggestions from content designer.

Some more copy changes might be implemented on follow-up PRs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-254

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="633" alt="Screenshot 2023-02-24 at 12 54 42" src="https://user-images.githubusercontent.com/687910/221184096-21917887-49e5-4212-bb95-3b55d420f647.png">

<img width="555" alt="Screenshot 2023-02-24 at 12 55 43" src="https://user-images.githubusercontent.com/687910/221184114-b75b2b54-859b-4132-af60-ea27af909a3c.png">


## How to manually test the feature
Go to the corresponding pages and produce the errors by leaving blank fields or incorrect dates, etc.