### PR TITLE
CRIMAP-337 Deal with returned passported applications

### DIFF
--- a/app/models/concerns/passportable.rb
+++ b/app/models/concerns/passportable.rb
@@ -1,0 +1,24 @@
+module Passportable
+  extend ActiveSupport::Concern
+
+  delegate :age_passported?,
+           :benefit_check_passported?, to: :means_passporter
+
+  def means_passported?
+    means_passporter.passported?
+  end
+
+  def ioj_passported?
+    ioj_passporter.passported?
+  end
+
+  private
+
+  def means_passporter
+    Passporting::MeansPassporter.new(self)
+  end
+
+  def ioj_passporter
+    Passporting::IojPassporter.new(self)
+  end
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,4 +1,6 @@
 class CrimeApplication < ApplicationRecord
+  include Passportable
+
   has_one :case, dependent: :destroy
 
   has_one :applicant, dependent: :destroy

--- a/app/presenters/tasks/case_details.rb
+++ b/app/presenters/tasks/case_details.rb
@@ -9,8 +9,7 @@ module Tasks
     end
 
     def can_start?
-      applicant.present? &&
-        (applicant.under18? || applicant.passporting_benefit?)
+      applicant.present? && crime_application.means_passported?
     end
 
     # If we have a `case` record we consider this in progress

--- a/app/presenters/tasks/ioj.rb
+++ b/app/presenters/tasks/ioj.rb
@@ -17,15 +17,9 @@ module Tasks
     end
 
     def completed?
-      return true if ioj_passported?
+      return true if crime_application.ioj_passported?
 
       ioj.present? && ioj.types.any?
-    end
-
-    private
-
-    def ioj_passported?
-      Passporting::IojPassporter.new(crime_application).passported?
     end
   end
 end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -31,7 +31,7 @@ module Decisions
     end
 
     def after_client_details
-      if applicant.under18?
+      if current_crime_application.age_passported?
         start_address_journey(HomeAddress)
       else
         edit(:has_nino)
@@ -39,6 +39,8 @@ module Decisions
     end
 
     def after_has_nino
+      return edit(:benefit_check_result) if current_crime_application.benefit_check_passported?
+
       DWP::UpdateBenefitCheckResultService.call(applicant)
 
       if applicant.passporting_benefit.nil?

--- a/app/services/passporting/base_passporter.rb
+++ b/app/services/passporting/base_passporter.rb
@@ -20,6 +20,10 @@ module Passporting
 
     private
 
+    def resubmission?
+      crime_application.parent_id.present?
+    end
+
     def applicant_under18?
       applicant.under18?
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  u18_means_passport:
+    local: true
+    staging: true
+    production: false
   u18_ioj_passport:
     local: true
     staging: true

--- a/spec/models/concerns/passportable_spec.rb
+++ b/spec/models/concerns/passportable_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Passportable do
+  let(:test_class) do
+    Class.new { include Passportable }
+  end
+
+  let(:crime_application) { test_class.new }
+
+  describe '#means_passported?' do
+    let(:means_double) { double }
+
+    before do
+      allow(
+        Passporting::MeansPassporter
+      ).to receive(:new).with(crime_application).and_return(means_double)
+    end
+
+    it 'delegates to the MeansPassporter' do
+      expect(means_double).to receive(:passported?)
+
+      crime_application.means_passported?
+    end
+  end
+
+  describe '#ioj_passported?' do
+    let(:ioj_double) { double }
+
+    before do
+      allow(
+        Passporting::IojPassporter
+      ).to receive(:new).with(crime_application).and_return(ioj_double)
+    end
+
+    it 'delegates to the IojPassporter' do
+      expect(ioj_double).to receive(:passported?)
+
+      crime_application.ioj_passported?
+    end
+  end
+end

--- a/spec/presenters/tasks/case_details_spec.rb
+++ b/spec/presenters/tasks/case_details_spec.rb
@@ -29,37 +29,22 @@ RSpec.describe Tasks::CaseDetails do
     end
 
     context 'when there is an applicant record' do
-      let(:applicant) do
-        instance_double(
-          Applicant,
-          under18?: under18,
-          passporting_benefit?: passporting_benefit,
-        )
+      let(:applicant) { double }
+
+      before do
+        allow(crime_application).to receive(:means_passported?).and_return(means_passported)
       end
 
-      let(:under18) { nil }
-      let(:passporting_benefit) { nil }
-
-      context 'when applicant is under 18' do
-        let(:under18) { true }
+      context 'when applicant is means passported' do
+        let(:means_passported) { true }
 
         it { expect(subject.can_start?).to be(true) }
       end
 
-      context 'when applicant is over 18' do
-        let(:under18) { false }
+      context 'when applicant is not means passported' do
+        let(:means_passported) { false }
 
-        context 'and DWP check was successful' do
-          let(:passporting_benefit) { true }
-
-          it { expect(subject.can_start?).to be(true) }
-        end
-
-        context 'and DWP check failed' do
-          let(:passporting_benefit) { false }
-
-          it { expect(subject.can_start?).to be(false) }
-        end
+        it { expect(subject.can_start?).to be(false) }
       end
     end
   end

--- a/spec/presenters/tasks/ioj_spec.rb
+++ b/spec/presenters/tasks/ioj_spec.rb
@@ -67,12 +67,8 @@ RSpec.describe Tasks::Ioj do
   end
 
   describe '#completed?' do
-    let(:passporter_double) { instance_double(Passporting::IojPassporter, passported?: passporter_result) }
-
     before do
-      allow(
-        Passporting::IojPassporter
-      ).to receive(:new).with(crime_application).and_return(passporter_double)
+      allow(crime_application).to receive(:ioj_passported?).and_return(passporter_result)
     end
 
     context 'when the application is Ioj passported (and there is no override)' do

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -265,26 +265,9 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :ioj_passport }
 
-    before do
-      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(means_passported)
-    end
-
-    context 'and the means passporter was not triggered' do
-      let(:means_passported) { false }
-
-      it 'raises an error' do
-        expect {
-          subject.destination
-        }.to raise_error(
-          Decisions::BaseDecisionTree::InvalidStep, 'application is not means-passported'
-        )
-      end
-    end
-
-    context 'and the means passporter was triggered' do
-      let(:means_passported) { true }
-
-      it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
+    it 'runs the same logic as the `ioj` step' do
+      expect(subject).to receive(:after_ioj)
+      subject.destination
     end
   end
 

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe Passporting::MeansPassporter do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:, parent_id:) }
   let(:applicant) { instance_double(Applicant, under18?: under18, passporting_benefit: passporting_benefit) }
 
+  let(:parent_id) { nil }
   let(:under18) { nil }
   let(:passporting_benefit) { nil }
 
@@ -15,6 +16,17 @@ RSpec.describe Passporting::MeansPassporter do
   end
 
   describe '#call' do
+    context 'for a resubmitted application' do
+      let(:parent_id) { 'uuid' }
+
+      it 'uses the existing values' do
+        expect(crime_application).not_to receive(:update)
+        expect(subject).to receive(:passported?)
+
+        subject.call
+      end
+    end
+
     context 'means passporting on age' do
       context 'when applicant is over 18' do
         let(:under18) { false }
@@ -81,20 +93,83 @@ RSpec.describe Passporting::MeansPassporter do
   end
 
   describe '#passported?' do
-    before do
-      allow(crime_application).to receive(:means_passport).and_return(means_passport)
+    it 'checks if any of the passporting kinds has triggered' do
+      expect(subject).to receive(:age_passported?).and_return(false)
+      expect(subject).to receive(:benefit_check_passported?).and_return(false)
+
+      subject.passported?
+    end
+  end
+
+  describe '#age_passported?' do
+    context 'for a new application' do
+      context 'for under 18' do
+        let(:under18) { true }
+
+        it { expect(subject.age_passported?).to be(true) }
+      end
+
+      context 'for over 18' do
+        let(:under18) { false }
+
+        it { expect(subject.age_passported?).to be(false) }
+      end
     end
 
-    context 'when there is passporting of any kind' do
-      let(:means_passport) { ['foobar'] }
+    context 'for a resubmitted application' do
+      let(:parent_id) { 'uuid' }
 
-      it { expect(subject.passported?).to be(true) }
+      before do
+        allow(crime_application).to receive(:means_passport).and_return(means_passport)
+      end
+
+      context 'passported on age' do
+        let(:means_passport) { [MeansPassportType::ON_AGE_UNDER18.to_s] }
+
+        it { expect(subject.age_passported?).to be(true) }
+      end
+
+      context 'not passported on age' do
+        let(:means_passport) { [MeansPassportType::ON_BENEFIT_CHECK.to_s] }
+
+        it { expect(subject.age_passported?).to be(false) }
+      end
+    end
+  end
+
+  describe '#benefit_check_passported?' do
+    context 'for a new application' do
+      context 'with benefit check passed' do
+        let(:passporting_benefit) { true }
+
+        it { expect(subject.benefit_check_passported?).to be(true) }
+      end
+
+      context 'with benefit check failed' do
+        let(:passporting_benefit) { false }
+
+        it { expect(subject.benefit_check_passported?).to be(false) }
+      end
     end
 
-    context 'when there is no passporting' do
-      let(:means_passport) { [] }
+    context 'for a resubmitted application' do
+      let(:parent_id) { 'uuid' }
 
-      it { expect(subject.passported?).to be(false) }
+      before do
+        allow(crime_application).to receive(:means_passport).and_return(means_passport)
+      end
+
+      context 'passported on benefit check' do
+        let(:means_passport) { [MeansPassportType::ON_BENEFIT_CHECK.to_s] }
+
+        it { expect(subject.benefit_check_passported?).to be(true) }
+      end
+
+      context 'not passported on benefit check' do
+        let(:means_passport) { [MeansPassportType::ON_AGE_UNDER18.to_s] }
+
+        it { expect(subject.benefit_check_passported?).to be(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
One edge case not covered in previous PR was the fact, a passported application (mostly on the basis of under 18, but could also be on the basis of the DWP check) that is returned back to the provider, should keep the original passporting and not try to re-run the checks or take the provider through a different journey to the original one.

In practice this means:

- if original application was for an under 18 client, then the returned application will not ask for NINO nor run the DWP check, and remain passported upon submission.
- same for over 18 with a successful DWP check (in this case, the NINO page is shown to the provider, but the DWP check is not triggered).

This PR introduce some refactor to make this easier, with some syntax-sugar methods in a concern `Passportable`.

Also, introduced (although enabled on staging) a feature flag to enable/disable the means passport on under 18 (i.e. ask or not for NINO + DWP check). Just in case we need to turn this off.

Additional edge cases need to be studied and covered with code if required, as follow-up PRs. Also some changes might be required to the IoJ Passporter once we introduced the offence passporting.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-337

## Notes for reviewer

## How to manually test the feature
Submit a passported application (either on age or on DWP check) and return it. Child application should inherit parent passporting and thus should not ask for NINO or for DWP check (depending on the original passporting). Child application can also be submitted and again returned etc.