### PR TITLE
Offence suggestions a11y tweaks

### DIFF
--- a/app/javascript/local/suggestions.js
+++ b/app/javascript/local/suggestions.js
@@ -26,6 +26,11 @@ Input.prototype.init = function () {
     this.$suggestionsHeader.textContent = this.$module.getAttribute('data-suggestions-header') || 'Suggestions'
     this.$suggestionsHeader.hidden = true
 
+    // [change: suggestions counter and aria attrs]
+    this.$suggestionsHeader.setAttribute('role', 'status')
+    this.$suggestionsHeader.setAttribute('aria-live', 'polite')
+    this.$suggestionsHeader.appendChild(document.createElement('span'))
+
     this.$ul = document.createElement('ul')
     this.$ul.setAttribute('id', this.$module.getAttribute('id') + '-suggestions')
     this.$ul.addEventListener('click', this.handleSuggestionClicked.bind(this))
@@ -96,6 +101,9 @@ Input.prototype.updateSuggestions = function () {
 Input.prototype.updateSuggestionsWithOptions = function (options) {
   // Remove all the existing suggestions
   this.$ul.textContent = ''
+
+  // [change: suggestions counter]
+  this.$suggestionsHeader.querySelector('span').textContent = ' (' + options.length + ' found)'
 
   for (var option of options) {
     var li = document.createElement('li')


### PR DESCRIPTION
## Description of change
This minor improvement will show in the "Suggestions" dropdown header, the number of offences returned. This is handy for non visually impaired users, as it may not be immediately evident to some that the suggestions box is scrollable when more than 5 or 6 offences are returned.

Additionally, it is even more important for visually impaired users, using screen readers, as the number of suggestions will be announced whenever there are any changes (polite so it waits for any other text to be read first).

Tested with VoiceOver on Mac, further testing or tweaks might be needed, these may come up as part of the accessibility audit.

NOTE: I've marked the code changes, as with other tweaks we've made to this component, with `[change]`, so it is easy to cherry pick these in case the component remote branch is updated.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="706" alt="Screenshot 2023-02-27 at 09 24 35" src="https://user-images.githubusercontent.com/687910/221542548-f62a8f69-a3fa-4291-99e2-390511086790.png">

### After changes:
<img width="707" alt="Screenshot 2023-02-27 at 09 24 55" src="https://user-images.githubusercontent.com/687910/221542578-61a7efb4-7e9b-4a13-9511-08c864634e8f.png">

## How to manually test the feature
