### PR TITLE
Differentiate envs by changing header/phase colour

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -12,6 +12,22 @@
   background-color: transparent;
 }
 
+// Differentiate the header in non-production envs by
+// overriding the color of the header and phase tag
+.app-body {
+  &--staging,
+  &--local {
+    $colour: govuk-colour("orange");
+
+    .govuk-header__container {
+      border-bottom-color: $colour;
+    }
+    .govuk-tag.govuk-phase-banner__content__tag {
+      background-color: $colour;
+    }
+  }
+}
+
 // Avoid flickering header menu on small screens, where on page load
 // the header menu briefly shows before being hidden. This makes it
 // visually hidden from the start, and a bit of javascript removes

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -1,8 +1,10 @@
 <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">alpha</strong>
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      <%= t ".tag.#{HostEnv.env_name}", default: t('.tag.production') %>
+    </strong>
     <span class="govuk-phase-banner__text">
-      This is an MVP. Some things may not work as expected.
+      <%= t '.text' %>
     </span>
   </p>
 </div>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -24,7 +24,7 @@
   <%= yield :head %>
 </head>
 
-<body class="govuk-template__body">
+<body class="govuk-template__body <%= ['app-body', HostEnv.env_name].join('--') %>">
 <script>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -1,6 +1,13 @@
 ---
 en:
   layouts:
+    phase_banner:
+      text: This is an MVP. Some things may not work as expected.
+      tag:
+        local: local
+        staging: staging
+        production: alpha
+
     header_navigation:
       menu_button: Menu
       nav_aria_label: Menu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   web:
     build: .
     environment:
-      ENV_NAME: staging # or `production` in the future
+      ENV_NAME: production
       RAILS_ENV: production
       DATABASE_URL: postgresql://postgres@db/laa-apply-for-criminal-legal-aid
       SECRET_KEY_BASE: f22760a0bd78a9191ba4c247e23a281cb251461cdba6b5215043ca11b694d734


### PR DESCRIPTION
## Description of change
Similar to the approach taken on Review, but I consider only 2 envs, prod and non-prod. Anything non-prod will have orange colour, and production will have the default (blue) color.

The phase tag name will however show the name of the env, being it `local`, `test`, `staging` or `alpha` (for production).

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1039" alt="Screenshot 2023-05-17 at 15 59 42" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/0f83333d-209f-419d-9a82-c210397e23dc">
<img width="1045" alt="Screenshot 2023-05-17 at 15 59 22" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/28ad89a1-5097-469c-847e-8e51dbc7f11f">
<img width="1036" alt="Screenshot 2023-05-17 at 15 59 57" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/207ef7d4-c733-4901-ad11-982182620a4b">

## How to manually test the feature
