### PR TITLE
CRIMAP-383 Propagate `application_type` to datastore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.9'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: d9802d263c9a0fb34c6cfdb10473567c592f34a9
-  tag: v0.1.9
+  revision: 5e8f4dd9b08185ce8801bd64141187df2519b42f
+  tag: v0.2.0
   specs:
-    laa-criminal-legal-aid-schemas (0.1.9)
+    laa-criminal-legal-aid-schemas (0.2.0)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/app/serializers/submission_serializer/sections/application_details.rb
+++ b/app/serializers/submission_serializer/sections/application_details.rb
@@ -8,6 +8,7 @@ module SubmissionSerializer
           json.parent_id crime_application.parent_id
           json.schema_version 1.0
           json.reference crime_application.reference
+          json.application_type ApplicationType::INITIAL.to_s
           json.created_at crime_application.created_at
           json.submitted_at crime_application.submitted_at
           json.date_stamp crime_application.date_stamp

--- a/app/value_objects/application_type.rb
+++ b/app/value_objects/application_type.rb
@@ -1,0 +1,6 @@
+class ApplicationType < ValueObject
+  # NOTE: for MVP, all applications are "initial"
+  VALUES = [
+    INITIAL = new(:initial),
+  ].freeze
+end

--- a/spec/serializers/submission_serializer/sections/application_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/application_details_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SubmissionSerializer::Sections::ApplicationDetails do
       parent_id: nil,
       schema_version: 1.0,
       reference: 6_000_001,
+      application_type: 'initial',
       created_at: created_at,
       submitted_at: submitted_at,
       date_stamp: date_stamp,

--- a/spec/value_objects/application_type_spec.rb
+++ b/spec/value_objects/application_type_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationType do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(
+        %w[initial]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This attribute is always "initial" for MVP, but we prepare the path for post-MVP where other types will be needed.

Propagates the type in the JSON to the datastore.

New schemas gem validates/uses this new attribute too.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-383
https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/26

## Notes for reviewer

## How to manually test the feature
Submissions should work as expected, and propagate the new attribute to the datastore. Existing applications can be read back with no issues.