### PR TITLE
[a11y] Date format not clear (offence page)

### DIFF
--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -30,7 +30,10 @@
                                   legend: {
                                     text: t("helpers.legend.#{f.object_name}.date_from", index:),
                                     size: 's'
-                                  } %>
+                                  },
+                                  hint: {
+                                    text: t("helpers.hint.#{f.object_name}.date_from")
+                                  }%>
 
           <%= od.govuk_date_field :date_to, maxlength_enabled: true,
                                   legend: {

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -65,6 +65,7 @@ en:
       steps_case_charges_form:
         offence_name: Add one offence at a time, for example, robbery. You can add more later.
         date_to: Leave blank if the offence happened on a single date
+        date_from: For example, 27 3 2007
       steps_case_hearing_details_form:
         hearing_court_name: For example, Cardiff Crown Court
         hearing_date: For example, 27 3 2024


### PR DESCRIPTION
## Description of change
This PR adds a hint to the start date field on the offence page to specify to screenreader users what format the date should be.  This was flagged in the [accessibility audit](https://uv2866-apply-for-criminal-legal-aid.uservisionaccessibility.co.uk/date-format-not-clear-medium.html)

## Link to relevant ticket
[CRIMAP-368](https://dsdmoj.atlassian.net/browse/CRIMAP-368)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1113" alt="Screenshot 2023-05-22 at 16 31 54" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/79ac6983-88b7-448f-a126-2e6223b7320c">


### After changes:
<img width="1113" alt="Screenshot 2023-05-22 at 16 31 21" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/22fb1555-8d8c-4b06-8602-67f6b21761a9">


## How to manually test the feature


[CRIMAP-368]: https://dsdmoj.atlassian.net/browse/CRIMAP-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ