### PR TITLE
[CRIMAP-311] Temporarily add split_case locale entry

### DIFF
--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -72,6 +72,7 @@ en:
         duplicate_application: because it is a duplicated application
         case_concluded: because the case has already concluded
         provider_request: at your request
+        split_case: because the case has now been split and we require IOJ justification for all offences
       update_application: Update application
   shared:
     dashboard_header:


### PR DESCRIPTION
## Description of change
Without split_case in dashboard.yml the app will fail to work as expected when a split_case return type is returned (possible as laa schema now allows it)

## Link to relevant ticket
Partially completes https://dsdmoj.atlassian.net/browse/CRIMAP-311

## Notes for reviewer
N/A

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Manually change the return_details.reason field to 'split_case' in datastore DB

Load Apply, navigate to the returned application and the banner title will have the 'split case' title 