### PR TITLE
CRIMAP-387 Support for pruned application struct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.3.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 0a80f2d03dd5fdffafbfcfababa518c186d33a00
-  tag: v0.2.1
+  revision: 183785d967669e94009623978e094de03e910b12
+  tag: v0.3.0
   specs:
-    laa-criminal-legal-aid-schemas (0.2.1)
+    laa-criminal-legal-aid-schemas (0.3.0)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/app/services/adapters/json_application.rb
+++ b/app/services/adapters/json_application.rb
@@ -2,8 +2,18 @@ module Adapters
   class JsonApplication < BaseApplication
     def initialize(payload)
       super(
-        Structs::CrimeApplication.new(payload)
+        struct_for(payload)
       )
+    end
+
+    private
+
+    def struct_for(payload)
+      if payload.key?('case_details')
+        Structs::CrimeApplication.new(payload)
+      else
+        Structs::PrunedApplication.new(payload)
+      end
     end
   end
 end

--- a/app/services/adapters/structs/pruned_application.rb
+++ b/app/services/adapters/structs/pruned_application.rb
@@ -1,0 +1,11 @@
+require 'laa_crime_schemas'
+
+module Adapters
+  module Structs
+    class PrunedApplication < LaaCrimeSchemas::Structs::PrunedApplication
+      def applicant
+        Structs::Applicant.new(client_details.applicant)
+      end
+    end
+  end
+end

--- a/spec/services/adapters/structs/pruned_application_spec.rb
+++ b/spec/services/adapters/structs/pruned_application_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::PrunedApplication do
+  subject { build_struct_application(fixture_name: 'pruned_application') }
+
+  describe '#applicant' do
+    it 'returns the applicant struct' do
+      expect(subject.applicant).to be_a(Adapters::Structs::Applicant)
+    end
+  end
+
+  # Just a sanity check to ensure we are using the correct fixture
+  describe '#case_details' do
+    it 'has no case details' do
+      expect { subject.case_details }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -8,7 +8,7 @@ module FactoryHelpers
   end
 
   def build_struct_application(fixture_name: 'application')
-    Adapters::Structs::CrimeApplication.new(
+    Adapters::JsonApplication.new(
       JSON.parse(LaaCrimeSchemas.fixture(1.0, name: fixture_name).read)
     )
   end


### PR DESCRIPTION
## Description of change
This is part of the overall work to simplify the JSON response when listing applications, by removing all unneeded attributes.

As this new representation lacks many of the required attributes, and could even change structure in the future, a new struct has been created to handle it. Otherwise trying to use the existing struct with the pruned JSON raises multiple errors about required attributes (case_details, provider_details, etc.)

Other than that there is little more to it, as Apply will still find in this pruned struct everything it needs to render the dashboard lists and pagination.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-387

## Notes for reviewer
To be deployed at the same time that the datastore changes in PR https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/104

## How to manually test the feature
It requires checking out the datastore in the above PR, and Apply, bundle to ensure they are using latest schemas version, restart servers and Apply dashboard should work as usual.