### PR TITLE
CRIMAP-275 Remove unused DWP check param

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -42,9 +42,11 @@ OMNIAUTH_TEST_MODE=true
 # ENABLE_PROMETHEUS_EXPORTER=true
 # PROMETHEUS_EXPORTER_VERBOSE=false
 
-# Benefit Checker configuration
-BC_LSC_SERVICE_NAME=<benefit_checker_service_name>
-BC_CLIENT_ORG_ID=<benefit_checker_organisation_id>
-BC_CLIENT_USER_ID=<benefit_checker_user_id>
-BC_WSDL_URL=<benefit_checker_wsdl_url>
-BC_USE_DEV_MOCK=<true or false>
+# Benefit Checker configuration. In local, it uses a mock by default
+# Refer to `services/dwp/mock_benefit_check_service.rb`
+# Ask a team member if you require these
+BC_USE_DEV_MOCK=true
+BC_LSC_SERVICE_NAME=
+BC_CLIENT_ORG_ID=
+BC_CLIENT_USER_ID=
+BC_WSDL_URL=

--- a/app/services/dwp/benefit_check_service.rb
+++ b/app/services/dwp/benefit_check_service.rb
@@ -22,7 +22,7 @@ module DWP
     end
 
     def self.use_mock?
-      ActiveModel::Type::Boolean.new.cast(Rails.configuration.x.benefit_checker.use_mock)
+      Rails.configuration.x.benefit_checker.use_mock.inquiry.true?
     end
 
     def call
@@ -39,11 +39,10 @@ module DWP
 
     def benefit_checker_params
       {
-        clientReference: applicant.id,
+        clientReference: applicant.crime_application_id,
         nino: applicant.nino,
         surname: applicant.last_name.strip.upcase,
         dateOfBirth: applicant.date_of_birth.strftime('%Y%m%d'),
-        dateOfAward: Time.zone.today.strftime('%Y%m%d'),
       }.merge(credential_params)
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module LaaApplyForCriminalLegalAid
     config.x.analytics.cookies_consent_name = 'crime_apply_cookies_consent'.freeze
     config.x.analytics.cookies_consent_expiration = 6.months
 
-    config.x.benefit_checker.use_mock = ENV.fetch('BC_USE_DEV_MOCK', false)
+    config.x.benefit_checker.use_mock = ENV.fetch('BC_USE_DEV_MOCK', 'false')
     config.x.benefit_checker.wsdl_url = ENV.fetch('BC_WSDL_URL', nil)
     config.x.benefit_checker.lsc_service_name = ENV.fetch('BC_LSC_SERVICE_NAME', nil)
     config.x.benefit_checker.client_org_id = ENV.fetch('BC_CLIENT_ORG_ID', nil)

--- a/spec/fixtures/files/benefit_checker_responses/successful.xml
+++ b/spec/fixtures/files/benefit_checker_responses/successful.xml
@@ -2,7 +2,7 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <soapenv:Body>
     <benefitCheckerResponse xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check">
-      <ns1:originalClientRef xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">x123</ns1:originalClientRef>
+      <ns1:originalClientRef xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">5678</ns1:originalClientRef>
       <ns2:benefitCheckerStatus xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus>
       <ns3:confirmationRef xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1675786402666</ns3:confirmationRef>
     </benefitCheckerResponse>

--- a/spec/services/dwp/benefit_check_service_spec.rb
+++ b/spec/services/dwp/benefit_check_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe DWP::BenefitCheckService do
   let(:date_of_birth) { '1980/01/10'.to_date }
   let(:nino) { 'JA293483A' }
   let(:id) { '123' }
+  let(:crime_application_id) { '5678' }
 
   let(:applicant) do
     double(
       Applicant,
+      crime_application_id:,
       id:,
       last_name:,
       date_of_birth:,
@@ -19,7 +21,7 @@ RSpec.describe DWP::BenefitCheckService do
     )
   end
 
-  let(:use_mock) { false }
+  let(:use_mock) { 'false' }
 
   before do
     allow(Rails.configuration.x.benefit_checker)
@@ -36,9 +38,10 @@ RSpec.describe DWP::BenefitCheckService do
     let(:expected_params) do
       hash_including(
         message: hash_including(
-          clientReference: applicant.id,
-          surname: applicant.last_name.strip.upcase,
-          dateOfBirth: applicant.date_of_birth.strftime('%Y%m%d'),
+          clientReference: '5678',
+          nino: 'JA293483A',
+          surname: 'WALKER',
+          dateOfBirth: '19800110',
         ),
       )
     end
@@ -48,6 +51,7 @@ RSpec.describe DWP::BenefitCheckService do
     context 'when the call is successful' do
       it 'returns the right parameters' do
         result = subject.new(applicant).call
+
         expect(result[:benefit_checker_status]).to eq('Yes')
         expect(result[:original_client_ref]).not_to be_empty
         expect(result[:confirmation_ref]).not_to be_empty
@@ -116,7 +120,7 @@ RSpec.describe DWP::BenefitCheckService do
     end
 
     describe 'behaviour with mock' do
-      let(:use_mock) { true }
+      let(:use_mock) { 'true' }
 
       it 'returns the right parameters' do
         expect(subject.passporting_benefit?(applicant)).to be(true)


### PR DESCRIPTION
## Description of change
Michael has confirmed the `dateOfAward` parameter is no longer needed, in any environment, so it is safe to be removed.

Make sure the `clientReference` can be traced back to one of our applications, so changed to the application UUID (because the applicant record UUID is not persisted anywhere post-submission).

Few other non-functional tweaks.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-275

## Notes for reviewer

## How to manually test the feature
Everything should keep working as before, no functional changes.