### PR TITLE
[a11y] Make offence input field accessible on ios

### DIFF
--- a/app/javascript/local/suggestions.js
+++ b/app/javascript/local/suggestions.js
@@ -16,11 +16,6 @@ Input.prototype.init = function () {
   if (suggestionsSourceId) {
     this.suggestions = document.getElementById(suggestionsSourceId)
 
-    this.$formGroup.setAttribute('role', 'combobox')
-    this.$formGroup.setAttribute('aria-owns', this.$module.getAttribute('id'))
-    this.$formGroup.setAttribute('aria-haspopup', 'listbox')
-    this.$formGroup.setAttribute('aria-expanded', 'false')
-
     this.$suggestionsHeader = document.createElement('h2')
     this.$suggestionsHeader.setAttribute('class', 'govuk-input__suggestions-header')
     this.$suggestionsHeader.textContent = this.$module.getAttribute('data-suggestions-header') || 'Suggestions'
@@ -45,6 +40,9 @@ Input.prototype.init = function () {
     this.$module.removeAttribute('list') // [change: deactivate browser-native suggestions]
     this.$module.setAttribute('aria-autocomplete', 'list')
     this.$module.setAttribute('aria-controls', this.$module.getAttribute('id') + '-suggestions')
+    this.$module.setAttribute('role', 'combobox')
+    this.$module.setAttribute('aria-haspopup', 'listbox')
+    this.$module.setAttribute('aria-expanded', 'false')
 
     this.$module.addEventListener('input', this.handleInputInput.bind(this))
     this.$module.addEventListener('keydown', this.handleInputKeyDown.bind(this))


### PR DESCRIPTION
## Description of change
The accessibility audit flagged an issue on the ‘What has your client been charged with’ page where the offence input field was not accessible on iOS using swipe gestures when voice over is active (see before changes video below).

This was fixed by setting the aria attributes on the offence input element that controls the listbox rather than the overall form container

## Link to relevant ticket
[CRIMAP-371](https://dsdmoj.atlassian.net/browse/CRIMAP-371)

## Notes for reviewer
Bare with my terrible swipe navigation skills! 

## Screenshots of changes (if applicable)

### Before changes:
https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/d33ceaa2-c477-4693-a961-d2d3552e3ab9

### After changes:

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/8dcbf39a-2381-441b-8c09-ccb0d51b0057

## How to manually test the feature


[CRIMAP-371]: https://dsdmoj.atlassian.net/browse/CRIMAP-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ