### PR TITLE
CRIMAP-427 Validate format of previous MAAT ID

### DIFF
--- a/app/forms/steps/case/appeal_details_form.rb
+++ b/app/forms/steps/case/appeal_details_form.rb
@@ -4,6 +4,8 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :case
 
+      MAAT_ID_REGEXP = /\A[0-9]{6,9}\z/
+
       attribute :appeal_lodged_date, :multiparam_date
       attribute :appeal_with_changes_details, :string
       attribute :appeal_maat_id, :string
@@ -13,6 +15,9 @@ module Steps
 
       validates :appeal_with_changes_details,
                 presence: true, if: -> { appeal_with_changes? }
+
+      validates :appeal_maat_id,
+                format: { with: MAAT_ID_REGEXP }, allow_blank: true
 
       def appeal_with_changes?
         case_type.appeal_to_crown_court_with_changes?

--- a/app/forms/steps/case/urn_form.rb
+++ b/app/forms/steps/case/urn_form.rb
@@ -4,7 +4,7 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :case
 
-      URN_REGEXP = /\A[0-9]{2}[A-Z]{2}[0-9]{7}\Z/
+      URN_REGEXP = /\A[0-9]{2}[A-Z]{2}[0-9]{7}\z/
 
       attribute :urn, :string
 

--- a/app/forms/steps/client/contact_details_form.rb
+++ b/app/forms/steps/client/contact_details_form.rb
@@ -5,7 +5,7 @@ module Steps
       has_one_association :applicant
 
       # Very basic validation to allow numeric and common telephone number symbols
-      TEL_REGEXP = /\A[0-9#+()-.]{7,18}\Z/
+      TEL_REGEXP = /\A[0-9#+()-.]{7,18}\z/
 
       attribute :telephone_number, :string
       attribute :correspondence_address_type, :value_object, source: CorrespondenceType

--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -4,7 +4,7 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :applicant
 
-      NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z][0-9]{6}([A-DFM])\Z/
+      NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z][0-9]{6}([A-DFM])\z/
 
       attribute :nino, :string
       validates :nino, format: { with: NINO_REGEXP }

--- a/app/forms/steps/submission/declaration_form.rb
+++ b/app/forms/steps/submission/declaration_form.rb
@@ -6,7 +6,7 @@ module Steps
       attribute :legal_rep_telephone, :string
 
       # Very basic validation to allow numeric and common telephone number symbols
-      TEL_REGEXP = /\A[0-9#+()-.]{7,18}\Z/
+      TEL_REGEXP = /\A[0-9#+()-.]{7,18}\z/
 
       validates :legal_rep_first_name,
                 :legal_rep_last_name,

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -88,7 +88,7 @@ en:
             appeal_with_changes_details:
               blank: Enter details of changes in financial circumstances
             appeal_maat_id:
-              invalid: Enter a valid previous MAAT ID
+              invalid: Enter a valid MAAT ID
             appeal_lodged_date:
               blank: Enter the date the appeal was lodged
               invalid: Enter a valid date

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -87,6 +87,8 @@ en:
           attributes:
             appeal_with_changes_details:
               blank: Enter details of changes in financial circumstances
+            appeal_maat_id:
+              invalid: Enter a valid previous MAAT ID
             appeal_lodged_date:
               blank: Enter the date the appeal was lodged
               invalid: Enter a valid date

--- a/spec/forms/steps/case/appeal_details_form_spec.rb
+++ b/spec/forms/steps/case/appeal_details_form_spec.rb
@@ -47,6 +47,40 @@ RSpec.describe Steps::Case::AppealDetailsForm do
                       attribute_name: :appeal_lodged_date,
                       allow_past: true, allow_future: false
     end
+
+    context 'previous MAAT ID format' do
+      # It behaves the same for both appeal types
+      let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
+
+      context 'when `appeal_maat_id` is not numeric' do
+        let(:appeal_maat_id) { 'X123Z' }
+
+        it 'has a validation error on the field' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:appeal_maat_id, :invalid)).to be(true)
+        end
+      end
+
+      context 'when `appeal_maat_id` is out of bounds' do
+        context 'not enough digits' do
+          let(:appeal_maat_id) { '12345' }
+
+          it 'has a validation error on the field' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.of_kind?(:appeal_maat_id, :invalid)).to be(true)
+          end
+        end
+
+        context 'too many digits' do
+          let(:appeal_maat_id) { '1234567890' }
+
+          it 'has a validation error on the field' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.of_kind?(:appeal_maat_id, :invalid)).to be(true)
+          end
+        end
+      end
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
## Description of change
Simple validation to avoid fat fingers or other issues.

The attribute is optional so we still allow blanks. But if the attribute is filled, then we validate is a numeric 6-9 digits.

Ensure all existing regex in other places use `\z` (lowercase) instead of `\Z` (uppercase) as:
> \Z Matches the end of the string unless the string ends with a "\n", in which case it matches just before the "\n".

Which means by using \Z someone could sneak in a newline character and still pass validation.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-427

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="631" alt="Screenshot 2023-07-05 at 13 46 57" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/5b411d7d-47a6-4b10-904e-b600ee3f918c">

## How to manually test the feature
Absense is allowed. If something is entered, only numeric values 6-9 digits length will pass validation.