### PR TITLE
Fix routing for u18 post client details

### DIFF
--- a/app/services/age_calculator.rb
+++ b/app/services/age_calculator.rb
@@ -1,0 +1,12 @@
+class AgeCalculator
+  attr_reader :crime_application
+
+  def initialize(crime_application)
+    @crime_application = crime_application
+  end
+
+  def applicant_under18?
+    dob = crime_application.applicant.date_of_birth
+    dob + 18.years > Time.zone.today
+  end
+end

--- a/app/services/age_calculator.rb
+++ b/app/services/age_calculator.rb
@@ -1,12 +1,12 @@
 class AgeCalculator
-  attr_reader :crime_application
+  attr_reader :person
 
-  def initialize(crime_application)
-    @crime_application = crime_application
+  def initialize(person)
+    @person = person
   end
 
-  def applicant_under18?
-    dob = crime_application.applicant.date_of_birth
+  def under18?
+    dob = person.date_of_birth
     dob + 18.years > Time.zone.today
   end
 end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -6,7 +6,7 @@ module Decisions
       when :has_partner
         after_has_partner
       when :details
-        edit(:has_nino)
+        after_client_details
       when :has_nino, :retry_benefit_check
         after_has_nino
       when :benefit_check_result
@@ -27,6 +27,14 @@ module Decisions
       else
         # Task list
         edit('/crime_applications')
+      end
+    end
+
+    def after_client_details
+      if IojPassporter.new(form_object).applicant_under18_passport?
+        start_address_journey(HomeAddress)
+      else
+        edit(:has_nino)
       end
     end
 

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -31,7 +31,7 @@ module Decisions
     end
 
     def after_client_details
-      if AgeCalculator.new(current_crime_application).applicant_under18?
+      if AgeCalculator.new(current_crime_application.applicant).under18?
         start_address_journey(HomeAddress)
       else
         edit(:has_nino)

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -31,7 +31,7 @@ module Decisions
     end
 
     def after_client_details
-      if IojPassporter.new(form_object).applicant_under18_passport?
+      if AgeCalculator.new(current_crime_application).applicant_under18?
         start_address_journey(HomeAddress)
       else
         edit(:has_nino)

--- a/app/services/ioj_passporter.rb
+++ b/app/services/ioj_passporter.rb
@@ -19,6 +19,6 @@ class IojPassporter
   def applicant_under18_passport?
     return false unless FeatureFlags.u18_ioj_passport.enabled?
 
-    AgeCalculator.new(crime_application).applicant_under18?
+    AgeCalculator.new(crime_application.applicant).under18?
   end
 end

--- a/app/services/ioj_passporter.rb
+++ b/app/services/ioj_passporter.rb
@@ -16,8 +16,6 @@ class IojPassporter
     crime_application.ioj_passport.any?
   end
 
-  private
-
   def applicant_under18_passport?
     return false unless FeatureFlags.u18_ioj_passport.enabled?
 

--- a/app/services/ioj_passporter.rb
+++ b/app/services/ioj_passporter.rb
@@ -19,7 +19,6 @@ class IojPassporter
   def applicant_under18_passport?
     return false unless FeatureFlags.u18_ioj_passport.enabled?
 
-    dob = crime_application.applicant.date_of_birth
-    dob + 18.years > Time.zone.today
+    AgeCalculator.new(crime_application).applicant_under18?
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,7 +5,6 @@ feature_flags:
     production: false
   u18_ioj_passport:
     local: true
-    test: true
     staging: false
     production: false
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ feature_flags:
     production: false
   u18_ioj_passport:
     local: true
+    test: true
     staging: false
     production: false
 

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Decisions::ClientDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant: 'applicant') }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
+  let(:applicant) { 'applicant' }
 
   before do
     allow(
@@ -33,23 +34,24 @@ RSpec.describe Decisions::ClientDecisionTree do
   context 'when the step is `details`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :details }
-    let(:ioj_passporter_double) { instance_double(IojPassporter) }
+    let(:age_calculator_double) { instance_double(AgeCalculator) }
+    let(:applicant) { instance_double(Applicant, date_of_birth: 'dob') }
 
     before do
       allow(
-        IojPassporter
-      ).to receive(:new).and_return(ioj_passporter_double)
+        AgeCalculator
+      ).to receive(:new).and_return(age_calculator_double)
     end
 
     context 'and client is under 18' do
       before do
         allow(
-          ioj_passporter_double
-        ).to receive(:applicant_under18_passport?).and_return(true)
+          age_calculator_double
+        ).to receive(:applicant_under18?).and_return(true)
 
         allow(
           Address
-        ).to receive(:find_or_create_by).with(person: 'applicant').and_return('address')
+        ).to receive(:find_or_create_by).with(person: applicant).and_return('address')
       end
 
       it {
@@ -61,8 +63,8 @@ RSpec.describe Decisions::ClientDecisionTree do
     context 'and client is over 18' do
       before do
         allow(
-          ioj_passporter_double
-        ).to receive(:applicant_under18_passport?).and_return(false)
+          age_calculator_double
+        ).to receive(:applicant_under18?).and_return(false)
       end
 
       it { is_expected.to have_destination(:has_nino, :edit, id: crime_application) }

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Decisions::ClientDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :details }
     let(:age_calculator_double) { instance_double(AgeCalculator) }
-    let(:applicant) { instance_double(Applicant, date_of_birth: 'dob') }
+    let(:applicant_double) { instance_double(Applicant, date_of_birth: 'dob') }
 
     before do
       allow(
@@ -47,7 +47,7 @@ RSpec.describe Decisions::ClientDecisionTree do
       before do
         allow(
           age_calculator_double
-        ).to receive(:applicant_under18?).and_return(true)
+        ).to receive(:under18?).and_return(true)
 
         allow(
           Address
@@ -64,7 +64,7 @@ RSpec.describe Decisions::ClientDecisionTree do
       before do
         allow(
           age_calculator_double
-        ).to receive(:applicant_under18?).and_return(false)
+        ).to receive(:under18?).and_return(false)
       end
 
       it { is_expected.to have_destination(:has_nino, :edit, id: crime_application) }


### PR DESCRIPTION
Currently all applicants route from client details to NINO u18 applicants are passported and do not need a passporting benefit therefore do not need a NINO to run a DWP check
This PR changes the routing for u18 applicants from client details to address lookup
u18 passporting feature flag turned on for test env

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-317

## Notes for reviewer
Feature flag for u18 passporting is on in the test env

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Enter a dob on client details page that means a user is u18 
