### PR TITLE
[a11y] Dynamic changes not announced to screen reader users

### DIFF
--- a/app/views/crime_applications/confirm_destroy.html.erb
+++ b/app/views/crime_applications/confirm_destroy.html.erb
@@ -23,11 +23,13 @@
       <div class="govuk-button-group">
         <%= f.button t('.confirm_delete_button'),
                      class: 'govuk-button govuk-button--warning',
-                     data: { module: 'govuk-button' } %>
+                     data: { module: 'govuk-button' },
+                     'aria-label': t('.confirm_delete_button_a11y') %>
 
-        <%= link_to crime_applications_path,
-                    class: 'govuk-button govuk-button--primary',
-                    data: { module: 'govuk-button' } do; t('.cancel_delete_button'); end %>
+        <%= link_button t('.cancel_delete_button'),
+                        crime_applications_path,
+                        class: 'govuk-button--primary',
+                        'aria-label': t('.cancel_delete_button_a11y') %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -18,7 +18,7 @@
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
               <%= f.govuk_text_field :appeal_with_changes_maat_id, width: 'one-third', autocomplete: 'off' %>
-              <%= f.govuk_text_area :appeal_with_changes_details %>
+              <%= f.govuk_text_area :appeal_with_changes_details, 'aria-label': t('helpers.label.steps_case_case_type_form.appeal_with_changes_details_a11y') %>
             <% end %>
 
           <% else %>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -18,7 +18,10 @@
 
             <%= f.govuk_radio_button :case_type, choice.value do %>
               <%= f.govuk_text_field :appeal_with_changes_maat_id, width: 'one-third', autocomplete: 'off' %>
-              <%= f.govuk_text_area :appeal_with_changes_details, 'aria-label': t('helpers.label.steps_case_case_type_form.appeal_with_changes_details_a11y') %>
+              <%= f.govuk_text_area :appeal_with_changes_details,
+                                    'aria-live': 'polite',
+                                    'aria-label': t('helpers.label.steps_case_case_type_form.appeal_with_changes_details_a11y')
+                                 %>
             <% end %>
 
           <% else %>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -22,7 +22,7 @@
                                      extra_letter_spacing: true %>
               <%= f.govuk_text_area :appeal_with_changes_details,
                                     'aria-live': 'polite',
-                                    'aria-label': t('helpers.label.steps_case_case_type_form.appeal_with_changes_details_a11y') %>
+                                    'aria-label': t("helpers.label.#{f.object_name}.appeal_with_changes_details_a11y") %>
             <% end %>
 
           <% else %>

--- a/app/views/steps/case/charges/confirm_destroy.html.erb
+++ b/app/views/steps/case/charges/confirm_destroy.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl" id='charges-confirm-destroy-desc'>
+    <h1 class="govuk-heading-xl">
       <%=t '.heading' %>
     </h1>
 
@@ -16,13 +16,12 @@
       <div class="govuk-button-group">
         <%= f.button t('.confirm_delete_button'),
                      class: 'govuk-button govuk-button--warning',
-                     'aria-labelledby': 'charges-confirm-destroy-desc',
+                     'aria-label': t('.confirm_delete_button_a11y'),
                      data: { module: 'govuk-button' } %>
 
-        <%= link_to edit_steps_case_charges_summary_path,
-                    class: 'govuk-button govuk-button--primary',
-                    'aria-labelledby': 'charges-confirm-destroy-desc',
-                    data: { module: 'govuk-button' } do; t('.cancel_delete_button'); end %>
+        <%= link_button t('.cancel_delete_button'), edit_steps_case_charges_summary_path,
+                        class: 'govuk-button--primary',
+                        'aria-label': t('.cancel_delete_button_a11y') %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/case/ioj/edit.html.erb
+++ b/app/views/steps/case/ioj/edit.html.erb
@@ -13,8 +13,7 @@
             <% f.govuk_text_area ioj_type.justification_field_name,
                                  label: { hidden: true },
                                  'aria-live': 'polite',
-                                 'aria-label': t('helpers.label.steps_case_ioj_form.ioj_justification_hint_a11y')
-                                 %>
+                                 'aria-label': t('helpers.label.steps_case_ioj_form.ioj_justification_hint_a11y') %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/steps/case/ioj/edit.html.erb
+++ b/app/views/steps/case/ioj/edit.html.erb
@@ -13,7 +13,7 @@
             <% f.govuk_text_area ioj_type.justification_field_name,
                                  label: { hidden: true },
                                  'aria-live': 'polite',
-                                 'aria-label': t('helpers.label.steps_case_ioj_form.ioj_justification_hint_a11y') %>
+                                 'aria-label': t("helpers.label.#{f.object_name}.ioj_justification_hint_a11y") %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/steps/case/ioj/edit.html.erb
+++ b/app/views/steps/case/ioj/edit.html.erb
@@ -10,7 +10,7 @@
         <% IojReasonType.values.each_with_index do |ioj_type, index| %>
           <span id="<%= ioj_type %>"></span>
           <%= f.govuk_check_box :types, ioj_type.to_s, link_errors: index.zero? do %>
-            <% f.govuk_text_area ioj_type.justification_field_name, label: { hidden: true } %>
+            <% f.govuk_text_area ioj_type.justification_field_name, label: { hidden: true }, 'aria-label': t('helpers.label.steps_case_ioj_form.ioj_justification_hint_a11y') %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/steps/case/ioj/edit.html.erb
+++ b/app/views/steps/case/ioj/edit.html.erb
@@ -10,7 +10,11 @@
         <% IojReasonType.values.each_with_index do |ioj_type, index| %>
           <span id="<%= ioj_type %>"></span>
           <%= f.govuk_check_box :types, ioj_type.to_s, link_errors: index.zero? do %>
-            <% f.govuk_text_area ioj_type.justification_field_name, label: { hidden: true }, 'aria-label': t('helpers.label.steps_case_ioj_form.ioj_justification_hint_a11y') %>
+            <% f.govuk_text_area ioj_type.justification_field_name,
+                                 label: { hidden: true },
+                                 'aria-live': 'polite',
+                                 'aria-label': t('helpers.label.steps_case_ioj_form.ioj_justification_hint_a11y')
+                                 %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -33,6 +33,8 @@ en:
       subheading: This application has not been submitted yet.
       confirm_delete_button: Yes, delete it
       cancel_delete_button: No, do not delete it
+      confirm_delete_button_a11y: Yes, delete this application
+      cancel_delete_button_a11y: No, do not delete this application
       warning:
         title: Warning
         text: You cannot undo this action

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -136,6 +136,7 @@ en:
         appeal_maat_id: Previous MAAT ID (optional)
         appeal_with_changes_maat_id: Previous MAAT ID (optional)
         appeal_with_changes_details: Enter the details of what has changed
+        appeal_with_changes_details_a11y: Enter details of what has changed regarding your clients financial circumstances
       steps_case_charges_form:
         offence_name: Offence
       steps_case_charges_summary_form:
@@ -159,6 +160,7 @@ en:
         expert_examination_justification: Expert cross-examination justification
         interest_of_another_justification: Interest of another person justification
         other_justification: Other justification
+        ioj_justification_hint_a11y: Enter justification for legal aid according to your selection
         types_options:
           loss_of_liberty: It is likely that they will lose their liberty if any matter in the proceedings is decided against them
           suspended_sentence: They have been given a sentence that is suspended or non-custodial. If they break this, the court may be able to deal with them for the original offence

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -138,6 +138,8 @@ en:
           heading: Are you sure you want to delete this offence?
           confirm_delete_button: Yes, delete it
           cancel_delete_button: No, do not delete it
+          confirm_delete_button_a11y: Yes, delete this offence
+          cancel_delete_button_a11y: No, do not delete this offence
         destroy:
           success_flash: The offence has been deleted
       charges_summary:


### PR DESCRIPTION
## Description of change
The accessibility audit flagged instances throughout the user journey where changes that dynamically appear on screen are not communicated to screen reader users. These are fixed on the `'What is the case type'` and '`Reason for legal aid'` pages by adding aria-labels `aria-live` and `aria-label` that notify users of changes and overrides the visually presented text adding additional context to the user as to what is being requested

This pr also fixes an issue in a [previous PR](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/351) where newly added `aria-labelledby` attributes to delete buttons was subsequently only reading out the question and not the button text. This was replaced by an `aria-label` that will add further context as to what is being deleted

## Link to relevant ticket
[CRIMAP-366](https://dsdmoj.atlassian.net/browse/CRIMAP-366)

## Notes for reviewer
The ticket also includes [an instance of dynamic content not being announced on the offences list dropdown](https://uv2866-apply-for-criminal-legal-aid.uservisionaccessibility.co.uk/dynamic-changes-not-announced-to-screen-reader-users-high.html). This is when the number of suggested offences within the offences dropdown is inconsistently read out to the screen reader user. Through investigating, this appears to happen when a user continues to type letters but there is no change in the number of suggested results so it is not read out as there has been no update. However, no obvious solution could be found so this will be disclosed as an issue in the accessibility statement.

## Screenshots of changes (if applicable)

### Before changes:
<img width="1792" alt="Screenshot 2023-05-25 at 15 38 08" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/af6602ae-6a2f-481a-b7e2-768e3836b0a5">

### After changes:
<img width="1792" alt="Screenshot 2023-05-26 at 11 30 47" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/b5bdbf9b-1d51-4e79-8fef-021e9c090e98">
<img width="1792" alt="Screenshot 2023-05-26 at 11 31 45" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/4e29fbdd-d32d-44a0-b9e6-df72e3af21db">
<img width="1792" alt="Screenshot 2023-05-26 at 11 48 10" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/beeec897-9d0e-4ec6-a65b-61eac7c7cd77">
<img width="1792" alt="Screenshot 2023-05-26 at 09 01 21" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/35340803-41ef-4dc7-b9dd-b4338d359501">

## How to manually test the feature


[CRIMAP-366]: https://dsdmoj.atlassian.net/browse/CRIMAP-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ