### PR TITLE
CRIMAP-375 Cover additional passporting edge cases

### DIFF
--- a/app/forms/concerns/steps/has_one_association.rb
+++ b/app/forms/concerns/steps/has_one_association.rb
@@ -2,6 +2,7 @@ module Steps
   module HasOneAssociation
     extend ActiveSupport::Concern
 
+    # rubocop:disable Metrics/BlockLength
     class_methods do
       attr_accessor :association_name, :through_association
 
@@ -14,9 +15,7 @@ module Steps
       # Return the record if already exists, or initialise a blank one
       def associated_record(crime_application)
         parent = if through_association
-                   # :nocov: enable coverage once we use this in any form
                    existing_or_build(crime_application, through_association)
-                   # :nocov:
                  else
                    crime_application
                  end
@@ -32,12 +31,17 @@ module Steps
         self.association_name = name
         self.through_association = through
 
+        # Example: for a name argument `applicant`, we create
+        # read methods for `#applicant` and alias as `#record`
+        # For the special name `case`, we alias also as `#kase`
         define_method(name) do
           @_assoc ||= self.class.associated_record(crime_application)
         end
 
+        alias_method :record, name
         alias_method :kase, :case if name == :case
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end

--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -2,7 +2,6 @@ module Steps
   module Client
     class DetailsForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-
       has_one_association :applicant
 
       attribute :first_name, :string
@@ -18,8 +17,14 @@ module Steps
       private
 
       def persist!
+        return true unless changed?
+
         applicant.update(
-          attributes
+          attributes.merge(
+            # The following are dependent attributes that need to be reset
+            has_nino: nil,
+            nino: nil,
+          )
         )
       end
     end

--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -2,13 +2,11 @@ module Steps
   module Client
     class HasNinoForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
+      has_one_association :applicant
 
       NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z][0-9]{6}([A-DFM])\Z/
 
       attribute :nino, :string
-
-      has_one_association :applicant
-
       validates :nino, format: { with: NINO_REGEXP }
 
       def nino=(str)
@@ -18,8 +16,13 @@ module Steps
       private
 
       def persist!
+        return true unless changed?
+
         applicant.update(
-          attributes
+          attributes.merge(
+            # The following are dependent attributes that need to be reset
+            passporting_benefit: nil,
+          )
         )
       end
     end

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -6,14 +6,23 @@ RSpec.describe Steps::Client::DetailsForm do
   let(:arguments) do
     {
       crime_application: crime_application,
-    first_name: 'John',
-    last_name: 'Doe',
-    other_names: nil,
-    date_of_birth: Date.yesterday,
+      record: applicant_record,
+    }.merge(
+      form_attributes
+    )
+  end
+
+  let(:form_attributes) do
+    {
+      first_name: 'John',
+      last_name: 'Doe',
+      other_names: nil,
+      date_of_birth: Date.yesterday,
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
+  let(:applicant_record) { Applicant.new }
 
   describe '#save' do
     context 'validations' do
@@ -29,14 +38,29 @@ RSpec.describe Steps::Client::DetailsForm do
     end
 
     context 'when validations pass' do
-      it_behaves_like 'a has-one-association form',
-                      association_name: :applicant,
-                      expected_attributes: {
-                        'first_name' => 'John',
-                        'last_name' => 'Doe',
-                        'other_names' => nil,
-                        'date_of_birth' => Date.yesterday,
-                      }
+      let(:applicant_record) { Applicant.new(form_attributes) }
+
+      context 'when any details have changed' do
+        let(:form_attributes) { super().merge(last_name: 'Smith') }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :applicant,
+                        expected_attributes: {
+                          'first_name' => 'John',
+                          'last_name' => 'Smith',
+                          'other_names' => nil,
+                          'date_of_birth' => Date.yesterday,
+                          :has_nino => nil,
+                          :nino => nil,
+                        }
+      end
+
+      context 'when details are the same as in the persisted record' do
+        it 'does not save the record but returns true' do
+          expect(applicant_record).not_to receive(:update)
+          expect(subject.save).to be(true)
+        end
+      end
     end
   end
 end

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -1,35 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::HasNinoForm do
-  # NOTE: not using shared examples for form objects yet, to be added
-  # once we have some more form objects and some patterns emerge
-
   subject { described_class.new(arguments) }
 
   let(:arguments) do
     {
-      crime_application:,
-    nino:
-    }
+      crime_application: crime_application,
+      record: applicant_record,
+    }.merge(
+      form_attributes
+    )
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant: 'applicant') }
+  let(:form_attributes) do
+    { nino: }
+  end
 
-  let(:nino) { nil }
+  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
+  let(:applicant_record) { Applicant.new }
 
   describe '#save' do
-    context 'when `nino` is blank' do
-      let(:nino) { '' }
-
-      it 'has a validation error on the field' do
-        expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
-      end
-    end
-
-    context 'when `nino` is invalid' do
-      context 'with a random string' do
-        let(:nino) { 'not a NINO' }
+    context 'validations' do
+      context 'when `nino` is blank' do
+        let(:nino) { '' }
 
         it 'has a validation error on the field' do
           expect(subject).not_to be_valid
@@ -37,48 +30,72 @@ RSpec.describe Steps::Client::HasNinoForm do
         end
       end
 
-      context 'with an unused prefix' do
-        let(:nino) { 'BG123456C' }
+      context 'when `nino` is invalid' do
+        context 'with a random string' do
+          let(:nino) { 'not a NINO' }
 
-        it 'has a validation error on the field' do
-          expect(subject).not_to be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
-        end
-      end
-    end
-
-    context 'when `nino` is valid' do
-      context 'with spaces between numbers' do
-        let(:nino) { 'AB 12 34 56 C' }
-
-        it 'passes validation' do
-          expect(subject).to be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to be(false)
+          it 'has a validation error on the field' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
+          end
         end
 
-        it 'removes spaces from input' do
-          expect(subject.nino).to eq('AB123456C')
+        context 'with an unused prefix' do
+          let(:nino) { 'BG123456C' }
+
+          it 'has a validation error on the field' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.of_kind?(:nino, :invalid)).to be(true)
+          end
         end
       end
 
-      context 'with trailing spaces' do
-        let(:nino) { ' AB 1234 56C ' }
+      context 'when `nino` is valid' do
+        context 'with spaces between numbers' do
+          let(:nino) { 'AB 12 34 56 C' }
 
-        it 'passed validation' do
-          expect(subject).to be_valid
-          expect(subject.errors.of_kind?(:nino, :invalid)).to be(false)
+          it 'passes validation' do
+            expect(subject).to be_valid
+            expect(subject.errors.of_kind?(:nino, :invalid)).to be(false)
+          end
+
+          it 'removes spaces from input' do
+            expect(subject.nino).to eq('AB123456C')
+          end
+        end
+
+        context 'with trailing spaces' do
+          let(:nino) { ' AB 1234 56C ' }
+
+          it 'passed validation' do
+            expect(subject).to be_valid
+            expect(subject.errors.of_kind?(:nino, :invalid)).to be(false)
+          end
         end
       end
     end
 
     context 'when validations pass' do
+      let(:applicant_record) { Applicant.new(form_attributes) }
       let(:nino) { 'AB123456C' }
 
-      it_behaves_like 'a has-one-association form',
-                      association_name: :applicant,
-                      expected_attributes: {
-                        'nino' => 'AB123456C'
-                      }
+      context 'when NINO has changed' do
+        let(:form_attributes) { super().merge(nino: 'NC123456A') }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :applicant,
+                        expected_attributes: {
+                          'nino' => 'NC123456A',
+                          :passporting_benefit => nil,
+                        }
+      end
+
+      context 'when NINO is the same as in the persisted record' do
+        it 'does not save the record but returns true' do
+          expect(applicant_record).not_to receive(:update)
+          expect(subject.save).to be(true)
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples 'a has-one-association form' do |options|
   let(:expected_attributes) { options[:expected_attributes] }
   let(:build_method_name) { "build_#{association_name}".to_sym }
 
-  let(:association_double) { instance_double(associated_class_name.camelize.constantize) }
+  let(:association_double) { associated_class_name.camelize.constantize.new }
 
   def associated_class_name
     reflection = CrimeApplication.reflect_on_association(association_name)


### PR DESCRIPTION
## Description of change
This is an evolving piece of work so we might have to tweak some things later on.

But for now (bear in mind most of this PR are refactored tests), this will ensure proper handling of dependent attributes on the `client details` page, and the `NINO` page.

This covers a few scenarios that most likely will never happen in real life but it is easy to trigger these when doing test applications. In particular, the one where DWP was successful, and changing the NINO keeps saying it is successful (as it will take previous value and not re-trigger the check).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-375

## Notes for reviewer

## How to manually test the feature
```
New applications (not yet submitted):
	- Client is under 18 based on DoB, thus, NINO was not asked
		- Provider goes back to client details and submit without any changes
			- Still under 18, still no NINO is asked
		- Provider goes back to client details and submit with some changes
			- Change in first name, last name or other names
				- Still under 18, still no NINO is asked
			- Change in DoB
				- If new DoB keeps client under 18
					- Still under 18, still no NINO is asked
				- If new DoB takes client over 18
					- Client becomes over 18, NINO is asked, followed by DWP check

New applications (not yet submitted):
	- Client is over 18 based on DoB, thus, NINO was asked followed by DWP check
		- Provider goes back to NINO and submit without any changes
			- If previous check result was passported, still is passported (no recheck)
			- If previous check result was not passported, still is not passported (does recheck)
		- Provider goes back to NINO and submit with any changes
			- DWP check triggers again no matter previous result

Returned submitted application being resubmitted:
	- Further consideration to be taken, these scenarios are not covered in this PR.
```