### PR TITLE
Enable prometheus exporter in production

### DIFF
--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -1,5 +1,6 @@
 module PrometheusMetrics
   module Configuration
+    DEFAULT_PREFIX = 'ruby_'.freeze
     SERVER_BINDING_HOST = '0.0.0.0'.freeze
     SERVER_BINDING_PORT = 9394
 
@@ -38,7 +39,7 @@ module PrometheusMetrics
       false
     end
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def self.configure
       return unless should_configure?
       return unless start_server
@@ -47,6 +48,9 @@ module PrometheusMetrics
       require 'prometheus_exporter/middleware'
 
       Rails.logger.info '[PrometheusExporter] Initialising middleware...'
+
+      # Metrics will be prefixed, for example `ruby_http_requests_total`
+      PrometheusExporter::Metric::Base.default_prefix = DEFAULT_PREFIX
 
       # This reports stats per request like HTTP status and timings
       Rails.application.middleware.unshift PrometheusExporter::Middleware
@@ -67,7 +71,7 @@ module PrometheusMetrics
       Rails.logger.info '[PrometheusExporter] Initialising ActiveRecord instrumentation...'
       PrometheusExporter::Instrumentation::ActiveRecord.start
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
     # :nocov:
   end
 end

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -12,6 +12,7 @@ data:
   GA_TRACKING_ID: G-ZKHETCMDR1
   SESSION_TIMEOUT_MINUTES: "60"
   REAUTHENTICATE_AFTER_MINUTES: "1440"
+  ENABLE_PROMETHEUS_EXPORTER: "true"
   DATASTORE_API_ROOT: http://service-production.laa-criminal-applications-datastore-production.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   LAA_PORTAL_IDP_METADATA_URL: https://portal.legalservices.gov.uk/oamfed/idp/metadata

--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -26,6 +26,7 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
+          - containerPort: 9394
         resources:
           requests:
             cpu: 25m

--- a/config/kubernetes/production/service.yml
+++ b/config/kubernetes/production/service.yml
@@ -16,7 +16,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-service-staging
+  name: prometheus-service-production
   namespace: laa-apply-for-criminal-legal-aid-production
   labels:
     app: apply-for-criminal-legal-aid-web-production

--- a/config/kubernetes/production/service.yml
+++ b/config/kubernetes/production/service.yml
@@ -12,3 +12,18 @@ spec:
     targetPort: 3000
   selector:
     app: apply-for-criminal-legal-aid-web-production
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service-staging
+  namespace: laa-apply-for-criminal-legal-aid-production
+  labels:
+    app: apply-for-criminal-legal-aid-web-production
+spec:
+  ports:
+  - port: 9394
+    name: metrics
+    targetPort: 9394
+  selector:
+    app: apply-for-criminal-legal-aid-web-production


### PR DESCRIPTION
## Description of change
Also, set the default prefix for prometheus metrics to `ruby_`. This was previously set in the background process which we don't run anymore.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-414
