### PR TITLE
CRIMAP-355 Implement session lifespan

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -32,6 +32,10 @@ OMNIAUTH_TEST_MODE=true
 # or shorter timeout can be configured (default is 60 minutes)
 # SESSION_TIMEOUT_MINUTES=60
 
+# Time, in minutes, that a user's authentication session remains
+# active. When the lifetime is reached the session expires
+# REAUTHENTICATE_AFTER_MINUTES=1440
+
 # Benefit Checker configuration
 BC_LSC_SERVICE_NAME=<benefit_checker_service_name>
 BC_CLIENT_ORG_ID=<benefit_checker_organisation_id>

--- a/app/lib/devise/hooks/reauthable.rb
+++ b/app/lib/devise/hooks/reauthable.rb
@@ -1,0 +1,23 @@
+# Each time a record is retrieved from the session (:fetch)
+# we check whether the `current_sign_in_at` is older than the
+# `reauthenticate_in` value. If so, the record is logged out.
+#
+module Devise
+  module Hooks
+    module Reauthable
+      Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+        scope = options[:scope]
+
+        if warden.authenticated?(scope) &&
+           record.respond_to?(:reauthenticate?) &&
+           record.reauthenticate?
+
+          proxy = Devise::Hooks::Proxy.new(warden)
+
+          Devise.sign_out_all_scopes ? proxy.sign_out : proxy.sign_out(scope)
+          throw :warden, scope: scope, message: :reauthenticate
+        end
+      end
+    end
+  end
+end

--- a/app/lib/devise/models/reauthable.rb
+++ b/app/lib/devise/models/reauthable.rb
@@ -1,0 +1,23 @@
+require 'devise/hooks/reauthable'
+
+module Devise
+  mattr_accessor :reauthenticate_in
+
+  module Models
+    module Reauthable
+      extend ActiveSupport::Concern
+
+      def reauthenticate?
+        current_sign_in_at < reauthenticate_in.ago
+      end
+
+      def reauthenticate_in
+        self.class.reauthenticate_in
+      end
+
+      module ClassMethods
+        Devise::Models.config(self, :reauthenticate_in)
+      end
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,5 +1,5 @@
 class Provider < ApplicationRecord
-  devise :lockable, :timeoutable, :trackable,
+  devise :lockable, :timeoutable, :reauthable, :trackable,
          :omniauthable, omniauth_providers: %i[saml]
 
   store_accessor :settings,

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,13 @@ module LaaApplyForCriminalLegalAid
     config.x.benefit_checker.client_org_id = ENV.fetch('BC_CLIENT_ORG_ID', nil)
     config.x.benefit_checker.client_user_id = ENV.fetch('BC_CLIENT_USER_ID', nil)
 
+    # Time after which a user's session will expire if they
+    # haven’t interacted with the service.
     config.x.session.timeout_in = ENV.fetch('SESSION_TIMEOUT_MINUTES', 60).to_i.minutes
+
+    # Time after which a user will be required to sign in again,
+    # regardless of their activity (session lifespan).
+    config.x.session.reauthenticate_in = ENV.fetch('REAUTHENTICATE_AFTER_MINUTES', 1440).to_i.minutes
 
     config.x.gatekeeper= config_for(
       :gatekeeper, env: ENV.fetch('ENV_NAME', 'localhost')

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,6 +2,7 @@
 
 Devise.setup do |config|
   require 'devise/orm/active_record'
+  require 'devise/models/reauthable'
   require 'laa_portal/saml_strategy'
   require 'laa_portal/saml_setup'
 
@@ -9,6 +10,11 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   config.timeout_in = Rails.configuration.x.session.timeout_in
+
+  # ==> Configuration for :reauthable
+  # The time you want to timeout the user session after their last sign in,
+  # regardless of their activity.
+  config.reauthenticate_in = Rails.configuration.x.session.reauthenticate_in
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -10,6 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
   SESSION_TIMEOUT_MINUTES: "60"
+  REAUTHENTICATE_AFTER_MINUTES: "1440"
   DATASTORE_API_ROOT: http://service-production.laa-criminal-applications-datastore-production.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   LAA_PORTAL_IDP_METADATA_URL: https://portal.legalservices.gov.uk/oamfed/idp/metadata

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -10,6 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
   SESSION_TIMEOUT_MINUTES: "1440"
+  REAUTHENTICATE_AFTER_MINUTES: "2880"
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
 

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -10,7 +10,8 @@ en:
     failure:
       already_authenticated: ""
       locked: "Your account is locked."
-      timeout: "Your session expired. Please sign in again to continue."
+      timeout: "Your session expired due to inactivity. Please sign in again to continue."
+      reauthenticate: "Your Portal session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in before continuing."
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Provider, type: :model do
 
   let(:office_codes) { %w[A1 B2 C3] }
 
+  it_behaves_like 'a reauthable model'
+
   describe '#display_name' do
     it { expect(subject.display_name).to eq('provider@example.com') }
   end

--- a/spec/support/shared_examples/reauthable_shared_examples.rb
+++ b/spec/support/shared_examples/reauthable_shared_examples.rb
@@ -1,0 +1,23 @@
+RSpec.shared_examples 'a reauthable model' do
+  let(:record) { described_class.new(current_sign_in_at:) }
+
+  describe 'reauthenticate?' do
+    subject { record.reauthenticate? }
+
+    before do
+      allow(record).to receive(:reauthenticate_in).and_return(5.minutes)
+    end
+
+    context 'when `current_sign_in_at` has not exceeded the session lifespan' do
+      let(:current_sign_in_at) { 3.minutes.ago }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when `current_sign_in_at` has exceeded the session lifespan' do
+      let(:current_sign_in_at) { 6.minutes.ago }
+
+      it { is_expected.to be(true) }
+    end
+  end
+end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -97,4 +97,22 @@ RSpec.describe 'Sign in user journey' do
       expect(current_url).to match(crime_applications_path)
     end
   end
+
+  context 'user is signed out if session lifespan is exceeded' do
+    before do
+      allow_any_instance_of(Provider).to receive(:office_codes).and_return(['A1'])
+      allow(Provider).to receive(:reauthenticate_in).and_return(5.minutes)
+
+      click_button 'Sign in with LAA Portal'
+    end
+
+    it 'signs out the user after `reauthenticate_in` time has passed' do
+      travel 6.minutes
+
+      click_link 'Your applications'
+
+      expect(current_url).to match('/login')
+      expect(page).to have_content('Your Portal session expired. Please sign in again to continue.')
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
This is in addition to the existing idle session timeout mechanism. Implemented via a new custom Devise module `:reauthable`.

The session lifespan will sign out a user (provider), and force them to re-authenticate with Portal, after X minutes have passed from their last sign in, regardless of their activity.

It is configurable, so in localhost we can still have a longer or shorter period that can help with development by setting the `REAUTHENTICATE_AFTER_MINUTES` variable in the `.env.development.local` file.

Staging set to 48 hours. Production set to 24 hours. These are sensible defaults, can be tuned later on.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-355

## Notes for reviewer

## How to manually test the feature
On localhost, as per above instructions to set the ENV variable. On staging or prod, waiting for time to pass.