### PR TITLE
Update client details task completed rules

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -10,6 +10,10 @@ class Person < ApplicationRecord
   scope :with_name, -> { where.not(first_name: [nil, '']) }
 
   def home_address?
-    home_address.address_line_one.present?
+    home_address&.address_line_one.present?
+  end
+
+  def correspondence_address?
+    correspondence_address&.address_line_one.present?
   end
 end

--- a/app/presenters/tasks/client_details.rb
+++ b/app/presenters/tasks/client_details.rb
@@ -15,17 +15,33 @@ module Tasks
 
     # If we have an `applicant` record we consider this in progress
     def in_progress?
-      crime_application.applicant.present?
+      applicant.present?
     end
 
     # The last step of the applicant details task is the contact details
+    # Only `correspondence_address_type` is mandatory, `telephone_number`
+    # is not mandatory and can be left blank.
     #
-    # NOTE: might be refined for the scenario the correspondence type
-    # is `other_address` but there is no `CorrespondenceAddress` record
+    # Depending on the selected `correspondence_address_type`, we check
+    # if the address record exists.
+    #
     def completed?
-      crime_application.applicant.values_at(
-        :telephone_number, :correspondence_address_type
-      ).all?(&:present?)
+      case applicant.correspondence_address_type
+      when CorrespondenceType::HOME_ADDRESS.to_s
+        applicant.home_address?
+      when CorrespondenceType::OTHER_ADDRESS.to_s
+        applicant.correspondence_address?
+      when CorrespondenceType::PROVIDERS_OFFICE_ADDRESS.to_s
+        true
+      else
+        false
+      end
+    end
+
+    private
+
+    def applicant
+      @applicant ||= crime_application.applicant
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe Person, type: :model do
   let(:attributes) do
     {
       first_name: 'Joe',
-    last_name: 'Bloggs'
+      last_name: 'Bloggs',
     }
   end
 
   let(:address_line_one) { '1 North Pole' }
 
-  let(:mock_home_address) do
-    instance_double(
-      Address,
-      address_line_one:
-    )
-  end
+  describe '#home_address?' do
+    let(:mock_address) do
+      instance_double(
+        HomeAddress,
+        address_line_one:
+      )
+    end
 
-  before do
-    allow(subject).to receive(:home_address).and_return(mock_home_address)
-  end
+    before do
+      allow(subject).to receive(:home_address).and_return(mock_address)
+    end
 
-  describe '#has_home_address?' do
     context 'home address is not blank' do
       let(:address_line_one) { '1 North Pole' }
 
@@ -37,6 +37,51 @@ RSpec.describe Person, type: :model do
 
       it 'returns false when a home address does not have values' do
         expect(subject.home_address?).to be(false)
+      end
+    end
+
+    context 'there is no home address record' do
+      let(:mock_address) { nil }
+
+      it 'returns false' do
+        expect(subject.home_address?).to be(false)
+      end
+    end
+  end
+
+  describe '#correspondence_address?' do
+    let(:mock_address) do
+      instance_double(
+        CorrespondenceAddress,
+        address_line_one:
+      )
+    end
+
+    before do
+      allow(subject).to receive(:correspondence_address).and_return(mock_address)
+    end
+
+    context 'correspondence address is not blank' do
+      let(:address_line_one) { '1 North Pole' }
+
+      it 'returns true when a correspondence address has values' do
+        expect(subject.correspondence_address?).to be(true)
+      end
+    end
+
+    context 'correspondence address is blank' do
+      let(:address_line_one) { nil }
+
+      it 'returns false when a correspondence address does not have values' do
+        expect(subject.correspondence_address?).to be(false)
+      end
+    end
+
+    context 'there is no correspondence address record' do
+      let(:mock_address) { nil }
+
+      it 'returns false' do
+        expect(subject.correspondence_address?).to be(false)
       end
     end
   end

--- a/spec/presenters/tasks/client_details_spec.rb
+++ b/spec/presenters/tasks/client_details_spec.rb
@@ -38,22 +38,48 @@ RSpec.describe Tasks::ClientDetails do
   end
 
   describe '#completed?' do
-    context 'when we have completed contact details' do
+    context 'when we have completed mandatory contact details' do
       let(:applicant) do
         Applicant.new(
-          telephone_number: '123456789',
-          correspondence_address_type: 'something'
+          telephone_number: '',
+          correspondence_address_type: correspondence_address_type
         )
       end
 
-      it { expect(subject.completed?).to be(true) }
+      let(:address) { instance_double(Address, address_line_one: 'some address') }
+
+      context 'for a home address' do
+        let(:correspondence_address_type) { CorrespondenceType::HOME_ADDRESS.to_s }
+
+        before do
+          allow(applicant).to receive(:home_address).and_return(address)
+        end
+
+        it { expect(subject.completed?).to be(true) }
+      end
+
+      context 'for other address' do
+        let(:correspondence_address_type) { CorrespondenceType::OTHER_ADDRESS.to_s }
+
+        before do
+          allow(applicant).to receive(:correspondence_address).and_return(address)
+        end
+
+        it { expect(subject.completed?).to be(true) }
+      end
+
+      context 'for providers office address' do
+        let(:correspondence_address_type) { CorrespondenceType::PROVIDERS_OFFICE_ADDRESS.to_s }
+
+        it { expect(subject.completed?).to be(true) }
+      end
     end
 
-    context 'when we have not completed yet contact details' do
+    context 'when we have not completed yet mandatory contact details' do
       let(:applicant) do
         Applicant.new(
           telephone_number: '123456789',
-          correspondence_address_type: ''
+          correspondence_address_type: 'home_address'
         )
       end
 


### PR DESCRIPTION
## Description of change
Originally we had the `telephone_number` as a mandatory field, but some time ago we decided to make it optional, thus we don't have to check for presence in order to consider the task "completed", as `telephone_number` can be left blank.

Only `correspondence_address_type` is mandatory now.

Made the rules for the correspondence address more stringent by checking we have indeed the address record filled when `home address` or `other address` are selected.

## Screenshots of changes (if applicable)

### Before changes:
<img width="719" alt="Screenshot 2023-03-13 at 10 36 15" src="https://user-images.githubusercontent.com/687910/224677730-ac540b4d-efbf-4ed2-93d5-7f9d7430ac58.png">

### After changes:
<img width="712" alt="Screenshot 2023-03-13 at 10 36 27" src="https://user-images.githubusercontent.com/687910/224677748-f49c85cc-38fc-4e21-82d6-9e473b709dc0.png">

## How to manually test the feature
