### PR TITLE
CRIMAP-14 Show cookie consent banner

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,5 +1,9 @@
 class CookiesController < UnauthenticatedController
-  def show; end
+  def show
+    @form_object = Cookies::SettingsForm.build(
+      helpers.analytics_consent_cookie
+    )
+  end
 
   def update
     result = Cookies::SettingsForm.new(
@@ -13,6 +17,6 @@ class CookiesController < UnauthenticatedController
   private
 
   def consent_param
-    params.require(:cookies)
+    params.require(:cookies_settings_form).fetch(:consent)
   end
 end

--- a/app/forms/cookies/settings_form.rb
+++ b/app/forms/cookies/settings_form.rb
@@ -9,6 +9,10 @@ module Cookies
       CONSENT_REJECT = 'reject'.freeze,
     ].freeze
 
+    def self.build(consent)
+      new(consent:)
+    end
+
     def save
       cookies[cookie_name] = {
         expires: expiration,

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,14 @@
 import { initAll } from 'govuk-frontend'
 initAll()
 
+// Cookie banner
+// https://design-system.service.gov.uk/components/cookie-banner/
+import CookieBanner from "local/cookie-banner"
+const $cookieBanner = document.querySelector('[data-module="govuk-cookie-banner"]')
+if ($cookieBanner) {
+  new CookieBanner($cookieBanner).init()
+}
+
 // NOTE: suggestions input component not yet part of GOV.UK frontend
 // https://github.com/alphagov/govuk-frontend/pull/2453
 import Input from "local/suggestions"

--- a/app/javascript/local/cookie-banner.js
+++ b/app/javascript/local/cookie-banner.js
@@ -1,0 +1,22 @@
+'use strict';
+
+function CookieBanner($module) {
+  this.$cookieBanner = $module
+  this.$hideButtonSelector = '.app--js-cookie-banner-hide'
+}
+
+CookieBanner.prototype.init = function () {
+  const self = this,
+        $hideButton = this.$cookieBanner.querySelector(this.$hideButtonSelector)
+
+  if ($hideButton) {
+    $hideButton.addEventListener('click', self.hideBanner.bind(self))
+  }
+}
+
+CookieBanner.prototype.hideBanner = function (e) {
+  this.$cookieBanner.setAttribute('hidden', true)
+  e.preventDefault()
+}
+
+export default CookieBanner

--- a/app/views/cookies/show.en.html.erb
+++ b/app/views/cookies/show.en.html.erb
@@ -2,11 +2,89 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner',
+               locals: {
+                 flash: { success: t(".settings_updated.#{flash['cookies_consent_updated']}") }
+               } if flash['cookies_consent_updated'] %>
+
     <h1 class="govuk-heading-xl">Cookies</h1>
 
     <p class="govuk-body"><%= service_name -%> puts small files (known as ‘cookies’) onto your device to collect
-      information about how you browse the site.</p>
+      information about how you use the service.</p>
 
-    <!-- Content to be added later -->
+    <p class="govuk-body">We only set cookies when javascript is running in your browser and you’ve accepted them. If
+      you choose not to run javascript, the information on this page will not apply to you.</p>
+
+    <p class="govuk-body">You’ll normally see a message on the site before we store a cookie on your device.</p>
+    <p class="govuk-body">Cookies aren’t used to identify you personally.</p>
+
+    <p class="govuk-body">Find out
+      <a class="govuk-link" rel="external" target="_blank" href="https://ico.org.uk/for-the-public/online/cookies">how
+        to manage cookies</a> from the Information Commissioner's Office.</p>
+
+    <h2 class="govuk-heading-l">Essential cookies (strictly necessary)</h2>
+
+    <p class="govuk-body">We use these cookies to remember your progress on this device and your cookie consent
+      settings.</p>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">
+            _laa_apply_for_criminal_legal_aid_session
+          </th>
+          <td class="govuk-table__cell">
+            Saves your current progress on this device and tracks inactivity periods
+          </td>
+          <td class="govuk-table__cell">
+            After <%= Rails.configuration.x.session.timeout_in.inspect %> of inactivity or when you close your browser
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">
+            <%= Rails.configuration.x.analytics.cookies_consent_name %>
+          </th>
+          <td class="govuk-table__cell">
+            Saves your cookie consent settings
+          </td>
+          <td class="govuk-table__cell">
+            After <%= Rails.configuration.x.analytics.cookies_consent_expiration.inspect %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-l">Analytics cookies (optional)</h2>
+    <p class="govuk-body">
+      We use Google Analytics software to collect information about how you use this service. We do this to help make sure
+      this service is meeting the needs of its users and to help us make improvements. Google Analytics stores information
+      about:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the pages you visit</li>
+      <li>how long you spend on each page</li>
+      <li>the device and browser you use</li>
+      <li>what you click on while you’re visiting the site</li>
+    </ul>
+
+    <p class="govuk-body">We do not allow Google to use or share our analytics data.</p>
+
+    <h3 class="govuk-heading-m govuk-!-margin-top-8">
+      Change your cookie settings
+    </h3>
+
+    <%= form_for @form_object, url: cookies_path, method: :put do |f| %>
+      <%= f.govuk_collection_radio_buttons :consent, Cookies::SettingsForm::VALUES,
+                                           :to_s, legend: { size: 's' } %>
+      <%= f.continue_button(primary: :save_cookie_settings, secondary: false) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-cookie-banner" data-nosnippet role="region"
+     aria-label="<%= t('.title', service_name:) %>" data-module="govuk-cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" role="alert">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+          <%= t('.title', service_name:) %>
+        </h2>
+
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body"><%= t('.content_line1') %></p>
+          <p class="govuk-body"><%= t('.content_line2') %></p>
+        </div>
+      </div>
+    </div>
+
+    <%= form_with url: cookies_path, method: :put do %>
+      <div class="govuk-button-group">
+        <button value="accept" type="submit" name="cookies_settings_form[consent]" class="govuk-button" data-module="govuk-button">
+          <%= t('.accept_button') %>
+        </button>
+
+        <button value="reject" type="submit" name="cookies_settings_form[consent]" class="govuk-button" data-module="govuk-button">
+          <%= t('.reject_button') %>
+        </button>
+
+        <%= link_to t('.cookies_link'), cookies_path, class: 'govuk-link ga-pageLink',
+                    data: { ga_category: 'cookie banner', ga_label: 'view cookies' } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_cookie_banner_confirmation.html.erb
+++ b/app/views/layouts/_cookie_banner_confirmation.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-cookie-banner" data-nosnippet role="region"
+     aria-label="<%= t('.title', service_name:) %>" data-module="govuk-cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" role="alert">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">
+            <%= t(".result.#{result}") %>
+            <%= t('.content_html', cookies_link: cookies_path) %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-button-group">
+      <a href="/" role="button" draggable="false" class="app--js-cookie-banner-hide govuk-button" data-module="govuk-button">
+        <%= t('.hide_button') %>
+      </a>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -1,29 +1,29 @@
-<h2 class="govuk-visually-hidden">Support links</h2>
+<h2 class="govuk-visually-hidden"><%= t('.header') %></h2>
 
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
-    <%= link_to 'Cookies', cookies_path, class: 'govuk-footer__link' %>
+    <%= link_to t('.cookies'), cookies_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">
-    <%= link_to 'Contact', about_contact_path, class: 'govuk-footer__link' %>
+    <%= link_to t('.contact'), about_contact_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">
-    <%= link_to 'Feedback', about_feedback_path, class: 'govuk-footer__link' %>
+    <%= link_to t('.feedback'), about_feedback_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">
-    <%= link_to 'Privacy policy', about_privacy_path, class: 'govuk-footer__link' %>
+    <%= link_to t('.privacy'), about_privacy_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">
-    <%= link_to 'Accessibility statement', about_accessibility_path, class: 'govuk-footer__link' %>
+    <%= link_to t('.accessibility'), about_accessibility_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">
     <%# Destination needs validating %>
 
-    <%= link_to 'Terms and conditions', 'https://www.gov.uk/government/publications/laa-online-portal-help-and-information', class: 'govuk-footer__link' %>
+    <%= link_to t('.terms_and_conditions'), 'https://www.gov.uk/government/publications/laa-online-portal-help-and-information', class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,16 @@
   <% render partial: 'layouts/header_navigation' %>
 <% end %>
 
+<% content_for(:cookie_banner) do %>
+  <% unless analytics_consent_cookie.present? %>
+    <%= render partial: 'layouts/cookie_banner' %>
+  <% end %>
+
+  <% if flash['cookies_consent_updated'] %>
+    <%= render partial: 'layouts/cookie_banner_confirmation', locals: { result: flash['cookies_consent_updated'] } %>
+  <% end %>
+<% end %>
+
 <% content_for(:phase_banner) do %>
   <% render partial: 'layouts/phase_banner' %>
 <% end %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -29,6 +29,8 @@
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
 
+<%= yield(:cookie_banner) unless controller_name == 'cookies' %>
+
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">
   <%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content' %>
 </a>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -1,4 +1,5 @@
 <% flash.each do |type, msg| %>
+  <% next unless %w[success notice alert].include?(type.to_s) %>
   <% next unless msg.is_a?(String) %>
 
   <div class="govuk-notification-banner govuk-notification-banner--<%= type %>" role="alert"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,12 @@ en:
   service:
     name: Apply for criminal legal aid
 
+  cookies:
+    show:
+      settings_updated:
+        accept: You’ve accepted analytics cookies.
+        reject: You’ve rejected analytics cookies.
+
   date:
     formats:
       <<: *DATE_FORMATS
@@ -22,15 +28,6 @@ en:
       title: Notice
     alert:
       title: Alert
-
-  layouts:
-    header_navigation:
-      menu_button: Menu
-      nav_aria_label: Menu
-      button_aria_label: Show or hide menu
-      your_applications: Your applications
-      sign_in: Sign in
-      sign_out: Sign out
 
   support:
     array:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -14,11 +14,14 @@ en:
       save_and_continue: Save and continue
       save_and_come_back_later: Save and come back later
       save_and_submit: Save and submit application
+      save_cookie_settings: Save cookie settings
       find_address: Find address
       try_again: Try again
       apply_in_eforms: Apply using eForms
 
     legend:
+      cookies_settings_form:
+        consent: Do you want to accept analytics cookies?
       steps_provider_select_office_form:
         office_code: Select your office account number
       steps_client_has_partner_form:
@@ -80,6 +83,10 @@ en:
         legal_rep_telephone: For example, 01632 960 001 or +44 808 157 0192
 
     label:
+      cookies_settings_form:
+        consent_options:
+          accept: 'Yes'
+          reject: 'No'
       steps_provider_confirm_office_form:
         is_current_office_options:
           'yes': 'Yes'

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -1,0 +1,36 @@
+---
+en:
+  layouts:
+    header_navigation:
+      menu_button: Menu
+      nav_aria_label: Menu
+      button_aria_label: Show or hide menu
+      your_applications: Your applications
+      sign_in: Sign in
+      sign_out: Sign out
+
+    footer_links:
+      header: Support links
+      cookies: Cookies
+      contact: Contact
+      feedback: Feedback
+      privacy: Privacy
+      accessibility: Accessibility
+      terms_and_conditions: Terms and conditions
+
+    cookie_banner:
+      title: Cookies on %{service_name}
+      content_line1: We use some essential cookies to make this service work.
+      content_line2: We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+      accept_button: Accept analytics cookies
+      reject_button: Reject analytics cookies
+      cookies_link: View cookies
+    cookie_banner_confirmation:
+      title: Cookies on %{service_name}
+      result:
+        accept: You’ve accepted analytics cookies.
+        reject: You’ve rejected analytics cookies.
+      content_html: |
+        You can <a href="%{cookies_link}" class="govuk-link ga-pageLink" data-ga-category="cookie banner"
+        data-ga-label="change cookies">change your cookie settings</a> at any time.
+      hide_button: Hide cookie message

--- a/spec/controllers/cookies_controller_spec.rb
+++ b/spec/controllers/cookies_controller_spec.rb
@@ -2,7 +2,15 @@ require 'rails_helper'
 
 RSpec.describe CookiesController do
   describe '#show' do
+    before do
+      allow(controller.helpers).to receive(:analytics_consent_cookie).and_return('foobar')
+    end
+
     it 'renders the expected page' do
+      expect(
+        Cookies::SettingsForm
+      ).to receive(:build).with('foobar').and_call_original
+
       get :show
       expect(response).to have_http_status(:ok)
     end
@@ -20,7 +28,7 @@ RSpec.describe CookiesController do
         cookies: an_instance_of(ActionDispatch::Cookies::CookieJar),
       ).and_call_original
 
-      post :update, params: { cookies: param_value }
+      post :update, params: { cookies_settings_form: { consent: param_value } }
 
       expect(flash[:cookies_consent_updated]).to eq(param_value)
       expect(response).to redirect_to(root_path)

--- a/spec/forms/cookies/settings_form_spec.rb
+++ b/spec/forms/cookies/settings_form_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Cookies::SettingsForm do
 
   let(:cookies_double) { {} }
 
+  describe '.build' do
+    it 'initialises the form object with the existing cookie value' do
+      expect(described_class).to receive(:new).with(consent: 'foobar')
+      described_class.build('foobar')
+    end
+  end
+
   describe '#save' do
     context 'for an `accept` value' do
       let(:consent_value) { described_class::CONSENT_ACCEPT }
@@ -26,6 +33,15 @@ RSpec.describe Cookies::SettingsForm do
 
     context 'for an unknown value' do
       let(:consent_value) { 'foobar' }
+
+      it 'sets the cookie and defaults to `reject` consent' do
+        expect(subject.save).to eq('reject')
+        expect(cookies_double['crime_apply_cookies_consent']).to eq({ expires: 6.months, value: 'reject' })
+      end
+    end
+
+    context 'for a nil value' do
+      let(:consent_value) { nil }
 
       it 'sets the cookie and defaults to `reject` consent' do
         expect(subject.save).to eq('reject')

--- a/spec/requests/dwp_benefit_checker_spec.rb
+++ b/spec/requests/dwp_benefit_checker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'DWP passporting sub journey' do
       expect(response).to have_http_status(:success)
 
       assert_select 'h1', 'Check your client’s details'
-      assert_select 'h2.govuk-heading-m', false # the summary is headless
+      assert_select 'h2.govuk-heading-m', { text: 'Client details', count: 0 } # the summary is headless
 
       assert_select 'dl.govuk-summary-list' do
         assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(1)' do

--- a/spec/system/cookies_banner_spec.rb
+++ b/spec/system/cookies_banner_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe 'Cookie consent banner' do
+  before do
+    visit root_path
+  end
+
+  context 'when the consent is not set yet' do
+    it 'shows the consent banner' do
+      expect(page).to have_css('.govuk-cookie-banner', text: 'Cookies on Apply for criminal legal aid')
+      expect(page).to have_button('Accept analytics cookies')
+      expect(page).to have_button('Reject analytics cookies')
+      expect(page).to have_link('View cookies', href: cookies_path)
+    end
+
+    it 'does not show the consent banner in the cookies page' do
+      visit cookies_path
+      expect(page).not_to have_css('.govuk-cookie-banner')
+    end
+
+    it 'can accept cookies' do
+      click_button 'Accept analytics cookies'
+      expect(current_url).to match(root_path)
+
+      expect(page).not_to have_css('.govuk-cookie-banner', text: 'Cookies on Apply for criminal legal aid')
+      expect(page).to have_css('.govuk-cookie-banner p.govuk-body', text: 'You’ve accepted analytics cookies.')
+      expect(page).to have_css('.govuk-button-group a.govuk-button', text: 'Hide cookie message')
+    end
+
+    it 'can reject cookies' do
+      click_button 'Reject analytics cookies'
+      expect(current_url).to match(root_path)
+
+      expect(page).not_to have_css('.govuk-cookie-banner', text: 'Cookies on Apply for criminal legal aid')
+      expect(page).to have_css('.govuk-cookie-banner p.govuk-body', text: 'You’ve rejected analytics cookies.')
+      expect(page).to have_css('.govuk-button-group a.govuk-button', text: 'Hide cookie message')
+    end
+
+    it 'redirects to the page where the banner was accepted or rejected' do
+      visit about_contact_path
+      expect(page).to have_css('.govuk-cookie-banner')
+      click_button 'Accept analytics cookies'
+      expect(current_url).to match(about_contact_path)
+    end
+
+    it 'can hide cookies message' do
+      click_button 'Accept analytics cookies'
+      click_link 'Hide cookie message'
+      expect(page).not_to have_css('.govuk-cookie-banner')
+    end
+  end
+
+  context 'when the consent is already set' do
+    before do
+      click_button 'Accept analytics cookies'
+    end
+
+    it 'do not show the consent banner' do
+      visit root_path
+      expect(page).not_to have_css('.govuk-cookie-banner')
+    end
+  end
+end

--- a/spec/system/cookies_page_spec.rb
+++ b/spec/system/cookies_page_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Cookies page' do
+  before do
+    visit cookies_path
+  end
+
+  context 'configuring the consent' do
+    it 'shows the cookie settings form' do
+      expect(page).to have_css('form legend', text: 'Do you want to accept analytics cookies?')
+
+      expect(page).to have_css('form .govuk-radios__label', text: 'Yes')
+      expect(page).not_to have_checked_field('cookies-settings-form-consent-accept-field')
+
+      expect(page).to have_css('form .govuk-radios__label', text: 'No')
+      expect(page).not_to have_checked_field('cookies-settings-form-consent-reject-field')
+
+      expect(page).to have_button('Save cookie settings')
+    end
+
+    it 'accepting analytics cookies' do
+      find(:label, for: 'cookies-settings-form-consent-accept-field').click
+      click_button 'Save cookie settings'
+
+      expect(current_url).to match(cookies_path)
+
+      expect(page).to have_css('div.govuk-notification-banner--success', text: 'You’ve accepted analytics cookies.')
+      expect(page).to have_checked_field('cookies-settings-form-consent-accept-field')
+    end
+
+    it 'rejecting analytics cookies' do
+      find(:label, for: 'cookies-settings-form-consent-reject-field').click
+      click_button 'Save cookie settings'
+
+      expect(current_url).to match(cookies_path)
+
+      expect(page).to have_css('div.govuk-notification-banner--success', text: 'You’ve rejected analytics cookies.')
+      expect(page).to have_checked_field('cookies-settings-form-consent-reject-field')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Follow-up to PR #344.

Show the cookie consent banner on page load, and hook the accept/reject buttons to the controller.

Add a bit of javascript to allow to close the banner without reloading the page. With JS disabled, it will reload the page.

This follows the guidelines and design stated in the design system: https://design-system.service.gov.uk/components/cookie-banner/

Also added the cookie settings to the cookies page, as per https://design-system.service.gov.uk/patterns/cookies-page/

Content of the cookies page is best effort, guidelines, and based on what other services do, but may require a review of the copy.

Reorganised a bit some locales.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-14

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1070" alt="Screenshot 2023-05-16 at 14 39 08" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/0ce7c23f-bf3a-41ee-9dfa-2741eda31c05">

<img width="1065" alt="Screenshot 2023-05-16 at 14 39 18" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/75740810-f39c-4df2-83bd-1ca6106466a3">

<img width="696" alt="Screenshot 2023-05-16 at 14 41 02" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/4494b617-3c17-4cdd-a815-bac9741e753c">

## How to manually test the feature
In order to test this repeatedly, once the cookie has been set, either for accept or reject, remove the cookie and reload the page, so the banner will show again.
Note in localhost you can set the ENV variable `GA_TRACKING_ID` to some dummy value for the GA code to be inserted in the page. If the consent is not accepted, the GA code will not be inserted.