### PR TITLE
CRIMAP-300 Tweaks for Portal SLO

### DIFF
--- a/app/lib/laa_portal/saml_setup.rb
+++ b/app/lib/laa_portal/saml_setup.rb
@@ -19,9 +19,10 @@ module LaaPortal
       parse_metadata_and_merge(
         sp_entity_id: SP_ENTITY_ID,
         name_identifier_format: NAME_ID_FORMAT,
-        idp_sso_service_binding: :redirect,
         certificate: ENV.fetch('LAA_PORTAL_SP_CERT', nil),
         private_key: ENV.fetch('LAA_PORTAL_SP_PRIVATE_KEY', nil),
+        idp_sso_service_binding: :redirect,
+        idp_slo_service_binding: :post,
         single_logout_service_url: sp_single_logout_url,
         security: {
           digest_method: XMLSecurity::Document::SHA256,

--- a/app/lib/laa_portal/saml_strategy.rb
+++ b/app/lib/laa_portal/saml_strategy.rb
@@ -4,20 +4,6 @@ module LaaPortal
     def auth_hash
       self.class.auth_adapter.call(super)
     end
-
-    # Reason for overriding this method is the gem `omniauth-saml`
-    # is raising an `Exception` class, instead of an `StandardError`,
-    # and Omniauth is not catching it because of that, blowing up
-    # at the Rack level, without showing a "nice" error page.
-    # Re-raise as `StandardError` and also report to Sentry.
-    # rubocop:disable Lint/RescueException
-    def other_phase
-      super
-    rescue Exception => e
-      Sentry.capture_exception(e)
-      raise StandardError, e
-    end
-    # rubocop:enable Lint/RescueException
     # :nocov:
 
     class << self

--- a/app/lib/laa_portal/saml_strategy.rb
+++ b/app/lib/laa_portal/saml_strategy.rb
@@ -4,6 +4,20 @@ module LaaPortal
     def auth_hash
       self.class.auth_adapter.call(super)
     end
+
+    # Reason for overriding this method is the gem `omniauth-saml`
+    # is raising an `Exception` class, instead of an `StandardError`,
+    # and Omniauth is not catching it because of that, blowing up
+    # at the Rack level, without showing a "nice" error page.
+    # Re-raise as `StandardError` and also report to Sentry.
+    # rubocop:disable Lint/RescueException
+    def other_phase
+      super
+    rescue Exception => e
+      Sentry.capture_exception(e)
+      raise StandardError, e
+    end
+    # rubocop:enable Lint/RescueException
     # :nocov:
 
     class << self

--- a/spec/lib/laa_portal/saml_setup_spec.rb
+++ b/spec/lib/laa_portal/saml_setup_spec.rb
@@ -104,9 +104,10 @@ describe LaaPortal::SamlSetup do
             foo: 'bar',
             sp_entity_id: 'crime-apply',
             name_identifier_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
-            idp_sso_service_binding: :redirect,
             certificate: nil,
             private_key: nil,
+            idp_sso_service_binding: :redirect,
+            idp_slo_service_binding: :post,
             single_logout_service_url: 'http://example.com/providers/auth/saml/slo',
             security: {
               digest_method: XMLSecurity::Document::SHA256,


### PR DESCRIPTION
## Description of change
This is a follow-up to PR #293 for the SLO investigations/spike.

Trying out `post` binding instead of `redirect` binding, as with redirect we get blocked with a 403 by cloudfront.

Also, do not blow up at the rack level if the endpoint can't process the SLO request (for example if it is called without a SAML payload), and show a nice page with a flash error instead (by bubbling up a re-raised `StandardError`).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-300
