### PR TITLE
CRIMAP-259 Show provider email in header

### DIFF
--- a/app/lib/laa_portal_setup.rb
+++ b/app/lib/laa_portal_setup.rb
@@ -47,8 +47,8 @@ class LaaPortalSetup
       uid: 'test-user',
       info: {
         email: 'provider@example.com',
-        roles: 'CCR_CCRGradeA1,CCLF_BillManager',
-        office_codes: '1A123B,2A555X',
+        roles: 'EFORMS,EFORMS_eFormsAuthor,CRIMEAPPLY',
+        office_codes: '1A123B:2A555X',
       }
     )
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -13,7 +13,7 @@ class Provider < ApplicationRecord
                  :legal_rep_telephone
 
   def display_name
-    uid
+    email
   end
 
   def multiple_offices?

--- a/app/services/provider_gatekeeper.rb
+++ b/app/services/provider_gatekeeper.rb
@@ -1,0 +1,24 @@
+class ProviderGatekeeper
+  attr_reader :auth_info, :reason
+
+  def initialize(auth_info)
+    @auth_info = auth_info
+  end
+
+  # NOTE: this method will be refactored to include some more
+  # rules for allowing or not access to providers depending
+  # if they've been onboarded into our private MVP, based on
+  # office codes, or email address, etc.
+  # Until we know more, we just do a very high level check.
+  #
+  def access_allowed?
+    @reason = :no_office_codes if office_codes.blank?
+    @reason.blank?
+  end
+
+  private
+
+  def office_codes
+    auth_info.office_codes
+  end
+end

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -15,6 +15,8 @@ en:
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
+      provider_gatekeeper:
+        no_office_codes: "Your account cannot use this service as it does not have any office codes."
     sessions:
       signed_in: ""
       signed_out: ""

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Provider, type: :model do
   let(:attributes) do
     {
       uid: 'test-user',
+      email: 'provider@example.com',
       office_codes: office_codes,
     }
   end
@@ -13,7 +14,7 @@ RSpec.describe Provider, type: :model do
   let(:office_codes) { %w[A1 B2 C3] }
 
   describe '#display_name' do
-    it { expect(subject.display_name).to eq('test-user') }
+    it { expect(subject.display_name).to eq('provider@example.com') }
   end
 
   describe '#multiple_offices?' do

--- a/spec/services/provider_gatekeeper_spec.rb
+++ b/spec/services/provider_gatekeeper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ProviderGatekeeper do
+  subject { described_class.new(auth_info) }
+
+  let(:auth_info) do
+    double(
+      email:,
+      roles:,
+      office_codes:,
+    )
+  end
+
+  let(:email) { 'test@example.com' }
+  let(:roles) { 'role1,role2' }
+  let(:office_codes) { 'code1:code2' }
+
+  describe '#access_allowed?' do
+    context 'when there are office codes' do
+      it 'allows the access' do
+        expect(subject.access_allowed?).to be(true)
+        expect(subject.reason).to be_nil
+      end
+    end
+
+    context 'when there are no office codes' do
+      let(:office_codes) { '' }
+
+      it 'disallows the access' do
+        expect(subject.access_allowed?).to be(false)
+        expect(subject.reason).to be(:no_office_codes)
+      end
+    end
+  end
+end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -27,6 +27,23 @@ RSpec.describe 'Sign in user journey' do
     end
   end
 
+  context 'user signs in but is not allowed to use the service' do
+    before do
+      allow(
+        OmniAuth.config
+      ).to receive(:mock_auth).and_return(
+        saml: OmniAuth::AuthHash.new(info: { office_codes: '' })
+      )
+
+      click_button 'Sign in with LAA Portal'
+    end
+
+    it 'redirects to the home page with a flash alert' do
+      expect(current_url).to eq(root_url)
+      expect(page).to have_content('Your account cannot use this service as it does not have any office codes.')
+    end
+  end
+
   context 'user is signed in, has multiple accounts' do
     before do
       allow_any_instance_of(
@@ -55,7 +72,7 @@ RSpec.describe 'Sign in user journey' do
 
     it 'renders the user menu in the header' do
       expect(page).to have_css('nav.govuk-header__navigation')
-      expect(page).to have_css('.app-header__auth-user', text: 'test-user')
+      expect(page).to have_css('.app-header__auth-user', text: 'provider@example.com')
       expect(page).to have_button('Sign out')
     end
 


### PR DESCRIPTION
## Description of change
Also there is some work in preparation for CRIMAP-261, to allow or disallow providers using our service unless they've been onboarded to our private MVP.

In this PR the rules based on office code are not implemented yet, but I've implemented some boilerplate code to prepare for this, and to stop providers without LAA accounts (office codes) from using our service.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-259
https://dsdmoj.atlassian.net/browse/CRIMAP-261

## How to manually test the feature
This can be tested locally by checking out the branch, using the SAMLmock, and signing in with user "ABRA-S" who doesn't have any office codes. On staging I don't know how likely this scenario would be, probably very unlikely, but as some degree of gatekeeping is necessary, this is a fair check.
Email of the signed in provider is shown in the header, instead of the UID, as per service designer request.