### PR TITLE
CRIMAP-346 Under 18 IoJ on returned applications

### DIFF
--- a/app/services/passporting/base_passporter.rb
+++ b/app/services/passporting/base_passporter.rb
@@ -16,6 +16,10 @@ module Passporting
     def passported?
       raise 'implement in subclasses'
     end
+
+    def passport_types_collection
+      raise 'implement in subclasses'
+    end
     # :nocov:
 
     private
@@ -26,6 +30,10 @@ module Passporting
 
     def applicant_under18?
       applicant.under18?
+    end
+
+    def passported_on?(kind)
+      passport_types_collection.include?(kind.to_s)
     end
   end
 end

--- a/app/services/passporting/ioj_passporter.rb
+++ b/app/services/passporting/ioj_passporter.rb
@@ -2,7 +2,7 @@ module Passporting
   class IojPassporter < BasePassporter
     def call
       ioj_passport = []
-      ioj_passport << IojPassportType::ON_AGE_UNDER18 if applicant_under18?
+      ioj_passport << IojPassportType::ON_AGE_UNDER18 if age_passported?
 
       crime_application.update(ioj_passport:)
 
@@ -12,7 +12,19 @@ module Passporting
     def passported?
       # IoJ passporting can be overridden for applications returned
       # back to the provider due to the case being split
-      crime_application.ioj_passport.any? && !ioj_passport_override?
+      passport_types_collection.any? && !ioj_passport_override?
+    end
+
+    def age_passported?
+      # For resubmissions, we use the original age passport result,
+      # instead of running a new age calculation
+      return passported_on?(IojPassportType::ON_AGE_UNDER18) if resubmission?
+
+      applicant_under18?
+    end
+
+    def passport_types_collection
+      crime_application.ioj_passport
     end
 
     private

--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -28,6 +28,10 @@ module Passporting
       benefit_check_passed?
     end
 
+    def passport_types_collection
+      crime_application.means_passport
+    end
+
     private
 
     def applicant_under18?
@@ -36,10 +40,6 @@ module Passporting
 
     def benefit_check_passed?
       applicant.passporting_benefit.present?
-    end
-
-    def passported_on?(kind)
-      crime_application.means_passport.include?(kind.to_s)
     end
   end
 end

--- a/spec/services/passporting/ioj_passporter_spec.rb
+++ b/spec/services/passporting/ioj_passporter_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe Passporting::IojPassporter do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant:, ioj:) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:, ioj:, parent_id:) }
   let(:applicant) { instance_double(Applicant, under18?: under18) }
 
+  let(:parent_id) { nil }
   let(:under18) { nil }
   let(:ioj) { nil }
 
@@ -15,21 +16,35 @@ RSpec.describe Passporting::IojPassporter do
   end
 
   describe '#call' do
-    context 'when applicant is over 18' do
-      let(:under18) { false }
-
-      it 'does not add a passported type to the array' do
-        expect(crime_application).to receive(:update).with({ ioj_passport: [] })
+    context 'IoJ passporting on age' do
+      it 'calls #age_passported? method' do
+        # we test this method logic more in deep separately
+        expect(subject).to receive(:age_passported?)
         subject.call
       end
-    end
 
-    context 'when applicant is under 18' do
-      let(:under18) { true }
+      context 'when applicant is over 18' do
+        let(:under18) { false }
 
-      it 'adds a passported type to the array' do
-        expect(crime_application).to receive(:update).with({ ioj_passport: [IojPassportType::ON_AGE_UNDER18] })
-        subject.call
+        it 'does not add an age passported type to the array' do
+          expect(crime_application).to receive(:update).with(ioj_passport: [])
+
+          subject.call
+        end
+      end
+
+      context 'when applicant is under 18' do
+        let(:under18) { true }
+
+        it 'adds an age passported type to the array' do
+          expect(
+            crime_application
+          ).to receive(:update).with(
+            ioj_passport: [IojPassportType::ON_AGE_UNDER18]
+          )
+
+          subject.call
+        end
       end
     end
   end
@@ -65,6 +80,42 @@ RSpec.describe Passporting::IojPassporter do
       let(:ioj_passport) { [] }
 
       it { expect(subject.passported?).to be(false) }
+    end
+  end
+
+  describe '#age_passported?' do
+    context 'for a new application' do
+      context 'for under 18' do
+        let(:under18) { true }
+
+        it { expect(subject.age_passported?).to be(true) }
+      end
+
+      context 'for over 18' do
+        let(:under18) { false }
+
+        it { expect(subject.age_passported?).to be(false) }
+      end
+    end
+
+    context 'for a resubmitted application' do
+      let(:parent_id) { 'uuid' }
+
+      before do
+        allow(crime_application).to receive(:ioj_passport).and_return(ioj_passport)
+      end
+
+      context 'passported on age' do
+        let(:ioj_passport) { [IojPassportType::ON_AGE_UNDER18.to_s] }
+
+        it { expect(subject.age_passported?).to be(true) }
+      end
+
+      context 'not passported on age' do
+        let(:ioj_passport) { [] }
+
+        it { expect(subject.age_passported?).to be(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
This covers an edge case where the applicant is aged under 18 and thus is passported on IoJ on the first submission and then the application is returned by the caseworker when applicant is already over 18, or the applicant turns 18 before the application is resubmitted again.

In summary, if the application is a resubmission, we don't run again the age check, instead we use whatever result the initial submission had.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-346

## Notes for reviewer

## How to manually test the feature
Application remains IoJ passported on age, even when the applicant have turned 18 between the original application being submitted and the resubmitted application being submitted.