### PR TITLE
Tweaks to header colour handling and smoke test

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -15,14 +15,13 @@
 // Differentiate the header in non-production envs by
 // overriding the color of the header and phase tag
 .app-body {
-  &--staging,
-  &--local {
+  &:not(&--production) {
     $colour: govuk-colour("orange");
 
     .govuk-header__container {
       border-bottom-color: $colour;
     }
-    .govuk-tag.govuk-phase-banner__content__tag {
+    .govuk-phase-banner__content__tag {
       background-color: $colour;
     }
   }

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
-      <%= t ".tag.#{HostEnv.env_name}", default: t('.tag.production') %>
+      <%= t ".tag.#{HostEnv.env_name}", default: HostEnv.env_name %>
     </strong>
     <span class="govuk-phase-banner__text">
       <%= t '.text' %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -24,7 +24,7 @@
   <%= yield :head %>
 </head>
 
-<body class="govuk-template__body <%= ['app-body', HostEnv.env_name].join('--') %>">
+<body class="govuk-template__body app-body <%= ['app-body', HostEnv.env_name].join('--') %>">
 <script>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -4,8 +4,6 @@ en:
     phase_banner:
       text: This is an MVP. Some things may not work as expected.
       tag:
-        local: local
-        staging: staging
         production: alpha
 
     header_navigation:

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -3,8 +3,46 @@ require 'rails_helper'
 RSpec.describe 'Home' do
   describe 'index' do
     it 'renders the expected page' do
-      get '/'
+      get root_path
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # Basic smoke test
+  describe 'customisation of header and phase tag' do
+    context 'for `test` env name' do
+      before do
+        get root_path
+      end
+
+      it 'has the correct body css classes' do
+        assert_select 'body.app-body.app-body--test'
+      end
+
+      it 'has the correct phase tag' do
+        assert_select 'body.app-body.app-body--test' do
+          assert_select '.govuk-phase-banner__content__tag', 'test'
+        end
+      end
+    end
+
+    context 'for `production` env name' do
+      before do
+        allow(Rails.env).to receive(:test?).and_return(false)
+        allow(ENV).to receive(:fetch).with('ENV_NAME').and_return('production')
+
+        get root_path
+      end
+
+      it 'has the correct body css classes' do
+        assert_select 'body.app-body.app-body--production'
+      end
+
+      it 'has the correct phase tag' do
+        assert_select 'body.app-body.app-body--production' do
+          assert_select '.govuk-phase-banner__content__tag', 'alpha'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
A few tweaks that makes it more robust. Follow-up to PR #346.

The CSS will in effect use the orange colour for any environment unless it is production (this is better than having to specify one by one the non-prod envs).

The phase tag text will also default to whatever is the name of the env, unless overridden by locales (as it is the case of `production` -> `alpha`). This is also better than having to specify one by one all the env names, as usually the phase tag just shows the same (`staging` -> `staging`, `local` -> `local`).

Added a simple smoke test to ensure the CSS classes are applied correctly and the phase tag text is also correct.
