### PR TITLE
CRIMAP-421 Configure Content Security Policy - CSP

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -8,6 +8,10 @@ exclude:
   - 'vendor/**/*'
 
 linters:
+  RequireScriptNonce:
+    enabled: true
+  NoJavascriptTagHelper:
+    enabled: false
   SpaceAroundErbTag:
     enabled: false
   PartialInstanceVariable:

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -49,6 +49,13 @@ if ($headerNavigation) {
   $headerNavigation.classList.remove("app-header-menu-hidden-on-load")
 }
 
+// Allow window.print(), otherwise blocked by CSP
+import PrintAction from "local/print-action"
+const $elements = document.querySelectorAll('[data-module="print"]')
+for (let i = 0; i < $elements.length; i++) {
+  new PrintAction($elements[i]).init()
+}
+
 // Google analytics additional tracking
 // Keep this at the bottom of this file
 import GAEvents from "local/ga-events"

--- a/app/javascript/local/print-action.js
+++ b/app/javascript/local/print-action.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function PrintAction($element) {
+  this.$element = $element
+}
+
+PrintAction.prototype.init = function() {
+  const self = this
+  this.$element.addEventListener('click', self.print.bind(self))
+}
+
+PrintAction.prototype.print = function(e) {
+  window.print()
+  e.preventDefault()
+}
+
+export default PrintAction

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -26,13 +26,13 @@
     <% end %>
 
     <div class="govuk-!-margin-top-8 app-no-print">
-      <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+      <%= link_button t('.print_application'), '#', data: { module: 'print' } %>
     </div>
 
     <%= render @presenter.sections %>
 
     <div class="govuk-button-group govuk-!-margin-top-8 app-no-print">
-      <%= link_button t('.print_application'), '#', onclick: 'window.print(); return false;' %>
+      <%= link_button t('.print_application'), '#', data: { module: 'print' } %>
       <%= link_button t('helpers.back_to_applications'), crime_applications_path, class: 'govuk-button--secondary' %>
     </div>
   </div>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,7 +1,8 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytics_tracking_id %>"></script>
-<script>
+<%= javascript_include_tag "https://www.googletagmanager.com/gtag/js?id=#{analytics_tracking_id}", async: true, nonce: true %>
+
+<%= javascript_tag nonce: true do %>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', <%== analytics_tracking_id.to_json %>, { 'anonymize_ip': true, 'allow_google_signals': false });
-</script>
+<% end %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -25,9 +25,9 @@
 </head>
 
 <body class="govuk-template__body app-body <%= ['app-body', HostEnv.env_name].join('--') %>">
-<script>
+<%= javascript_tag nonce: true do %>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-</script>
+<% end %>
 
 <%= yield(:cookie_banner) unless controller_name == 'cookies' %>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,23 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :none
+    policy.style_src   :self
+    policy.font_src    :self, :data
+    policy.img_src     :self, :data, 'https://*.google-analytics.com', 'https://*.googletagmanager.com'
+    policy.connect_src :self, 'https://ga.jspm.io', 'https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com'
+    policy.script_src  :self, 'https://ga.jspm.io', 'https://*.googletagmanager.com'
+    policy.form_action :self, 'https://*.legalservices.gov.uk/oamfed/idp/samlv20'
+
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
## Description of change
Configure and enforce Configure Content Security Policy.

It will block all fetch directives by default. Other directives added as needed (for example GA and Portal).

Had to change the way the print worked as no inline JS is now allowed.

I didn't find any issues or violations on my testing but we should keep an eye.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-421

## Notes for reviewer

## How to manually test the feature
Just use the service as usual, everything should keep working as before and no violations are reported in the browser console.