### PR TITLE
Crimap 398 update privacy content

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -128,3 +128,10 @@ $app-blue-button-colour: govuk-colour("blue");
     outline: none;
   }
 }
+
+// Grey line separator for updated at date, taken from
+// https://github.com/alphagov/government-frontend/
+.app-c-updated-date {
+  padding-top: govuk-spacing(2);
+  border-top: 1px solid $govuk-border-colour;
+}

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,154 +1,163 @@
+<%# N.B. Update the updated at date at the bottom of this file when modifying this page %>
+
 <% title 'Privacy notice' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Privacy notice</h1>
-    <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
-    <p class="govuk-body">This service is provided by the
-      <%= link_to 'Legal Aid Agency (LAA)', 'https://www.gov.uk/government/organisations/legal-aid-agency/', rel: 'external' %>,
-      part of the Ministry of Justice (MoJ).
-    </p>
+    <div class="govuk-!-margin-bottom-9">
+      <h1 class="govuk-heading-xl">Privacy notice</h1>
+      <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
+      <p class="govuk-body">This service is provided by the
+        <%= link_to 'Legal Aid Agency (LAA)', 'https://www.gov.uk/government/organisations/legal-aid-agency/', rel: 'external' %>,
+        part of the Ministry of Justice (MoJ).
+      </p>
 
-    <p class="govuk-body">This privacy notice covers how the digital service (“Apply for criminal legal aid”) collects personal data from providers who are submitting information on behalf of their clients.</p>
+      <p class="govuk-body">This privacy notice covers how the digital service (“Apply for criminal legal aid”) collects personal data from providers who are submitting information on behalf of their clients.</p>
 
-    <p class="govuk-body">
-      For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
-      <%= link_to 'Legal Aid Agency privacy notice', Settings.portal_help_info_url, rel: 'external' %>.
-    </p>
+      <p class="govuk-body">
+        For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
+        <%= link_to 'Legal Aid Agency privacy notice', Settings.portal_help_info_url, rel: 'external' %>.
+      </p>
 
-    <h2 class="govuk-heading-l">What data we collect</h2>
+      <h2 class="govuk-heading-l">What data we collect</h2>
 
-    <p class="govuk-body">We collect:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>
-          your portal login and office account number provided by the LAA Portal service
-          (<%= link_to 'LAA Portal terms and conditions', Settings.portal_help_info_url, rel: 'external' %>)
-        </li>
-        <li>
-          your Internet Protocol (IP) address
-        </li>
-        <li>
-          details of which version of
-          <%= link_to 'web browser', 'https://www.gov.uk/support/browsers', rel: 'external' %>
-          you used
-        </li>
-        <li>
-          information on how you use the site, using <%= link_to 'cookies', cookies_path %> and page tagging techniques
-        </li>
-      </ul>
+      <p class="govuk-body">We collect:</p>
+      <div class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            your portal login and office account number provided by the LAA Portal service
+            (<%= link_to 'LAA Portal terms and conditions', Settings.portal_help_info_url, rel: 'external' %>)
+          </li>
+          <li>
+            your Internet Protocol (IP) address
+          </li>
+          <li>
+            details of which version of
+            <%= link_to 'web browser', 'https://www.gov.uk/support/browsers', rel: 'external' %>
+            you used
+          </li>
+          <li>
+            information on how you use the site, using <%= link_to 'cookies', cookies_path %> and page tagging techniques
+          </li>
+        </ul>
+      </div>
+
+      <p class="govuk-body">Where you provide your consent, we use
+        <%= link_to 'Google Analytics', 'https://support.google.com/analytics/topic/2919631', rel: 'external' %>
+        cookies. Google Analytics processes information about:
+      </p>
+      <div class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the pages you visit in this service</li>
+          <li>how long you spend on each page</li>
+          <li>how you got to this service</li>
+          <li>what you click on while you’re using the service</li>
+        </ul>
+      </div>
+
+      <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
+      <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
+      <p class="govuk-body">Find out more about <%= link_to 'cookies', cookies_path %> how we use Google Analytics and other cookies</a>
+  on this service.</p>
+
+      <h2 class="govuk-heading-l">What data we collect</h2>
+
+      <p class="govuk-body">We collect your data to:</p>
+      <div class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>gather feedback to improve our services</li>
+          <li>monitor use of the site to identify security threats</li>
+        </ul>
+      </div>
+
+      <p class="govuk-body">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
+      <p class="govuk-body">We do this to help:</p>
+      <div class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>make sure the service is meeting the needs of its users</li>
+          <li>make improvements to the service</li>
+          <li>make performance improvements, for example improving page load time and data usage</li>
+        </ul>
+      </div>
+
+      <h2 class="govuk-heading-l">Our legal basis for processing your data</h2>
+      <p class="govuk-body">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
+      <p class="govuk-body">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
+
+      <h2 class="govuk-heading-l">What we do with your data</h2>
+
+      <p class="govuk-body">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
+      <p class="govuk-body">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
+
+      <p class="govuk-body">We will not:</p>
+      <div class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>sell or rent data to third parties</li>
+          <li>share data with third parties for marketing purposes</li>
+        </ul>
+      </div>
+
+      <h2 class="govuk-heading-l">How long we keep your data</h2>
+
+      <p class="govuk-body">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
+      <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
+      <p class="govuk-body">This is managed in line with the
+        <%= link_to 'Ministry of Justice Headquarters Record retention and disposition schedules Schedule',
+                    'https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'%>
+      </p>
+
+      <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
+      <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
+
+      <h2 class="govuk-heading-l">How we protect your data and keep it secure</h2>
+      <p class="govuk-body">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
+
+      <h2 class="govuk-heading-l">Contact us or make a complaint</h2>
+
+      <p class="govuk-body">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
+      <div class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>have a question about anything in this privacy notice</li>
+          <li>think that your personal data has been misused or mishandled</li>
+        </ul>
+      </div>
+
+      <p class="govuk-body">You can also contact our Data Protection Officer (DPO):</p>
+      <p class="govuk-body"><%= mail_to 'dataprotection@justice.gov.uk' %></p>
+      <p class="govuk-body">
+        Data Protection Officer<br>
+        Ministry of Justice<br>
+        102 Petty France<br>
+        London<br>
+        SW1H 9AJ
+      </p>
+
+      <p class="govuk-body">The DPO leads on all aspects of data protection for the MoJ.</p>
+      <p class="govuk-body">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
+      <p class="govuk-body">Information Commissioner.</p>
+      <p class="govuk-body"><%= mail_to 'icocasework@ico.org.uk' %></p>
+      <p class="govuk-body">Telephone: 0303 123 1113</p>
+      <p class="govuk-body">Textphone: 01625 545860</p>
+      <p class="govuk-body">Monday to Friday, 9am to 4:30pm</p>
+      <p class="govuk-body">
+        <%= link_to 'Find out about call charges', 'https://www.gov.uk/call-charges', rel: 'external' %>
+      </p>
+      <p class="govuk-body">
+        Information Commissioner's Office<br>
+        Wycliffe House<br>
+        Water Lane<br>
+        Wilmslow<br>
+        SK9 5AF<br>
+      </p>
+
+      <h2 class="govuk-heading-l">Changes to this policy</h2>
+
+      <p class="govuk-body">We may change this privacy notice. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and your data immediately.</p>
     </div>
+    <div class="app-c-updated-date">
+      <%# TODO Implement non-hardcoded solution %>
 
-    <p class="govuk-body">Where you provide your consent, we use
-      <%= link_to 'Google Analytics', 'https://support.google.com/analytics/topic/2919631', rel: 'external' %>
-      cookies. Google Analytics processes information about:
-    </p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>the pages you visit in this service</li>
-        <li>how long you spend on each page</li>
-        <li>how you got to this service</li>
-        <li>what you click on while you’re using the service</li>
-      </ul>
+      <p class="govuk-body-s">Last updated 20 June 2023</p>
     </div>
-
-    <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
-    <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
-    <p class="govuk-body">Find out more about <%= link_to 'cookies', cookies_path %> how we use Google Analytics and other cookies</a>
- on this service.</p>
-
-    <h2 class="govuk-heading-l">What data we collect</h2>
-
-    <p class="govuk-body">We collect your data to:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>gather feedback to improve our services</li>
-        <li>monitor use of the site to identify security threats</li>
-      </ul>
-    </div>
-
-    <p class="govuk-body">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
-    <p class="govuk-body">We do this to help:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>make sure the service is meeting the needs of its users</li>
-        <li>make improvements to the service</li>
-        <li>make performance improvements, for example improving page load time and data usage</li>
-      </ul>
-    </div>
-
-    <h2 class="govuk-heading-l">Our legal basis for processing your data</h2>
-    <p class="govuk-body">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
-    <p class="govuk-body">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
-
-    <h2 class="govuk-heading-l">What we do with your data</h2>
-
-    <p class="govuk-body">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
-    <p class="govuk-body">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
-
-    <p class="govuk-body">We will not:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>sell or rent data to third parties</li>
-        <li>share data with third parties for marketing purposes</li>
-      </ul>
-    </div>
-
-    <h2 class="govuk-heading-l">How long we keep your data</h2>
-
-    <p class="govuk-body">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
-    <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
-    <p class="govuk-body">This is managed in line with the
-      <%= link_to 'Ministry of Justice Headquarters Record retention and disposition schedules Schedule',
-                  'https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'%>
-    </p>
-
-    <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
-    <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
-
-    <h2 class="govuk-heading-l">How we protect your data and keep it secure</h2>
-    <p class="govuk-body">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
-
-    <h2 class="govuk-heading-l">Contact us or make a complaint</h2>
-
-    <p class="govuk-body">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>have a question about anything in this privacy notice</li>
-        <li>think that your personal data has been misused or mishandled</li>
-      </ul>
-    </div>
-
-    <p class="govuk-body">You can also contact our Data Protection Officer (DPO):</p>
-    <p class="govuk-body"><%= mail_to 'dataprotection@justice.gov.uk' %></p>
-    <p class="govuk-body">
-      Data Protection Officer<br>
-      Ministry of Justice<br>
-      102 Petty France<br>
-      London<br>
-      SW1H 9AJ
-    </p>
-
-    <p class="govuk-body">The DPO leads on all aspects of data protection for the MoJ.</p>
-    <p class="govuk-body">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
-    <p class="govuk-body">Information Commissioner.</p>
-    <p class="govuk-body"><%= mail_to 'icocasework@ico.org.uk' %></p>
-    <p class="govuk-body">Telephone: 0303 123 1113</p>
-    <p class="govuk-body">Textphone: 01625 545860</p>
-    <p class="govuk-body">Monday to Friday, 9am to 4:30pm</p>
-    <p class="govuk-body">
-      <%= link_to 'Find out about call charges', 'https://www.gov.uk/call-charges', rel: 'external' %>
-    </p>
-    <p class="govuk-body">
-      Information Commissioner's Office<br>
-      Wycliffe House<br>
-      Water Lane<br>
-      Wilmslow<br>
-      SK9 5AF<br>
-    </p>
-
-    <h2 class="govuk-heading-l">Changes to this policy</h2>
-
-    <p class="govuk-body">We may change this privacy notice. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and your data immediately.</p>
   </div>
 </div>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Privacy notice</h1>
     <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
     <p class="govuk-body">This service is provided by the
-      <%= link_to 'Legal Aid Agency (LAA)', 'https://www.gov.uk/government/organisations/legal-aid-agency/', class: 'govuk-link', rel: 'external' %>,
+      <%= link_to 'Legal Aid Agency (LAA)', 'https://www.gov.uk/government/organisations/legal-aid-agency/', rel: 'external' %>,
       part of the Ministry of Justice (MoJ).
     </p>
 
@@ -13,7 +13,7 @@
 
     <p class="govuk-body">
       For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
-      <%= link_to 'Legal Aid Agency privacy notice', Settings.portal_help_info_url, class: 'govuk-link', rel: 'external' %>.
+      <%= link_to 'Legal Aid Agency privacy notice', Settings.portal_help_info_url, rel: 'external' %>.
     </p>
 
     <h2 class="govuk-heading-l">What data we collect</h2>
@@ -23,24 +23,24 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>
           your portal login and office account number provided by the LAA Portal service
-          (<%= link_to 'LAA Portal terms and conditions', Settings.portal_help_info_url, class: 'govuk-link', rel: 'external' %>)
+          (<%= link_to 'LAA Portal terms and conditions', Settings.portal_help_info_url, rel: 'external' %>)
         </li>
         <li>
           your Internet Protocol (IP) address
         </li>
         <li>
           details of which version of
-          <%= link_to 'web browser', 'https://www.gov.uk/support/browsers', class: 'govuk-link', rel: 'external' %>
+          <%= link_to 'web browser', 'https://www.gov.uk/support/browsers', rel: 'external' %>
           you used
         </li>
         <li>
-          information on how you use the site, using <%= link_to 'cookies', cookies_path, class: 'govuk-link' %> and page tagging techniques
+          information on how you use the site, using <%= link_to 'cookies', cookies_path %> and page tagging techniques
         </li>
       </ul>
     </div>
 
     <p class="govuk-body">Where you provide your consent, we use
-      <%= link_to 'Google Analytics', 'https://support.google.com/analytics/topic/2919631', class: 'govuk-link', rel: 'external' %>
+      <%= link_to 'Google Analytics', 'https://support.google.com/analytics/topic/2919631', rel: 'external' %>
       cookies. Google Analytics processes information about:
     </p>
     <div class="govuk-list">
@@ -54,7 +54,7 @@
 
     <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
     <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
-    <p class="govuk-body">Find out more about <%= link_to 'cookies', cookies_path, class: 'govuk-link' %> how we use Google Analytics and other cookies</a>
+    <p class="govuk-body">Find out more about <%= link_to 'cookies', cookies_path %> how we use Google Analytics and other cookies</a>
  on this service.</p>
 
     <h2 class="govuk-heading-l">What data we collect</h2>
@@ -100,8 +100,7 @@
     <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
     <p class="govuk-body">This is managed in line with the
       <%= link_to 'Ministry of Justice Headquarters Record retention and disposition schedules Schedule',
-                  'https://www.gov.uk/government/publications/record-retention-and-disposition-schedules',
-                  class: 'govuk-link' %>
+                  'https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'%>
     </p>
 
     <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
@@ -138,7 +137,7 @@
     <p class="govuk-body">Textphone: 01625 545860</p>
     <p class="govuk-body">Monday to Friday, 9am to 4:30pm</p>
     <p class="govuk-body">
-      <%= link_to 'Find out about call charges', 'https://www.gov.uk/call-charges', class: 'govuk-link ', rel: 'external' %>
+      <%= link_to 'Find out about call charges', 'https://www.gov.uk/call-charges', rel: 'external' %>
     </p>
     <p class="govuk-body">
       Information Commissioner's Office<br>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,8 +1,8 @@
-<% title "Privacy policy" %>
+<% title 'Privacy notice' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Privacy policy</h2>
+    <h1 class="govuk-heading-xl">Privacy notice</h2>
     <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
     <p class="govuk-body">This service is provided by the
       <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/organisations/legal-aid-agency/">Legal Aid Agency (LAA)</a>,
@@ -13,38 +13,38 @@
 
     <p class="govuk-body">
       For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
-      <a class="govuk-link" rel="external" target="_blank" href=<%= Settings.portal_help_info_url %>>Legal Aid Agency privacy notice</a>.
+      <a class="govuk-link" rel="external" target="_blank" href="<%= Settings.portal_help_info_url %>">Legal Aid Agency privacy notice</a>.
     </p>
 
-    <h2 class="govuk-heading-l">What data we collect</h2>
+    <h2 class=" govuk-heading-l ">What data we collect</h2>
 
-    <p class="govuk-body">We collect:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
+    <p class=" govuk-body ">We collect:</p>
+    <div class=" govuk-list ">
+      <ul class=" govuk-list govuk-list--bullet ">
         <li>
           your portal login and office account number provided by the LAA Portal service
-          (<a class="govuk-link" rel="external" target="_blank" href=<%= Settings.portal_help_info_url %>>LAA Portal terms and conditions</a>)
+          (<a class=" govuk-link " rel=" external " target=" _blank " href="<%= Settings.portal_help_info_url %>">LAA Portal terms and conditions</a>)
         </li>
         <li>
           your Internet Protocol (IP) address
         </li>
         <li>
           details of which version of
-          <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/support/browsers/">web browser</a>
+          <a class=" govuk-link " rel=" external " target=" _blank " href=" https: www.gov.uk support browsers ">web browser</a>
           you used
         </li>
         <li>
-          information on how you use the site, using <a class="govuk-link" target="_blank" href="/cookies">cookies</a> and page tagging techniques
+          information on how you use the site, using <a class=" govuk-link " target=" _blank " href=" cookies ">cookies</a> and page tagging techniques
         </li>
       </ul>
     </div>
 
-    <p class="govuk-body">Where you provide your consent, we use
-      <a class="govuk-link" rel="external" target="_blank" href="https://support.google.com/analytics/topic/2919631/">Google Analytics</a>
+    <p class=" govuk-body ">Where you provide your consent, we use
+      <a class=" govuk-link " rel=" external " target=" _blank " href=" https: support.google.com analytics topic 2919631 ">Google Analytics</a>
         cookies. Google Analytics processes information about:
     </p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
+    <div class=" govuk-list ">
+      <ul class=" govuk-list govuk-list--bullet ">
         <li>the pages you visit in this service</li>
         <li>how long you spend on each page</li>
         <li>how you got to this service</li>
@@ -52,76 +52,76 @@
       </ul>
     </div>
 
-    <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
-    <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
-    <p class="govuk-body">Find out more about <a class="govuk-link" target="_blank" href="/cookies">how we use Google Analytics and other cookies</a>
+    <p class=" govuk-body ">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
+    <p class=" govuk-body ">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
+    <p class=" govuk-body ">Find out more about <a class=" govuk-link " target=" _blank " href=" cookies ">how we use Google Analytics and other cookies</a>
  on this service.</p>
 
-    <h2 class="govuk-heading-l">What data we collect</h2>
+    <h2 class=" govuk-heading-l ">What data we collect</h2>
 
-    <p class="govuk-body">We collect your data to:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
+    <p class=" govuk-body ">We collect your data to:</p>
+    <div class=" govuk-list ">
+      <ul class=" govuk-list govuk-list--bullet ">
         <li>gather feedback to improve our services</li>
         <li>monitor use of the site to identify security threats</li>
       </ul>
     </div>
 
-    <p class="govuk-body">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
-    <p class="govuk-body">We do this to help:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
+    <p class=" govuk-body ">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
+    <p class=" govuk-body ">We do this to help:</p>
+    <div class=" govuk-list ">
+      <ul class=" govuk-list govuk-list--bullet ">
         <li>make sure the service is meeting the needs of its users</li>
         <li>make improvements to the service</li>
         <li>make performance improvements, for example improving page load time and data usage</li>
       </ul>
     </div>
 
-    <h2 class="govuk-heading-l">Our legal basis for processing your data</h2>
-    <p class="govuk-body">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
-    <p class="govuk-body">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
+    <h2 class=" govuk-heading-l ">Our legal basis for processing your data</h2>
+    <p class=" govuk-body ">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
+    <p class=" govuk-body ">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
 
-    <h2 class="govuk-heading-l">What we do with your data</h2>
+    <h2 class=" govuk-heading-l ">What we do with your data</h2>
 
-    <p class="govuk-body">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
-    <p class="govuk-body">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
+    <p class=" govuk-body ">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
+    <p class=" govuk-body ">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
 
-    <p class="govuk-body">We will not:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
+    <p class=" govuk-body ">We will not:</p>
+    <div class=" govuk-list ">
+      <ul class=" govuk-list govuk-list--bullet ">
         <li>sell or rent data to third parties</li>
         <li>share data with third parties for marketing purposes</li>
       </ul>
     </div>
 
-    <h2 class="govuk-heading-l">How long we keep your data</h2>
+    <h2 class=" govuk-heading-l ">How long we keep your data</h2>
 
-    <p class="govuk-body">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
-    <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
-    <p class="govuk-body">This is managed in line with the
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/record-retention-and-disposition-schedules">
+    <p class=" govuk-body ">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
+    <p class=" govuk-body ">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
+    <p class=" govuk-body ">This is managed in line with the
+      <a class=" govuk-link " rel=" external " target=" _blank " href=" https: www.gov.uk government publications record-retention-and-disposition-schedules ">
         Ministry of Justice Headquarters Record retention and disposition schedules Schedule</a>.
     </p>
 
-    <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
-    <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
+    <h2 class=" govuk-heading-l ">Where your data is processed and stored</h2>
+    <p class=" govuk-body ">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
 
-    <h2 class="govuk-heading-l">How we protect your data and keep it secure</h2>
-    <p class="govuk-body">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
+    <h2 class=" govuk-heading-l ">How we protect your data and keep it secure</h2>
+    <p class=" govuk-body ">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
 
-    <h2 class="govuk-heading-l">Contact us or make a complaint</h2>
+    <h2 class=" govuk-heading-l ">Contact us or make a complaint</h2>
 
-    <p class="govuk-body">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
+    <p class=" govuk-body ">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
+    <div class=" govuk-list ">
+      <ul class=" govuk-list govuk-list--bullet ">
         <li>have a question about anything in this privacy notice</li>
         <li>think that your personal data has been misused or mishandled</li>
       </ul>
     </div>
 
-    <p class="govuk-body">You can also contact our Data Protection Officer (DPO):</p>
-    <p class="govuk-body"><%= mail_to "dataprotection@justice.gov.uk" %></p>
-    <p class="govuk-body">
+    <p class=" govuk-body ">You can also contact our Data Protection Officer (DPO):</p>
+    <p class=" govuk-body "><%= mail_to 'dataprotection@justice.gov.uk' %></p>
+    <p class=" govuk-body ">
       Data Protection Officer<br>
       Ministry of Justice<br>
       102 Petty France<br>
@@ -129,17 +129,17 @@
       SW1H 9AJ
     </p>
 
-    <p class="govuk-body">The DPO leads on all aspects of data protection for the MoJ.</p>
-    <p class="govuk-body">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
-    <p class="govuk-body">Information Commissioner.</p>
-    <p class="govuk-body"><%= mail_to "icocasework@ico.org.uk" %></p>
-    <p class="govuk-body">Telephone: 0303 123 1113</p>
-    <p class="govuk-body">Textphone: 01625 545860</p>
-    <p class="govuk-body">Monday to Friday, 9am to 4:30pm</p>
-    <p class="govuk-body">
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges</a>
+    <p class=" govuk-body ">The DPO leads on all aspects of data protection for the MoJ.</p>
+    <p class=" govuk-body ">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
+    <p class=" govuk-body ">Information Commissioner.</p>
+    <p class=" govuk-body "><%= mail_to 'icocasework@ico.org.uk' %></p>
+    <p class=" govuk-body ">Telephone: 0303 123 1113</p>
+    <p class=" govuk-body ">Textphone: 01625 545860</p>
+    <p class=" govuk-body ">Monday to Friday, 9am to 4:30pm</p>
+    <p class=" govuk-body ">
+      <a class=" govuk-link " rel=" external " target=" _blank " href=" https: www.gov.uk call-charges ">Find out about call charges</a>
     </p>
-    <p class="govuk-body">
+    <p class=" govuk-body ">
       Information Commissioner's Office<br>
       Wycliffe House<br>
       Water Lane<br>
@@ -147,8 +147,8 @@
       SK9 5AF<br>
     </p>
 
-    <h2 class="govuk-heading-l">Changes to this policy</h2>
+    <h2 class=" govuk-heading-l ">Changes to this policy</h2>
 
-    <p class="govuk-body">We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.</p>
+    <p class=" govuk-body ">We may change this privacy notice. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and your data immediately.</p>
   </div>
 </div>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,155 +1,154 @@
-<% title 'Privacy policy' %>
+<% title "Privacy policy" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Privacy policy</h2>
-    <h2 class="govuk-heading-l">Purpose</h2>
-    <p class="govuk-body">This privacy notice sets out:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>the standards that you can expect from the Legal Aid Agency (LAA) when we request or hold personal data about you</li>
-        <li>how you can get access to a copy of your personal data</li>
-        <li>what you can do if you think the standards are not being met</li>
-      </ul>
-    </div>
-    <p class="govuk-body">The LAA is an Executive Agency of the Ministry of Justice (MoJ). The MoJ is the data controller for the personal information we hold.</p>
-    <p class="govuk-body">The LAA collects and processes personal data for the exercise of its own and associated public functions. Our public function is to provide legal aid.</p>
+    <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
+    <p class="govuk-body">This service is provided by the
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/organisations/legal-aid-agency/">Legal Aid Agency (LAA)</a>
+        , part of the Ministry of Justice (MoJ).</p>
 
-    <h2 class="govuk-heading-l">About personal information</h2>
-    <p class="govuk-body">Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you've provided in this service such as:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>your financial circumstances</li>
-        <li>information relating to any current or previous legal proceedings concerning you</li>
-      </ul>
-    </div>
-    <p class="govuk-body">We know how important it is to protect customers’ privacy and to comply with data protection laws. We will safeguard your personal data and will only disclose it where it is lawful to do so, or with your consent.</p>
+    <p class="govuk-body">This privacy notice covers how the digital service (“Apply for criminal legal aid”) collects personal data from providers who are submitting information on behalf of their clients.</p>
 
-    <h2 class="govuk-heading-l">Types of personal data we process</h2>
-    <p class="govuk-body">We only process personal data that is relevant for the services we provide.</p>
-    <p class="govuk-body">The personal data which you've provided for this service will only be used for the purposes set out below.</p>
-
-    <h2 class="govuk-heading-l">Purpose of processing and the lawful basis for the process</h2>
-    <p class="govuk-body">The LAA collects and processes personal data for the purpose of providing legal aid. Specifically, we use personal data to:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>decide whether you need to make a contribution towards the costs of legal aid and to assist the LAA in collecting those contributions</li>
-        <li>assess claims from your legal representative(s) for payment from the legal aid fund for the work that they've conducted on your behalf</li>
-        <li>conduct periodic assurance audits on legal aid files to ensure that decisions have been made correctly and accurately</li>
-        <li>produce statistics and information on our systems and processes to help us improve them and to assist us in carrying out our functions</li>
-      </ul>
-    </div>
-    <p class="govuk-body">Were the LAA unable to collect this personal information, we would not be able to conduct the activities above, which would prevent us from providing legal aid.</p>
-    <p class="govuk-body">The lawful basis for the LAA collecting and processing your personal data is in the administration of justice and the result of the powers contained in the Legal Aid, Sentencing and Punishment of Offenders Act 2012 (LASPO).</p>
-    <p class="govuk-body">We also collect ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities under the Equality Act 2010.</p>
-    <p class="govuk-body">Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence. Any information published will not identify you or anyone else associated with your legal aid application.</p>
-
-    <h2 class="govuk-heading-l">Who we may share your information with</h2>
-    <p class="govuk-body">We sometimes need to share the personal information we process with other organisations. When this is necessary, we'll comply with all aspects of the relevant data protection laws.</p>
-    <p class="govuk-body">The organisations we may share your personal information with include:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>public authorities such as HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC), Department of Work and Pensions (DWP) and HM Land Registry</li>
-        <li>non-public authorities such as the credit reference agencies Equifax and TransUnion</li>
-        <li>fraud prevention agencies if false or inaccurate information is provided or fraud has been identified</li>
-      </ul>
-    </div>
-    <p class="govuk-body">You can contact our Data Protection Officer for further information on the organisations we may share your personal information with.</p>
-
-    <h2 class="govuk-heading-l">Data Processors</h2>
-    <p class="govuk-body">The LAA may contract with third party data processors to provide email, system administration, document management and IT storage services. Data processors may also provide anonymised statistical information about your use of this service.</p>
-    <p class="govuk-body">Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.</p>
-
-    <h2 class="govuk-heading-l">Details of transfers to third country and safeguards</h2>
-    <p class="govuk-body">It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to the European Economic Area (EEA).</p>
-    <p class="govuk-body">Any transfers made will be in full compliance with all aspects of the data protection law.</p>
-
-    <h2 class="govuk-heading-l">Retention period for information collected</h2>
-    <p class="govuk-body">Your personal information will not be retained for any longer than is necessary for the lawful purposes for which it has been collected and processed. This is to ensure that your personal information does not become inaccurate, out of date or irrelevant.</p>
-    <p class="govuk-body">The LAA have set retention periods for the personal information that we collect. This can be accessed via our website:</p>
-    <p class="govuk-body"><a href='https://www.gov.uk/government/publications/record-retention-and-disposition-schedules'>https://www.gov.uk/government/publications/record-retention-and-disposition-schedules</a></p>
-    <p class="govuk-body">You can also contact our Data Protection Officer for a copy of our retention policies.</p>
-    <p class="govuk-body">We'll ensure that your personal data is secure and protected from loss, misuse or unauthorised access and disclosure. Once the retention period has been reached, your personal data will be permanently and securely deleted and destroyed.</p>
-
-    <h2 class="govuk-heading-l">Access to personal information</h2>
-    <p class="govuk-body">You can find out if we hold any personal data about you by making a ‘subject access request’. If you wish to make a subject access request please contact:</p>
-    <p class="govuk-body">
-      Disclosure Team - Post point 10.25<br>
-      Ministry of Justice<br>
-      102 Petty France<br>
-      London<br>
-      SW1H 9AJ<br>
-    </p>
-    <p class="govuk-body">
-      <a href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>
+    <p class="govuk-body">For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
+      <%= link_to "Legal Aid Agency privacy notice", Settings.portal_help_info_url, class: "govuk-link", rel: "external", target: "_blank" %>.
     </p>
 
-    <h2 class="govuk-heading-l">When we ask you for personal data</h2>
-    <p class="govuk-body">We promise to tell you why we need your personal data and ask only for the data we need and not collect information that is irrelevant or excessive.</p>
-    <p class="govuk-body">When we collect your personal data, we have responsibilities, and you have rights.</p>
-    <p class="govuk-body">We will:</p>
+    <h2 class="govuk-heading-l">What data we collect</h2>
+
+    <p class="govuk-body">We collect:</p>
     <div class="govuk-list">
       <ul class="govuk-list govuk-list--bullet">
-        <li>protect and ensure that no unauthorised person has access to your personal data</li>
-        <li>share your personal data with other organisations only for legitimate purposes</li>
-        <li>consider your request to correct, stop processing or erase your personal data</li>
+        <li>
+          your portal login and office account number provided by the LAA Portal service
+          (<%= link_to "LAA Portal terms and conditions", Settings.portal_help_info_url, class: "govuk-link", rel: "external", target: "_blank" %>)
+        </li>
+        <li>
+          your Internet Protocol (IP) address
+        </li>
+        <li>
+          details of which version of
+          <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/support/browsers/">web browser</a>
+          you used
+        </li>
+        <li>
+          information on how you use the site, using
+          <%= link_to "cookies", cookies_path, class: "govuk-link" %>
+          and page tagging techniques
+        </li>
       </ul>
     </div>
+
+    <p class="govuk-body">Where you provide your consent, we use
+      <a class="govuk-link" rel="external" target="_blank" href="https://support.google.com/analytics/topic/2919631/">Google Analytics</a>
+        cookies. Google Analytics processes information about:
+    </p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the pages you visit in this service</li>
+        <li>how long you spend on each page</li>
+        <li>how you got to this service</li>
+        <li>what you click on while you’re using the service</li>
+      </ul>
+    </div>
+
+    <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
+    <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
+    <p class="govuk-body">Find out more about <%= link_to "how we use Google Analytics and other cookies", cookies_path, class: "govuk-link" %> on this service.</p>
+
+    <h2 class="govuk-heading-l">What data we collect</h2>
+
+    <p class="govuk-body">We collect your data to:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>gather feedback to improve our services</li>
+        <li>monitor use of the site to identify security threats</li>
+      </ul>
+    </div>
+
+    <p class="govuk-body">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
+    <p class="govuk-body">We do this to help:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>make sure the service is meeting the needs of its users</li>
+        <li>make improvements to the service</li>
+        <li>make performance improvements, for example improving page load time and data usage</li>
+      </ul>
+    </div>
+
+    <h2 class="govuk-heading-l">Our legal basis for processing your data</h2>
+    <p class="govuk-body">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
+    <p class="govuk-body">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
+
+    <h2 class="govuk-heading-l">What we do with your data</h2>
+
+    <p class="govuk-body">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
+    <p class="govuk-body">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
+
     <p class="govuk-body">We will not:</p>
     <div class="govuk-list">
       <ul class="govuk-list govuk-list--bullet">
-        <li>keep your personal data longer than needed</li>
-        <li>make your personal data available for commercial use without your consent</li>
-      </ul>
-    </div>
-    <p class="govuk-body">You can:</p>
-    <div class="govuk-list">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>withdraw consent at any time where relevant</li>
-        <li>lodge a complaint with the supervisory authority</li>
+        <li>sell or rent data to third parties</li>
+        <li>share data with third parties for marketing purposes</li>
       </ul>
     </div>
 
-    <h2 class="govuk-heading-l">The Data Protection Officer</h2>
-    <p class="govuk-body">The Data Protection Officer can provide details on:</p>
+    <h2 class="govuk-heading-l">How long we keep your data</h2>
+
+    <p class="govuk-body">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
+    <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
+    <p class="govuk-body">This is managed in line with the
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/record-retention-and-disposition-schedules">
+        Ministry of Justice Headquarters Record retention and disposition schedules Schedule
+      </a>
+    </p>
+
+    <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
+    <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
+
+    <h2 class="govuk-heading-l">How we protect your data and keep it secure</h2>
+    <p class="govuk-body">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
+
+    <h2 class="govuk-heading-l">Contact us or make a complaint</h2>
+
+    <p class="govuk-body">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
     <div class="govuk-list">
       <ul class="govuk-list govuk-list--bullet">
-        <li>agreements we have with other organisations for sharing information</li>
-        <li>circumstances where we can pass on personal information without telling you, for example to help with the prevention or detection of crime or to produce anonymised statistics</li>
-        <li>how we instruct staff to collect, use or delete your personal information</li>
-        <li>how we check that the information we hold is accurate and up-to-date</li>
-        <li>how to make a complaint</li>
+        <li>have a question about anything in this privacy notice</li>
+        <li>think that your personal data has been misused or mishandled</li>
       </ul>
     </div>
 
-    <p class="govuk-body">Contact the Data Protection Officer at:</p>
+    <p class="govuk-body">You can also contact our Data Protection Officer (DPO):</p>
+    <p class="govuk-body"><%= mail_to "dataprotection@justice.gov.uk" %></p>
     <p class="govuk-body">
-      The Data Protection Officer<br>
+      Data Protection Officer<br>
       Ministry of Justice<br>
-      3rd Floor, Post Point 3.20<br>
-      10 South Colonnades<br>
-      Canary Wharf<br>
+      102 Petty France<br>
       London<br>
-      E14 4PU<br>
-    </p>
-    <p class="govuk-body">
-      <a href="mailto:privacy@justice.gov.uk">privacy@justice.gov.uk</a>
+      SW1H 9AJ
     </p>
 
-    <h2 class="govuk-heading-l">Complaints</h2>
-    <p class="govuk-body">When we ask you for information, we will comply with the law. If you do not think that we've handled your information correctly, you can contact the Information Commissioner for independent advice about data protection.</p>
-    <p class="govuk-body">Contact the Information Commissioner at:</p>
+    <p class="govuk-body">The DPO leads on all aspects of data protection for the MoJ.</p>
+    <p class="govuk-body">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
+    <p class="govuk-body">Information Commissioner.</p>
+    <p class="govuk-body"><%= mail_to "icocasework@ico.org.uk" %></p>
+    <p class="govuk-body">Telephone: 0303 123 1113</p>
+    <p class="govuk-body">Textphone: 01625 545860</p>
+    <p class="govuk-body">Monday to Friday, 9am to 4:30pm</p>
+    <p class="govuk-body">
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges</a>
+    </p>
     <p class="govuk-body">
       Information Commissioner's Office<br>
       Wycliffe House<br>
       Water Lane<br>
       Wilmslow<br>
-      Cheshire<br>
       SK9 5AF<br>
-      Tel: 0303 123 1113<br>
     </p>
-    <p class="govuk-body">
-      <a href='http://www.ico.org.uk'>ico.org.uk</a>
-    </p>
+
+    <h2 class="govuk-heading-l">Changes to this policy</h2>
+
+    <p class="govuk-body">We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.</p>
   </div>
 </div>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -5,13 +5,15 @@
     <h1 class="govuk-heading-xl">Privacy policy</h2>
     <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
     <p class="govuk-body">This service is provided by the
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/organisations/legal-aid-agency/">Legal Aid Agency (LAA)</a>
-        , part of the Ministry of Justice (MoJ).</p>
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/organisations/legal-aid-agency/">Legal Aid Agency (LAA)</a>,
+      part of the Ministry of Justice (MoJ).
+    </p>
 
     <p class="govuk-body">This privacy notice covers how the digital service (“Apply for criminal legal aid”) collects personal data from providers who are submitting information on behalf of their clients.</p>
 
-    <p class="govuk-body">For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
-      <%= link_to "Legal Aid Agency privacy notice", Settings.portal_help_info_url, class: "govuk-link", rel: "external", target: "_blank" %>.
+    <p class="govuk-body">
+      For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
+      <a class="govuk-link" rel="external" target="_blank" href=<%= Settings.portal_help_info_url %>>Legal Aid Agency privacy notice</a>.
     </p>
 
     <h2 class="govuk-heading-l">What data we collect</h2>
@@ -21,7 +23,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>
           your portal login and office account number provided by the LAA Portal service
-          (<%= link_to "LAA Portal terms and conditions", Settings.portal_help_info_url, class: "govuk-link", rel: "external", target: "_blank" %>)
+          (<a class="govuk-link" rel="external" target="_blank" href=<%= Settings.portal_help_info_url %>>LAA Portal terms and conditions</a>)
         </li>
         <li>
           your Internet Protocol (IP) address
@@ -32,9 +34,7 @@
           you used
         </li>
         <li>
-          information on how you use the site, using
-          <%= link_to "cookies", cookies_path, class: "govuk-link" %>
-          and page tagging techniques
+          information on how you use the site, using <a class="govuk-link" target="_blank" href="/cookies">cookies</a> and page tagging techniques
         </li>
       </ul>
     </div>
@@ -54,7 +54,8 @@
 
     <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
     <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
-    <p class="govuk-body">Find out more about <%= link_to "how we use Google Analytics and other cookies", cookies_path, class: "govuk-link" %> on this service.</p>
+    <p class="govuk-body">Find out more about <a class="govuk-link" target="_blank" href="/cookies">how we use Google Analytics and other cookies</a>
+ on this service.</p>
 
     <h2 class="govuk-heading-l">What data we collect</h2>
 
@@ -99,8 +100,7 @@
     <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
     <p class="govuk-body">This is managed in line with the
       <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/record-retention-and-disposition-schedules">
-        Ministry of Justice Headquarters Record retention and disposition schedules Schedule
-      </a>
+        Ministry of Justice Headquarters Record retention and disposition schedules Schedule</a>.
     </p>
 
     <h2 class="govuk-heading-l">Where your data is processed and stored</h2>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -2,10 +2,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Privacy notice</h2>
+    <h1 class="govuk-heading-xl">Privacy notice</h1>
     <h2 class="govuk-heading-l">Apply for Criminal Legal Aid Service</h2>
     <p class="govuk-body">This service is provided by the
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/organisations/legal-aid-agency/">Legal Aid Agency (LAA)</a>,
+      <%= link_to 'Legal Aid Agency (LAA)', 'https://www.gov.uk/government/organisations/legal-aid-agency/', class: 'govuk-link', rel: 'external' %>,
       part of the Ministry of Justice (MoJ).
     </p>
 
@@ -13,38 +13,38 @@
 
     <p class="govuk-body">
       For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
-      <a class="govuk-link" rel="external" target="_blank" href="<%= Settings.portal_help_info_url %>">Legal Aid Agency privacy notice</a>.
+      <%= link_to 'Legal Aid Agency privacy notice', Settings.portal_help_info_url, class: 'govuk-link', rel: 'external' %>.
     </p>
 
-    <h2 class=" govuk-heading-l ">What data we collect</h2>
+    <h2 class="govuk-heading-l">What data we collect</h2>
 
-    <p class=" govuk-body ">We collect:</p>
-    <div class=" govuk-list ">
-      <ul class=" govuk-list govuk-list--bullet ">
+    <p class="govuk-body">We collect:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>
           your portal login and office account number provided by the LAA Portal service
-          (<a class=" govuk-link " rel=" external " target=" _blank " href="<%= Settings.portal_help_info_url %>">LAA Portal terms and conditions</a>)
+          (<%= link_to 'LAA Portal terms and conditions', Settings.portal_help_info_url, class: 'govuk-link', rel: 'external' %>)
         </li>
         <li>
           your Internet Protocol (IP) address
         </li>
         <li>
           details of which version of
-          <a class=" govuk-link " rel=" external " target=" _blank " href=" https: www.gov.uk support browsers ">web browser</a>
+          <%= link_to 'web browser', 'https://www.gov.uk/support/browsers', class: 'govuk-link', rel: 'external' %>
           you used
         </li>
         <li>
-          information on how you use the site, using <a class=" govuk-link " target=" _blank " href=" cookies ">cookies</a> and page tagging techniques
+          information on how you use the site, using <%= link_to 'cookies', cookies_path, class: 'govuk-link' %> and page tagging techniques
         </li>
       </ul>
     </div>
 
-    <p class=" govuk-body ">Where you provide your consent, we use
-      <a class=" govuk-link " rel=" external " target=" _blank " href=" https: support.google.com analytics topic 2919631 ">Google Analytics</a>
-        cookies. Google Analytics processes information about:
+    <p class="govuk-body">Where you provide your consent, we use
+      <%= link_to 'Google Analytics', 'https://support.google.com/analytics/topic/2919631', class: 'govuk-link', rel: 'external' %>
+      cookies. Google Analytics processes information about:
     </p>
-    <div class=" govuk-list ">
-      <ul class=" govuk-list govuk-list--bullet ">
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>the pages you visit in this service</li>
         <li>how long you spend on each page</li>
         <li>how you got to this service</li>
@@ -52,76 +52,77 @@
       </ul>
     </div>
 
-    <p class=" govuk-body ">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
-    <p class=" govuk-body ">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
-    <p class=" govuk-body ">Find out more about <a class=" govuk-link " target=" _blank " href=" cookies ">how we use Google Analytics and other cookies</a>
+    <p class="govuk-body">We make sure you cannot be identified by Google Analytics data. We do not pass any of your personal data to Google Analytics, and Google Analytics does not store your IP address.</p>
+    <p class="govuk-body">We will not combine analytics information with other data sets in a way that would identify who you are.</p>
+    <p class="govuk-body">Find out more about <%= link_to 'cookies', cookies_path, class: 'govuk-link' %> how we use Google Analytics and other cookies</a>
  on this service.</p>
 
-    <h2 class=" govuk-heading-l ">What data we collect</h2>
+    <h2 class="govuk-heading-l">What data we collect</h2>
 
-    <p class=" govuk-body ">We collect your data to:</p>
-    <div class=" govuk-list ">
-      <ul class=" govuk-list govuk-list--bullet ">
+    <p class="govuk-body">We collect your data to:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>gather feedback to improve our services</li>
         <li>monitor use of the site to identify security threats</li>
       </ul>
     </div>
 
-    <p class=" govuk-body ">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
-    <p class=" govuk-body ">We do this to help:</p>
-    <div class=" govuk-list ">
-      <ul class=" govuk-list govuk-list--bullet ">
+    <p class="govuk-body">We use the information we collect through Google Analytics to see how you use the service and to see how well it performs on your device.</p>
+    <p class="govuk-body">We do this to help:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>make sure the service is meeting the needs of its users</li>
         <li>make improvements to the service</li>
         <li>make performance improvements, for example improving page load time and data usage</li>
       </ul>
     </div>
 
-    <h2 class=" govuk-heading-l ">Our legal basis for processing your data</h2>
-    <p class=" govuk-body ">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
-    <p class=" govuk-body ">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
+    <h2 class="govuk-heading-l">Our legal basis for processing your data</h2>
+    <p class="govuk-body">The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.</p>
+    <p class="govuk-body">The legal basis for processing data collected with Google Analytics in this service is your consent.</p>
 
-    <h2 class=" govuk-heading-l ">What we do with your data</h2>
+    <h2 class="govuk-heading-l">What we do with your data</h2>
 
-    <p class=" govuk-body ">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
-    <p class=" govuk-body ">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
+    <p class="govuk-body">The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Google Analytics 4). We do not allow Google to use or share this data for their own purposes.</p>
+    <p class="govuk-body">No information that you provide will be shared outside the MoJ, other than with MoJ IT providers that provide services supporting the running of this service.</p>
 
-    <p class=" govuk-body ">We will not:</p>
-    <div class=" govuk-list ">
-      <ul class=" govuk-list govuk-list--bullet ">
+    <p class="govuk-body">We will not:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>sell or rent data to third parties</li>
         <li>share data with third parties for marketing purposes</li>
       </ul>
     </div>
 
-    <h2 class=" govuk-heading-l ">How long we keep your data</h2>
+    <h2 class="govuk-heading-l">How long we keep your data</h2>
 
-    <p class=" govuk-body ">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
-    <p class=" govuk-body ">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
-    <p class=" govuk-body ">This is managed in line with the
-      <a class=" govuk-link " rel=" external " target=" _blank " href=" https: www.gov.uk government publications record-retention-and-disposition-schedules ">
-        Ministry of Justice Headquarters Record retention and disposition schedules Schedule</a>.
+    <p class="govuk-body">We will only retain your data for as long as it is needed for the purposes set out on this page.</p>
+    <p class="govuk-body">We will retain long term summary logs of interactions with the service, but these logs are fully anonymous.</p>
+    <p class="govuk-body">This is managed in line with the
+      <%= link_to 'Ministry of Justice Headquarters Record retention and disposition schedules Schedule',
+                  'https://www.gov.uk/government/publications/record-retention-and-disposition-schedules',
+                  class: 'govuk-link' %>
     </p>
 
-    <h2 class=" govuk-heading-l ">Where your data is processed and stored</h2>
-    <p class=" govuk-body ">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
+    <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
+    <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored. All personal data is processed in the EEA.</p>
 
-    <h2 class=" govuk-heading-l ">How we protect your data and keep it secure</h2>
-    <p class=" govuk-body ">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
+    <h2 class="govuk-heading-l">How we protect your data and keep it secure</h2>
+    <p class="govuk-body">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
 
-    <h2 class=" govuk-heading-l ">Contact us or make a complaint</h2>
+    <h2 class="govuk-heading-l">Contact us or make a complaint</h2>
 
-    <p class=" govuk-body ">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
-    <div class=" govuk-list ">
-      <ul class=" govuk-list govuk-list--bullet ">
+    <p class="govuk-body">Contact us by email at <%= mail_to Settings.support_email %> if you:</p>
+    <div class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>have a question about anything in this privacy notice</li>
         <li>think that your personal data has been misused or mishandled</li>
       </ul>
     </div>
 
-    <p class=" govuk-body ">You can also contact our Data Protection Officer (DPO):</p>
-    <p class=" govuk-body "><%= mail_to 'dataprotection@justice.gov.uk' %></p>
-    <p class=" govuk-body ">
+    <p class="govuk-body">You can also contact our Data Protection Officer (DPO):</p>
+    <p class="govuk-body"><%= mail_to 'dataprotection@justice.gov.uk' %></p>
+    <p class="govuk-body">
       Data Protection Officer<br>
       Ministry of Justice<br>
       102 Petty France<br>
@@ -129,17 +130,17 @@
       SW1H 9AJ
     </p>
 
-    <p class=" govuk-body ">The DPO leads on all aspects of data protection for the MoJ.</p>
-    <p class=" govuk-body ">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
-    <p class=" govuk-body ">Information Commissioner.</p>
-    <p class=" govuk-body "><%= mail_to 'icocasework@ico.org.uk' %></p>
-    <p class=" govuk-body ">Telephone: 0303 123 1113</p>
-    <p class=" govuk-body ">Textphone: 01625 545860</p>
-    <p class=" govuk-body ">Monday to Friday, 9am to 4:30pm</p>
-    <p class=" govuk-body ">
-      <a class=" govuk-link " rel=" external " target=" _blank " href=" https: www.gov.uk call-charges ">Find out about call charges</a>
+    <p class="govuk-body">The DPO leads on all aspects of data protection for the MoJ.</p>
+    <p class="govuk-body">When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:</p>
+    <p class="govuk-body">Information Commissioner.</p>
+    <p class="govuk-body"><%= mail_to 'icocasework@ico.org.uk' %></p>
+    <p class="govuk-body">Telephone: 0303 123 1113</p>
+    <p class="govuk-body">Textphone: 01625 545860</p>
+    <p class="govuk-body">Monday to Friday, 9am to 4:30pm</p>
+    <p class="govuk-body">
+      <%= link_to 'Find out about call charges', 'https://www.gov.uk/call-charges', class: 'govuk-link ', rel: 'external' %>
     </p>
-    <p class=" govuk-body ">
+    <p class="govuk-body">
       Information Commissioner's Office<br>
       Wycliffe House<br>
       Water Lane<br>
@@ -147,8 +148,8 @@
       SK9 5AF<br>
     </p>
 
-    <h2 class=" govuk-heading-l ">Changes to this policy</h2>
+    <h2 class="govuk-heading-l">Changes to this policy</h2>
 
-    <p class=" govuk-body ">We may change this privacy notice. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and your data immediately.</p>
+    <p class="govuk-body">We may change this privacy notice. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and your data immediately.</p>
   </div>
 </div>

--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -22,8 +22,6 @@
   </li>
 
   <li class="govuk-footer__inline-list-item">
-    <%# Destination needs validating %>
-
-    <%= link_to t('.terms_and_conditions'), 'https://www.gov.uk/government/publications/laa-online-portal-help-and-information', class: 'govuk-footer__link' %>
+    <%= link_to t('.terms_and_conditions'), Settings.portal_help_info_url, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -13,7 +13,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <a href="/about/privacy">LAA privacy policy</a></li>
+      <li>they’ve read the <%= link_to "LAA privacy notice", Settings.portal_help_info_url, class: "govuk-link", rel: "external", target: "_blank" %></li>
       <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy policy)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -13,7 +13,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <a class="govuk-link" rel="external" target="_blank" href="<%= Settings.portal_help_info_url %>">LAA privacy notice</a></li>
+      <li>they’ve read the <%= link_to 'LAA privacy notice', Settings.portal_help_info_url, class: 'govuk-link', rel: 'external' %></li>
       <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -13,7 +13,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <%= link_to 'LAA privacy notice', Settings.portal_help_info_url, class: 'govuk-link', rel: 'external' %></li>
+      <li>they’ve read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.portal_help_info_url, target: '_blank', rel: 'noopener' %></li>
       <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -13,7 +13,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <%= link_to "LAA privacy notice", Settings.portal_help_info_url, class: "govuk-link", rel: "external", target: "_blank" %></li>
+      <li>they’ve read the <a class="govuk-link" rel="external" target="_blank" href=<%= Settings.portal_help_info_url %>>LAA privacy notice</a></li>
       <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy policy)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -13,8 +13,8 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <a class="govuk-link" rel="external" target="_blank" href=<%= Settings.portal_help_info_url %>>LAA privacy notice</a></li>
-      <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy policy)</li>
+      <li>they’ve read the <a class="govuk-link" rel="external" target="_blank" href="<%= Settings.portal_help_info_url %>">LAA privacy notice</a></li>
+      <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>
       <li>the information they’ve given is complete and correct</li>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@ feature_flags:
 settings:
   portal_url: https://portal.legalservices.gov.uk
   eforms_url: https://portal.legalservices.gov.uk/oamfed/idp/initiatesso?providerid=eForms
+  portal_help_info_url: https://www.gov.uk/government/publications/laa-online-portal-help-and-information
   onboarding_email: LAAapplyonboarding@justice.gov.uk
   support_email: apply-for-criminal-legal-aid@justice.gov.uk
   case_enquiries_tel: 0300 200 2020


### PR DESCRIPTION
## Description of change
Updated privacy policy as per https://docs.google.com/document/d/1fVLqKKDMeZ2gIWfR99ULjPWh6TFT-xNdm5f22rlFPUA/edit
Decision was made not to duplicate the LAA-wide privacy policy, but to link out to the help and info page where the pdf is hosted. 
Updated link text in the declaration to "privacy notice" which is the title on the help and info page to ensure that it is clear which pdf we are directing the user to. 
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-398
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
