### PR TITLE
CRIMAP-415 Rename `passportable` to `slipstreamable`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.4.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.5.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 39186b9ebf3d71c00e3b53b506c936aed52429ef
-  tag: v0.4.0
+  revision: 86ed15ee153a473c77e9683e3f0e51895d9e935f
+  tag: v0.5.0
   specs:
-    laa-criminal-legal-aid-schemas (0.4.0)
+    laa-criminal-legal-aid-schemas (0.5.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -7,7 +7,7 @@ class Offence
                  :name,
                  :offence_class,
                  :offence_type,
-                 :ioj_passport
+                 :slipstreamable
 
   def self.find_by_name(name)
     find_by(name:)

--- a/app/serializers/submission_serializer/definitions/offence.rb
+++ b/app/serializers/submission_serializer/definitions/offence.rb
@@ -4,8 +4,8 @@ module SubmissionSerializer
       def to_builder
         Jbuilder.new do |json|
           json.name offence_name
-          json.offence_class offence.try(:offence_class)          # non-listed offences lack class
-          json.passportable offence.try(:ioj_passport) || false   # non-listed offences lack passporting
+          json.offence_class offence.try(:offence_class)             # non-listed offences lack this attribute
+          json.slipstreamable offence.try(:slipstreamable) || false  # non-listed offences lack this attribute
           json.dates do
             json.merge! offence_dates.as_json(only: [:date_from, :date_to])
           end

--- a/app/services/passporting/ioj_passporter.rb
+++ b/app/services/passporting/ioj_passporter.rb
@@ -31,8 +31,8 @@ module Passporting
       # Appeal cases do not trigger IoJ passporting
       return false if appeal_case_type?
 
-      FeatureFlags.offence_ioj_passport.enabled? &&
-        offences.any?(&:ioj_passport)
+      FeatureFlags.offence_ioj_slipstream.enabled? &&
+        offences.any?(&:slipstreamable)
     end
 
     def passport_types_collection

--- a/config/data/offences.csv
+++ b/config/data/offences.csv
@@ -1,4 +1,4 @@
-code,name,offence_type,offence_class,ioj_passport
+code,name,offence_type,offence_class,slipstreamable
 TH68010,"Theft from a shop (£30,000 or less)",CE Either Way,F,false
 TH68010,"Theft from a shop (Over £30,000 up to £100,000)",CE Either Way,G,false
 TH68010,"Theft from a shop (Over £100,000)",CE Either Way,K,false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,15 +6,15 @@ feature_flags:
   u18_means_passport:
     local: true
     staging: true
-    production: false
+    production: true
   u18_ioj_passport:
     local: true
     staging: true
-    production: false
-  offence_ioj_passport:
+    production: true
+  offence_ioj_slipstream:
     local: true
     staging: true
-    production: false
+    production: true
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Offence, type: :model do
         expect(subject.name).to eq('Assault by beating')
         expect(subject.offence_class).to eq('H')
         expect(subject.offence_type).to eq('CS Summary Non-Motoring')
-        expect(subject.ioj_passport).to be(true)
+        expect(subject.slipstreamable).to be(true)
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Offence, type: :model do
         expect(subject.code).to eq('RT88333')
         expect(subject.offence_class).to eq('H')
         expect(subject.offence_type).to eq('CM Summary - Motoring')
-        expect(subject.ioj_passport).to be(false)
+        expect(subject.slipstreamable).to be(false)
       end
     end
 

--- a/spec/serializers/submission_serializer/definitions/offence_spec.rb
+++ b/spec/serializers/submission_serializer/definitions/offence_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SubmissionSerializer::Definitions::Offence do
       {
         name: 'Common assault',
         offence_class: 'H',
-        passportable: true,
+        slipstreamable: true,
         dates: [
           { date_from: 'date_from_1', date_to: 'date_to_1' }, { date_from: 'date_from_2', date_to: nil }
         ],
@@ -21,7 +21,7 @@ RSpec.describe SubmissionSerializer::Definitions::Offence do
       {
         name: 'An unlisted offence',
         offence_class: nil,
-        passportable: false,
+        slipstreamable: false,
         dates: [
           { date_from: 'date_from_1', date_to: nil }
         ]

--- a/spec/services/passporting/ioj_passporter_spec.rb
+++ b/spec/services/passporting/ioj_passporter_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Passporting::IojPassporter do
 
     before do
       allow(
-        FeatureFlags.offence_ioj_passport
+        FeatureFlags.offence_ioj_slipstream
       ).to receive(:enabled?).and_return(feat_enabled)
     end
 


### PR DESCRIPTION
## Description of change
No functional changes other than this renaming.

Enabled the passport-related feature flags on production as we'll soon start doing some final round of testing before going live.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-415

## Notes for reviewer

## How to manually test the feature
No functional changes, everything should continue working as before. Just the attribute sent to the datastore has changed.

A separate PR to the datastore will follow.