### PR TITLE
More precise `change` address link in Review page

### DIFF
--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -50,7 +50,18 @@ module Summary
       end
 
       def change_path(address)
-        edit_steps_address_details_path(address) if address.try(:to_param)
+        return unless address.try(:to_param)
+
+        if address.lookup_id.present?
+          # A postcode lookup was performed and an address was selected
+          edit_steps_address_results_path(address)
+        elsif address.address_line_one.present?
+          # Postcode lookup didn't return correct results, failed, or manual address
+          edit_steps_address_details_path(address)
+        else
+          # No address present, we take them to the postcode lookup
+          edit_steps_address_lookup_path(address)
+        end
       end
 
       def full_address(address)

--- a/spec/presenters/summary/sections/contact_details_spec.rb
+++ b/spec/presenters/summary/sections/contact_details_spec.rb
@@ -38,6 +38,7 @@ describe Summary::Sections::ContactDetails do
   let(:correspondence_address) do
     CorrespondenceAddress.new(
       id: 'e77e4fa3-76f1-4db6-8b92-72b36c8b327a',
+      lookup_id: 123,
       address_line_one: 'Test',
       address_line_two: 'Correspondence',
       postcode: 'Postcode',
@@ -84,13 +85,27 @@ describe Summary::Sections::ContactDetails do
 
       expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[2].question).to eq(:correspondence_address)
-      expect(answers[2].change_path).to match('applications/12345/steps/address/details/e77e4fa3')
+      expect(answers[2].change_path).to match('applications/12345/steps/address/results/e77e4fa3')
       expect(answers[2].value).to eq("Test\r\nCorrespondence\r\nPostcode\r\nCity\r\nCountry")
 
       expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[3].question).to eq(:telephone_number)
       expect(answers[3].change_path).to match('applications/12345/steps/client/contact_details')
       expect(answers[3].value).to eq('123456789')
+    end
+
+    context 'when client has no home address' do
+      # NOTE: a DB record will always be present, but its attributes will be nil
+      let(:home_address) { HomeAddress.new(id: 'ff53a8dd-43f3-4e82-acba-53b1c0ce2b4c') }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(4)
+
+        expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answers[0].question).to eq(:home_address)
+        expect(answers[0].change_path).to match('applications/12345/steps/address/lookup/ff53a8dd')
+        expect(answers[0].value).to eq('')
+      end
     end
 
     context 'for `home_address` correspondence type' do


### PR DESCRIPTION
## Description of change
Small QoL refinement.

We can direct the provider to a more precise page when they click the `change` link on an address in the Review application page.

- If the address has not been entered, on the Review page it shows as "None", and the change link will take the provider to the postcode lookup so they can start the address journey.

- If an address haas been selected via postcode lookup, the change link will take them back to the dropdown with the results, so they can either pick a different one, or go back to change the postcode and run again the lookup.

- If an address has been manually entered we take them directly to the details page where they can tweak any part of the address (line one, line two, city, country...)

