### PR TITLE
Use DWP mock in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
       OMNIAUTH_TEST_MODE: "true"
+      BC_USE_DEV_MOCK: "true"
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Description of change
In order to facilitate some "production-like" tests, enable the DWP mock when using docker-compose so we can proceed with the application beginning to end.

This does not affect any real environment, we use docker-compose only in our local dev envs.

