### PR TITLE
Tentatively fix flaky tests

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -46,6 +46,10 @@ class FeatureFlags
 
   class << self
     delegate :method_missing, :respond_to?, to: :instance
+
+    def reset!
+      Singleton.__init__(self)
+    end
   end
 
   def method_missing(name, *args)

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -28,10 +28,13 @@ RSpec.describe 'Home' do
 
     context 'for `production` env name' do
       before do
-        allow(Rails.env).to receive(:test?).and_return(false)
-        allow(ENV).to receive(:fetch).with('ENV_NAME').and_return('production')
+        allow(HostEnv).to receive(:env_name).and_return(HostEnv::PRODUCTION)
 
         get root_path
+      end
+
+      after do
+        FeatureFlags.reset!
       end
 
       it 'has the correct body css classes' do


### PR DESCRIPTION
## Description of change
Although very rare to occur, as we run the tests randomised, there was a scenario where the `FeatureFlags` which is a Singleton was being initialised with an incorrect stubbed `env_name`, and a few subsequent tests making use of some feature flags, were unpredictable.

If this keep happening will investigate further or another solution.

## How to manually test the feature
Without this fix, a seed that has failures was:
`rspec spec --seed 26039`
With the changes in this PR, using the same seed, should have green tests.