### PR TITLE
Upgrade ci/cd postgres version

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.6-alpine
+        image: postgres:15.2-alpine
         env:
           POSTGRES_DB: laa-apply-for-criminal-legal-aid-test
           POSTGRES_USER: postgres

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Brewfile.lock.json
 .env.development.local
 .env.test.local
 .env.local
+
+# Ignore IntelliJ IDE project-specific settings
+.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3'
 
 services:
   db:
-    image: postgres:14.6-alpine
+    image: postgres:15.2-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 


### PR DESCRIPTION
## Description of change

The version of postgres in cloud platform Apply namespace has been upgraded to 15.2.

For consistency, use the same version in the CI/CD pipeline and in the docker-compose file.

Also as I have set up RubyMine locally, so i've added code to ignore the local `.idea/` repository which contains project-specific settings 

## Link to relevant ticket

https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-343

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
