### PR TITLE
Fix random modsec false positives in session cookie

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -20,13 +20,13 @@ metadata:
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecRuleUpdateTargetById 941100 !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -20,13 +20,13 @@ metadata:
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecRuleUpdateTargetById 941100 !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION

## Description of change
Rule ID 941100 was triggering randomly on session cookies:

```"Matched Data: XSS data found within REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session: TJwwf4nGhgKbr9DgkOrRS5..."```

Skip this rule on the session cookie. We will need to do this in all services, each one has a different cookie name.

Also, remove unnecessary annotation `enable-owasp-core-rules`, because cloud-platform modsec ingress has these enabled by default and it should not be used together with `modsecurity-snippet` as per documentation:

```Note: If you use both enable-owasp-core-rules and modsecurity-snippet annotations together, only the modsecurity-snippet will take effect.```

More info on slack:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1685710140212729