### PR TITLE
CRIMAP-329 Copy change to representation order page

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,5 +1,5 @@
 // Print specific overrides.
-// Currently this is only used in the application certificate page.
+// Currently this is only used in the representation order page.
 //
 @media print {
   header,

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -52,8 +52,8 @@ en:
         submitted: Submitted
       no_records: There are no %{status} applications
     show:
-      page_title: Application certificate
-      heading: Application for criminal legal aid certificate
+      page_title: Application representation order
+      heading: Application for a criminal legal aid representation order
       laa_reference: "Reference number:"
       date_stamp: "Date stamp:"
       date_submitted: "Date submitted:"

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Dashboard' do
     end
   end
 
-  describe 'show an application certificate (in `submitted` status)' do
+  describe 'show an application representation order (in `submitted` status)' do
     before do
       stub_request(:get, "http://datastore-webmock/api/v2/applications/#{application_fixture_id}")
         .to_return(body: application_fixture)
@@ -24,10 +24,10 @@ RSpec.describe 'Dashboard' do
       get completed_crime_application_path(application_fixture_id)
     end
 
-    it 'renders the certificate page' do
+    it 'renders the representation order page' do
       expect(response).to have_http_status(:success)
 
-      assert_select 'h1', 'Application for criminal legal aid certificate'
+      assert_select 'h1', 'Application for a criminal legal aid representation order'
     end
 
     it 'has print buttons' do
@@ -113,7 +113,7 @@ RSpec.describe 'Dashboard' do
     # rubocop:enable Layout/LineLength
   end
 
-  describe 'show an application certificate (in `returned` status)' do
+  describe 'show an application representation order (in `returned` status)' do
     # NOTE: this is almost identical to `submitted` state, only difference
     # is there is a notification banner with the return details and CTA button.
     # No need to test everything again.
@@ -125,10 +125,10 @@ RSpec.describe 'Dashboard' do
       get completed_crime_application_path(returned_application_fixture_id)
     end
 
-    it 'renders the certificate page' do
+    it 'renders the representation order page' do
       expect(response).to have_http_status(:success)
 
-      assert_select 'h1', 'Application for criminal legal aid certificate'
+      assert_select 'h1', 'Application for a criminal legal aid representation order'
     end
 
     # rubocop:disable Layout/LineLength


### PR DESCRIPTION
## Description of change
Based on feedback from Chris, "Certificate" is used in Civil legal aid and the equivalent in Criminal legal aid is "representation order".

More context:
https://mojdt.slack.com/archives/C02AFLHGK9S/p1682089993247579

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-329

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="722" alt="Screenshot 2023-04-24 at 08 47 26" src="https://user-images.githubusercontent.com/687910/233932267-2b84c15c-7ceb-47ad-862d-e41a7907e222.png">

### After changes:
<img width="720" alt="Screenshot 2023-04-24 at 08 47 10" src="https://user-images.githubusercontent.com/687910/233932303-eb33b276-5cdf-41b7-b7ba-d134bc8f76ec.png">

## How to manually test the feature
Open a submitted application.