### PR TITLE
Handle user time zone (London) when presenting dates

### DIFF
--- a/app/lib/refinements/localize_with_tz.rb
+++ b/app/lib/refinements/localize_with_tz.rb
@@ -1,0 +1,17 @@
+module Refinements
+  module LocalizeWithTz
+    DEFAULT_USER_TIME_ZONE = 'London'.freeze
+
+    def self.included(base)
+      base.class_eval { alias_method :l, :tz_l }
+    end
+
+    def tz_l(object, **options)
+      raise ArgumentError, 'Object must be a Date, DateTime or Time object.' unless object.respond_to?(:strftime)
+
+      I18n.l(
+        object.in_time_zone(DEFAULT_USER_TIME_ZONE), **options
+      )
+    end
+  end
+end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,8 +1,7 @@
 class BasePresenter < SimpleDelegator
+  include ActionView::Helpers::TranslationHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Context
-
-  delegate :t, :t!, :l, to: I18n
 
   def self.present(model)
     ApplicationController.helpers.present(model, self)

--- a/app/services/date_stamper.rb
+++ b/app/services/date_stamper.rb
@@ -24,7 +24,7 @@ class DateStamper
     #    stamp.
 
     if CaseType.new(@case_type).date_stampable? && @crime_app.date_stamp.nil?
-      @crime_app.update(date_stamp: DateTime.now)
+      @crime_app.update(date_stamp: Time.current)
     else
       false
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,8 +25,12 @@ module LaaApplyForCriminalLegalAid
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
+
+    # Do not change unless you know what you are doing. All services
+    # should be configured to UTC zone, and only in the views present
+    # dates in the user’s time zone (in our case, `London`).
+    config.time_zone = 'UTC'
+
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Do not autoload all helpers in all controllers

--- a/config/initializers/refinements.rb
+++ b/config/initializers/refinements.rb
@@ -1,5 +1,7 @@
 Dir[File.expand_path('app/lib/refinements') + '/*.rb'].each { |f| require f }
 
+ActionView::Helpers::TranslationHelper.include Refinements::LocalizeWithTz
+
 Array.include Refinements::DecorateCollection,
               Refinements::PresentCollection
 

--- a/spec/presenters/summary/sections/next_court_hearing_spec.rb
+++ b/spec/presenters/summary/sections/next_court_hearing_spec.rb
@@ -16,7 +16,7 @@ describe Summary::Sections::NextCourtHearing do
       Case,
       urn: 'xyz',
       hearing_court_name: 'Court name',
-      hearing_date: Date.tomorrow,
+      hearing_date: Date.new(2028, 1, 20),
     )
   end
 
@@ -54,7 +54,7 @@ describe Summary::Sections::NextCourtHearing do
       expect(answers[1]).to be_an_instance_of(Summary::Components::DateAnswer)
       expect(answers[1].question).to eq(:hearing_date)
       expect(answers[1].change_path).to match('applications/12345/steps/case/hearing_details')
-      expect(answers[1].value).to eq(Date.tomorrow)
+      expect(answers[1].value).to eq(Date.new(2028, 1, 20))
     end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe 'Dashboard', authorized: true do
         end
         assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
           assert_select 'dt:nth-of-type(1)', 'Date stamp'
-          assert_select 'dd:nth-of-type(1)', '24 October 2022 9:50am'
+          assert_select 'dd:nth-of-type(1)', '24 October 2022 10:50am'
         end
         assert_select 'div.govuk-summary-list__row:nth-of-type(3)' do
           assert_select 'dt:nth-of-type(1)', 'Date submitted'
-          assert_select 'dd:nth-of-type(1)', '24 October 2022 9:50am'
+          assert_select 'dd:nth-of-type(1)', '24 October 2022 10:50am'
         end
         assert_select 'div.govuk-summary-list__row:nth-of-type(4)' do
           assert_select 'dt:nth-of-type(1)', 'Submitted by'
@@ -181,7 +181,12 @@ RSpec.describe 'Dashboard', authorized: true do
   describe 'edit an in progress application (aka task list)' do
     before :all do
       # sets up a test record
-      app = CrimeApplication.create
+      app = CrimeApplication.create(
+        date_stamp: DateTime.new(2023, 4, 20, 23, 15) # date is past March daylight saving change
+      )
+
+      # needs a proper case type so it shows the interim date stamp
+      Case.create(crime_application: app, case_type: CaseType::SUMMARY_ONLY.to_s)
 
       Applicant.create(crime_application: app, first_name: 'Jane', last_name: 'Doe',
                        date_of_birth: Date.new(1990, 2, 1))
@@ -217,6 +222,9 @@ RSpec.describe 'Dashboard', authorized: true do
 
         assert_select 'h3:nth-of-type(4)', 'Date of birth'
         assert_select 'p:nth-of-type(4)', '1 Feb 1990'
+
+        assert_select 'h3:nth-of-type(5)', 'Date stamp'
+        assert_select 'p:nth-of-type(5)', '21 April 2023 12:15am'
       end
     end
   end

--- a/spec/services/date_stamper_spec.rb
+++ b/spec/services/date_stamper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DateStamper do
       let(:date) { nil }
 
       it 'adds a date stamp to the crime app' do
-        expect(crime_app).to receive(:update).with({ date_stamp: instance_of(DateTime) })
+        expect(crime_app).to receive(:update).with({ date_stamp: instance_of(ActiveSupport::TimeWithZone) })
         subject.call
       end
     end


### PR DESCRIPTION
## Description of change
The application by default is set to UTC time zone, same as Datastore and Review. In the database(s) we store dates in UTC across the board.

However in some places, the presented date/time should be in the corresponding user's timezone which by default for our service (and unlikely to change or be configurable) will be `London`.

In order to avoid repetition, a new view helper has been exposed, analogous to `#l()` named `#tz_l()` to localize dates in the time zone of the user. This is used in the views.

Also, although originally unrelated to this, ensure the date stamp and the submission date have both the same precision (`Time.current`)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-409

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="736" alt="before" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/73f4ca65-9fc0-4762-9a4e-7dcdd0f308a3">

### After changes:
<img width="831" alt="after" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/aec7e0e7-81d3-49a9-a7c4-3685e862546b">

## How to manually test the feature
