### PR TITLE
Fix cookie banner JS module blocked by browsers

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,12 +4,12 @@
 import { initAll } from 'govuk-frontend'
 initAll()
 
-// Cookie banner
+// Cookie banner -- Script name is obfuscated to avoid browsers blocking it
 // https://design-system.service.gov.uk/components/cookie-banner/
-import CookieBanner from "local/cookie-banner"
+import Cbc from "local/cbc"
 const $cookieBanner = document.querySelector('[data-module="govuk-cookie-banner"]')
 if ($cookieBanner) {
-  new CookieBanner($cookieBanner).init()
+  new Cbc($cookieBanner).init()
 }
 
 // NOTE: suggestions input component not yet part of GOV.UK frontend

--- a/app/javascript/local/cbc.js
+++ b/app/javascript/local/cbc.js
@@ -1,11 +1,11 @@
 'use strict';
 
-function CookieBanner($module) {
+function Cbc($module) {
   this.$cookieBanner = $module
   this.$hideButtonSelector = '.app--js-cookie-banner-hide'
 }
 
-CookieBanner.prototype.init = function () {
+Cbc.prototype.init = function () {
   const self = this,
         $hideButton = this.$cookieBanner.querySelector(this.$hideButtonSelector)
 
@@ -14,9 +14,9 @@ CookieBanner.prototype.init = function () {
   }
 }
 
-CookieBanner.prototype.hideBanner = function (e) {
+Cbc.prototype.hideBanner = function (e) {
   this.$cookieBanner.setAttribute('hidden', true)
   e.preventDefault()
 }
 
-export default CookieBanner
+export default Cbc


### PR DESCRIPTION
## Description of change
Some browsers come with built in extra privacy measures, and also some plugins can be used to block some "annoyances" like cookie banners.

Main issue was, the blocking was stopping other genuine modules from being properly loaded by the browser, making some functionality that relies on JS fail, like the offences list, or the print button.

Seems to be "fixed" by obfuscating the name of the JS module so it doesn't contain keywords that are likely to be blocked, like `cookie`, `banner` or `consent`.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)
![Screenshot 2023-06-30 at 15 57 10](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/feaef4ef-c5b5-452c-a3bc-6bafcf1a1869)
