### PR TITLE
CRIMAP-427 First part of appeal details refactor

### DIFF
--- a/app/controllers/steps/case/appeal_details_controller.rb
+++ b/app/controllers/steps/case/appeal_details_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class AppealDetailsController < Steps::CaseStepController
+      def edit
+        @form_object = AppealDetailsForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(AppealDetailsForm, as: :appeal_details)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/appeal_details_form.rb
+++ b/app/forms/steps/case/appeal_details_form.rb
@@ -1,0 +1,34 @@
+module Steps
+  module Case
+    class AppealDetailsForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :case
+
+      attribute :appeal_lodged_date, :multiparam_date
+      attribute :appeal_with_changes_details, :string
+      attribute :appeal_maat_id, :string
+
+      validates :appeal_lodged_date,
+                presence: true, multiparam_date: true
+
+      validates :appeal_with_changes_details,
+                presence: true, if: -> { appeal_with_changes? }
+
+      def appeal_with_changes?
+        case_type.appeal_to_crown_court_with_changes?
+      end
+
+      private
+
+      def persist!
+        kase.update(
+          attributes
+        )
+      end
+
+      def case_type
+        CaseType.new(kase.case_type)
+      end
+    end
+  end
+end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -12,6 +12,10 @@ class Case < ApplicationRecord
     end
   end
 
+  # Temporarily, because some applications in datastore might
+  # have this, now unused, attribute, to be able to re-hydrate
+  alias_attribute :appeal_with_changes_maat_id, :appeal_maat_id
+
   private
 
   def initialise_dates(charge)

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -22,25 +22,22 @@ module Summary
             change_path: edit_steps_case_case_type_path
           ),
 
+          Components::DateAnswer.new(
+            :appeal_lodged_date, kase.appeal_lodged_date,
+            change_path: edit_steps_case_appeal_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :appeal_with_changes_details, kase.appeal_with_changes_details,
+            change_path: edit_steps_case_appeal_details_path
+          ),
+
           # This is an optional field, depending on case type
           # If it is an empty string (not nil), it will show as `None`
           Components::FreeTextAnswer.new(
             :previous_maat_id, kase.appeal_maat_id,
             show: !kase.appeal_maat_id.nil?,
-            change_path: edit_steps_case_case_type_path
-          ),
-
-          # This is an optional field, depending on case type
-          # If it is an empty string (not nil), it will show as `None`
-          Components::FreeTextAnswer.new(
-            :previous_maat_id, kase.appeal_with_changes_maat_id,
-            show: !kase.appeal_with_changes_maat_id.nil?,
-            change_path: edit_steps_case_case_type_path
-          ),
-
-          Components::FreeTextAnswer.new(
-            :appeal_with_changes_details, kase.appeal_with_changes_details,
-            change_path: edit_steps_case_case_type_path
+            change_path: edit_steps_case_appeal_details_path
           ),
         ].select(&:show?)
       end

--- a/app/serializers/submission_serializer/sections/case_details.rb
+++ b/app/serializers/submission_serializer/sections/case_details.rb
@@ -8,7 +8,8 @@ module SubmissionSerializer
             json.urn kase.urn
             json.case_type kase.case_type
             json.appeal_maat_id kase.appeal_maat_id
-            json.appeal_with_changes_maat_id kase.appeal_with_changes_maat_id
+            json.appeal_with_changes_maat_id nil # TODO: to be removed in schemas/fixtures
+            json.appeal_lodged_date kase.appeal_lodged_date
             json.appeal_with_changes_details kase.appeal_with_changes_details
             json.hearing_court_name kase.hearing_court_name
             json.hearing_date kase.hearing_date

--- a/app/services/adapters/structs/case_details.rb
+++ b/app/services/adapters/structs/case_details.rb
@@ -20,6 +20,11 @@ module Adapters
         codefendants.any? ? YesNoAnswer::YES : YesNoAnswer::NO
       end
 
+      # TODO: to be added to schemas/fixtures
+      def appeal_lodged_date
+        nil
+      end
+
       def serializable_hash(options = {})
         super(
           options.merge(

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -1,4 +1,5 @@
 module Decisions
+  # rubocop:disable Metrics/ClassLength
   class CaseDecisionTree < BaseDecisionTree
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
     def destination
@@ -7,6 +8,8 @@ module Decisions
         edit(:case_type)
       when :case_type
         after_case_type
+      when :appeal_details
+        date_stamp_if_needed
       when :date_stamp
         charges_summary_or_edit_new_charge
       when :charges
@@ -38,6 +41,12 @@ module Decisions
     private
 
     def after_case_type
+      return edit(:appeal_details) if form_object.case_type.appeal?
+
+      date_stamp_if_needed
+    end
+
+    def date_stamp_if_needed
       if DateStamper.new(form_object.crime_application, form_object.case.case_type).call
         edit(:date_stamp)
       else
@@ -126,4 +135,5 @@ module Decisions
       current_charge.offence_dates.map(&:date_from).exclude?(nil)
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/views/steps/case/appeal_details/edit.en.html.erb
+++ b/app/views/steps/case/appeal_details/edit.en.html.erb
@@ -1,0 +1,22 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_date_field :appeal_lodged_date, maxlength_enabled: true, legend: { size: 's' } %>
+
+      <%= f.govuk_text_area :appeal_with_changes_details,
+                            label: { size: 's' } if @form_object.appeal_with_changes? %>
+
+      <%= f.govuk_text_field :appeal_maat_id, autocomplete: 'off', width: 'one-third',
+                             extra_letter_spacing: true, label: { size: 's' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/case/case_type/edit.html.erb
+++ b/app/views/steps/case/case_type/edit.html.erb
@@ -6,32 +6,9 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:case_type, legend: { tag: 'h1', size: 'xl' }) do %>
-        <% @form_object.choices.each_with_index do |choice, index| %>
-          <% if choice == CaseType::APPEAL_TO_CROWN_COURT %>
+      <%= f.govuk_collection_radio_buttons :case_type, @form_object.choices,
+                                           :value, legend: { tag: 'h1', size: 'xl' } %>
 
-            <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :appeal_maat_id, autocomplete: 'off', width: 'one-third',
-                                     extra_letter_spacing: true %>
-            <% end %>
-
-          <% elsif choice == CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES %>
-
-            <%= f.govuk_radio_button :case_type, choice.value do %>
-              <%= f.govuk_text_field :appeal_with_changes_maat_id, autocomplete: 'off', width: 'one-third',
-                                     extra_letter_spacing: true %>
-              <%= f.govuk_text_area :appeal_with_changes_details,
-                                    'aria-live': 'polite',
-                                    'aria-label': t("helpers.label.#{f.object_name}.appeal_with_changes_details_a11y") %>
-            <% end %>
-
-          <% else %>
-
-            <%= f.govuk_radio_button :case_type, choice.value, link_errors: index.zero? %>
-
-          <% end %>
-        <% end %>
-      <% end %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -83,9 +83,18 @@ en:
           attributes:
             case_type:
               inclusion: Select a case type
+        steps/case/appeal_details_form:
+          attributes:
             appeal_with_changes_details:
-              blank: Add the details of what has changed
-              present: Details of what has changed are required for Appeal to Crown Court with changes to financial circumstances only
+              blank: Enter details of changes in financial circumstances
+            appeal_lodged_date:
+              blank: Enter the date the appeal was lodged
+              invalid: Enter a valid appeal lodged date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date the appeal was lodged is too far in the past
+              future_not_allowed: Date the appeal was lodged must be today or in the past
         steps/case/has_codefendants_form:
           attributes:
             has_codefendants:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -89,7 +89,7 @@ en:
               blank: Enter details of changes in financial circumstances
             appeal_lodged_date:
               blank: Enter the date the appeal was lodged
-              invalid: Enter a valid appeal lodged date
+              invalid: Enter a valid date
               invalid_day: Enter a valid day
               invalid_month: Enter a valid month
               invalid_year: Enter a valid year

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -66,7 +66,7 @@ en:
       steps_address_lookup_form:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
       steps_case_urn_form:
-        urn: For example, ‘12 AB 3456789’
+        urn: For example, ‘12 AB 3456789’.
       steps_case_appeal_details_form:
         appeal_lodged_date: For example, 27 3 2007
       steps_case_charges_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -38,6 +38,8 @@ en:
         confirm_details: Are these details correct?
       steps_case_case_type_form:
         case_type: What is the case type?
+      steps_case_appeal_details_form:
+        appeal_lodged_date: Date the appeal was lodged
       steps_case_charges_form:
         date_from: Start date %{index}
         date_to: End date %{index} (optional)
@@ -64,7 +66,9 @@ en:
       steps_address_lookup_form:
         postcode: This must be a valid UK postcode. For example, SW1A 2AA.
       steps_case_urn_form:
-        urn: For example, ‘12 AB 3456789’.
+        urn: For example, ‘12 AB 3456789’
+      steps_case_appeal_details_form:
+        appeal_lodged_date: For example, 27 3 2007
       steps_case_charges_form:
         offence_name: Add one offence at a time, for example, robbery. You can add more later.
         offence_dates_attributes:
@@ -139,10 +143,9 @@ en:
           committal: Committal for sentence
           appeal_to_crown_court: Appeal to crown court
           appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
+      steps_case_appeal_details_form:
         appeal_maat_id: Previous MAAT ID (optional)
-        appeal_with_changes_maat_id: Previous MAAT ID (optional)
-        appeal_with_changes_details: Enter the details of what has changed
-        appeal_with_changes_details_a11y: Enter details of what has changed regarding your clients financial circumstances
+        appeal_with_changes_details: Details of changes in financial circumstances
       steps_case_charges_form:
         offence_name: Offence
       steps_case_charges_summary_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -119,8 +119,11 @@ en:
           urn_guidance: This makes it easier for LAA caseworkers to match the details you provide with HM Courts & Tribunals (HMCTS) records
       case_type:
         edit:
-          page_title: Enter the case type
-          heading:  Enter the case type
+          page_title: What is the case type?
+      appeal_details:
+        edit:
+          page_title: Enter the appeal details
+          heading: Enter details of your client’s appeal to Crown Court
       date_stamp:
         edit:
           page_title: Your application has been date stamped

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -87,6 +87,8 @@ en:
       previous_maat_id:
         question: Previous MAAT ID
         absence_answer: *absence_none
+      appeal_lodged_date:
+        question: Date lodged
       appeal_with_changes_details:
         question: Change details
       # END case details section

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
       namespace :case do
         edit_step :urn
         edit_step :case_type
+        edit_step :appeal_details
         edit_step :date_stamp
         crud_step :charges, param: :charge_id
         edit_step :charges_summary

--- a/db/migrate/20230704081647_refactor_appeal_case_fields.rb
+++ b/db/migrate/20230704081647_refactor_appeal_case_fields.rb
@@ -1,0 +1,11 @@
+class RefactorAppealCaseFields < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :cases, :appeal_with_changes_maat_id, :appeal_lodged_date
+    change_column :cases, :appeal_lodged_date, :date, using: 'NULL::date'
+  end
+
+  def down
+    rename_column :cases, :appeal_lodged_date, :appeal_with_changes_maat_id
+    change_column :cases, :appeal_with_changes_maat_id, :string, using: 'NULL::varchar'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_100803) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_04_081647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -37,7 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_100803) do
     t.datetime "updated_at", null: false
     t.string "case_type"
     t.string "appeal_maat_id"
-    t.string "appeal_with_changes_maat_id"
+    t.date "appeal_lodged_date"
     t.text "appeal_with_changes_details"
     t.string "has_codefendants"
     t.string "hearing_court_name"

--- a/spec/controllers/steps/case/appeal_details_controller_spec.rb
+++ b/spec/controllers/steps/case/appeal_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::AppealDetailsController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::AppealDetailsForm, Decisions::CaseDecisionTree
+end

--- a/spec/forms/steps/case/appeal_details_form_spec.rb
+++ b/spec/forms/steps/case/appeal_details_form_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::AppealDetailsForm do
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      appeal_maat_id:,
+      appeal_lodged_date:,
+      appeal_with_changes_details:,
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, case: case_record) }
+  let(:case_record) { Case.new(case_type:) }
+
+  let(:case_type) { nil }
+  let(:appeal_maat_id) { nil }
+  let(:appeal_lodged_date) { nil }
+  let(:appeal_with_changes_details) { nil }
+
+  describe 'validations' do
+    context 'when case type is `appeal_to_crown_court`' do
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
+
+      it { is_expected.to validate_presence_of(:appeal_lodged_date) }
+
+      it { is_expected.not_to validate_presence_of(:appeal_with_changes_details) }
+      it { is_expected.not_to validate_presence_of(:appeal_maat_id) }
+
+      it_behaves_like 'a multiparam date validation',
+                      attribute_name: :appeal_lodged_date,
+                      allow_past: true, allow_future: false
+    end
+
+    context 'when case type is `appeal_to_crown_court_with_changes`' do
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES.to_s }
+      let(:appeal_with_changes_details) { 'mandatory details' }
+
+      it { is_expected.to validate_presence_of(:appeal_lodged_date) }
+      it { is_expected.to validate_presence_of(:appeal_with_changes_details) }
+
+      it { is_expected.not_to validate_presence_of(:appeal_maat_id) }
+
+      it_behaves_like 'a multiparam date validation',
+                      attribute_name: :appeal_lodged_date,
+                      allow_past: true, allow_future: false
+    end
+  end
+
+  describe '#save' do
+    before do
+      allow(subject).to receive(:kase).and_return(case_record)
+    end
+
+    let(:appeal_lodged_date) { Time.zone.today }
+    let(:appeal_maat_id) { '12345678' }
+
+    context 'when case type is `appeal_to_crown_court`' do
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
+
+      it 'updates the record' do
+        expect(case_record).to receive(:update).with(
+          {
+            'appeal_maat_id' => appeal_maat_id,
+            'appeal_lodged_date' => appeal_lodged_date,
+            'appeal_with_changes_details' => nil,
+          }
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when case type is `appeal_to_crown_court_with_changes`' do
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES.to_s }
+      let(:appeal_with_changes_details) { 'mandatory details' }
+
+      it 'updates the record' do
+        expect(case_record).to receive(:update).with(
+          {
+            'appeal_maat_id' => appeal_maat_id,
+            'appeal_lodged_date' => appeal_lodged_date,
+            'appeal_with_changes_details' => appeal_with_changes_details,
+          }
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/case/case_type_form_spec.rb
+++ b/spec/forms/steps/case/case_type_form_spec.rb
@@ -5,25 +5,18 @@ RSpec.describe Steps::Case::CaseTypeForm do
 
   let(:arguments) do
     {
-      crime_application:,
-      case_type:,
-      appeal_maat_id:,
-      appeal_with_changes_maat_id:,
-      appeal_with_changes_details:
+      crime_application: crime_application,
+      record: case_record,
+      case_type: case_type,
     }
   end
 
-  let(:crime_application) do
-    instance_double(CrimeApplication, date_stamp: nil, case: kase)
-  end
+  let(:crime_application) { instance_double(CrimeApplication, case: case_record) }
+  let(:case_record) { Case.new }
 
-  let(:kase) { Case.new }
-  let(:case_type) { nil }
-  let(:appeal_maat_id) { nil }
-  let(:appeal_with_changes_maat_id) { nil }
-  let(:appeal_with_changes_details) { nil }
+  let(:case_type) { CaseType::INDICTABLE.to_s }
 
-  describe '#save' do
+  describe 'validations' do
     context 'when `case_type` is blank' do
       let(:case_type) { '' }
 
@@ -43,130 +36,35 @@ RSpec.describe Steps::Case::CaseTypeForm do
     end
 
     context 'when `case_type` is valid' do
-      let(:case_type) { CaseType::INDICTABLE.to_s }
-
       it { is_expected.to be_valid }
+    end
+  end
 
-      it 'passes validation' do
-        expect(form.errors.of_kind?(:case_type, :invalid)).to be(false)
-      end
-
-      context 'when non-appeal case type' do
-        context 'with a previous MAAT ID' do
-          let(:appeal_maat_id) { '123456' }
-          let(:appeal_with_changes_maat_id) { '234567' }
-
-          it { is_expected.to be_valid }
-
-          it 'can make MAAT ID fields nil if case types do not require them' do
-            attributes = form.send(:attributes_to_reset)
-            expect(attributes['appeal_maat_id']).to be_nil
-            expect(attributes['appeal_with_changes_maat_id']).to be_nil
-          end
-        end
-
-        context 'with details of a change of financial circumstances' do
-          let(:appeal_with_changes_details) { 'These are the details' }
-
-          it 'can financial change details nil if case type doesnt require it' do
-            attributes = form.send(:attributes_to_reset)
-            expect(form).to be_valid
-            expect(attributes['appeal_with_changes_details']).to be_nil
-          end
-        end
-      end
-
-      context 'when Appeal to crown court' do
-        context 'with a previous MAAT ID' do
-          let(:case_type) { 'appeal_to_crown_court' }
-          let(:appeal_maat_id) { '123456' }
-
-          it 'is valid' do
-            expect(form).to be_valid
-            expect(
-              form.errors.of_kind?(
-                :appeal_maat_id,
-                :present
-              )
-            ).to be(false)
-          end
-
-          it 'cannot reset MAAT IDs as the are relevant to this case type' do
-            attributes = form.send(:attributes_to_reset)
-            expect(attributes['appeal_maat_id']).to eq(appeal_maat_id)
-          end
-        end
-
-        context 'without a previous MAAT ID' do
-          let(:case_type) { 'appeal_to_crown_court' }
-
-          it 'is also valid' do
-            expect(form).to be_valid
-            expect(
-              form.errors.of_kind?(
-                :appeal_maat_id,
-                :present
-              )
-            ).to be(false)
-          end
-        end
-      end
-
-      context 'when Appeal to crown court with changes in financial circumstances' do
-        context 'with details of what has changed' do
-          let(:case_type) { 'appeal_to_crown_court_with_changes' }
-          let(:appeal_with_changes_maat_id) { '123456' }
-          let(:appeal_with_changes_details) { 'These are the details' }
-
-          it 'is valid' do
-            expect(form).to be_valid
-            expect(
-              form.errors.of_kind?(
-                :appeal_with_changes_details,
-                :present
-              )
-            ).to be(false)
-          end
-
-          it 'cannot reset MAAT IDs as the are relevant to this case type' do
-            attributes = form.send(:attributes_to_reset)
-            expect(attributes['appeal_with_changes_maat_id']).to eq(appeal_with_changes_maat_id)
-          end
-
-          it 'cannot reset change details as the are relevant to this case type' do
-            attributes = form.send(:attributes_to_reset)
-            expect(attributes['appeal_with_changes_details']).to eq(appeal_with_changes_details)
-          end
-        end
-
-        context 'with no details of what has changed' do
-          let(:case_type) { 'appeal_to_crown_court_with_changes' }
-          let(:appeal_maat_id) { '123456' }
-
-          it 'is invalid' do
-            expect(form).not_to be_valid
-            expect(
-              form.errors.of_kind?(
-                :appeal_with_changes_details,
-                :blank
-              )
-            ).to be(true)
-          end
-        end
-      end
+  describe '#save' do
+    before do
+      allow(case_record).to receive(:case_type).and_return(previous_case_type)
     end
 
-    context 'when validations pass' do
-      let(:case_type) { CaseType::INDICTABLE.to_s }
+    context 'when the case type has changed' do
+      let(:previous_case_type) { CaseType::SUMMARY_ONLY.to_s }
 
       it_behaves_like 'a has-one-association form',
                       association_name: :case,
                       expected_attributes: {
                         'case_type' => CaseType::INDICTABLE,
-                        'appeal_maat_id' => nil,
-                        'appeal_with_changes_maat_id' => nil,
-                        'appeal_with_changes_details' => nil
+                        :appeal_maat_id => nil,
+                        :appeal_lodged_date => nil,
+                        :appeal_with_changes_details => nil,
                       }
+    end
+
+    context 'when case type is the same as in the persisted record' do
+      let(:previous_case_type) { CaseType::INDICTABLE.to_s }
+
+      it 'does not save the record but returns true' do
+        expect(case_record).not_to receive(:update)
+        expect(subject.save).to be(true)
+      end
     end
   end
 end

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -17,13 +17,13 @@ describe Summary::Sections::CaseDetails do
       urn: 'xyz',
       case_type: 'foobar',
       appeal_maat_id: appeal_maat_id,
-      appeal_with_changes_maat_id: appeal_with_changes_maat_id,
+      appeal_lodged_date: appeal_lodged_date,
       appeal_with_changes_details: appeal_with_changes_details,
     )
   end
 
   let(:appeal_maat_id) { nil }
-  let(:appeal_with_changes_maat_id) { nil }
+  let(:appeal_lodged_date) { nil }
   let(:appeal_with_changes_details) { nil }
 
   describe '#name' do
@@ -64,16 +64,23 @@ describe Summary::Sections::CaseDetails do
     end
 
     context 'for appeal to crown court' do
+      let(:appeal_lodged_date) { Date.new(2018, 11, 22) }
+
       context 'with previous MAAT ID' do
         let(:appeal_maat_id) { '123' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(3)
+          expect(answers.count).to eq(4)
 
-          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[2].question).to eq(:previous_maat_id)
-          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
-          expect(answers[2].value).to eq('123')
+          expect(answers[2]).to be_an_instance_of(Summary::Components::DateAnswer)
+          expect(answers[2].question).to eq(:appeal_lodged_date)
+          expect(answers[2].change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answers[2].value).to eq(appeal_lodged_date)
+
+          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[3].question).to eq(:previous_maat_id)
+          expect(answers[3].change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answers[3].value).to eq('123')
         end
       end
 
@@ -81,54 +88,55 @@ describe Summary::Sections::CaseDetails do
         let(:appeal_maat_id) { '' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(3)
+          expect(answers.count).to eq(4)
 
-          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[2].question).to eq(:previous_maat_id)
-          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
-          expect(answers[2].value).to eq('')
-          expect(answers[2].show).to be(true)
+          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[3].question).to eq(:previous_maat_id)
+          expect(answers[3].change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answers[3].value).to eq('')
+          expect(answers[3].show).to be(true)
         end
       end
     end
 
     context 'for appeal to crown court with changes in financial circumstances' do
+      let(:appeal_lodged_date) { Date.new(2018, 11, 22) }
       let(:appeal_with_changes_details) { 'details' }
 
       context 'with previous MAAT ID' do
-        let(:appeal_with_changes_maat_id) { '345' }
+        let(:appeal_maat_id) { '123' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(4)
+          expect(answers.count).to eq(5)
 
-          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[2].question).to eq(:previous_maat_id)
-          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
-          expect(answers[2].value).to eq('345')
+          expect(answers[2]).to be_an_instance_of(Summary::Components::DateAnswer)
+          expect(answers[2].question).to eq(:appeal_lodged_date)
+          expect(answers[2].change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answers[2].value).to eq(appeal_lodged_date)
 
           expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answers[3].question).to eq(:appeal_with_changes_details)
-          expect(answers[3].change_path).to match('applications/12345/steps/case/case_type')
+          expect(answers[3].change_path).to match('applications/12345/steps/case/appeal_details')
           expect(answers[3].value).to eq('details')
+
+          expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[4].question).to eq(:previous_maat_id)
+          expect(answers[4].change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answers[4].value).to eq('123')
         end
       end
 
       context 'without previous MAAT ID (field is optional)' do
-        let(:appeal_with_changes_maat_id) { '' }
+        let(:appeal_maat_id) { '' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(4)
+          expect(answers.count).to eq(5)
 
-          expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[2].question).to eq(:previous_maat_id)
-          expect(answers[2].change_path).to match('applications/12345/steps/case/case_type')
-          expect(answers[2].value).to eq('')
-          expect(answers[2].show).to be(true)
-
-          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[3].question).to eq(:appeal_with_changes_details)
-          expect(answers[3].change_path).to match('applications/12345/steps/case/case_type')
-          expect(answers[3].value).to eq('details')
+          expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[4].question).to eq(:previous_maat_id)
+          expect(answers[4].change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answers[4].value).to eq('')
+          expect(answers[4].show).to be(true)
         end
       end
     end

--- a/spec/serializers/submission_serializer/sections/case_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/case_details_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
     instance_double(
       Case,
       urn: '12345',
-      case_type: 'Indictable',
-      appeal_maat_id: 1,
-      appeal_with_changes_maat_id: 2,
+      case_type: case_type,
+      appeal_maat_id: '123',
+      appeal_with_changes_maat_id: nil,
+      appeal_lodged_date: appeal_lodged_date,
       appeal_with_changes_details: 'appeal changes',
       hearing_court_name: 'Court',
       hearing_date: hearing_date,
@@ -20,15 +21,18 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
     )
   end
 
+  let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES.to_s }
+  let(:appeal_lodged_date) { DateTime.new(2021, 5, 8) }
   let(:hearing_date) { DateTime.new(2023, 3, 2) }
 
   let(:json_output) do
     {
       case_details: {
         urn: '12345',
-        case_type: 'Indictable',
-        appeal_maat_id: 1,
-        appeal_with_changes_maat_id: 2,
+        case_type: case_type,
+        appeal_maat_id: '123',
+        appeal_with_changes_maat_id: nil,
+        appeal_lodged_date: appeal_lodged_date,
         appeal_with_changes_details: 'appeal changes',
         hearing_court_name: 'Court',
         hearing_date: hearing_date,

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -34,13 +34,25 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:form_object) { double('FormObject', case: kase, case_type: CaseType.new(case_type)) }
     let(:step_name) { :case_type }
 
+    context 'and the case type is `appeal_to_crown_court`' do
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
+
+      it { is_expected.to have_destination(:appeal_details, :edit, id: crime_application) }
+    end
+
+    context 'and the case type is `appeal_to_crown_court_with_changes`' do
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES.to_s }
+
+      it { is_expected.to have_destination(:appeal_details, :edit, id: crime_application) }
+    end
+
     context 'and the application already has a date stamp' do
       before do
         allow(crime_application).to receive(:date_stamp) { Time.zone.today }
         allow(kase).to receive(:case_type).and_return(case_type)
       end
 
-      let(:case_type) { CaseType::VALUES.sample }
+      let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
       context 'and there are no charges input yet' do
         let(:charges_double) { double(any?: false, create!: 'charge') }
@@ -63,8 +75,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
       context 'and the case type is "date stampable"' do
         let(:charges_double) { double(any?: false, create!: 'charge') }
-
-        let(:case_type) { CaseType::DATE_STAMPABLE.sample }
+        let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
         it { is_expected.to have_destination(:date_stamp, :edit, id: crime_application) }
       end
@@ -84,6 +95,18 @@ RSpec.describe Decisions::CaseDecisionTree do
           it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
         end
       end
+    end
+  end
+
+  context 'when the step is `appeal_details`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :appeal_details }
+
+    # We've tested this logic for non-appeals, no need to test again
+    # as this step runs the same method/code
+    it 'performs the date stamp logic' do
+      expect(subject).to receive(:date_stamp_if_needed)
+      subject.destination
     end
   end
 


### PR DESCRIPTION
## Description of change
I'm worried the PRs might become too big so I'll try to split them up into (almost) functional smaller PRs.

In order to keep backward compatibility as much as possible with existing applications in datastore, I've done a few temporary workarounds that will be removed once all the work is finalised and the schemas/fixtures/datastore are also updated.

This first part cleanup the existing case type step, adds the new appeal details step, adapt the decision tree with the new logic, and also updates the serialisers and the summary presenters.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-427

## Notes for reviewer
Few things still to do, and separately there will be changes to schema/fixtures. Will be done next.

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2023-07-04 at 15 20 00](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/ee439473-fa88-48e3-a0f3-76a7b5497ece)

### After changes:
<img width="791" alt="Screenshot 2023-07-04 at 15 30 19" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/f198e842-9e9b-4285-846c-db2b372494f6">
<img width="809" alt="Screenshot 2023-07-04 at 15 30 28" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/3b77925e-7303-41fb-a245-c210455fc32d">

## How to manually test the feature
Go the case type page, select any appeal radio option, you will be directed to the appeal details page, validations should work, etc. And in the review application page, details should show depending if they've been entered or not.