### PR TITLE
Fix github set-output command deprecation

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -40,13 +40,14 @@ jobs:
           bundler-cache: true
 
       - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: JS package cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
+        id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -95,7 +96,7 @@ jobs:
 
       - name: Push to ECR
         id: ecr
-        uses: jwalton/gh-ecr-push@3197046958514d9f2b97073bb797ca426db8061f
+        uses: jwalton/gh-ecr-push@b10a019116283fff10914554dfe85bfb1c21d41b
         with:
           access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description of change
Github is deprecating the `set-output` and `save-state` commands. More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updated the cache action where this is used.

Also bumped `gh-ecr-push` action to latest version (sha).

