### PR TITLE
CRIMAP-38 Replace samlmock with portal staging

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -22,6 +22,5 @@ data:
   # Important: make sure whatever Portal env is declared here, uses the
   # corresponding certificates, if required (in `deployment.tpl` file)
   #
-  # LAA_PORTAL_IDP_METADATA_URL: https://samlmock.dev.legalservices.gov.uk/metadata
-  LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/samlmock.xml
-  # LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/dev.xml
+  # LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/samlmock.xml
+  LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/staging.xml

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -67,12 +67,12 @@ spec:
           - name: LAA_PORTAL_SP_CERT
             valueFrom:
               secretKeyRef:
-                name: portal-sp-certificate-dev
+                name: portal-sp-certificate-staging
                 key: tls.crt
           - name: LAA_PORTAL_SP_PRIVATE_KEY
             valueFrom:
               secretKeyRef:
-                name: portal-sp-certificate-dev
+                name: portal-sp-certificate-staging
                 key: tls.key
           #
           # secrets created by `terraform`

--- a/config/laa_portal/metadata/dev.xml
+++ b/config/laa_portal/metadata/dev.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"
                      xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
                      xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"

--- a/config/laa_portal/metadata/samlmock.xml
+++ b/config/laa_portal/metadata/samlmock.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_415ca934-b9a3-4d04-8f88-b8feda265ac5"
                      entityID="http://mock-idp" validUntil="2023-01-28T16:02:31.873Z">
   <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">

--- a/config/laa_portal/metadata/staging.xml
+++ b/config/laa_portal/metadata/staging.xml
@@ -1,0 +1,87 @@
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"
+                     xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
+                     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                     xmlns:mdext="urn:oasis:names:tc:SAML:metadata:extension"
+                     xmlns:ns10="urn:oasis:names:tc:SAML:profiles:v1metadata"
+                     xmlns:query="urn:oasis:names:tc:SAML:metadata:ext:query"
+                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                     xmlns:x500="urn:oasis:names:tc:SAML:2.0:profiles:attribute:X500"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     ID="id-vDpzk9nYzAsGZD9gP6b-GDlX024jfKqGppPsbrnX" cacheDuration="P30DT0H0M0S"
+                     entityID="LAA_Identity_Provider" validUntil="2028-09-10T08:22:13Z">
+  <dsig:Signature>
+    <dsig:SignedInfo>
+      <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <dsig:Reference URI="#id-vDpzk9nYzAsGZD9gP6b-GDlX024jfKqGppPsbrnX">
+        <dsig:Transforms>
+          <dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <dsig:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </dsig:Transforms>
+        <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <dsig:DigestValue>lR24SyLSQSWJgasb8rVH4QbfG3c=</dsig:DigestValue>
+      </dsig:Reference>
+    </dsig:SignedInfo>
+    <dsig:SignatureValue>
+      RKS5v+ZTKr1g7KJiOmKWQgs/PpQobBcqx9ATC6uiUKTPBjxdC1NrvoRI/x0+TXZPaGIn7205RkvMRfb0rGhT9uAXuiNF2TV1F1nGFmlQlIf2BR92VrmA4/Y3AqZWImtePXOw3Vo3yuWDpvSp+97m7BDw0+7/X+gVvtbbtO3Q0Vwbvx3jnCgMlwxz71zxTNuUUR4oA3/lag85FU6gbLnVS0R+XM62OEQiUY0KGuzhYhhliPxOOqNNjLEClnir1yGrDGtQUz2AUw24oBR5OP0+XTOUcgOfMpDH9wHFDAOpFvoEjNci4BGU1w7cLluOlprL64FPy5bZSqYRoFNBcuPXF+GODi2dFf5BrE/z8YBotyNcMXVtat6qkIFfveWGC2zuHxNHJBOYo6EJooYQ+d3UK4Uhg52AKMjM1uawjOhH9oVhUCrc/ZEWX5Z76sSWH4Z+Bun4CwQQunMO4l0p3E8pC33zKRYuTgkfg0Fn2Yv9a2tKBmjF5CZF4H6i+hExRKpp
+    </dsig:SignatureValue>
+    <dsig:KeyInfo>
+      <dsig:X509Data>
+        <dsig:X509Certificate>
+          MIIEJTCCAo2gAwIBAgIBZjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEyppcC0xMC0yMDQtNC0yNTEuZXUtd2VzdC0yLmNvbXB1dGUuaW50ZXJuYWwwHhcNMTgwOTEzMDgyMjEzWhcNMjgwOTEwMDgyMjEzWjA1MTMwMQYDVQQDEyppcC0xMC0yMDQtNC0yNTEuZXUtd2VzdC0yLmNvbXB1dGUuaW50ZXJuYWwwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCNUVYZM9CgDjf3y9pW0iE2WcnJX4wLMAiFDBPKQQoxIrqJ7lMWo5ndaaHIUkXXSBJqy7y1Qeui3rq09U5QWILnKTvoNOBH6kr2GiUoyW6Y6xrUap3TSn/qTw50w4TTn/+WSaqycxEAODLJqz9uVUumPV/cdCO4fH5wQTDUGiOwJQ+/maArsgsIi2o3i1gNEWDa1eMLY9ge25gJKPLfq3Vl/0n4bXOG0qIkfer85ODkv+ZZRjUiZnv8xngRvRNcn3YnDdhGFrT11+HmbuXC/ACBGhewk1cuYbL0t73K/Eva42sKjGwSj3DNkIW9V7CZE4MhHgQ11MT0kMdUD08mJO9aCKL8eL0YEtikkTvTcAak+Bhfpxuor4ofE/Mno9kJYzV456U0QEv1OsMC0Rycl3h+LLY3zj3JqskfrGCPcdRutuQ9VnkYilDKcnMiPxjap6Szz+2I7o3zOsYlKr+gVLQw7ofIs1zGnoMFW/V/Xy3T5FRndQwiZyEO2HQ+d4dA8i0CAwEAAaNAMD4wDAYDVR0TAQH/BAIwADAPBgNVHQ8BAf8EBQMDB9gAMB0GA1UdDgQWBBTchxKHy+MfUgxuX1Tjy+kQzOsAijANBgkqhkiG9w0BAQsFAAOCAYEAFtgNLRAzb0Npr8/7KnjX3nxUYNJeM/NyKKksLepwV5aZd5+kBjNomiCLAJBDohqcN6B/kICfdBEbo7MZQp5VjoIOsZxowAKKanJF5LGgY4sz87ZXgCnTkE9toYPSwwxX6xJThm4AuX/iOzDKCaxaqZ/53tABu3npRGyVf9m9Wc0rj/J3g25pJL0xyw2tIpfmGuYEZ6r3fF3yAcHcnmNJGY0OgXNPXpKRvZf8EnHW9MjhCXUGFxrsUz5x4+AMJcy3EBqTsWNyyHi2Vd6PkxVGOodPs9Mm0M4LcG9gtlFNbXYRncYdobBRFnWkgEoa++wTrNDwWCKi3tu2W5z+sEwrs7rrbynln0OS95eK6gNn8AkRwJo9ub7xSfj6uwN5VUKe+fdi1aT1M5CqPuczUyUHRC3qjyNzjLsaBlCShWgMhWouaU5HOIAvLoTAoNmQeR+QbZG+Uql6TJdH86yT3SAnMav8ZiOcfTZ3Dk5stTdD1OpxNHtEDVCGWtRgjExaU9FQ
+        </dsig:X509Certificate>
+      </dsig:X509Data>
+    </dsig:KeyInfo>
+  </dsig:Signature>
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false"
+                       protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <dsig:KeyInfo>
+        <dsig:X509Data>
+          <dsig:X509Certificate>
+            MIIEJTCCAo2gAwIBAgIBZjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEyppcC0xMC0yMDQtNC0yNTEuZXUtd2VzdC0yLmNvbXB1dGUuaW50ZXJuYWwwHhcNMTgwOTEzMDgyMjEzWhcNMjgwOTEwMDgyMjEzWjA1MTMwMQYDVQQDEyppcC0xMC0yMDQtNC0yNTEuZXUtd2VzdC0yLmNvbXB1dGUuaW50ZXJuYWwwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCNUVYZM9CgDjf3y9pW0iE2WcnJX4wLMAiFDBPKQQoxIrqJ7lMWo5ndaaHIUkXXSBJqy7y1Qeui3rq09U5QWILnKTvoNOBH6kr2GiUoyW6Y6xrUap3TSn/qTw50w4TTn/+WSaqycxEAODLJqz9uVUumPV/cdCO4fH5wQTDUGiOwJQ+/maArsgsIi2o3i1gNEWDa1eMLY9ge25gJKPLfq3Vl/0n4bXOG0qIkfer85ODkv+ZZRjUiZnv8xngRvRNcn3YnDdhGFrT11+HmbuXC/ACBGhewk1cuYbL0t73K/Eva42sKjGwSj3DNkIW9V7CZE4MhHgQ11MT0kMdUD08mJO9aCKL8eL0YEtikkTvTcAak+Bhfpxuor4ofE/Mno9kJYzV456U0QEv1OsMC0Rycl3h+LLY3zj3JqskfrGCPcdRutuQ9VnkYilDKcnMiPxjap6Szz+2I7o3zOsYlKr+gVLQw7ofIs1zGnoMFW/V/Xy3T5FRndQwiZyEO2HQ+d4dA8i0CAwEAAaNAMD4wDAYDVR0TAQH/BAIwADAPBgNVHQ8BAf8EBQMDB9gAMB0GA1UdDgQWBBTchxKHy+MfUgxuX1Tjy+kQzOsAijANBgkqhkiG9w0BAQsFAAOCAYEAFtgNLRAzb0Npr8/7KnjX3nxUYNJeM/NyKKksLepwV5aZd5+kBjNomiCLAJBDohqcN6B/kICfdBEbo7MZQp5VjoIOsZxowAKKanJF5LGgY4sz87ZXgCnTkE9toYPSwwxX6xJThm4AuX/iOzDKCaxaqZ/53tABu3npRGyVf9m9Wc0rj/J3g25pJL0xyw2tIpfmGuYEZ6r3fF3yAcHcnmNJGY0OgXNPXpKRvZf8EnHW9MjhCXUGFxrsUz5x4+AMJcy3EBqTsWNyyHi2Vd6PkxVGOodPs9Mm0M4LcG9gtlFNbXYRncYdobBRFnWkgEoa++wTrNDwWCKi3tu2W5z+sEwrs7rrbynln0OS95eK6gNn8AkRwJo9ub7xSfj6uwN5VUKe+fdi1aT1M5CqPuczUyUHRC3qjyNzjLsaBlCShWgMhWouaU5HOIAvLoTAoNmQeR+QbZG+Uql6TJdH86yT3SAnMav8ZiOcfTZ3Dk5stTdD1OpxNHtEDVCGWtRgjExaU9FQ
+          </dsig:X509Certificate>
+          <dsig:X509IssuerSerial>
+            <dsig:X509IssuerName>CN=ip-10-204-4-251.eu-west-2.compute.internal</dsig:X509IssuerName>
+            <dsig:X509SerialNumber>102</dsig:X509SerialNumber>
+          </dsig:X509IssuerSerial>
+          <dsig:X509SubjectName>CN=ip-10-204-4-251.eu-west-2.compute.internal</dsig:X509SubjectName>
+        </dsig:X509Data>
+      </dsig:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <dsig:KeyInfo>
+        <dsig:X509Data>
+          <dsig:X509Certificate>
+            MIIEJTCCAo2gAwIBAgIBZjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEyppcC0xMC0yMDQtNC0yNTEuZXUtd2VzdC0yLmNvbXB1dGUuaW50ZXJuYWwwHhcNMTgwOTEzMDgyMjEzWhcNMjgwOTEwMDgyMjEzWjA1MTMwMQYDVQQDEyppcC0xMC0yMDQtNC0yNTEuZXUtd2VzdC0yLmNvbXB1dGUuaW50ZXJuYWwwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCNUVYZM9CgDjf3y9pW0iE2WcnJX4wLMAiFDBPKQQoxIrqJ7lMWo5ndaaHIUkXXSBJqy7y1Qeui3rq09U5QWILnKTvoNOBH6kr2GiUoyW6Y6xrUap3TSn/qTw50w4TTn/+WSaqycxEAODLJqz9uVUumPV/cdCO4fH5wQTDUGiOwJQ+/maArsgsIi2o3i1gNEWDa1eMLY9ge25gJKPLfq3Vl/0n4bXOG0qIkfer85ODkv+ZZRjUiZnv8xngRvRNcn3YnDdhGFrT11+HmbuXC/ACBGhewk1cuYbL0t73K/Eva42sKjGwSj3DNkIW9V7CZE4MhHgQ11MT0kMdUD08mJO9aCKL8eL0YEtikkTvTcAak+Bhfpxuor4ofE/Mno9kJYzV456U0QEv1OsMC0Rycl3h+LLY3zj3JqskfrGCPcdRutuQ9VnkYilDKcnMiPxjap6Szz+2I7o3zOsYlKr+gVLQw7ofIs1zGnoMFW/V/Xy3T5FRndQwiZyEO2HQ+d4dA8i0CAwEAAaNAMD4wDAYDVR0TAQH/BAIwADAPBgNVHQ8BAf8EBQMDB9gAMB0GA1UdDgQWBBTchxKHy+MfUgxuX1Tjy+kQzOsAijANBgkqhkiG9w0BAQsFAAOCAYEAFtgNLRAzb0Npr8/7KnjX3nxUYNJeM/NyKKksLepwV5aZd5+kBjNomiCLAJBDohqcN6B/kICfdBEbo7MZQp5VjoIOsZxowAKKanJF5LGgY4sz87ZXgCnTkE9toYPSwwxX6xJThm4AuX/iOzDKCaxaqZ/53tABu3npRGyVf9m9Wc0rj/J3g25pJL0xyw2tIpfmGuYEZ6r3fF3yAcHcnmNJGY0OgXNPXpKRvZf8EnHW9MjhCXUGFxrsUz5x4+AMJcy3EBqTsWNyyHi2Vd6PkxVGOodPs9Mm0M4LcG9gtlFNbXYRncYdobBRFnWkgEoa++wTrNDwWCKi3tu2W5z+sEwrs7rrbynln0OS95eK6gNn8AkRwJo9ub7xSfj6uwN5VUKe+fdi1aT1M5CqPuczUyUHRC3qjyNzjLsaBlCShWgMhWouaU5HOIAvLoTAoNmQeR+QbZG+Uql6TJdH86yT3SAnMav8ZiOcfTZ3Dk5stTdD1OpxNHtEDVCGWtRgjExaU9FQ
+          </dsig:X509Certificate>
+          <dsig:X509IssuerSerial>
+            <dsig:X509IssuerName>CN=ip-10-204-4-251.eu-west-2.compute.internal</dsig:X509IssuerName>
+            <dsig:X509SerialNumber>102</dsig:X509SerialNumber>
+          </dsig:X509IssuerSerial>
+          <dsig:X509SubjectName>CN=ip-10-204-4-251.eu-west-2.compute.internal</dsig:X509SubjectName>
+        </dsig:X509Data>
+      </dsig:KeyInfo>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+    </md:KeyDescriptor>
+    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                                  Location="https://portal.stg.legalservices.gov.uk/oamfed/idp/soap" index="1"
+                                  isDefault="true"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                            Location="https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20"
+                            ResponseLocation="https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                            Location="https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20"
+                            ResponseLocation="https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                            Location="https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                            Location="https://portal.stg.legalservices.gov.uk/oamfed/idp/soap"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                            Location="https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
## Description of change
Swap SAMLmock with Portal Staging.
So our staging talks to Portal staging, as it should be.

Keeping the DEV and samlmock metadata files around, because on localhost envs is useful to be able to use SAMLmock, although ideally this will some day be replaced with DEV (but it is not working so far).

There will be some follow-up PRs for some tickets that are unblocked by this PR.

NOTE 1: there is still a chance this will not work on staging. I've tested locally SP-initiated auth and it works, but can't test IdP-initiated auth until this is deployed and our service is using the staging certificates.

NOTE 2: if this works, new credentials are required to sign in to Apply. These credentials will be shared with the team. Also, the office codes of the new user(s) will change so old applications will not be accessible from Apply anymore. We can create a migration task for the datastore to re-assign office codes.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-38

## Notes for reviewer
Read notes above.
