### PR TITLE
CRIMAP-146 Prepare for offence IoJ passporting

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -6,7 +6,8 @@ class Offence
   csv_attributes :code,
                  :name,
                  :offence_class,
-                 :offence_type
+                 :offence_type,
+                 :ioj_passport
 
   def self.find_by_name(name)
     find_by(name:)

--- a/app/services/passporting/ioj_passporter.rb
+++ b/app/services/passporting/ioj_passporter.rb
@@ -3,6 +3,7 @@ module Passporting
     def call
       ioj_passport = []
       ioj_passport << IojPassportType::ON_AGE_UNDER18 if age_passported?
+      ioj_passport << IojPassportType::ON_OFFENCE     if offence_passported?
 
       crime_application.update(ioj_passport:)
 
@@ -23,11 +24,20 @@ module Passporting
       applicant_under18?
     end
 
+    def offence_passported?
+      FeatureFlags.offence_ioj_passport.enabled? &&
+        offences.any?(&:ioj_passport)
+    end
+
     def passport_types_collection
       crime_application.ioj_passport
     end
 
     private
+
+    def offences
+      crime_application.case.charges.filter_map(&:offence)
+    end
 
     def applicant_under18?
       FeatureFlags.u18_ioj_passport.enabled? && super

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  offence_ioj_passport:
+    local: true
+    staging: true
+    production: false
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/spec/services/passporting/ioj_passporter_spec.rb
+++ b/spec/services/passporting/ioj_passporter_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.describe Passporting::IojPassporter do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant:, ioj:, parent_id:) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:, case:, ioj:, parent_id:) }
   let(:applicant) { instance_double(Applicant, under18?: under18) }
+  let(:case) { instance_double(Case, charges:) }
 
   let(:parent_id) { nil }
   let(:under18) { nil }
   let(:ioj) { nil }
+  let(:charges) { [] }
 
   before do
     allow(crime_application).to receive(:update)
@@ -117,5 +119,51 @@ RSpec.describe Passporting::IojPassporter do
         it { expect(subject.age_passported?).to be(false) }
       end
     end
+  end
+
+  describe '#offence_passported?' do
+    before do
+      allow(
+        FeatureFlags.offence_ioj_passport
+      ).to receive(:enabled?).and_return(feat_enabled)
+    end
+
+    context 'feature flag is disabled' do
+      let(:feat_enabled) { false }
+
+      it { expect(subject.offence_passported?).to be(false) }
+    end
+
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'feature flag is enabled' do
+      let(:feat_enabled) { true }
+
+      let(:passported_charge) { Charge.new(offence_name: 'Attempt robbery') }
+      let(:non_passported_charge) { Charge.new(offence_name: 'Affray') }
+      let(:non_listed_charge) { Charge.new(offence_name: 'This is a test offence') }
+
+      before do
+        allow(passported_charge.offence).to receive(:ioj_passport).and_return(true)
+      end
+
+      context 'when there is at least one passported offence' do
+        let(:charges) { [non_passported_charge, passported_charge] }
+
+        it { expect(subject.offence_passported?).to be(true) }
+      end
+
+      context 'when there is at least one passported offence but also non listed offences' do
+        let(:charges) { [non_listed_charge, non_passported_charge, passported_charge] }
+
+        it { expect(subject.offence_passported?).to be(true) }
+      end
+
+      context 'when there are no passported offences' do
+        let(:charges) { [non_listed_charge, non_passported_charge] }
+
+        it { expect(subject.offence_passported?).to be(false) }
+      end
+    end
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 end


### PR DESCRIPTION
## Description of change
Still awaiting final CSV file that will mark the offences that are "passportable". This PR just assumes a new column, named `ioj_passport` and for now it is `nil` for all offences, thus none is passportable.

The logic however is implemented in this PR and also a feature flag to globally (instead of at the offence level) can enable/disable this IoJ passporting.

I've not wanted to make changes to our current CSV file because it will have to change soon again, probably the columns too, as we are splitting multi-class offences.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-146

## Notes for reviewer

## How to manually test the feature
User-facing there are no changes with this PR as everything is backend and no offences are passportable yet (CSV file needs to be updated). Can be tested by doctoring the CSV locally. Specs also cover the expected logic.