### PR TITLE
Fix developer tools override attribute name

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -85,7 +85,7 @@ module DeveloperTools
           other_names: '',
           date_of_birth: overrides.fetch(:dob, details[:dob]),
           nino: overrides.fetch(:nino, details[:nino]),
-          passporting_benefit: overrides.fetch(:dwp, true),
+          passporting_benefit: overrides.fetch(:passporting_benefit, true),
         )
       end
     end

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -16,7 +16,7 @@
         <p>Speed up some common application actions</p>
 
         <div class="govuk-button-group">
-          <% if crime_application.in_progress? && !crime_application.applicant&.passporting_benefit %>
+          <% if crime_application.in_progress? && crime_application.case.nil? %>
             <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
                           class: 'govuk-button govuk-!-margin-right-1',
                           data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>


### PR DESCRIPTION
## Description of change
In previous PR #356, the attribute for override should be `passporting_benefit` instead of `dwp`.

Also, hide the bypass buttons once we reach the case details section as by that point these are no longer needed. Keep them during client details section.
