### PR TITLE
Remove references to the datastore harness

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,20 +6,13 @@
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-apply-for-criminal-legal-aid
 
-# Choose your preferred datastore method.
-# Locally running datastore service (recommended way) or remote harness (shared with others).
-#
 # Local datastore endpoint
 DATASTORE_API_ROOT=http://localhost:3003
+
 # Local datastore API shared secret for JWT auth
 # Value does not matter, as long as it is not blank or nil,
 # and the datastore has the same env value
 DATASTORE_API_AUTH_SECRET=foobar
-
-# Harness datastore (ask a team member for the credentials)
-# DATASTORE_API_ROOT=https://criminal-applications-datastore-harness.apps.live.cloud-platform.service.justice.gov.uk
-# DATASTORE_AUTH_USERNAME=
-# DATASTORE_AUTH_PASSWORD=
 
 # LAA Portal SAML authentication metadata endpoint
 # or path to a locally-stored metadata file, one or the other

--- a/README.md
+++ b/README.md
@@ -49,12 +49,8 @@ Mainly, the service can be fully used without any external dependencies up until
 to receive the submitted application.  
 Also, some functionality in the dashboard will make use of this datastore.
 
-To facilitate an end-to-end local setup without worrying about dependencies, instead of running the local datastore service, 
-you can rely on a shared remote datastore harness service, which is identical to the one running on staging, but can be used by developers as 
-if it was running locally.
-
-However, for active development, and to debug or diagnose issues, running the datastore service locally will always be 
-the recommended way. Also it is much easier to inspect the database, wipe it, run migrations, etc.
+For active development, and to debug or diagnose issues, running the datastore locally along the Apply application is 
+the recommended way. Follow the instructions in the above repository to setup and run the datastore locally.
 
 ## Running the tests
 


### PR DESCRIPTION
## Description of change
The harness has been decommissioned in favour of running a local instance of the datastore.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-287

