### PR TITLE
CRIMAP-296 IoJ secondary input field copy tweaks

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -143,12 +143,12 @@ en:
         loss_of_liberty_justification: Loss of liberty justification
         suspended_sentence_justification: Suspended sentence justification
         loss_of_livelihood_justification: Loss of livelihood justification
-        reputation_justification: Reputation justification
+        reputation_justification: Damage to reputation justification
         question_of_law_justification: Question of law justification
-        understanding_justification: Understanding justification
+        understanding_justification: Unable to represent themselves justification
         witness_tracing_justification: Witness tracing justification
-        expert_examination_justification: Expert examination justification
-        interest_of_another_justification: Interest of another justification
+        expert_examination_justification: Expert cross-examination justification
+        interest_of_another_justification: Interest of another person justification
         other_justification: Other justification
         types_options:
           loss_of_liberty: It is likely that they will lose their liberty if any matter in the proceedings is decided against them


### PR DESCRIPTION
## Description of change
Related to accessibility issue "Secondary input field not linked to primary input".

We are using visually-hidden labels for each of those text areas, so I believe a screen reader should have additional context when using each of the text areas.

For example these visually hidden labels read like this:

- Unable to represent themselves justification
- Expert cross-examination justification

Etc.

I've updated to copy in some of them to be in line with the same copy we use in the Check your answers page.

Tested with VoiceOver on Mac, the visually hidden label is read aloud when entering the text area, giving full context to the user.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-296

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="743" alt="Screenshot 2023-02-27 at 11 19 11" src="https://user-images.githubusercontent.com/687910/221550833-e6630fd1-1ff1-49c7-91a8-efd724fd9316.png">
<img width="778" alt="Screenshot 2023-02-27 at 11 19 41" src="https://user-images.githubusercontent.com/687910/221550839-fed682ca-fa47-46fb-bdb1-ef39581c2475.png">


## How to manually test the feature
