### PR TITLE
CRIMAP-246 Provider's office account enrolment check

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -15,6 +15,10 @@ class ErrorsController < ApplicationController
   end
 
   def unauthorized
+    respond_with_status(:unauthorized)
+  end
+
+  def not_enrolled
     respond_with_status(:forbidden)
   end
 

--- a/app/services/providers/gatekeeper.rb
+++ b/app/services/providers/gatekeeper.rb
@@ -1,26 +1,28 @@
 module Providers
   class Gatekeeper
-    attr_reader :auth_info, :reason
+    attr_reader :auth_info
 
     def initialize(auth_info)
       @auth_info = auth_info
     end
 
-    # NOTE: this method will be refactored to include some more
-    # rules for allowing or not access to providers depending
-    # if they've been onboarded into our private MVP, based on
-    # office codes, or email address, etc.
-    # Until we know more, we just do a very high level check.
-    #
-    def access_allowed?
-      @reason = :no_office_codes if office_codes.blank?
-      @reason.blank?
+    def provider_enrolled?
+      email_enrolled? || office_enrolled?
+    end
+
+    def office_enrolled?
+      allowed_office_codes.intersect?(auth_info.office_codes)
+    end
+
+    # TODO: implement separately once decided if this is required
+    def email_enrolled?
+      false
     end
 
     private
 
-    def office_codes
-      auth_info.office_codes
+    def allowed_office_codes
+      Rails.configuration.x.gatekeeper.office_codes
     end
   end
 end

--- a/app/views/errors/not_enrolled.en.html.erb
+++ b/app/views/errors/not_enrolled.en.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Your account cannot use this service yet
+    </h1>
+
+    <p class="govuk-body">
+      Copy TBD.
+    </p>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,9 @@ module LaaApplyForCriminalLegalAid
     config.x.benefit_checker.lsc_service_name = ENV.fetch('BC_LSC_SERVICE_NAME', nil)
     config.x.benefit_checker.client_org_id = ENV.fetch('BC_CLIENT_ORG_ID', nil)
     config.x.benefit_checker.client_user_id = ENV.fetch('BC_CLIENT_USER_ID', nil)
+
+    config.x.gatekeeper= config_for(
+      :gatekeeper, env: ENV.fetch('ENV_NAME', 'localhost')
+    )
   end
 end

--- a/config/gatekeeper.yml
+++ b/config/gatekeeper.yml
@@ -1,0 +1,19 @@
+# List of providers (office codes and/or emails)
+# who can use the service (phased private MVP access).
+#
+# If a provider has more than one office code, then
+# access is granted if any code is allowed.
+#
+localhost:
+  office_codes:
+    - 1A123B # samlmock and tests
+    - 1K022G # temporarily, portal stg
+
+staging:
+  office_codes:
+    - 1A123B # samlmock and tests
+    - 1K022G
+    - 0Z981E
+
+production:
+  office_codes: []

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -15,8 +15,6 @@ en:
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
-      provider_gatekeeper:
-        no_office_codes: "Your account cannot use this service as it does not have any office codes."
     sessions:
       signed_in: ""
       signed_out: ""

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -26,6 +26,8 @@ en:
       heading: Access restricted
       lead_text: This page requires you to be signed in to LAA Portal. You will be redirected back to this service after you sign in.
       sign_in_button: Sign in with LAA Portal
+    not_enrolled:
+      page_title: Account not enrolled
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     get :invalid_session
     get :unhandled
     get :unauthorized
+    get :not_enrolled
     get :not_found
   end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -29,10 +29,17 @@ RSpec.describe 'Error pages' do
     end
   end
 
+  context 'not_enrolled' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/not_enrolled'
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   context 'unauthorized' do
     it 'renders the expected page and has expected status code' do
       get '/errors/unauthorized'
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to have_http_status(:unauthorized)
     end
 
     context 'when the sign in fails' do

--- a/spec/services/providers/gatekeeper_spec.rb
+++ b/spec/services/providers/gatekeeper_spec.rb
@@ -6,29 +6,42 @@ RSpec.describe Providers::Gatekeeper do
   let(:auth_info) do
     double(
       email:,
-      roles:,
       office_codes:,
     )
   end
 
   let(:email) { 'test@example.com' }
-  let(:roles) { 'role1,role2' }
-  let(:office_codes) { 'code1:code2' }
+  let(:office_codes) { %w[1A123B 2A555X] }
 
-  describe '#access_allowed?' do
-    context 'when there are office codes' do
-      it 'allows the access' do
-        expect(subject.access_allowed?).to be(true)
-        expect(subject.reason).to be_nil
+  describe '#provider_enrolled?' do
+    before do
+      allow(subject).to receive(:email_enrolled?).and_return(false)
+      allow(subject).to receive(:office_enrolled?).and_return(false)
+    end
+
+    it 'checks if the email is enrolled' do
+      expect(subject).to receive(:email_enrolled?)
+      subject.provider_enrolled?
+    end
+
+    it 'checks if any office codes are enrolled' do
+      expect(subject).to receive(:office_enrolled?)
+      subject.provider_enrolled?
+    end
+  end
+
+  describe '#office_enrolled?' do
+    context 'when any of the office codes are in the allow list' do
+      it 'returns true' do
+        expect(subject.office_enrolled?).to be(true)
       end
     end
 
-    context 'when there are no office codes' do
-      let(:office_codes) { '' }
+    context 'when no office codes are in the allow list' do
+      let(:office_codes) { %w[1X000X] }
 
-      it 'disallows the access' do
-        expect(subject.access_allowed?).to be(false)
-        expect(subject.reason).to be(:no_office_codes)
+      it 'returns false' do
+        expect(subject.office_enrolled?).to be(false)
       end
     end
   end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -27,20 +27,20 @@ RSpec.describe 'Sign in user journey' do
     end
   end
 
-  context 'user signs in but does not have any office codes' do
+  context 'user signs in but is not yet enrolled' do
     before do
       allow(
         OmniAuth.config
       ).to receive(:mock_auth).and_return(
-        saml: OmniAuth::AuthHash.new(info: { office_codes: [] })
+        saml: OmniAuth::AuthHash.new(info: { office_codes: ['1X000X'] })
       )
 
       click_button 'Sign in with LAA Portal'
     end
 
-    it 'redirects to the home page with a flash alert' do
-      expect(current_url).to eq(root_url)
-      expect(page).to have_content('Your account cannot use this service as it does not have any office codes.')
+    it 'redirects to the error page' do
+      expect(current_url).to match(not_enrolled_errors_path)
+      expect(page).to have_content('Your account cannot use this service yet')
     end
   end
 


### PR DESCRIPTION
## Description of change
Implement an initial enrolment/allowlist based on office account codes.

The error page where the user is redirected is still TBD and copy and design will be provided once that has been agreed (there is a separate ticket).

Upon some comments in previous PR #294 I cleanup some of the previous gatekeeper code, and did some renaming too.

Note it may be we also want to allow by email address, but that has not been decided yet. If required, it is almost ready to implement, only caveat we would not want emails committed to the repo, so they might require hashing.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-246
https://dsdmoj.atlassian.net/browse/CRIMAP-303

## Notes for reviewer
Copy in the error page TBD. There is a separate ticket for design/content (CRIMAP-260)

## How to manually test the feature
This can be tested locally by using the SAMLmock and trying to sign in with user `ABRA-S`.
On staging it can be tested by trying to sign in with any user not in our list in confluence. I will update the page to add one specifically for exercising the unhappy path scenario.