### PR TITLE
[CRIMAP-408] Change wording for passporting

### DIFF
--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -138,8 +138,8 @@ en:
 
       # BEGIN passport justification for legal aid section
       passport:
-        question: Passported
-        answers: 
+        question: Not needed
+        answers:
           'true': Details provided do not require further justification for legal aid
       passport_override:
         question: Passported


### PR DESCRIPTION
## Description of change
Changes the output for "Justification for legal aid" section from `Passported` to `Not needed` - but only for standard applications. Still says 'Passported' for split case.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-408

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
