### PR TITLE
CRIMAP-407 Add postcode label

### DIFF
--- a/app/views/steps/address/lookup/edit.html.erb
+++ b/app/views/steps/address/lookup/edit.html.erb
@@ -7,9 +7,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
+    <h1 class="govuk-heading-xl"><%=t @form_object.heading %></h1>
+
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third',
-                             label: { tag: 'h1', size: 'xl', text: t(@form_object.heading) } %>
+      <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third' %>
 
       <p class="govuk-body govuk-!-margin-bottom-2">
         <%= link_to t('.manual_entry'), edit_steps_address_details_path %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -116,6 +116,8 @@ en:
         confirm_details_options:
           'yes': 'Yes'
           'no': 'No, I need to change these details'
+      steps_address_lookup_form:
+        postcode: Postcode
       steps_address_results_form:
         lookup_id: Select an address
       steps_address_details_form:


### PR DESCRIPTION
## Description of change
The postcode lookup step didn't have a specific label for the input, instead it used the h1 of the page as label, but it wasn't entirely clear. Also the hint text didn't make a lot of sense because of this.

As per content/service designers, we are adding a specific label, with text `Postcode`.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-407

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="634" alt="Screenshot 2023-06-13 at 09 06 55" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/23c3040e-a970-41a0-84b8-4b05a1370299">

### After changes:
<img width="653" alt="Screenshot 2023-06-13 at 09 04 46" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/63ba4b30-8a8e-48ad-9f34-3ba93fb15a09">

## How to manually test the feature
Go to the postcode lookup page and see the label.