### PR TITLE
CRIMAP-308 Fix offence dates validation

### DIFF
--- a/app/forms/steps/case/offence_date_fieldset_form.rb
+++ b/app/forms/steps/case/offence_date_fieldset_form.rb
@@ -1,7 +1,7 @@
 module Steps
   module Case
     class OffenceDateFieldsetForm < Steps::BaseFormObject
-      attribute :_destroy, :boolean
+      attribute :_destroy, :boolean, default: false
       attribute :id, :string
       attribute :date_from, :multiparam_date
       attribute :date_to, :multiparam_date


### PR DESCRIPTION
## Description of change
On the offences page, the dates are nested attributes. On submit these nested attributes were assigned to the `record` (`Charge` model) with `record.offence_dates_attributes=(params)`.

We use `accepts_nested_attributes_for :offence_dates` in `Charge` for this.

This works perfectly fine when the dates are valid. However if any of the dates is invalid, for instance month 13, or day 38, it blows up with `ActiveRecord::MultiparameterAssignmentErrors` because Rails internally was instantiating Date objects from the params, and `Date.new(2022, 13, 5)` is invalid.

What we want is to give a meaningful error to the user, and style as "red" the field giving the error, and show the error summary.

In order to do this we have to change the approach, instead of:
1. Assign the dates params (which instantiate Dates and then the `OffenceDate` objects).
2. Perform validation on the new instantiated (not yet persisted) `OffenceDate` records.
3. Persist if all was good.

We now do:
1. Instantiate from the params the OffenceDate objects
2. Perform validation on these with our `multiparam_date` validator
3. If all good persist the record and their offence dates.
4. If error, re-render the page showing the errors.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-308

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="649" alt="Screenshot 2023-03-15 at 17 48 09" src="https://user-images.githubusercontent.com/687910/225572706-f19a5669-8369-4c7d-bce0-2319a4a969ea.png">
<img width="624" alt="Screenshot 2023-03-15 at 17 48 30" src="https://user-images.githubusercontent.com/687910/225572716-a00e2f5c-f647-47db-a214-2ad7859c33b3.png">

## How to manually test the feature
