### PR TITLE
[a11y] No programmatic association between interactive controls and question

### DIFF
--- a/app/views/steps/case/charges/confirm_destroy.html.erb
+++ b/app/views/steps/case/charges/confirm_destroy.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-xl" id='charges-confirm-destroy-desc'>
       <%=t '.heading' %>
     </h1>
 
@@ -16,10 +16,12 @@
       <div class="govuk-button-group">
         <%= f.button t('.confirm_delete_button'),
                      class: 'govuk-button govuk-button--warning',
+                     'aria-labelledby': 'charges-confirm-destroy-desc',
                      data: { module: 'govuk-button' } %>
 
         <%= link_to edit_steps_case_charges_summary_path,
                     class: 'govuk-button govuk-button--primary',
+                    'aria-labelledby': 'charges-confirm-destroy-desc',
                     data: { module: 'govuk-button' } do; t('.cancel_delete_button'); end %>
       </div>
     <% end %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -30,7 +30,7 @@ en:
         edit:
           page_title: Enter your client’s details
           heading: Enter your client’s details
-          full_name_legend: Full name
+          full_name_legend: Client's full name
       has_nino:
         edit:
           page_title: Enter your client’s NINO


### PR DESCRIPTION
## Description of change
The accessibility audit flagged instances of there being no programmatic association between input fields and their question. 

On the 'Clients details' page, context regarding who's details need to be entered is missing for screen reader users where screen readers only announce the label and the type of input, (e.g. 'Full name grouping' "First name edit blank").  In this instance, it is not necessarily clear that those details are about the client.

On the 'Offences summary' page, when inputting the offence of the client, users are given an opportunity to delete the offence. There is no programmatic association between the question 'Are you sure you want to delete this offence?' and the buttons, 'Yes, delete it' and 'No, do not delete it'. For blind and low vision screen reader users the content that is being deleted or not is not communicated in this instance and could therefore lead to confusion regarding the purpose of the input. 

This PR adds the required context.

## Link to relevant ticket
[CRIMAP-367](https://dsdmoj.atlassian.net/browse/CRIMAP-367)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1113" alt="Screenshot 2023-05-24 at 11 26 05" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/ded2968f-32e3-45c3-97cf-0bed2c8ebf68">

### After changes:
<img width="1113" alt="Screenshot 2023-05-24 at 11 16 54" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/c6b1ac10-6fe0-46d6-8ee6-a852570d406e">

## How to manually test the feature


[CRIMAP-367]: https://dsdmoj.atlassian.net/browse/CRIMAP-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ