### PR TITLE
CRIMAP-172 Use non-cluster specific domain

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -11,7 +11,7 @@ data:
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
 
   # Datastore endpoint for staging
-  DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
+  DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.cloud-platform.service.justice.gov.uk
 
   # If this is uncommented, authentication will be mocked
   # OMNIAUTH_TEST_MODE: "true"

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -9,6 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: secrets-staging
     nginx.ingress.kubernetes.io/server-snippet: |
+      if ($host = 'laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk') {
+        return 301 https://laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk;
+      }
       location = /.well-known/security.txt {
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
@@ -18,8 +21,19 @@ spec:
   tls:
   - hosts:
     - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+    - laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk
   rules:
   - host: laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: service-staging
+            port:
+              number: 80
+  - host: laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Description of change
As per documentation:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrating-from-live-1-domain-name.html

This is part of a broader ticket to use a custom domain for staging, however, for now this makes the service more resilient in case of cluster changes, until we have a production namespace and we set the proper final (and public) domains.

Old `*.apps.live` domain redirects to new domain to avoid breaking bookmarks etc.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-172

## How to manually test the feature
Both domains should work. If using old one (the `live` one) it will redirect to the non-cluster one (as in, no `live` in the URL).