### PR TITLE
CRIMAP-14 Prepare for cookies consent

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,6 +1,4 @@
-class AboutController < ApplicationController
-  skip_before_action :authenticate_provider!
-
+class AboutController < UnauthenticatedController
   def privacy; end
   def contact; end
   def feedback; end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,0 +1,18 @@
+class CookiesController < ApplicationController
+  def show; end
+
+  def update
+    result = Cookies::SettingsForm.new(
+      consent: consent_param,
+      cookies: cookies
+    ).save
+
+    redirect_back fallback_location: root_path, flash: { cookies_consent_updated: result }
+  end
+
+  private
+
+  def consent_param
+    params.require(:cookies)
+  end
+end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,6 +1,5 @@
-class CookiesController < ApplicationController
-  def show; end
 class CookiesController < UnauthenticatedController
+  def show; end
 
   def update
     result = Cookies::SettingsForm.new(

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,5 +1,6 @@
 class CookiesController < ApplicationController
   def show; end
+class CookiesController < UnauthenticatedController
 
   def update
     result = Cookies::SettingsForm.new(

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,3 @@
-class HomeController < ApplicationController
-  skip_before_action :authenticate_provider!
-
+class HomeController < UnauthenticatedController
   def index; end
 end

--- a/app/controllers/unauthenticated_controller.rb
+++ b/app/controllers/unauthenticated_controller.rb
@@ -1,0 +1,3 @@
+class UnauthenticatedController < ApplicationController
+  skip_before_action :authenticate_provider!
+end

--- a/app/forms/cookies/settings_form.rb
+++ b/app/forms/cookies/settings_form.rb
@@ -4,8 +4,10 @@ module Cookies
 
     attr_accessor :consent, :cookies
 
-    CONSENT_ACCEPT = 'accept'.freeze
-    CONSENT_REJECT = 'reject'.freeze
+    VALUES = [
+      CONSENT_ACCEPT = 'accept'.freeze,
+      CONSENT_REJECT = 'reject'.freeze,
+    ].freeze
 
     def save
       cookies[cookie_name] = {
@@ -21,7 +23,7 @@ module Cookies
     # We filter the value to ensure it is either `accept` or `reject`, and if
     # it is none of those values, we default to `reject` as a precaution.
     def accept_or_reject
-      ([CONSENT_ACCEPT, CONSENT_REJECT] & Array(consent)).first || CONSENT_REJECT
+      (VALUES & Array(consent)).first || CONSENT_REJECT
     end
 
     def cookie_name

--- a/app/forms/cookies/settings_form.rb
+++ b/app/forms/cookies/settings_form.rb
@@ -1,0 +1,35 @@
+module Cookies
+  class SettingsForm
+    include ActiveModel::Model
+
+    attr_accessor :consent, :cookies
+
+    CONSENT_ACCEPT = 'accept'.freeze
+    CONSENT_REJECT = 'reject'.freeze
+
+    def save
+      cookies[cookie_name] = {
+        expires: expiration,
+        value: accept_or_reject
+      }
+
+      accept_or_reject
+    end
+
+    private
+
+    # We filter the value to ensure it is either `accept` or `reject`, and if
+    # it is none of those values, we default to `reject` as a precaution.
+    def accept_or_reject
+      ([CONSENT_ACCEPT, CONSENT_REJECT] & Array(consent)).first || CONSENT_REJECT
+    end
+
+    def cookie_name
+      Rails.configuration.x.analytics.cookies_consent_name
+    end
+
+    def expiration
+      Rails.configuration.x.analytics.cookies_consent_expiration
+    end
+  end
+end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -2,4 +2,16 @@ module AnalyticsHelper
   def analytics_tracking_id
     Rails.configuration.x.analytics.ga_tracking_id
   end
+
+  def analytics_consent_cookie
+    cookies[Rails.configuration.x.analytics.cookies_consent_name]
+  end
+
+  def analytics_consent_accepted?
+    analytics_consent_cookie.eql?(Cookies::SettingsForm::CONSENT_ACCEPT)
+  end
+
+  def analytics_allowed?
+    analytics_tracking_id.present? && analytics_consent_accepted?
+  end
 end

--- a/app/views/cookies/show.en.html.erb
+++ b/app/views/cookies/show.en.html.erb
@@ -1,0 +1,12 @@
+<% title 'Cookies' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Cookies</h1>
+
+    <p class="govuk-body"><%= service_name -%> puts small files (known as ‘cookies’) onto your device to collect
+      information about how you browse the site.</p>
+
+    <!-- Content to be added later -->
+  </div>
+</div>

--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -2,9 +2,7 @@
 
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
-    <%# Destination needs validating %>
-
-    <%= link_to 'Cookies', 'https://www.gov.uk/help/cookies', class: 'govuk-footer__link' %>
+    <%= link_to 'Cookies', cookies_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
+  <%= render partial: 'layouts/analytics' if analytics_allowed? %>
 <% end %>
 
 <% content_for(:service_name) do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ module LaaApplyForCriminalLegalAid
     end
 
     config.x.analytics.ga_tracking_id = ENV['GA_TRACKING_ID']
+    config.x.analytics.cookies_consent_name = 'crime_apply_cookies_consent'.freeze
+    config.x.analytics.cookies_consent_expiration = 6.months
 
     config.x.benefit_checker.use_mock = ENV.fetch('BC_USE_DEV_MOCK', false)
     config.x.benefit_checker.wsdl_url = ENV.fetch('BC_WSDL_URL', nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,9 @@ Rails.application.routes.draw do
     get :accessibility
   end
 
+  # Handle the cookies consent
+  resource :cookies, only: [:show, :update]
+
   resources :crime_applications, except: [:show, :new, :update], path: 'applications' do
     get :confirm_destroy, on: :member
 

--- a/spec/controllers/cookies_controller_spec.rb
+++ b/spec/controllers/cookies_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe CookiesController do
+  describe '#show' do
+    it 'renders the expected page' do
+      get :show
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#update' do
+    let(:param_value) { Cookies::SettingsForm::CONSENT_ACCEPT }
+
+    # NOTE: there are more in deep tests in `spec/forms/cookies/settings_form_spec.rb`
+    it 'saves the form and redirects setting the flash' do
+      expect(
+        Cookies::SettingsForm
+      ).to receive(:new).with(
+        consent: param_value,
+        cookies: an_instance_of(ActionDispatch::Cookies::CookieJar),
+      ).and_call_original
+
+      post :update, params: { cookies: param_value }
+
+      expect(flash[:cookies_consent_updated]).to eq(param_value)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/forms/cookies/settings_form_spec.rb
+++ b/spec/forms/cookies/settings_form_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Cookies::SettingsForm do
+  subject { described_class.new(consent: consent_value, cookies: cookies_double) }
+
+  let(:cookies_double) { {} }
+
+  describe '#save' do
+    context 'for an `accept` value' do
+      let(:consent_value) { described_class::CONSENT_ACCEPT }
+
+      it 'sets the cookie and return the consent value' do
+        expect(subject.save).to eq('accept')
+        expect(cookies_double['crime_apply_cookies_consent']).to eq({ expires: 6.months, value: 'accept' })
+      end
+    end
+
+    context 'for a `reject` value' do
+      let(:consent_value) { described_class::CONSENT_REJECT }
+
+      it 'sets the cookie and return the consent value' do
+        expect(subject.save).to eq('reject')
+        expect(cookies_double['crime_apply_cookies_consent']).to eq({ expires: 6.months, value: 'reject' })
+      end
+    end
+
+    context 'for an unknown value' do
+      let(:consent_value) { 'foobar' }
+
+      it 'sets the cookie and defaults to `reject` consent' do
+        expect(subject.save).to eq('reject')
+        expect(cookies_double['crime_apply_cookies_consent']).to eq({ expires: 6.months, value: 'reject' })
+      end
+    end
+  end
+end

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,10 +1,69 @@
 require 'rails_helper'
 
 RSpec.describe AnalyticsHelper, type: :helper do
+  before do
+    allow(
+      Rails.configuration.x.analytics
+    ).to receive(:ga_tracking_id).and_return(ga_tracking_id)
+  end
+
+  let(:ga_tracking_id) { 'XYZ-123' }
+
   describe '#analytics_tracking_id' do
     it 'retrieves the configuration variable' do
-      expect(Rails.configuration.x.analytics).to receive(:ga_tracking_id)
-      helper.analytics_tracking_id
+      expect(helper.analytics_tracking_id).to eq('XYZ-123')
+    end
+  end
+
+  describe '#analytics_consent_cookie' do
+    it 'retrieves the analytics consent cookie' do
+      expect(controller.cookies).to receive(:[]).with('crime_apply_cookies_consent')
+      helper.analytics_consent_cookie
+    end
+  end
+
+  describe '#analytics_consent_accepted?' do
+    before do
+      allow(controller.cookies).to receive(:[]).with('crime_apply_cookies_consent').and_return(value)
+    end
+
+    context 'cookies has been accepted' do
+      let(:value) { Cookies::SettingsForm::CONSENT_ACCEPT }
+
+      it { expect(helper.analytics_consent_accepted?).to be(true) }
+    end
+
+    context 'cookies has been rejected' do
+      let(:value) { Cookies::SettingsForm::CONSENT_REJECT }
+
+      it { expect(helper.analytics_consent_accepted?).to be(false) }
+    end
+  end
+
+  describe '#analytics_allowed?' do
+    before do
+      allow(helper).to receive(:analytics_consent_accepted?).and_return(consent_accepted)
+    end
+
+    context 'when there is no GA_TRACKING_ID set' do
+      let(:ga_tracking_id) { nil }
+      let(:consent_accepted) { nil }
+
+      it { expect(helper.analytics_allowed?).to be(false) }
+    end
+
+    context 'when there is GA_TRACKING_ID set' do
+      context 'and consent has been granted by the user' do
+        let(:consent_accepted) { true }
+
+        it { expect(helper.analytics_allowed?).to be(true) }
+      end
+
+      context 'and consent has not been granted by the user' do
+        let(:consent_accepted) { false }
+
+        it { expect(helper.analytics_allowed?).to be(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
This first PR implements the new cookies controller, helpers and the handling of the cookie settings.

The banner is not shown yet on the page, this is only the backend work.

In a follow-up PR we will enable the banner and its functionality on the frontend following the guidelines and design stated in the design system: https://design-system.service.gov.uk/components/cookie-banner/

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-14

## Notes for reviewer
Nothing visible yet (other than a placeholder cookies page, accessible from the footer).

## How to manually test the feature
