### PR TITLE
[CRIMAP-358] Add modsecurity rules to ingress

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -19,8 +19,16 @@ metadata:
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRequestBodyLimit 1048576
+      SecRequestBodyNoFilesLimit 1048576
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - laa-apply-for-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -19,8 +19,16 @@ metadata:
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRequestBodyLimit 1048576
+      SecRequestBodyNoFilesLimit 1048576
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change
Adds modsecurity to production/staging ingress, copied from Review app

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-358

## Notes for reviewer
- Limits HTTP request payloads to 1 Mib
- Limits file upload to 1 Mib
- Enables owasp rules as well
- May be too restrictive

## How to manually test the feature
Full smoke test required
Any file upload/download functionality requires manual testing on Staging.
