### PR TITLE
[CRIMAP-312] Change justification button text

### DIFF
--- a/app/views/completed_applications/_return_notification.html.erb
+++ b/app/views/completed_applications/_return_notification.html.erb
@@ -18,6 +18,6 @@
 
     <%= button_to recreate_completed_crime_application_path, method: :put,
                   class: 'govuk-button app-button--blue govuk-!-margin-bottom-2 app-no-print',
-                  data: { module: 'govuk-button' } do; t('.update_application'); end %>
+                  data: { module: 'govuk-button' } do; t('.add_justification'); end %>
   </div>
 </div>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -73,7 +73,7 @@ en:
         case_concluded: because the case has already concluded
         provider_request: at your request
         split_case: because the case has now been split and we require IOJ justification for all offences
-      update_application: Update application
+      add_justification: Add justification information
       split_case_meaning: Cases are split when the CPS decide not to try all the offences at the same time
   shared:
     dashboard_header:

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe 'Dashboard' do
       assert_select 'a.govuk-button', count: 2, text: 'Print application'
     end
 
-    it 'does not have an update application button' do
-      assert_select 'button.govuk-button', count: 0, text: 'Update application'
+    it 'does not have an add justification information button' do
+      assert_select 'button.govuk-button', count: 0, text: 'Add justification information'
     end
 
     # rubocop:disable RSpec/ExampleLength
@@ -107,7 +107,7 @@ RSpec.describe 'Dashboard' do
         assert_select 'div.govuk-notification-banner__content' do
           assert_select 'h3', 'LAA have returned this application because further clarification is needed'
           assert_select 'p.govuk-body', 'Further information regarding IoJ required'
-          assert_select 'button.govuk-button', count: 1, text: 'Update application'
+          assert_select 'button.govuk-button', count: 1, text: 'Add justification information'
         end
       end
     end


### PR DESCRIPTION
## Description of change
Alters button text to match figma

## Link to relevant ticket

## Notes for reviewer
Note sure if button text 'Add justification information' is meant to be shown for all return types of just split case

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="689" alt="Screenshot 2023-03-31 at 22 59 16" src="https://user-images.githubusercontent.com/47113046/229240653-b898169e-b089-4028-985b-d83cb47002e0.png">


## How to manually test the feature
Create a new application in Apply

In Review return the application with the split case reason

In Apply look for 'returned applications' and select the originally submitted application.