### PR TITLE
CRIMAP-328 Switch datastore URL to internal svc

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -9,8 +9,8 @@ data:
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
+  DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
-  DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.cloud-platform.service.justice.gov.uk
 
   # If this is uncommented, authentication will be mocked
   # OMNIAUTH_TEST_MODE: "true"


### PR DESCRIPTION
## Description of change
We are evaluating internal cross-namespace networking between Apply/Review and Datastore.

For the time being and until we decide so, external ingress will still be available.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-328

## Notes for reviewer

## How to manually test the feature
In theory everything should continue working as before, just slightly less latency when loading lists or paginating (thus difficult to evaluate as we don't have that many records yet).