### PR TITLE
CRIMAP-404 Tweak hearing date validation error

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -58,7 +58,6 @@ en:
               invalid_year: Enter a valid year
               year_too_late: Date of birth is too far in the future
               year_too_early: Date of birth is too far in the past
-              past_not_allowed: Date of birth must be in the future
               future_not_allowed: Date of birth must be in the past
         steps/client/has_nino_form:
           attributes:
@@ -178,7 +177,7 @@ en:
               invalid_month: Enter a valid month
               invalid_year: Enter a valid year
               year_too_late: Date of next hearing is too far in the future
-              past_not_allowed: Date of next hearing must be in the future
+              past_not_allowed: Date of next hearing must be today or in the future
         steps/case/ioj_form:
           attributes:
             types:


### PR DESCRIPTION
## Description of change
The error message for next court hearing wasn't clear enough, as "today" is a valid hearing date however is not in the future.

Tweaked the error message.
Deleted unused error from date of birth validation.

NOTE: we don't use "The [date of something] ..." for error messages so I've kept it consistent with what we have already. For example errors for date of birth or offence start/end date etc.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-404

## Notes for reviewer

## How to manually test the feature
In the hearing page, enter the current date.