### PR TITLE
CRIMAP-405 Appeal case types do not trigger IoJ passport

### DIFF
--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -20,4 +20,11 @@ class CaseType < ValueObject
   def date_stampable?
     DATE_STAMPABLE.include?(self)
   end
+
+  def appeal?
+    [
+      APPEAL_TO_CROWN_COURT,
+      APPEAL_TO_CROWN_COURT_WITH_CHANGES,
+    ].include?(self)
+  end
 end

--- a/spec/value_objects/case_type_spec.rb
+++ b/spec/value_objects/case_type_spec.rb
@@ -56,4 +56,30 @@ RSpec.describe CaseType do
       end
     end
   end
+
+  describe '#appeal?' do
+    context 'for `appeal_to_crown_court` case type' do
+      it 'returns true' do
+        expect(
+          described_class::APPEAL_TO_CROWN_COURT.appeal?
+        ).to be(true)
+      end
+    end
+
+    context 'for `appeal_to_crown_court_with_changes` case type' do
+      it 'returns true' do
+        expect(
+          described_class::APPEAL_TO_CROWN_COURT_WITH_CHANGES.appeal?
+        ).to be(true)
+      end
+    end
+
+    context 'for a non-appeal case type' do
+      it 'returns false' do
+        expect(
+          described_class::INDICTABLE.appeal?
+        ).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
The appeal is a separate issue to the original proceedings trying the offence(s), and the defendant must demonstrate they have grounds for appeal by completing the IoJ reasons.

As a result, the offences on the appeal application cannot be IoJ passported either by offence or age.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-405

## How to manually test the feature
Where previously an application would have been IoJ passported, now selecting an appeal case type, will ignore the passporting (either under 18 or on offence). No other changes made.