### PR TITLE
[a11y] No programmatic association between DWP records and radio buttons

### DIFF
--- a/app/views/steps/dwp/confirm_result/edit.html.erb
+++ b/app/views/steps/dwp/confirm_result/edit.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row app-inverted--card app-inverted-text govuk-!-margin-bottom-5">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l app-inverted-text govuk-!-margin-bottom-0">
+    <h1 class="govuk-heading-l app-inverted-text govuk-!-margin-bottom-0" id="dwp-desc">
       <%= t '.heading' %>
     </h1>
   </div>
@@ -19,7 +19,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :confirm_result, @form_object.choices, :value,
-                                           inline: false %>
+                                           inline: false,
+                                           legend: { aria_describedby: 'dwp-desc' }%>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/dwp/confirm_result/edit.html.erb
+++ b/app/views/steps/dwp/confirm_result/edit.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row app-inverted--card app-inverted-text govuk-!-margin-bottom-5">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l app-inverted-text govuk-!-margin-bottom-0" id="dwp-desc">
+    <h1 class="govuk-heading-l app-inverted-text govuk-!-margin-bottom-0" id="dwp-confirm-result-desc">
       <%= t '.heading' %>
     </h1>
   </div>
@@ -20,7 +20,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :confirm_result, @form_object.choices, :value,
                                            inline: false,
-                                           legend: { aria_describedby: 'dwp-desc' }%>
+                                           legend: { aria_describedby: 'dwp-confirm-result-desc' }%>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/dwp/confirm_result/edit.html.erb
+++ b/app/views/steps/dwp/confirm_result/edit.html.erb
@@ -20,7 +20,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :confirm_result, @form_object.choices, :value,
                                            inline: false,
-                                           legend: { aria_describedby: 'dwp-confirm-result-desc' }%>
+                                           legend: { 'aria-describedby': 'dwp-confirm-result-desc' }%>
 
       <%= f.continue_button %>
     <% end %>


### PR DESCRIPTION
## Description of change

Fixes accessibility issue flagged in the audit for screen reader users, where there is no programmatic association between the radio button grouping and the `h1` element on the confirm dwp result page which makes it difficult for non-sighted and low-vision screen reader users to answer if the DWP records are correct.

This PR adds the recommended `aria-describedby` attribute to establish a relationship between the question ‘Are the DWP records correct?’ and the content of the `h1` providing the DWP check result

## Link to relevant ticket

[CRIMAP-364](https://dsdmoj.atlassian.net/browse/CRIMAP-364)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-364]: https://dsdmoj.atlassian.net/browse/CRIMAP-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ