### PR TITLE
CRIMAP-385 Remove dependency on unneeded fixture

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5e8f4dd9b08185ce8801bd64141187df2519b42f
-  tag: v0.2.0
+  revision: 0a80f2d03dd5fdffafbfcfababa518c186d33a00
+  tag: v0.2.1
   specs:
-    laa-criminal-legal-aid-schemas (0.2.0)
+    laa-criminal-legal-aid-schemas (0.2.1)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -87,14 +87,22 @@ RSpec.describe 'Dashboard' do
     # NOTE: the return reason notification banner has different wording for
     # returned applications marked as split_case
 
-    let(:app_split_case_id) { '5d7d6320-98cb-40e2-b200-ccc10b75d96f' }
-    let(:app_split_case) { LaaCrimeSchemas.fixture(1.0, name: 'application_returned_split_case') }
+    let(:app_split_case) do
+      LaaCrimeSchemas.fixture(1.0, name: 'application_returned') do |json|
+        json.deep_merge(
+          'return_details' => {
+            'reason' => 'split_case',
+            'details' => 'Offence 1 reason requires more detail'
+          }
+        )
+      end.to_json
+    end
 
     before do
-      stub_request(:get, "http://datastore-webmock/api/v1/applications/#{app_split_case_id}")
+      stub_request(:get, "http://datastore-webmock/api/v1/applications/#{returned_application_fixture_id}")
         .to_return(body: app_split_case)
 
-      get completed_crime_application_path(app_split_case_id)
+      get completed_crime_application_path(returned_application_fixture_id)
     end
 
     # rubocop:disable Layout/LineLength

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Datastore::ApplicationRehydration do
     end
 
     context 'for a split case passported application' do
-      let(:parent) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_returned_split_case').read) }
+      let(:parent) { super().deep_merge('return_details' => { 'reason' => 'split_case' }) }
       let(:parent_ioj) { nil }
 
       it 'sets the `passport_override` flag on the Ioj record' do


### PR DESCRIPTION
## Description of change
This is part of an overall work to rationalise and remove any unneeded, unused, or superfluous fixtures, as these grow a bit out of hand for a while for no good reason.

On Apply I've only detected one superfluous fixture, `application_returned_split_case.json`

It has been replaced by the overarching `application_returned`, with reason variant `split_case`. There is nothing different or complicated that requires having this as a full separate fixture at all.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-385

## Notes for reviewer

## How to manually test the feature
