### PR TITLE
[a11y] Link purpose unclear (pagination)

### DIFF
--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,6 +1,9 @@
 <div class="govuk-pagination__next">
   <a class="govuk-link govuk-pagination__link govuk-link--no-visited-state" href="<%= url %>">
-    <span class="govuk-pagination__link-title"><%= t('.next') %></span>
+    <span class="govuk-pagination__link-title">
+      <%= t('.next') %>
+      <span class="govuk-visually-hidden"> <%= t('kaminari.paginator.nav_page_a11y') %></span>
+    </span>
     <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
       <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
     </svg>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,8 +1,7 @@
 <div class="govuk-pagination__next">
   <a class="govuk-link govuk-pagination__link govuk-link--no-visited-state" href="<%= url %>">
     <span class="govuk-pagination__link-title">
-      <%= t('.next') %>
-      <span class="govuk-visually-hidden"> <%= t('kaminari.paginator.nav_page_a11y') %></span>
+      <%= t('.next_html') %>
     </span>
     <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
       <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -5,6 +5,7 @@
     </svg>
     <span class="govuk-pagination__link-title">
       <%= t('.previous') %>
+      <span class="govuk-visually-hidden"> <%= t('kaminari.paginator.nav_page_a11y') %></span>
     </span>
   </a>
 </div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -4,8 +4,7 @@
       <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
     </svg>
     <span class="govuk-pagination__link-title">
-      <%= t('.previous') %>
-      <span class="govuk-visually-hidden"> <%= t('kaminari.paginator.nav_page_a11y') %></span>
+      <%= t('.previous_html') %>
     </span>
   </a>
 </div>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -115,6 +115,7 @@ en:
   kaminari:
     paginator:
       nav_aria_label: Results
+      nav_page_a11y: page of applications
     prev_page:
       previous: Previous
     next_page:

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -115,10 +115,9 @@ en:
   kaminari:
     paginator:
       nav_aria_label: Results
-      nav_page_a11y: page of applications
     prev_page:
-      previous: Previous
+      previous_html: Previous <span class="govuk-visually-hidden">page of applications</span>
     next_page:
-      next: Next
+      next_html: Next <span class="govuk-visually-hidden">page of applications</span>
     page:
       page: Page %{page}


### PR DESCRIPTION
## Description of change
The accessibility audit flagged an issue on the ‘Your Applications’ page where the 'next' link does not provide context for screen reader users as to where they will be navigated and what they will be shown. A visually hidden span element has been added to provide additional context to screen reader users that they will be navigated to the next page of applications (as opposed to the next page of the journey for example). This allows them to get a better sense of the content and functionality of the page without having to go through the content in its entirety

## Link to relevant ticket
[CRIMAP-369](https://dsdmoj.atlassian.net/browse/CRIMAP-369)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Can use voiceover on mac to verify 
<img width="1458" alt="Screenshot 2023-05-23 at 14 28 01" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/c61f0220-6909-4132-8512-9068a48f4791">


[CRIMAP-369]: https://dsdmoj.atlassian.net/browse/CRIMAP-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ