### PR TITLE
CRIMAP-9 Add basic google analytics setup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include ErrorHandling
-  helper StepsHelper
+
+  helper StepsHelper,
+         AnalyticsHelper
 
   prepend_before_action :authenticate_provider!
 

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,5 @@
+module AnalyticsHelper
+  def analytics_tracking_id
+    Rails.configuration.x.analytics.ga_tracking_id
+  end
+end

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,0 +1,7 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytics_tracking_id %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', <%== analytics_tracking_id.to_json %>, { 'anonymize_ip': true, 'allow_google_signals': false });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
 <% end %>
 
 <% content_for(:service_name) do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module LaaApplyForCriminalLegalAid
       g.orm :active_record, primary_key_type: :uuid
     end
 
+    config.x.analytics.ga_tracking_id = ENV['GA_TRACKING_ID']
+
     config.x.benefit_checker.use_mock = ENV.fetch('BC_USE_DEV_MOCK', false)
     config.x.benefit_checker.wsdl_url = ENV.fetch('BC_WSDL_URL', nil)
     config.x.benefit_checker.lsc_service_name = ENV.fetch('BC_LSC_SERVICE_NAME', nil)

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
+  GA_TRACKING_ID: G-ZKHETCMDR1
   SESSION_TIMEOUT_MINUTES: "60"
   REAUTHENTICATE_AFTER_MINUTES: "1440"
   DATASTORE_API_ROOT: http://service-production.laa-criminal-applications-datastore-production.svc.cluster.local

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
+  GA_TRACKING_ID: G-5V1GTJM5K7
   SESSION_TIMEOUT_MINUTES: "1440"
   REAUTHENTICATE_AFTER_MINUTES: "2880"
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe AnalyticsHelper, type: :helper do
+  describe '#analytics_tracking_id' do
+    it 'retrieves the configuration variable' do
+      expect(Rails.configuration.x.analytics).to receive(:ga_tracking_id)
+      helper.analytics_tracking_id
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This is the basic setup to track visits, drop outs, etc.

More complex analytics (to be able to measure interactions within the step forms) will come as a separate PR. Some custom javascript is required for these.

Also, no cookies consent yet, as that's part of a separate ticket.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-9

## How to manually test the feature
Traffic can be seen in the google analytics website.