### PR TITLE
CRIMAP-370 Keep focus on selected sub-nav tab

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -112,3 +112,11 @@ $app-blue-button-colour: govuk-colour("blue");
 .autocomplete__wrapper * {
   @include govuk-typography-common();
 }
+
+// The tabs are focusable with JS but not through normal
+// keyboard navigation. We remove the outline when focused.
+.moj-sub-navigation__item {
+  &:focus {
+    outline: none;
+  }
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -35,6 +35,13 @@ if ($acElements) {
   }
 }
 
+// Keep focus on the sub-navigation
+// This improves accessibility when navigating with
+// keyboard or screen readers
+import SubNavigation from 'local/subnavigation'
+const $subNavigation = document.querySelector('nav.moj-sub-navigation')
+new SubNavigation($subNavigation).init()
+
 // Avoid flickering header menu on small screens
 // Refer to `stylesheets/local/custom.scss`
 const $headerNavigation = document.querySelector('ul.app-header-menu-hidden-on-load')

--- a/app/javascript/local/subnavigation.js
+++ b/app/javascript/local/subnavigation.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function SubNavigation($element) {
+  this.$subNavigation = $element
+  this.$pageSelector  = '[aria-current="page"]'
+}
+
+SubNavigation.prototype.init = function () {
+  if (!(this.$subNavigation && window.location.hash)) { return }
+
+  const $currentTab = this.$subNavigation.querySelector(this.$pageSelector)
+  if (!$currentTab) { return }
+
+  try {
+    const $li = $currentTab.closest('li')
+
+    if ($li) {
+      $li.focus()
+    }
+  } catch(e) {}
+}
+
+export default SubNavigation

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -1,19 +1,19 @@
 <nav class="moj-sub-navigation" aria-label="<%= t('.nav_aria_label') %>">
   <ul class="moj-sub-navigation__list">
-    <li class="moj-sub-navigation__item">
-      <%= link_to t('.in_progress', count: in_progress_count), crime_applications_path,
+    <li class="moj-sub-navigation__item" tabindex="-1">
+      <%= link_to t('.in_progress', count: in_progress_count), crime_applications_path(anchor: :tab),
                   class: 'moj-sub-navigation__link',
                   'aria-current': aria_current_page(:in_progress) %>
     </li>
 
-    <li class="moj-sub-navigation__item">
-      <%= link_to t('.submitted'), completed_crime_applications_path,
+    <li class="moj-sub-navigation__item" tabindex="-1">
+      <%= link_to t('.submitted'), completed_crime_applications_path(anchor: :tab),
                   class: 'moj-sub-navigation__link',
                   'aria-current': aria_current_page(:submitted) %>
     </li>
 
-    <li class="moj-sub-navigation__item">
-      <%= link_to t('.returned', count: returned_count), completed_crime_applications_path(q: 'returned'),
+    <li class="moj-sub-navigation__item" tabindex="-1">
+      <%= link_to t('.returned', count: returned_count), completed_crime_applications_path(anchor: :tab, q: :returned),
                   class: 'moj-sub-navigation__link',
                   'aria-current': aria_current_page(:returned) %>
     </li>


### PR DESCRIPTION
## Description of change
As part of the accessibility audit, a medium severity issue was found with the way the applications sub-navigation tabs reload the whole page (as these are not AJAX).

When the user selects one of these tabs the page reloads and focus moves to the first focusable element on the page.

This can be frustrating for keyboard users who need to tab through the page again to get back to their previous position. For blind and low-vision users relying on screen readers, this behaviour can also be confusing.

The recommendations were to make it AJAX (which has other issues if JS is not enabled, etc.), so this option was disregarded, or to ensure the focus remains on the element it was on prior to the page refreshing.

This is the chosen fix, and although not perfect, it will ensure the navigation with keyboard is better by keeping the focus on the sub navigation bar.

Some code could have been simplified by just doing a `focus()` on the selected tab on page load, however this would also leave the element with the "focus" styling (yellow background, etc.) which I think is quite distracting, so I'm placing the focus on the container (the `li`) and removing the outline with CSS, so the focus is still nearby, but not actively "focused".

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-370

## Notes for reviewer

## Screenshots of changes (if applicable)
https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/79e1154d-5e73-42e4-943b-31d9f97e77bf



## How to manually test the feature
If testing locally, after checking out the branch, do not forget to run `rails assets:clobber && rails dartsass:build` to ensure the assets are properly compiled. Then go to the applications dashboard, and navigate the page using keyboard.