### PR TITLE
CRIMAP-298 Ensure DWP mock works in all cases

### DIFF
--- a/app/services/dwp/mock_benefit_check_service.rb
+++ b/app/services/dwp/mock_benefit_check_service.rb
@@ -1,12 +1,12 @@
 module DWP
   class MockBenefitCheckService
     KNOWN = {
-      'SMITH' => { nino: 'NC123459A', dob: '11-Jan-1999' },
-      'JONES' => { nino: 'NC123458A', dob: '1-Jun-1980' },
-      'BLOGGS' => { nino: 'NC123457A', dob: '4-Jan-1990' },
-      'WRINKLE' => { nino: 'NC010150A', dob: '01-Jan-1950' },
-      'WALKER' => { nino: 'JA293483A', dob: '10-Jan-1980' }, # Used in cucumber tests and specs
-      'POTTER' => { nino: 'NC010155A', dob: '01-Jan-2007' }, # For under 18 passported on IOJ testing
+      'SMITH'   => { nino: 'NC123459A', dob: '11-01-1999' },
+      'JONES'   => { nino: 'NC123458A', dob: '01-06-1980' },
+      'BLOGGS'  => { nino: 'NC123457A', dob: '04-01-1990' },
+      'WRINKLE' => { nino: 'NC010150A', dob: '01-01-1950' },
+      'WALKER'  => { nino: 'JA293483A', dob: '10-01-1980' },
+      'POTTER'  => { nino: 'NC010155A', dob: '01-01-2007' }, # For under 18 passported on IOJ testing
     }.freeze
 
     def self.call(*args)
@@ -32,17 +32,16 @@ module DWP
       known? ? 'Yes' : 'No'
     end
 
-    def known?
-      key = last_name.to_s.upcase
-      return unless KNOWN.key?(key)
+    private
 
-      KNOWN[key] == applicant_data
+    def known?
+      KNOWN.fetch(last_name.to_s.upcase, nil) == applicant_data
     end
 
     def applicant_data
       {
         nino: nino,
-        dob: date_of_birth&.strftime('%d-%b-%Y'),
+        dob: date_of_birth&.strftime('%d-%m-%Y'),
       }
     end
   end


### PR DESCRIPTION
## Description of change
There are some scenarios where the DWP mock values wouldn't work, if the day or the month was entered with a different format to the expected by the mock.

Tweaked the code so it works no matter the format, so it works for 1-digit or 2-digits days and months (i.e. 1/1/1980 or 01/01/1980).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-298

## Notes for reviewer
Raised as some team members found issues entering mock DWP details. I've also updated the confluence page.

## How to manually test the feature
You can enter date of births with 1-digit or 2-digits for day or month, and it will still validate if it is a mock DWP or not.