### PR TITLE
CRIMAP-172 Add staging subdomain to ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Read [how to connect the cluster](https://user-guide.cloud-platform.service.just
 
 **Namespaces for this service:**
 * [staging namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging)
-* [production namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-prod) (not yet used)
+* [production namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production)
 
 ### Encode secrets in Base64
 

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -12,6 +12,9 @@ metadata:
       if ($host = 'laa-apply-for-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk') {
         return 301 https://laa-apply-for-criminal-legal-aid-production.apps.cloud-platform.service.justice.gov.uk;
       }
+      if ($host = 'laa-apply-for-criminal-legal-aid-production.apps.cloud-platform.service.justice.gov.uk') {
+        return 301 https://apply-for-criminal-legal-aid.service.justice.gov.uk;
+      }
       location = /.well-known/security.txt {
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -12,6 +12,9 @@ metadata:
       if ($host = 'laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk') {
         return 301 https://laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk;
       }
+      if ($host = 'laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk') {
+        return 301 https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk;
+      }
       location = /.well-known/security.txt {
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
@@ -22,6 +25,9 @@ spec:
   - hosts:
     - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
     - laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - staging.apply-for-criminal-legal-aid.service.justice.gov.uk
+    secretName: domain-tls-certificate-staging
   rules:
   - host: laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
     http:
@@ -34,6 +40,16 @@ spec:
             port:
               number: 80
   - host: laa-apply-for-criminal-legal-aid-staging.apps.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: service-staging
+            port:
+              number: 80
+  - host: staging.apply-for-criminal-legal-aid.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Description of change
This is a subdomain of our production domain.
Follow-up to PR #331.

Internal cloud platform URLs are still available and functional, but this is now an easier to remember domain.
The cloud URLs will redirect to their corresponding "nice" domains.

Some functionality in Portal will still redirect to old cloud URL until metadata is updated on their side.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-172

