### PR TITLE
Bump the schemas gem to 0.1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.5'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.9'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 933253dc37dc20c51efe962418c59f4d8bf8c75b
-  tag: v0.1.5
+  revision: d9802d263c9a0fb34c6cfdb10473567c592f34a9
+  tag: v0.1.9
   specs:
-    laa-criminal-legal-aid-schemas (0.1.4)
+    laa-criminal-legal-aid-schemas (0.1.9)
       dry-struct
       json-schema (~> 3.0.0)
 
@@ -428,7 +428,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby

--- a/app/services/adapters/structs/case_details.rb
+++ b/app/services/adapters/structs/case_details.rb
@@ -24,7 +24,9 @@ module Adapters
         super(
           options.merge(
             methods: [:charges, :has_codefendants],
-            except: [:offences]
+            # `offence_class` is the overall application class, and is
+            # generated and injected by the datastore, we don't use it
+            except: [:offences, :offence_class]
           )
         )
       end

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Datastore::ApplicationSubmission do
 
     Charge.create(
       case: kase,
-      offence_name: 'Robbery',
+      offence_name: 'Attempt robbery',
       offence_dates: [OffenceDate.new(date_from: '01-02-2000')]
     )
 
@@ -137,6 +137,14 @@ RSpec.describe Datastore::ApplicationSubmission do
         expect(
           LaaCrimeSchemas::Validator.new(payload)
         ).to be_valid
+      end
+
+      # This test is redundant as we have the one above, but is a quick
+      # way to see in the logs why exactly the validation is failing
+      it 'has no schema errors' do
+        expect(
+          LaaCrimeSchemas::Validator.new(payload).fully_validate
+        ).to be_empty
       end
 
       it 'calls the API and submits the serialized application' do


### PR DESCRIPTION
## Description of change
This version has some breaking changes, mainly for the time being we will only be able to submit single-class (or manually entered) offences, until the split of offences is finalised and the new list is incorporated to the service.

Fixed a few test, one of them for this reason (Robbery was C/B class, changed to a single-class offence).

