### PR TITLE
Revert "Enable omniauth test mode temporarily (#307)"

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -13,7 +13,7 @@ data:
   DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.cloud-platform.service.justice.gov.uk
 
   # If this is uncommented, authentication will be mocked
-  OMNIAUTH_TEST_MODE: "true"
+  # OMNIAUTH_TEST_MODE: "true"
 
   # LAA Portal metadata endpoint or file
   # (endpoint not accessible from inside CP, using locally stored file)


### PR DESCRIPTION
## Description of change
This reverts commit 7bbfe33cdc35c5bacb8462cac60f2887e49cffa5.

Accessibility audit on mobile devices has concluded and we are re-enabling LAA Portal staging again.
