### PR TITLE
Tweak devise session timeout depending on env

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -28,6 +28,10 @@ LAA_PORTAL_IDP_METADATA_FILE=config/laa_portal/metadata/samlmock.xml
 # Set to true to bypass authentication (a mock will be used)
 OMNIAUTH_TEST_MODE=true
 
+# Session timeout, in minutes. For local development, a longer
+# or shorter timeout can be configured (default is 60 minutes)
+# SESSION_TIMEOUT_MINUTES=60
+
 # Benefit Checker configuration
 BC_LSC_SERVICE_NAME=<benefit_checker_service_name>
 BC_CLIENT_ORG_ID=<benefit_checker_organisation_id>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,8 @@ module LaaApplyForCriminalLegalAid
     config.x.benefit_checker.client_org_id = ENV.fetch('BC_CLIENT_ORG_ID', nil)
     config.x.benefit_checker.client_user_id = ENV.fetch('BC_CLIENT_USER_ID', nil)
 
+    config.x.session.timeout_in = ENV.fetch('SESSION_TIMEOUT_MINUTES', 60).to_i.minutes
+
     config.x.gatekeeper= config_for(
       :gatekeeper, env: ENV.fetch('ENV_NAME', 'localhost')
     )

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 48.hours
+  config.timeout_in = Rails.configuration.x.session.timeout_in
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
+  SESSION_TIMEOUT_MINUTES: "60"
   DATASTORE_API_ROOT: http://service-production.laa-criminal-applications-datastore-production.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   LAA_PORTAL_IDP_METADATA_URL: https://portal.legalservices.gov.uk/oamfed/idp/metadata

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
+  SESSION_TIMEOUT_MINUTES: "1440"
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,4 +17,3 @@ feature_flags:
 # usually the case if it varies per environment.
 settings:
   eforms_url: https://portal.legalservices.gov.uk
-  session_timeout_minutes: 60 # not used yet, just an example


### PR DESCRIPTION
## Description of change
We had a hardcoded, long session timeout. This was fine for staging as we don't want to have to continuously authenticate with Portal (specially because it also needs the VPN).

However in production we want this to be a much shorter period of time, to increase security.

It is configurable, so in localhost we can still have a longer or shorter period that can help with development by setting the `SESSION_TIMEOUT_MINUTES` variable in the `.env.development.local` file.

Reduced staging from 48 hours to 24 hours timeout. Configured production to 1 hour timeout.
These are sensible defaults, can be tuned later on.
