### PR TITLE
CRIMAP-307 Mitigate header menu flickering

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -12,6 +12,20 @@
   background-color: transparent;
 }
 
+// Avoid flickering header menu on small screens, where on page load
+// the header menu briefly shows before being hidden. This makes it
+// visually hidden from the start, and a bit of javascript removes
+// the class as soon as the page has loaded.
+// If javascript is disabled, the menu shows expanded on page load.
+// Refer to `app/javascript/application.js`
+body.js-enabled {
+  ul.app-header-menu-hidden-on-load {
+    @include govuk-media-query($until: desktop) {
+      display: none;
+    }
+  }
+}
+
 .app-header__auth-link {
   // 1. Remove any button styling
   @include app-button-reset;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -26,3 +26,10 @@ if ($acElements) {
     })
   }
 }
+
+// Avoid flickering header menu on small screens
+// Refer to `stylesheets/local/custom.scss`
+const $headerNavigation = document.querySelector('ul.app-header-menu-hidden-on-load')
+if ($headerNavigation) {
+  $headerNavigation.classList.remove("app-header-menu-hidden-on-load")
+}

--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -3,7 +3,7 @@
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="<%= t('.button_aria_label') %>" hidden>
       <%= t('.menu_button') %>
     </button>
-    <ul id="navigation" class="govuk-header__navigation-list">
+    <ul id="navigation" class="govuk-header__navigation-list app-header-menu-hidden-on-load">
       <li class="govuk-header__navigation-item">
         <%= link_to t('.your_applications'), crime_applications_path, class: 'govuk-header__link' %>
       </li>


### PR DESCRIPTION
## Description of change
This was driving me crazy when testing the site on small screens / mobile. It is very noticeable on Safari, less so on Chrome. The recordings are from Safari.

There is an annoying thing happening with the header menu when a user is signed in to Apply.

On small screens, like mobile devices, each time a page is loaded, the header menu briefly shows (a few milliseconds) before being hidden. This is a bit annoying.

The header menu should be hidden on small screens unless the user clicks the “Menu“ button, at that point the menu is revealed, until they click the “Menu” button again, and it is hidden.

After playing with the order of the javascript loading, `preload` and other things, I've not been able to pinpoint exactly why this happen and how to solve it, thus this mitigation which shouldn't have any adverse effect as far as I can tell.

With this fix the Menu link still flicks a bit on Safari, but at least the page content doesn't jump around.

Note: desktop is not affected. This only affects small screens where the menu is collapsed to save space. Also, when javascript is disabled, menu shows expanded by default on page load, same as before.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-307

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
https://user-images.githubusercontent.com/687910/224750845-f5e8a0ed-0d3e-4d2b-968d-dce26fd303af.mov

### After changes:
https://user-images.githubusercontent.com/687910/224750877-71c79fa0-946a-4adb-9d11-0bc62e2fd753.mov

## How to manually test the feature
