### PR TITLE
CRIMAP-425 update u18 no nino and CRIMAP-424 update not enrolled message 

### DIFF
--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-!-margin-bottom-9">
       <h1 class="govuk-heading-xl">Privacy notice</h1>
-      <p class="govuk-body">The 'Apply for criminal legal aid' service is provided by the
+      <p class="govuk-body">The ‘<%= service_name %>’ service is provided by the
         <%= link_to 'Legal Aid Agency (LAA)', 'https://www.gov.uk/government/organisations/legal-aid-agency/', rel: 'external' %>,
         part of the Ministry of Justice (MoJ).
       </p>
@@ -143,7 +143,7 @@
         <%= link_to 'Find out about call charges', 'https://www.gov.uk/call-charges', rel: 'external' %>
       </p>
       <p class="govuk-body">
-        Information Commissioner's Office<br>
+        Information Commissioner’s Office<br>
         Wycliffe House<br>
         Water Lane<br>
         Wilmslow<br>

--- a/app/views/cookies/show.en.html.erb
+++ b/app/views/cookies/show.en.html.erb
@@ -9,7 +9,7 @@
 
     <h1 class="govuk-heading-xl">Cookies</h1>
 
-    <p class="govuk-body">The '<%= service_name -%>' service puts small files (known as ‘cookies’) onto your device to collect
+    <p class="govuk-body">The ‘<%= service_name %>’ service puts small files (known as ‘cookies’) onto your device to collect
       information about how you use the service.</p>
 
     <p class="govuk-body">You’ll normally see a message on the site before we set a cookie on your device.</p>
@@ -18,7 +18,7 @@
 
     <p class="govuk-body">Find out
       <a class="govuk-link" rel="external" target="_blank" href="https://ico.org.uk/for-the-public/online/cookies">how
-        to manage cookies</a> from the Information Commissioner's Office.</p>
+        to manage cookies</a> from the Information Commissioner’s Office.</p>
 
     <h2 class="govuk-heading-l">Essential cookies (strictly necessary)</h2>
 

--- a/app/views/errors/not_enrolled.en.html.erb
+++ b/app/views/errors/not_enrolled.en.html.erb
@@ -13,13 +13,12 @@
     </p>
 
     <p class="govuk-body app-inverted-text">
-      You should apply using eForms for now.
+      We'll contact your law firm when you can use this service. Until then, you should apply using eForms.
     </p>
 
     <p class="govuk-body app-inverted-text">
-      Your law firm can register interest to use an early version of the service by emailing
-      <%= mail_to Settings.onboarding_email, class: 'app-link--inverted' %>. Otherwise, we’ll
-      contact you when you’re able to use it.
+      Contact <%= mail_to Settings.onboarding_email, class: 'app-link--inverted' %>
+      if you have any questions.
     </p>
 
     <div class="govuk-button-group govuk-!-margin-top-6">

--- a/app/views/errors/not_enrolled.en.html.erb
+++ b/app/views/errors/not_enrolled.en.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body app-inverted-text">
-      We'll contact your law firm when you can use this service. Until then, you should apply using eForms.
+      We’ll contact your law firm when you can use this service. Until then, you should apply using eForms.
     </p>
 
     <p class="govuk-body app-inverted-text">

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -14,7 +14,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the case is ongoing</li>
-      <li>you know your client's National Insurance number (if they are 18 years old or over)</li>
+      <li>you know your client’s National Insurance number (if they are 18 years old or over)</li>
       <li>your client does not have a partner</li>
       <li>your client receives a passporting benefit, including Universal Credit</li>
     </ul>

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -9,19 +9,12 @@
     </h1>
 
     <p class="govuk-body">
-      Use this service to apply for criminal legal aid.
+      Use this service to apply for criminal legal aid if:
     </p>
 
-    <h3 class="govuk-heading-m">
-      Before you start
-    </h3>
-
-    <p class="govuk-body">
-      You can only use this service if:
-    </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the case is ongoing</li>
-      <li>you know your client's National Insurance number</li>
+      <li>you know your client's National Insurance number (if they are 18 years old or over)</li>
       <li>your client does not have a partner</li>
       <li>your client receives a passporting benefit, including Universal Credit</li>
     </ul>

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -6,7 +6,7 @@
 
     <ul class="govuk-list govuk-list--bullet app-inverted-text">
       <li>has a partner</li>
-      <li>does not have a National Insurance number </li>
+      <li>does not have a National Insurance number (if they are 18 years old or over)</li>
       <li>does not receive a passporting benefit based on DWP records, including Universal Credits</li>
       <li>is employed, including self-employed, business partner, company director or shareholder</li>
     </ul>

--- a/config/kubernetes/staging/grafana-applications.yml
+++ b/config/kubernetes/staging/grafana-applications.yml
@@ -139,7 +139,7 @@ data:
           "datasource": {
             "uid": "$datasource"
           },
-          "description": "An application is considered in progress when at least the applicant's first name has been entered",
+          "description": "An application is considered in progress when at least the applicant’s first name has been entered",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -4,7 +4,7 @@ en:
     index:
       page_title: Your applications
       delete_button: Delete
-      delete_button_a11y: Delete %{applicant_name}'s application
+      delete_button_a11y: Delete %{applicant_name}’s application
       table_headings:
         applicant_name: Name
         created_at: Start date
@@ -77,7 +77,7 @@ en:
         default_html: ""
         split_case_html: |
           <p class="govuk-body">
-            We've returned your application because you need to add justification for all offences. This is because the case has been 'split'.
+            We’ve returned your application because you need to add justification for all offences. This is because the case has been ’split’.
           </p>
           <p class="govuk-body">
             A case is split into multiple cases when CPS decides offences are not related enough to be tried at the same time.

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -129,7 +129,7 @@ en:
         country: Country
         postcode: Postcode
       steps_case_urn_form:
-        urn: Enter the unique reference number (URN) for your client's case (optional)
+        urn: Enter the unique reference number (URN) for your client’s case (optional)
       steps_case_case_type_form:
         case_type_options:
           summary_only: Summary only

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>The page you were looking for doesn’t exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -58,7 +58,7 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
+      <h1>The page you were looking for doesn’t exist.</h1>
       <p>You may have mistyped the address or the page may have moved.</p>
     </div>
     <p>If you are the application owner check the logs for more information.</p>

--- a/public/422.html
+++ b/public/422.html
@@ -59,7 +59,7 @@
   <div class="dialog">
     <div>
       <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+      <p>Maybe you tried to change something you didn’t have access to.</p>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>

--- a/public/500.html
+++ b/public/500.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+v<!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>We’re sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -58,7 +58,7 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>We’re sorry, but something went wrong.</h1>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Dashboard', authorized: true do
         assert_select 'h2', 'Important'
         assert_select 'div.govuk-notification-banner__content' do
           assert_select 'h3', 'You need to tell us why your client should get legal aid'
-          assert_select 'p.govuk-body', "We've returned your application because you need to add justification for all offences. This is because the case has been 'split'."
+          assert_select 'p.govuk-body', 'We’ve returned your application because you need to add justification for all offences. This is because the case has been ’split’.'
           assert_select 'p.govuk-body', 'A case is split into multiple cases when CPS decides offences are not related enough to be tried at the same time.'
           assert_select 'p.govuk-body', 'The caseworker who returned this application says: Offence 1 reason requires more detail'
           assert_select 'button.govuk-button', count: 1, text: 'Add justification'


### PR DESCRIPTION
## Description of change
CRIMAP-425 update start page and eforms redirect page to include that u18 clients don't need a NINO
CRIMAP-424 update not enrolled message to remove suggestion that provider can join beta upon request

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-425
https://dsdmoj.atlassian.net/browse/CRIMAP-424
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="947" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/8eadae24-3672-4afa-b080-701e8f39883b">
<img width="1165" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/a8a54913-5345-4991-811d-cbf7c803210c">
<img width="1118" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/d7cceb24-c50a-483f-ad0e-d11a9da5d6f7">

### After changes:
<img width="922" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/6ecc5881-77f6-47b4-9841-70c0d4fc6199">
<img width="1017" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/d9feabce-cfaa-45f3-a841-65ff4b3501e3">

<img width="1006" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/d8b996dc-77a9-4339-8fd0-1d2c48949f30">

## How to manually test the feature
