### PR TITLE
CRIMAP-429 Refactor error reporting using Rails new API

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -14,8 +14,7 @@ module ErrorHandling
       else
         raise if Rails.application.config.consider_all_requests_local
 
-        Rails.logger.error(exception)
-        Sentry.capture_exception(exception)
+        Rails.error.report(exception, handled: false)
 
         redirect_to unhandled_errors_path
       end

--- a/app/lib/logger_error_subscriber.rb
+++ b/app/lib/logger_error_subscriber.rb
@@ -1,0 +1,7 @@
+# This subscriber will log exceptions to stdout, when using
+# new Rails error reporting API (i.e. `Rails.error.handle`, etc.)
+class LoggerErrorSubscriber
+  def report(error, *)
+    Rails.logger.error [error, error.backtrace[0]].join("\n")
+  end
+end

--- a/app/services/datastore/application_counters.rb
+++ b/app/services/datastore/application_counters.rb
@@ -15,19 +15,16 @@ module Datastore
 
     private
 
+    # Fallback to `zero`, but do not blow up.
+    # As per locales, it will not show counter on the tab.
     def count(status)
-      result = DatastoreApi::Requests::ListApplications.new(
-        status: status.to_s, office_code: office_code, per_page: PER_PAGE_LIMIT
-      ).call
+      Rails.error.handle(fallback: -> { FALLBACK_COUNT }) do
+        result = DatastoreApi::Requests::ListApplications.new(
+          status: status.to_s, office_code: office_code, per_page: PER_PAGE_LIMIT
+        ).call
 
-      result.pagination.fetch('total_count')
-    rescue StandardError => e
-      Rails.logger.error(e)
-      Sentry.capture_exception(e)
-
-      # Fallback to `zero`, but do not blow up.
-      # As per locales, it will not show counter on the tab.
-      FALLBACK_COUNT
+        result.pagination.fetch('total_count')
+      end
     end
   end
 end

--- a/app/services/datastore/get_application.rb
+++ b/app/services/datastore/get_application.rb
@@ -7,14 +7,15 @@ module Datastore
     end
 
     def call
-      app = DatastoreApi::Requests::GetApplication.new(
-        application_id:
-      ).call
+      app = Rails.error.record do
+        # Will report and re-raise the exception
+        DatastoreApi::Requests::GetApplication.new(application_id:).call
+      end
 
       raise DatastoreApi::Errors::NotFoundError if superseded?(app)
 
       app
-    rescue DatastoreApi::Errors::NotFoundError
+    rescue DatastoreApi::Errors::ApiError
       raise Errors::ApplicationNotFound
     end
 

--- a/app/services/datastore/list_applications.rb
+++ b/app/services/datastore/list_applications.rb
@@ -9,16 +9,13 @@ module Datastore
     end
 
     def call
-      result = DatastoreApi::Requests::ListApplications.new(
-        **filtering, **sorting, **pagination
-      ).call
+      Rails.error.handle do
+        result = DatastoreApi::Requests::ListApplications.new(
+          **filtering, **sorting, **pagination
+        ).call
 
-      Kaminari.paginate_array(result, total_count: result.pagination['total_count'])
-    rescue StandardError => e
-      Rails.logger.error(e)
-      Sentry.capture_exception(e)
-
-      nil
+        Kaminari.paginate_array(result, total_count: result.pagination['total_count'])
+      end
     end
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,6 +4,10 @@ Rails.application.config.to_prepare do
     config.breadcrumbs_logger = [:active_support_logger, :http_logger]
     config.environment = HostEnv.env_name
 
+    # Opt in to new Rails error reporting API
+    # https://edgeguides.rubyonrails.org/error_reporting.html
+    config.rails.register_error_subscriber = true
+
     # Filtering
     # https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/
 
@@ -14,4 +18,9 @@ Rails.application.config.to_prepare do
       params_filter.filter(event.to_hash)
     end
   end
+end
+
+# We also want to log the exception, to be aware
+Rails.application.config.after_initialize do
+  Rails.error.subscribe(LoggerErrorSubscriber.new)
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationController do
       it 'does not report the exception, and redirect to the error page' do
         routes.draw { get 'invalid_session' => 'anonymous#invalid_session' }
 
-        expect(Sentry).not_to receive(:capture_exception)
+        expect(Rails.error).not_to receive(:report)
 
         get :invalid_session
         expect(response).to redirect_to(invalid_session_errors_path)
@@ -23,7 +23,7 @@ RSpec.describe ApplicationController do
       it 'does not report the exception, and redirect to the error page' do
         routes.draw { get 'application_not_found' => 'anonymous#application_not_found' }
 
-        expect(Sentry).not_to receive(:capture_exception)
+        expect(Rails.error).not_to receive(:report)
 
         get :application_not_found
         expect(response).to redirect_to(application_not_found_errors_path)
@@ -38,7 +38,11 @@ RSpec.describe ApplicationController do
       it 'reports the exception, and redirect to the error page' do
         routes.draw { get 'another_exception' => 'anonymous#another_exception' }
 
-        expect(Sentry).to receive(:capture_exception)
+        expect(Rails.error).to receive(:report).with(
+          an_instance_of(StandardError), hash_including(handled: false)
+        ).and_call_original
+
+        expect(Rails.logger).to receive(:error)
 
         get :another_exception
         expect(response).to redirect_to(unhandled_errors_path)

--- a/spec/services/datastore/application_counters_spec.rb
+++ b/spec/services/datastore/application_counters_spec.rb
@@ -32,16 +32,14 @@ RSpec.describe Datastore::ApplicationCounters do
       stub_request(:get, 'http://datastore-webmock/api/v1/applications')
         .with(query: expected_query)
         .to_raise(StandardError)
-
-      allow(Sentry).to receive(:capture_exception)
     end
 
     it 'reports the exception, and returns 0 count' do
-      expect(subject.returned_count).to eq(0)
-
-      expect(Sentry).to have_received(:capture_exception).with(
-        an_instance_of(StandardError)
+      expect(Rails.error).to receive(:report).with(
+        an_instance_of(StandardError), hash_including(handled: true)
       )
+
+      expect(subject.returned_count).to eq(0)
     end
   end
 end

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Datastore::ApplicationSubmission do
   end
 
   before do
-    allow(crime_application).to receive(:destroy)
+    allow(crime_application).to receive(:destroy!)
 
     stub_request(:post, 'http://datastore-webmock/api/v1/applications')
       .to_return(status: 201, body: '{}')
@@ -156,7 +156,7 @@ RSpec.describe Datastore::ApplicationSubmission do
       end
 
       it 'purges the application from the local database' do
-        expect(crime_application).to have_received(:destroy)
+        expect(crime_application).to have_received(:destroy!)
       end
     end
 
@@ -165,13 +165,13 @@ RSpec.describe Datastore::ApplicationSubmission do
         stub_request(:post, 'http://datastore-webmock/api/v1/applications')
           .to_raise(StandardError)
 
-        allow(Sentry).to receive(:capture_exception)
+        allow(Rails.error).to receive(:report)
 
         subject.call
       end
 
       it 'does not purge the application from the local database' do
-        expect(crime_application).not_to have_received(:destroy)
+        expect(crime_application).not_to have_received(:destroy!)
       end
 
       it 'does not change any attributes of the application' do
@@ -181,8 +181,8 @@ RSpec.describe Datastore::ApplicationSubmission do
       end
 
       it 'reports the exception, and redirect to the error page' do
-        expect(Sentry).to have_received(:capture_exception).with(
-          an_instance_of(StandardError)
+        expect(Rails.error).to have_received(:report).with(
+          an_instance_of(StandardError), hash_including(handled: true)
         )
       end
     end

--- a/spec/services/datastore/get_application_spec.rb
+++ b/spec/services/datastore/get_application_spec.rb
@@ -29,10 +29,14 @@ RSpec.describe Datastore::GetApplication do
       stub_request(:get, endpoint).to_raise(error)
     end
 
-    context 'for not found errors' do
-      let(:error) { DatastoreApi::Errors::NotFoundError }
+    context 'for API errors' do
+      let(:error) { DatastoreApi::Errors::ConnectionError }
 
-      it 're-raises as `ApplicationNotFound`' do
+      it 'reports the exception and re-raises as `ApplicationNotFound' do
+        expect(Rails.error).to receive(:report).with(
+          an_instance_of(error), hash_including(handled: false)
+        )
+
         expect { subject.call }.to raise_exception(Errors::ApplicationNotFound)
       end
     end
@@ -40,7 +44,11 @@ RSpec.describe Datastore::GetApplication do
     context 'for other kind of errors' do
       let(:error) { StandardError }
 
-      it 'lets the exception bubble up' do
+      it 'reports the exception and lets it bubble up' do
+        expect(Rails.error).to receive(:report).with(
+          an_instance_of(error), hash_including(handled: false)
+        )
+
         expect { subject.call }.to raise_exception(StandardError)
       end
     end

--- a/spec/services/datastore/list_applications_spec.rb
+++ b/spec/services/datastore/list_applications_spec.rb
@@ -47,16 +47,14 @@ RSpec.describe Datastore::ListApplications do
       stub_request(:get, 'http://datastore-webmock/api/v1/applications')
         .with(query: expected_query)
         .to_raise(StandardError)
-
-      allow(Sentry).to receive(:capture_exception)
     end
 
     it 'reports the exception, and returns nil' do
-      expect(subject.call).to be_nil
-
-      expect(Sentry).to have_received(:capture_exception).with(
-        an_instance_of(StandardError)
+      expect(Rails.error).to receive(:report).with(
+        an_instance_of(StandardError), hash_including(handled: true)
       )
+
+      expect(subject.call).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Description of change
This is a first part of at least a couple PRs intended to remove some technical debt by refactoring exception capture and error reporting using the modern Rails error reporting API introduced in Rails 7+

https://edgeguides.rubyonrails.org/error_reporting.html

Functionally it should be the same as before, but some boilerplate code is simplified.

Only thing I noticed is the Rails.error.handle, Rails.error.report etc methods do not log the exception, which makes sense, but without it, the exception is quietly hidden and particularly in localhost it can be misleading.

I've made a basic error subscriber just to perform the `Rails.logger.error(e)` so it behaves like before, adding one line of backtrace for additional context.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-429

## Notes for reviewer

## How to manually test the feature
In localhost is easy to test by not running the datastore, and going to the dashboard. It will log errors about not being able to connect to datastore.
You can also expose a fake `SENTRY_DSN` env variable to see how it "attempts" to report the exception to Sentry.