### PR TITLE
Update portal doc links with fragment ids

### DIFF
--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -16,7 +16,7 @@
 
       <p class="govuk-body">
         For details of how the Legal Aid Agency collects and manages the personal data submitted within the application, check the
-        <%= link_to 'Legal Aid Agency privacy notice', Settings.portal_help_info_url, rel: 'external' %>.
+        <%= link_to 'Legal Aid Agency privacy notice', Settings.laa_privacy_notice_url, rel: 'external' %>.
       </p>
 
       <h2 class="govuk-heading-l">What data we collect</h2>
@@ -26,7 +26,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>
             your portal login and office account number provided by the LAA Portal service
-            (<%= link_to 'LAA Portal terms and conditions', Settings.portal_help_info_url, rel: 'external' %>)
+            (<%= link_to 'LAA Portal terms and conditions', Settings.portal_terms_url, rel: 'external' %>)
           </li>
           <li>
             your Internet Protocol (IP) address

--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -22,6 +22,6 @@
   </li>
 
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('.terms_and_conditions'), Settings.portal_help_info_url, class: 'govuk-footer__link' %>
+    <%= link_to t('.terms_and_conditions'), Settings.portal_terms_url, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -13,7 +13,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.portal_help_info_url, target: '_blank', rel: 'noopener' %></li>
+      <li>they’ve read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.laa_privacy_notice_url, target: '_blank', rel: 'noopener' %></li>
       <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
       <li>we can check their details with bank and credit reference agencies</li>
       <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,8 @@ feature_flags:
 settings:
   portal_url: https://portal.legalservices.gov.uk
   eforms_url: https://portal.legalservices.gov.uk/oamfed/idp/initiatesso?providerid=eForms
-  portal_help_info_url: https://www.gov.uk/government/publications/laa-online-portal-help-and-information
+  portal_terms_url: https://www.gov.uk/government/publications/laa-online-portal-help-and-information#attachment_6742318
+  laa_privacy_notice_url: https://www.gov.uk/government/publications/laa-online-portal-help-and-information#attachment_6742320
   onboarding_email: LAAapplyonboarding@justice.gov.uk
   support_email: apply-for-criminal-legal-aid@justice.gov.uk
   case_enquiries_tel: 0300 200 2020


### PR DESCRIPTION
## Description of change
Agreed with Fleur that adding fragment ids will assist with users finding the document we are getting them to navigate to. 

If the document id is updated, fragment will not cause a 404 but just result in the current behaviour. 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
