### PR TITLE
CRIMAP-312 Implement split case IoJ passporting logic

### DIFF
--- a/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
+++ b/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
@@ -10,13 +10,25 @@ module Summary
           Components::ValueAnswer.new(
             :passport, passport_triggered?
           ),
+          Components::ValueAnswer.new(
+            :passport_override, passport_override?,
+            change_path: edit_steps_case_ioj_path
+          ),
         ].select(&:show?)
       end
 
       private
 
+      def ioj
+        @ioj ||= crime_application.ioj
+      end
+
       def passport_triggered?
-        crime_application.ioj.blank? && crime_application.ioj_passport.any?
+        ioj.blank? && crime_application.ioj_passport.any?
+      end
+
+      def passport_override?
+        ioj.present? && ioj.types.blank? && ioj.passport_override
       end
     end
   end

--- a/app/presenters/tasks/ioj.rb
+++ b/app/presenters/tasks/ioj.rb
@@ -18,8 +18,16 @@ module Tasks
     end
 
     def completed?
-      crime_application.ioj_passport.any? ||
+      return true if ioj_passported?
+
+      crime_application.ioj.present? &&
         crime_application.ioj.types.any?
+    end
+
+    private
+
+    def ioj_passported?
+      IojPassporter.new(crime_application).call
     end
   end
 end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -26,12 +26,20 @@ module Datastore
       crime_application.applicant.present?
     end
 
+    def split_case?
+      parent.return_details.reason.inquiry.split_case?
+    end
+
     def applicant
       Applicant.new(parent.applicant.serializable_hash)
     end
 
     def ioj
-      Ioj.new(parent.ioj.serializable_hash) if parent.ioj.present?
+      if parent.ioj.present?
+        Ioj.new(parent.ioj.serializable_hash)
+      elsif split_case?
+        Ioj.new(passport_override: true)
+      end
     end
 
     def case_with_ioj

--- a/app/services/ioj_passporter.rb
+++ b/app/services/ioj_passporter.rb
@@ -13,12 +13,21 @@ class IojPassporter
                    end
 
     crime_application.update(ioj_passport:)
-    crime_application.ioj_passport.any?
+
+    # IoJ passporting can be overridden for applications returned
+    # back to the provider due to the case being split
+    crime_application.ioj_passport.any? && !passport_override?
   end
+
+  private
 
   def applicant_under18_passport?
     return false unless FeatureFlags.u18_ioj_passport.enabled?
 
     AgeCalculator.new(crime_application.applicant).under18?
+  end
+
+  def passport_override?
+    !!crime_application.ioj.try(:passport_override)
   end
 end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -141,6 +141,10 @@ en:
         question: Passported
         answers: 
           'true': Details provided do not require further justification for legal aid
+      passport_override:
+        question: Passported
+        answers:
+          'true': The case has been ‘split’ and you need to add justification for all offences
       # END passport justification for legal aid section
 
       # BEGIN legal representative details section

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,7 +5,7 @@ feature_flags:
     production: false
   u18_ioj_passport:
     local: true
-    staging: false
+    staging: true
     production: false
 
 # NOTE: consider if the setting you are adding here

--- a/db/migrate/20230411155225_add_ioj_override_field.rb
+++ b/db/migrate/20230411155225_add_ioj_override_field.rb
@@ -1,0 +1,5 @@
+class AddIojOverrideField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :iojs, :passport_override, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_30_161415) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_11_155225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_161415) do
     t.uuid "case_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "passport_override", default: false
     t.index ["case_id"], name: "index_iojs_on_case_id", unique: true
   end
 

--- a/spec/presenters/summary/sections/passport_justification_for_legal_aid_spec.rb
+++ b/spec/presenters/summary/sections/passport_justification_for_legal_aid_spec.rb
@@ -19,32 +19,6 @@ describe Summary::Sections::PassportJustificationForLegalAid do
     it { expect(subject.name).to eq(:passport_justification_for_legal_aid) }
   end
 
-  describe '#show?' do
-    context 'when there is an ioj present' do
-      let(:ioj) { 'foo' }
-
-      it 'does not show this section' do
-        expect(subject.show?).to be(false)
-      end
-    end
-
-    context 'when there is no ioj present' do
-      context 'when there is no ioj passport' do
-        let(:ioj_passport) { [] }
-
-        it 'does not show this section' do
-          expect(subject.show?).to be(false)
-        end
-      end
-
-      context 'when there is an ioj passport' do
-        it 'shows this section' do
-          expect(subject.show?).to be(true)
-        end
-      end
-    end
-  end
-
   describe '#answers' do
     let(:answers) { subject.answers }
 
@@ -62,6 +36,35 @@ describe Summary::Sections::PassportJustificationForLegalAid do
 
       it 'has the correct rows' do
         expect(answers.count).to eq(0)
+      end
+    end
+
+    context 'when there is ioj passport override' do
+      let(:ioj) do
+        instance_double(
+          Ioj,
+          types: ioj_types,
+          passport_override: true,
+        )
+      end
+
+      context 'and no justification has been provided yet' do
+        let(:ioj_types) { [] }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+          expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+          expect(answers[0].question).to eq(:passport_override)
+          expect(answers[0].show?).to be(true)
+        end
+      end
+
+      context 'and some justification has been provided already' do
+        let(:ioj_types) { [:foobar] }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(0)
+        end
       end
     end
   end

--- a/spec/presenters/tasks/ioj_spec.rb
+++ b/spec/presenters/tasks/ioj_spec.rb
@@ -67,13 +67,27 @@ RSpec.describe Tasks::Ioj do
   end
 
   describe '#completed?' do
-    context 'when we have set an Ioj passport' do
-      let(:ioj_passport) { ['foo'] }
+    let(:passporter_double) { instance_double(IojPassporter, call: passporter_result) }
+
+    before do
+      allow(IojPassporter).to receive(:new).with(crime_application).and_return(passporter_double)
+    end
+
+    context 'when the application is Ioj passported (and there is no override)' do
+      let(:passporter_result) { true }
 
       it { expect(subject.completed?).to be(true) }
     end
 
-    context 'when we have not set an Ioj passport' do
+    context 'when the application is not Ioj passported (or there is override)' do
+      let(:passporter_result) { false }
+
+      context 'and there is no Ioj record yet' do
+        let(:ioj) { nil }
+
+        it { expect(subject.completed?).to be(false) }
+      end
+
       context 'and we have completed the Ioj details' do
         let(:ioj_types) { ['bar'] }
 

--- a/spec/services/ioj_passporter_spec.rb
+++ b/spec/services/ioj_passporter_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe IojPassporter do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:, ioj:) }
   let(:applicant) { instance_double(Applicant, date_of_birth: applicant_dob) }
   let(:applicant_dob) { nil }
+  let(:ioj) { nil }
 
   before do
     allow(crime_application).to receive(:update)
@@ -28,6 +29,30 @@ RSpec.describe IojPassporter do
       it 'adds a passported type to the array' do
         expect(crime_application).to receive(:update).with({ ioj_passport: [IojPassportType::ON_AGE_UNDER18.to_s] })
         subject.call
+      end
+    end
+
+    context 'passport override (split case returned applications)' do
+      let(:applicant_dob) { 17.years.ago }
+
+      before do
+        allow(crime_application).to receive(:ioj_passport).and_return(['on_age_under18'])
+      end
+
+      context 'there is no Ioj record' do
+        it { expect(subject.call).to be(true) }
+      end
+
+      context 'there is no passport override' do
+        let(:ioj) { instance_double(Ioj, passport_override: false) }
+
+        it { expect(subject.call).to be(true) }
+      end
+
+      context 'there is passport override' do
+        let(:ioj) { instance_double(Ioj, passport_override: true) }
+
+        it { expect(subject.call).to be(false) }
       end
     end
   end


### PR DESCRIPTION
## Description of change
Split case passported applications are returned to the provider asking them to provide IoJ details.

This PR implements a new boolean flag in the `Ioj` table `passport_override` (false by default). This flag gets set on rehydration of returned application that have been returned due to split case.

In a few places along the application, changes has been made to use this flag so:

1. On a returned application, the "Review" page shows an "Justification for legal aid" section with a different copy and a change link (NOTE: copy to be confirmed with content designer, can be done in a separate PR).

2. If the provider clicks any other change link before the IOJ and goes through the application, the `passport_override` flag is used to show the IOJ page, even if they are passported.

3. The task list has been tweaked as the logic has changed slightly.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-312

## Notes for reviewer
On staging, unless we enable the `u18_ioj_passport` feature flag, this will not be fully testable. I've checked and we can enable this on staging, which I've done in this PR.

## Screenshots of changes (if applicable)

### Before changes:
<img width="783" alt="Screenshot 2023-04-12 at 15 14 47" src="https://user-images.githubusercontent.com/687910/231779412-925a2f83-5e82-458a-9337-872bab78ba23.png">

### After changes:
<img width="748" alt="Screenshot 2023-04-13 at 12 51 04" src="https://user-images.githubusercontent.com/687910/231779484-ec52aca3-69f4-4c41-a640-932c34bac458.png">

## How to manually test the feature
On localhost it can be tested by submitting a passported (under 18s for now only) application without IOJ, and on review returning it with `split_case` reason. The returned application will let the Provider enter IOJ details despite still being technically passported (i.e. applicant is still under 18)