### PR TITLE
Use v1 of the datastore

### DIFF
--- a/config/initializers/datastore_client.rb
+++ b/config/initializers/datastore_client.rb
@@ -2,7 +2,7 @@ require 'datastore_api'
 
 DatastoreApi.configure do |config|
   config.api_root = ENV.fetch('DATASTORE_API_ROOT', nil)
-  config.api_path = '/api/v2'
+  config.api_path = '/api/v1'
 
   config.auth_type = :jwt
 

--- a/spec/controllers/steps/submission/confirmation_controller_spec.rb
+++ b/spec/controllers/steps/submission/confirmation_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Submission::ConfirmationController, type: :controller do
     let(:application_fixture) { LaaCrimeSchemas.fixture(1.0) }
 
     before do
-      stub_request(:get, "http://datastore-webmock/api/v2/applications/#{application_id}")
+      stub_request(:get, "http://datastore-webmock/api/v1/applications/#{application_id}")
         .to_return(body: application_fixture)
     end
 

--- a/spec/requests/dashboard_lists_spec.rb
+++ b/spec/requests/dashboard_lists_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe 'Dashboard' do
     end
 
     before do
-      stub_request(:get, 'http://datastore-webmock/api/v2/applications')
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
         .with(query: hash_including({ 'status' => 'submitted', 'office_code' => '1A123B' }))
         .to_return(body: collection_fixture)
 
@@ -205,7 +205,7 @@ RSpec.describe 'Dashboard' do
     end
 
     before do
-      stub_request(:get, 'http://datastore-webmock/api/v2/applications')
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
         .with(query: hash_including({ 'status' => 'returned', 'office_code' => '1A123B' }))
         .to_return(body: collection_fixture)
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Dashboard' do
 
   describe 'show an application representation order (in `submitted` status)' do
     before do
-      stub_request(:get, "http://datastore-webmock/api/v2/applications/#{application_fixture_id}")
+      stub_request(:get, "http://datastore-webmock/api/v1/applications/#{application_fixture_id}")
         .to_return(body: application_fixture)
 
       get completed_crime_application_path(application_fixture_id)
@@ -91,7 +91,7 @@ RSpec.describe 'Dashboard' do
     let(:app_split_case) { LaaCrimeSchemas.fixture(1.0, name: 'application_returned_split_case') }
 
     before do
-      stub_request(:get, "http://datastore-webmock/api/v2/applications/#{app_split_case_id}")
+      stub_request(:get, "http://datastore-webmock/api/v1/applications/#{app_split_case_id}")
         .to_return(body: app_split_case)
 
       get completed_crime_application_path(app_split_case_id)
@@ -119,7 +119,7 @@ RSpec.describe 'Dashboard' do
     # No need to test everything again.
 
     before do
-      stub_request(:get, "http://datastore-webmock/api/v2/applications/#{returned_application_fixture_id}")
+      stub_request(:get, "http://datastore-webmock/api/v1/applications/#{returned_application_fixture_id}")
         .to_return(body: returned_application_fixture)
 
       get completed_crime_application_path(returned_application_fixture_id)

--- a/spec/services/datastore/application_counters_spec.rb
+++ b/spec/services/datastore/application_counters_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datastore::ApplicationCounters do
   end
 
   before do
-    stub_request(:get, 'http://datastore-webmock/api/v2/applications')
+    stub_request(:get, 'http://datastore-webmock/api/v1/applications')
       .with(query: expected_query)
       .to_return(body: datastore_result)
   end
@@ -29,7 +29,7 @@ RSpec.describe Datastore::ApplicationCounters do
     let(:status) { 'returned' }
 
     before do
-      stub_request(:get, 'http://datastore-webmock/api/v2/applications')
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
         .with(query: expected_query)
         .to_raise(StandardError)
 

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Datastore::ApplicationSubmission do
   before do
     allow(crime_application).to receive(:destroy)
 
-    stub_request(:post, 'http://datastore-webmock/api/v2/applications')
+    stub_request(:post, 'http://datastore-webmock/api/v1/applications')
       .to_return(status: 201, body: '{}')
   end
 
@@ -142,7 +142,7 @@ RSpec.describe Datastore::ApplicationSubmission do
       it 'calls the API and submits the serialized application' do
         expect(
           a_request(
-            :post, 'http://datastore-webmock/api/v2/applications'
+            :post, 'http://datastore-webmock/api/v1/applications'
           ).with(body: { application: payload })
         ).to have_been_made.once
       end
@@ -154,7 +154,7 @@ RSpec.describe Datastore::ApplicationSubmission do
 
     context 'handling of errors' do
       before do
-        stub_request(:post, 'http://datastore-webmock/api/v2/applications')
+        stub_request(:post, 'http://datastore-webmock/api/v1/applications')
           .to_raise(StandardError)
 
         allow(Sentry).to receive(:capture_exception)

--- a/spec/services/datastore/get_application_spec.rb
+++ b/spec/services/datastore/get_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Datastore::GetApplication do
   subject { described_class.new('12345') }
 
-  let(:endpoint) { 'http://datastore-webmock/api/v2/applications/12345' }
+  let(:endpoint) { 'http://datastore-webmock/api/v1/applications/12345' }
   let(:datastore_result) { '{"status":"submitted"}' }
 
   before do

--- a/spec/services/datastore/list_applications_spec.rb
+++ b/spec/services/datastore/list_applications_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Datastore::ListApplications do
   end
 
   before do
-    stub_request(:get, 'http://datastore-webmock/api/v2/applications')
+    stub_request(:get, 'http://datastore-webmock/api/v1/applications')
       .with(query: expected_query)
       .to_return(body: datastore_result)
   end
@@ -44,7 +44,7 @@ RSpec.describe Datastore::ListApplications do
 
   context 'handling of errors' do
     before do
-      stub_request(:get, 'http://datastore-webmock/api/v2/applications')
+      stub_request(:get, 'http://datastore-webmock/api/v1/applications')
         .with(query: expected_query)
         .to_raise(StandardError)
 


### PR DESCRIPTION
## Description of change
This needs to go together or soon after this other PR: https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/88

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-350

