### PR TITLE
CRIMAP-345 Implement content for not enrolled page

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -29,7 +29,9 @@ module Providers
       gatekeeper = Providers::Gatekeeper.new(auth_hash.info)
       return if gatekeeper.provider_enrolled?
 
-      Rails.logger.warn "Not enrolled provider access attempt, UID: #{auth_hash.uid}"
+      Rails.logger.warn 'Not enrolled provider access attempt. ' \
+                        "UID: #{auth_hash.uid}, accounts: #{auth_hash.info.office_codes}"
+
       redirect_to not_enrolled_errors_path
     end
   end

--- a/app/views/errors/not_enrolled.en.html.erb
+++ b/app/views/errors/not_enrolled.en.html.erb
@@ -1,13 +1,30 @@
 <% title t('.page_title') %>
+<% step_header(path: Settings.portal_url) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Your account cannot use this service yet
+<div class="govuk-grid-row app-inverted--card app-inverted-text">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l app-inverted-text">
+      You need to apply using eForms
     </h1>
 
-    <p class="govuk-body">
-      Copy TBD.
+    <p class="govuk-body app-inverted-text">
+      You do not have access to the ‘<%= service_name %>’ service yet. This is because it is only available to some
+      providers while we test and improve it.
     </p>
+
+    <p class="govuk-body app-inverted-text">
+      You should apply using eForms for now.
+    </p>
+
+    <p class="govuk-body app-inverted-text">
+      Your law firm can register interest to use an early version of the service by emailing
+      <%= mail_to Settings.onboarding_email, class: 'app-link--inverted' %>. Otherwise, we’ll
+      contact you when you’re able to use it.
+    </p>
+
+    <div class="govuk-button-group govuk-!-margin-top-6">
+      <%= link_button t('helpers.submit.apply_in_eforms'), Settings.eforms_url,
+                      class: 'app-button--m app-button--inverted' %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -12,7 +12,8 @@
     </ul>
 
     <div class="govuk-button-group govuk-!-margin-top-6">
-      <%= link_button 'Apply in eForms', Settings.eforms_url, class: 'app-button--m app-button--inverted' %>
+      <%= link_button t('helpers.submit.apply_in_eforms'), Settings.eforms_url,
+                      class: 'app-button--m app-button--inverted' %>
     </div>
 
     <%= link_to 'Back to all applications', crime_applications_path, class: 'app-link--inverted govuk-!-font-size-19' %>

--- a/config/gatekeeper.yml
+++ b/config/gatekeeper.yml
@@ -16,4 +16,5 @@ staging:
     - 0Z981E
 
 production:
-  office_codes: []
+  office_codes:
+    - 2N232W # test provider in test firm

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,4 +16,6 @@ feature_flags:
 # should belong in the k8s `config_map`, which is
 # usually the case if it varies per environment.
 settings:
-  eforms_url: https://portal.legalservices.gov.uk
+  portal_url: https://portal.legalservices.gov.uk
+  eforms_url: https://portal.legalservices.gov.uk/oamfed/idp/initiatesso?providerid=eForms
+  onboarding_email: LAAapplyonboarding@justice.gov.uk

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Sign in user journey' do
 
     it 'redirects to the error page' do
       expect(current_url).to match(not_enrolled_errors_path)
-      expect(page).to have_content('Your account cannot use this service yet')
+      expect(page).to have_content('You need to apply using eForms')
     end
   end
 


### PR DESCRIPTION
## Description of change
Implement the content agreed for the not enrolled "error" page, and add the prod test user to the list of allowed office codes in the gatekeeper, so we can access with this user in production.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-345

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1014" alt="Screenshot 2023-05-04 at 11 36 59" src="https://user-images.githubusercontent.com/687910/236180985-0198b755-d29b-4c90-90fd-09f8c03510d1.png">

## How to manually test the feature
This can be tested by using any provider that doesn't have their office codes allowed. Refer to confluence page.