### PR TITLE
CRIMAP-338 Handle resubmission date stamp

### DIFF
--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -13,7 +13,7 @@ module Datastore
       crime_application.update!(
         client_has_partner: YesNoAnswer::NO,
         parent_id: parent.id,
-        date_stamp: parent.date_stamp,
+        date_stamp: date_stamp,
         ioj_passport: parent.ioj_passport,
         means_passport: parent.means_passport,
         applicant: applicant,
@@ -29,6 +29,13 @@ module Datastore
 
     def split_case?
       parent.return_details.reason.inquiry.split_case?
+    end
+
+    # For re-hydration of returned applications, we keep the original
+    # date stamp if the parent case type was date-stampable, otherwise
+    # we leave it `nil`, so a new date is applied on resubmission.
+    def date_stamp
+      parent.date_stamp if CaseType.new(parent.case.case_type).date_stampable?
     end
 
     def applicant

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -61,6 +61,44 @@ RSpec.describe Datastore::ApplicationRehydration do
       end
     end
 
+    context 'date stamp' do
+      let(:parent) do
+        super().deep_merge('case_details' => { 'case_type' => case_type })
+      end
+
+      context 'for a parent with a date-stampable case type' do
+        let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
+
+        it 'inherits the existing date stamp' do
+          expect(
+            crime_application
+          ).to receive(:update!).with(
+            hash_including(
+              date_stamp: an_instance_of(DateTime)
+            )
+          )
+
+          subject.call
+        end
+      end
+
+      context 'for a parent with a non date-stampable case type' do
+        let(:case_type) { CaseType::INDICTABLE.to_s }
+
+        it 'leaves the date stamp `nil`' do
+          expect(
+            crime_application
+          ).to receive(:update!).with(
+            hash_including(
+              date_stamp: nil
+            )
+          )
+
+          subject.call
+        end
+      end
+    end
+
     context 'for an already re-hydrated application' do
       let(:applicant) { 'something' }
 


### PR DESCRIPTION
## Description of change
Non date-stampable case types should obtain a new date stamp on resubmission, instead of inheriting their parent's.

This fixes a bug observed on staging with resubmission of `Indictable` and `Already in Crown Court` application case types.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-338

## Notes for reviewer

## How to manually test the feature
Submit 2 applications. One application with a date-stampable case type, (for instance, Summary only) and another with a non date-stampable case type (for instance, Indictable).
Return both applications back to the provider.
Resubmit both applications. Date stampable one will retain original date stamp. Non date-stampable one will generate a new date stamp on submission (equal to submitted_at date).