### PR TITLE
Add `lookup_id` to filter_parameters config

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,15 +4,15 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate,
   :SAMLRequest, :SAMLResponse, :Signature, :SigAlg, :KeyInfo,
   # Attributes relating to an application
   # It does partial matching (i.e. `telephone_number` is covered by `phone`)
   :first_name,
   :last_name,
   :other_names,
-  :date_of_birth,
   :nino,
+  :lookup_id,
   :address_line,
   :postcode,
   :email,


### PR DESCRIPTION
## Description of change
This is the specific selected address (as per Ordnance Survey API) and can be used to retrieve back a full address.

Removed a few unneeded params.

