### PR TITLE
Upgrade version of postgres used in CI/CD

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.7-alpine
+        image: postgres:14.6-alpine
         env:
           POSTGRES_DB: laa-apply-for-criminal-legal-aid-test
           POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3'
 
 services:
   db:
-    image: postgres:13.7-alpine
+    image: postgres:14.6-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 


### PR DESCRIPTION
## Description of change
The version of postgres in cloud platform Apply namespace has been upgraded to 14.6 as part of CRIMAP-302.

For consistency, use the same version in the CI/CD pipeline and in the docker-compose file.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-302