### PR TITLE
Refactor application counters to use tags

### DIFF
--- a/app/lib/prometheus_metrics/applications_count_collector.rb
+++ b/app/lib/prometheus_metrics/applications_count_collector.rb
@@ -25,60 +25,46 @@ module PrometheusMetrics
 
     private
 
-    def total_count
-      counter = counter(
-        'crime_apply_total_applications_count',
-        'Number of application records'
+    def counter
+      PrometheusExporter::Metric::Counter.new(
+        'crime_apply_applications_count', 'Number of applications by status'
       )
+    end
 
+    def total_count
       result = Rails.cache.fetch(__method__, expires_in:) { CrimeApplication.count }
 
-      counter.observe(result)
-      counter
+      gauge = counter
+      gauge.observe(result, status: 'started')
+      gauge
     end
 
     def in_progress_count
-      counter = counter(
-        'crime_apply_in_progress_applications_count',
-        'Number of in progress applications'
-      )
-
       result = Rails.cache.fetch(__method__, expires_in:) { CrimeApplication.with_applicant.count }
 
-      counter.observe(result)
-      counter
+      gauge = counter
+      gauge.observe(result, status: 'in_progress')
+      gauge
     end
 
     def date_stamped_count
-      counter = counter(
-        'crime_apply_date_stamped_applications_count',
-        'Number of date stamped applications'
-      )
-
       result = Rails.cache.fetch(__method__, expires_in:) do
         CrimeApplication.where.not(date_stamp: nil).count
       end
 
-      counter.observe(result)
-      counter
+      gauge = counter
+      gauge.observe(result, status: 'date_stamped')
+      gauge
     end
 
     def stale_count
-      counter = counter(
-        'crime_apply_stale_applications_count',
-        'Number of stale applications (not updated for more than 1 week)'
-      )
-
       result = Rails.cache.fetch(__method__, expires_in:) do
         CrimeApplication.with_applicant.where(['crime_applications.updated_at < ?', 1.week.ago]).count
       end
 
-      counter.observe(result)
-      counter
-    end
-
-    def counter(name, help)
-      PrometheusExporter::Metric::Counter.new(name, help)
+      gauge = counter
+      gauge.observe(result, status: 'stale')
+      gauge
     end
   end
 end

--- a/spec/lib/prometheus_metrics/applications_count_collector_spec.rb
+++ b/spec/lib/prometheus_metrics/applications_count_collector_spec.rb
@@ -30,7 +30,12 @@ describe PrometheusMetrics::ApplicationsCountCollector do
     it 'calls the expected methods to gather metrics' do
       expect(
         subject.metrics.map(&:data)
-      ).to contain_exactly({ {} => 10 }, { {} => 8 }, { {} => 5 }, { {} => 2 })
+      ).to contain_exactly(
+        { { status: 'started' } => 10 },
+        { { status: 'in_progress' } => 8 },
+        { { status: 'date_stamped' } => 5 },
+        { { status: 'stale' } => 2 },
+      )
     end
 
     it 'uses Rails cache' do


### PR DESCRIPTION
## Description of change
This is more in line with how prometheus likes this kind of metrics and also makes it easier to visualise in graphs.

This is now the result:

```
# HELP ruby_crime_apply_applications_count Number of applications by status
# TYPE ruby_crime_apply_applications_count counter
ruby_crime_apply_applications_count{status="started"} 8

# HELP ruby_crime_apply_applications_count Number of applications by status
# TYPE ruby_crime_apply_applications_count counter
ruby_crime_apply_applications_count{status="in_progress"} 6

# HELP ruby_crime_apply_applications_count Number of applications by status
# TYPE ruby_crime_apply_applications_count counter
ruby_crime_apply_applications_count{status="date_stamped"} 5

# HELP ruby_crime_apply_applications_count Number of applications by status
# TYPE ruby_crime_apply_applications_count counter
ruby_crime_apply_applications_count{status="stale"} 3
```
