### PR TITLE
Enable omniauth test mode temporarily

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -13,7 +13,7 @@ data:
   DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.cloud-platform.service.justice.gov.uk
 
   # If this is uncommented, authentication will be mocked
-  # OMNIAUTH_TEST_MODE: "true"
+  OMNIAUTH_TEST_MODE: "true"
 
   # LAA Portal metadata endpoint or file
   # (endpoint not accessible from inside CP, using locally stored file)


### PR DESCRIPTION
## Description of change
The accessibility audit team needs testing on mobile devices, however the VPN is quite tricky to setup on mobile, thus temporarily we are going to disable LAA Portal auth and fake it with the omniauth test mode.

