### PR TITLE
CRIMAP-331 Propagate `means_passport` to datastore

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,6 +137,6 @@ RSpec/NestedGroups:
   Max: 5
 
 RSpec/ExampleLength:
-  Max: 16
+  Max: 18
   Exclude:
     - spec/presenters/summary/sections/*

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.4'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.5'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 4e09367dd4c6f874c6fdc8d8838491714bcd9ccd
-  tag: v0.1.4
+  revision: 933253dc37dc20c51efe962418c59f4d8bf8c75b
+  tag: v0.1.5
   specs:
     laa-criminal-legal-aid-schemas (0.1.4)
       dry-struct

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -56,7 +56,6 @@ module DeveloperTools
           last_name: surname,
           other_names: '',
           date_of_birth: details[:dob],
-          has_nino: YesNoAnswer::YES,
           nino: details[:nino],
           passporting_benefit: true,
         )

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -50,9 +50,8 @@ module Summary
         @applicant ||= crime_application.applicant
       end
 
-      # TODO: change once JSON schema is updated
       def means_passported?
-        true
+        crime_application.means_passport.any?
       end
     end
   end

--- a/app/serializers/submission_serializer/sections/application_details.rb
+++ b/app/serializers/submission_serializer/sections/application_details.rb
@@ -12,6 +12,7 @@ module SubmissionSerializer
           json.submitted_at crime_application.submitted_at
           json.date_stamp crime_application.date_stamp
           json.ioj_passport crime_application.ioj_passport
+          json.means_passport crime_application.means_passport
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -1,12 +1,6 @@
 module Adapters
   module Structs
     class Applicant < BaseStructAdapter
-      # For MVP this will always be `yes`
-      # This is not part of the application JSON for now.
-      def has_nino
-        YesNoAnswer::YES
-      end
-
       def home_address
         HomeAddress.new(super.attributes) if super
       end
@@ -18,7 +12,7 @@ module Adapters
       def serializable_hash(options = {})
         super(
           options.merge(
-            methods: [:has_nino]
+            methods: []
           )
         )
       end

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -1,14 +1,7 @@
 module Adapters
   module Structs
     class Applicant < BaseStructAdapter
-      # NOTE: for MVP this is always true, as we are doing
-      # screening of applicants with DWP. This will change
-      # post-MVP but we don't know yet how exactly.
-      def passporting_benefit
-        true
-      end
-
-      # Same as above, for MVP will always be `yes`
+      # For MVP this will always be `yes`
       # This is not part of the application JSON for now.
       def has_nino
         YesNoAnswer::YES
@@ -25,7 +18,7 @@ module Adapters
       def serializable_hash(options = {})
         super(
           options.merge(
-            methods: [:has_nino, :passporting_benefit]
+            methods: [:has_nino]
           )
         )
       end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -15,6 +15,7 @@ module Datastore
         parent_id: parent.id,
         date_stamp: parent.date_stamp,
         ioj_passport: parent.ioj_passport,
+        means_passport: parent.means_passport,
         applicant: applicant,
         case: case_with_ioj,
       )

--- a/app/services/passporting/ioj_passporter.rb
+++ b/app/services/passporting/ioj_passporter.rb
@@ -22,7 +22,7 @@ module Passporting
     end
 
     def ioj_passport_override?
-      !!ioj.try(:passport_override)
+      ioj&.passport_override.present?
     end
   end
 end

--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -17,7 +17,7 @@ module Passporting
     private
 
     def benefit_check_passed?
-      !!applicant.passporting_benefit
+      applicant.passporting_benefit.present?
     end
   end
 end

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -9,6 +9,7 @@ describe Summary::Sections::ClientDetails do
       to_param: '12345',
       client_has_partner: 'no',
       applicant: applicant,
+      means_passport: means_passport,
     )
   end
 
@@ -22,6 +23,8 @@ describe Summary::Sections::ClientDetails do
       nino: '123456',
     )
   end
+
+  let(:means_passport) { ['foobar'] }
 
   describe '#name' do
     it { expect(subject.name).to eq(:client_details) }
@@ -78,6 +81,14 @@ describe Summary::Sections::ClientDetails do
       expect(answers[5].question).to eq(:means_passporting)
       expect(answers[5].change_path).to be_nil
       expect(answers[5].value).to be(true)
+    end
+
+    context 'when there is no means passporting' do
+      let(:means_passport) { [] }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+      end
     end
   end
 end

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe SubmissionSerializer::Application do
       ).to match(
         a_hash_including(
           'schema_version' => 1.0,
-          'ioj_passport' => [],
+          'ioj_passport' => be_an(Array),
+          'means_passport' => be_an(Array),
           'provider_details' => be_a(Hash),
           'client_details' => a_hash_including('applicant'),
           'case_details' => a_hash_including('offences' => [], 'codefendants' => []),

--- a/spec/serializers/submission_serializer/sections/application_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/application_details_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
       submitted_at: submitted_at,
       date_stamp: date_stamp,
       ioj_passport: ['on_age_under18'],
+      means_passport: ['on_age_under18'],
     )
   end
 
@@ -30,6 +31,7 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
       submitted_at: submitted_at,
       date_stamp: date_stamp,
       ioj_passport: ['on_age_under18'],
+      means_passport: ['on_age_under18'],
     }.as_json
   end
 

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe Adapters::Structs::Applicant do
     end
   end
 
-  describe '#passporting_benefit' do
-    it 'returns always true for MVP' do
-      expect(subject.passporting_benefit).to be(true)
-    end
-  end
-
   describe '#has_nino' do
     it 'returns always `yes` for MVP' do
       expect(subject.has_nino).to be(YesNoAnswer::YES)
@@ -54,7 +48,6 @@ RSpec.describe Adapters::Structs::Applicant do
       ).to match(
         a_hash_including(
           'has_nino' => YesNoAnswer::YES,
-          'passporting_benefit' => true,
           'home_address' => an_instance_of(HomeAddress),
           'correspondence_address' => nil,
         )
@@ -67,7 +60,6 @@ RSpec.describe Adapters::Structs::Applicant do
       ).to match_array(
         %w[
           has_nino
-          passporting_benefit
           first_name
           last_name
           date_of_birth

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe Adapters::Structs::Applicant do
     end
   end
 
-  describe '#has_nino' do
-    it 'returns always `yes` for MVP' do
-      expect(subject.has_nino).to be(YesNoAnswer::YES)
-    end
-  end
-
   describe '#home_address' do
     it 'returns an `Address` instance if there is an address' do
       expect(subject.home_address).to be_an(Address)
@@ -47,7 +41,6 @@ RSpec.describe Adapters::Structs::Applicant do
         subject.serializable_hash
       ).to match(
         a_hash_including(
-          'has_nino' => YesNoAnswer::YES,
           'home_address' => an_instance_of(HomeAddress),
           'correspondence_address' => nil,
         )
@@ -59,7 +52,6 @@ RSpec.describe Adapters::Structs::Applicant do
         subject.serializable_hash.keys
       ).to match_array(
         %w[
-          has_nino
           first_name
           last_name
           date_of_birth

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Adapters::Structs::CaseDetails do
       end
     end
 
-    # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+    # rubocop:disable RSpec/MultipleExpectations
     context 'charges relationship' do
       it 'has the expected charges from the fixture' do
         charges = subject.serializable_hash['charges']
@@ -106,6 +106,6 @@ RSpec.describe Adapters::Structs::CaseDetails do
         expect(dates1.date_to).to be_nil
       end
     end
-    # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/services/adapters/structs/interests_of_justice_spec.rb
+++ b/spec/services/adapters/structs/interests_of_justice_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Adapters::Structs::InterestsOfJustice do
   end
 
   describe '#serializable_hash' do
-    # rubocop:disable RSpec/ExampleLength
     it 'has the expected attributes from the fixture' do
       expect(
         subject.serializable_hash
@@ -46,6 +45,5 @@ RSpec.describe Adapters::Structs::InterestsOfJustice do
         }
       )
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Datastore::ApplicationRehydration do
         parent_id: '47a93336-7da6-48ec-b139-808ddd555a41',
         date_stamp: an_instance_of(DateTime),
         ioj_passport: an_instance_of(Array),
+        means_passport: an_instance_of(Array),
         applicant: an_instance_of(Applicant),
         case: an_instance_of(Case),
       )

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Datastore::ApplicationSubmission do
       first_name: 'John',
       last_name: 'Doe',
       date_of_birth: 25.years.ago,
-      has_nino: 'yes',
       nino: 'AB123456A',
       telephone_number: '123456789',
       correspondence_address_type: 'home_address',


### PR DESCRIPTION
## Description of change
Second part of previous PR #321.

It bumps the schemas gem and uses the new attribute when reading back applications and on rehydration.

Removed some previous, hardcoded, unused attributes.

NOTE: DoB edge case is not yet deal with here (where a submitted application is under18 but on re-hydration applicant has become over18).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-331

## How to manually test the feature
Submission of under 18 passported applications (NINO will be nil as we don't ask for it) should be successful. On the submitted application JSON, the `ioj_passport` should contain `['on_age_under18']` and the `means_passport` should contain ['on_age_under18'].
IoJ page is not shown on first run, but it is shown on returned applications due to split case.