### PR TITLE
[a11y] No association between 'delete' button and applicant name

### DIFF
--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -44,7 +44,7 @@
               <td class="govuk-table__cell">
                 <%= button_to confirm_destroy_crime_application_path(app), method: :get,
                   class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
-                  'aria-label': "Delete #{app.applicant_name}'s application",
+                  'aria-label': t('.delete_button_a11y', applicant_name: app.applicant_name),
                   data: { module: 'govuk-button' } do; t('.delete_button'); end %>
               </td>
             </tr>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -44,6 +44,7 @@
               <td class="govuk-table__cell">
                 <%= button_to confirm_destroy_crime_application_path(app), method: :get,
                   class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                  'aria-label': "Delete #{app.applicant_name}'s application'",
                   data: { module: 'govuk-button' } do; t('.delete_button'); end %>
               </td>
             </tr>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -44,7 +44,7 @@
               <td class="govuk-table__cell">
                 <%= button_to confirm_destroy_crime_application_path(app), method: :get,
                   class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
-                  'aria-label': "Delete #{app.applicant_name}'s application'",
+                  'aria-label': "Delete #{app.applicant_name}'s application",
                   data: { module: 'govuk-button' } do; t('.delete_button'); end %>
               </td>
             </tr>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -4,6 +4,7 @@ en:
     index:
       page_title: Your applications
       delete_button: Delete
+      delete_button_a11y: Delete %{applicant_name}'s application
       table_headings:
         applicant_name: Name
         created_at: Start date


### PR DESCRIPTION
## Description of change
Fixes flagged issue from accessibility audit where there is no association between delete button and applicant name which makes it difficult for screen readers to know which application they are deleting as they are all announced by the screen reader as “Action Column 4 Delete button”

This PR adds an `aria-label` that overrides the existing text and adds the applicant's name as context to which application is being deleted  

## Link to relevant ticket

[CRIMAP-365](https://dsdmoj.atlassian.net/browse/CRIMAP-365)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-365]: https://dsdmoj.atlassian.net/browse/CRIMAP-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ