### PR TITLE
CRIMAP-388 Bump schemas gem (stricter structs)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.3.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.4.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,12 +15,12 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 183785d967669e94009623978e094de03e910b12
-  tag: v0.3.0
+  revision: 39186b9ebf3d71c00e3b53b506c936aed52429ef
+  tag: v0.4.0
   specs:
-    laa-criminal-legal-aid-schemas (0.3.0)
-      dry-struct
-      json-schema (~> 3.0.0)
+    laa-criminal-legal-aid-schemas (0.4.0)
+      dry-struct (~> 1.6.0)
+      json-schema (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -201,7 +201,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
-    json-schema (3.0.0)
+    json-schema (4.0.0)
       addressable (>= 2.8)
     jwt (2.7.0)
     kaminari (1.2.2)

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Adapters::Structs::CaseDetails do
           urn
           case_type
           appeal_maat_id
+          appeal_with_changes_maat_id
+          appeal_with_changes_details
           charges
           codefendants
           has_codefendants


### PR DESCRIPTION
## Description of change
Note by merging this PR, many existing submitted applications in the datastore will stop loading on Apply as their JSON representation will not "fit" into these more strict structs.

Do not merge until we are good to go (there is another PR on the datastore for this too).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-388
