### PR TITLE
Allow bypass with an under 18 (developer tools)

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -39,6 +39,34 @@ module DeveloperTools
       redirect_to edit_steps_client_benefit_check_result_path(crime_application)
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def under18_bypass
+      find_or_create_applicant(
+        dob: rand(15..17).years.ago,
+        nino: nil,
+        passporting_benefit: nil,
+      ).update(
+        correspondence_address_type: CorrespondenceType::PROVIDERS_OFFICE_ADDRESS,
+        telephone_number: '123456789',
+      )
+
+      find_or_create_case
+
+      crime_application.update(
+        client_has_partner: YesNoAnswer::NO,
+        navigation_stack: [
+          edit_steps_client_has_partner_path(crime_application),
+          edit_steps_client_details_path(crime_application),
+          edit_steps_client_contact_details_path(crime_application),
+          edit_steps_case_urn_path(crime_application),
+          edit_steps_case_case_type_path(crime_application),
+        ]
+      )
+
+      redirect_to edit_steps_case_case_type_path(crime_application)
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
     private
 
     def crime_application
@@ -47,7 +75,7 @@ module DeveloperTools
       )
     end
 
-    def find_or_create_applicant
+    def find_or_create_applicant(overrides = {})
       Applicant.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
         surname, details = DWP::MockBenefitCheckService::KNOWN.to_a.sample
 
@@ -55,9 +83,17 @@ module DeveloperTools
           first_name: record.first_name || 'Test',
           last_name: surname,
           other_names: '',
-          date_of_birth: details[:dob],
-          nino: details[:nino],
-          passporting_benefit: true,
+          date_of_birth: overrides.fetch(:dob, details[:dob]),
+          nino: overrides.fetch(:nino, details[:nino]),
+          passporting_benefit: overrides.fetch(:dwp, true),
+        )
+      end
+    end
+
+    def find_or_create_case
+      Case.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
+        record.update(
+          urn: '',
         )
       end
     end

--- a/app/services/dwp/mock_benefit_check_service.rb
+++ b/app/services/dwp/mock_benefit_check_service.rb
@@ -6,7 +6,6 @@ module DWP
       'BLOGGS'  => { nino: 'NC123457A', dob: '04-01-1990' },
       'WRINKLE' => { nino: 'NC010150A', dob: '01-01-1950' },
       'WALKER'  => { nino: 'JA293483A', dob: '10-01-1980' },
-      'POTTER'  => { nino: 'NC010155A', dob: '01-01-2007' }, # For under 18 passported on IOJ testing
     }.freeze
 
     def self.call(*args)

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -20,6 +20,10 @@
             <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
                           class: 'govuk-button govuk-!-margin-right-1',
                           data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>
+
+            <%= button_to under18_bypass_developer_tools_crime_application_path, method: :put,
+                          class: 'govuk-button govuk-!-margin-right-1',
+                          data: { module: 'govuk-button' } do; 'Under18 Bypass'; end %>
           <% end %>
 
           <% if crime_application.in_progress? %>
@@ -30,7 +34,7 @@
 
           <% if crime_application.submitted? %>
             <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
-                          class: 'govuk-button govuk-!-margin-right-1',
+                          class: 'govuk-button govuk-button--warning govuk-!-margin-right-1',
                           data: { module: 'govuk-button' } do; 'Return application'; end %>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   namespace :developer_tools, constraints: -> (_) { FeatureFlags.developer_tools.enabled? } do
     resources :crime_applications, only: [:update, :destroy], path: 'applications' do
       put :bypass_dwp, on: :member
+      put :under18_bypass, on: :member
       put :mark_as_returned, on: :member
     end
   end


### PR DESCRIPTION
## Description of change
Previously there was only one "bypass DWP", which picks a random "mock" user (dob, nino, surname) and creates the record.

However there was a mock under18 so randomly it could happen this under18 user was picked for bypass, leaving the underlying record with inconsistent data (like having NINO, or the `passporting_benefit` flag set to true), which is incorrect for under 18s as we don't ask for NINO nor perform DWP check for those.

Removed this mock user as is no longer needed (no DWP is performed for under 18 anyways) and added a new button to explicitly trigger a bypass of an under 18, which will set everything correctly and even advance a bit more, up to the case type step.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="904" alt="Screenshot 2023-05-24 at 17 21 01" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/11b332f6-c805-4788-9938-8475f4cb1b0f">

### After changes:
<img width="885" alt="Screenshot 2023-05-24 at 17 20 48" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/2b3ec52e-b251-42a2-9afd-743012a9f4b8">

## How to manually test the feature
