### PR TITLE
CRIMAP-430 Swap order of the URN step

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -58,7 +58,6 @@ module DeveloperTools
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_contact_details_path(crime_application),
-          edit_steps_case_urn_path(crime_application),
           edit_steps_case_case_type_path(crime_application),
         ]
       )
@@ -91,11 +90,7 @@ module DeveloperTools
     end
 
     def find_or_create_case
-      Case.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
-        record.update(
-          urn: '',
-        )
-      end
+      Case.find_or_initialize_by(crime_application_id: crime_application.id)
     end
   end
 end

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -12,11 +12,6 @@ module Summary
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
         [
-          Components::FreeTextAnswer.new(
-            :case_urn, kase.urn,
-            change_path: edit_steps_case_urn_path, show: true
-          ),
-
           Components::ValueAnswer.new(
             :case_type, kase.case_type,
             change_path: edit_steps_case_case_type_path
@@ -38,6 +33,11 @@ module Summary
             :previous_maat_id, kase.appeal_maat_id,
             show: !kase.appeal_maat_id.nil?,
             change_path: edit_steps_case_appeal_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :case_urn, kase.urn,
+            change_path: edit_steps_case_urn_path, show: true
           ),
         ].select(&:show?)
       end

--- a/app/presenters/tasks/case_details.rb
+++ b/app/presenters/tasks/case_details.rb
@@ -1,7 +1,7 @@
 module Tasks
   class CaseDetails < BaseTask
     def path
-      edit_steps_case_urn_path
+      edit_steps_case_case_type_path
     end
 
     def not_applicable?

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -4,13 +4,13 @@ module Decisions
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
     def destination
       case step_name
-      when :urn
-        edit(:case_type)
       when :case_type
         after_case_type
       when :appeal_details
         date_stamp_if_needed
       when :date_stamp
+        edit(:urn)
+      when :urn
         charges_summary_or_edit_new_charge
       when :charges
         edit(:charges_summary)
@@ -50,7 +50,7 @@ module Decisions
       if DateStamper.new(form_object.crime_application, form_object.case.case_type).call
         edit(:date_stamp)
       else
-        charges_summary_or_edit_new_charge
+        edit(:urn)
       end
     end
 

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -60,7 +60,7 @@ module Decisions
       if form_object.correspondence_address_type.other_address?
         start_address_journey(CorrespondenceAddress)
       else
-        edit('/steps/case/urn')
+        edit('/steps/case/case_type')
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,10 +111,10 @@ Rails.application.routes.draw do
       end
 
       namespace :case do
-        edit_step :urn
         edit_step :case_type
         edit_step :appeal_details
         edit_step :date_stamp
+        edit_step :urn
         crud_step :charges, param: :charge_id
         edit_step :charges_summary
         edit_step :has_codefendants

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -52,15 +52,17 @@ describe Summary::Sections::CaseDetails do
     it 'has the correct rows' do
       expect(answers.count).to eq(2)
 
-      expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-      expect(answers[0].question).to eq(:case_urn)
-      expect(answers[0].change_path).to match('applications/12345/steps/case/urn')
-      expect(answers[0].value).to eq('xyz')
+      answer = answers[0]
+      expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+      expect(answer.question).to eq(:case_type)
+      expect(answer.change_path).to match('applications/12345/steps/case/case_type')
+      expect(answer.value).to eq('foobar')
 
-      expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
-      expect(answers[1].question).to eq(:case_type)
-      expect(answers[1].change_path).to match('applications/12345/steps/case/case_type')
-      expect(answers[1].value).to eq('foobar')
+      answer = answers[1]
+      expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answer.question).to eq(:case_urn)
+      expect(answer.change_path).to match('applications/12345/steps/case/urn')
+      expect(answer.value).to eq('xyz')
     end
 
     context 'for appeal to crown court' do
@@ -72,15 +74,17 @@ describe Summary::Sections::CaseDetails do
         it 'has the correct rows' do
           expect(answers.count).to eq(4)
 
-          expect(answers[2]).to be_an_instance_of(Summary::Components::DateAnswer)
-          expect(answers[2].question).to eq(:appeal_lodged_date)
-          expect(answers[2].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[2].value).to eq(appeal_lodged_date)
+          answer = answers[1]
+          expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
+          expect(answer.question).to eq(:appeal_lodged_date)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq(appeal_lodged_date)
 
-          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[3].question).to eq(:previous_maat_id)
-          expect(answers[3].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[3].value).to eq('123')
+          answer = answers[2]
+          expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answer.question).to eq(:previous_maat_id)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq('123')
         end
       end
 
@@ -90,11 +94,12 @@ describe Summary::Sections::CaseDetails do
         it 'has the correct rows' do
           expect(answers.count).to eq(4)
 
-          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[3].question).to eq(:previous_maat_id)
-          expect(answers[3].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[3].value).to eq('')
-          expect(answers[3].show).to be(true)
+          answer = answers[2]
+          expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answer.question).to eq(:previous_maat_id)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq('')
+          expect(answer.show).to be(true)
         end
       end
     end
@@ -109,20 +114,23 @@ describe Summary::Sections::CaseDetails do
         it 'has the correct rows' do
           expect(answers.count).to eq(5)
 
-          expect(answers[2]).to be_an_instance_of(Summary::Components::DateAnswer)
-          expect(answers[2].question).to eq(:appeal_lodged_date)
-          expect(answers[2].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[2].value).to eq(appeal_lodged_date)
+          answer = answers[1]
+          expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
+          expect(answer.question).to eq(:appeal_lodged_date)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq(appeal_lodged_date)
 
-          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[3].question).to eq(:appeal_with_changes_details)
-          expect(answers[3].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[3].value).to eq('details')
+          answer = answers[2]
+          expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answer.question).to eq(:appeal_with_changes_details)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq('details')
 
-          expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[4].question).to eq(:previous_maat_id)
-          expect(answers[4].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[4].value).to eq('123')
+          answer = answers[3]
+          expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answer.question).to eq(:previous_maat_id)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq('123')
         end
       end
 
@@ -132,11 +140,12 @@ describe Summary::Sections::CaseDetails do
         it 'has the correct rows' do
           expect(answers.count).to eq(5)
 
-          expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-          expect(answers[4].question).to eq(:previous_maat_id)
-          expect(answers[4].change_path).to match('applications/12345/steps/case/appeal_details')
-          expect(answers[4].value).to eq('')
-          expect(answers[4].show).to be(true)
+          answer = answers[3]
+          expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answer.question).to eq(:previous_maat_id)
+          expect(answer.change_path).to match('applications/12345/steps/case/appeal_details')
+          expect(answer.value).to eq('')
+          expect(answer.show).to be(true)
         end
       end
     end

--- a/spec/presenters/tasks/case_details_spec.rb
+++ b/spec/presenters/tasks/case_details_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Tasks::CaseDetails do
   let(:kase) { nil }
 
   describe '#path' do
-    it { expect(subject.path).to eq('/applications/12345/steps/case/urn') }
+    it { expect(subject.path).to eq('/applications/12345/steps/case/case_type') }
   end
 
   describe '#not_applicable?' do

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -21,15 +21,6 @@ RSpec.describe Decisions::CaseDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step is `urn`' do
-    let(:form_object) { double('FormObject') }
-    let(:step_name) { :urn }
-
-    context 'has correct next step' do
-      it { is_expected.to have_destination(:case_type, :edit, id: crime_application) }
-    end
-  end
-
   context 'when the step is `case_type`' do
     let(:form_object) { double('FormObject', case: kase, case_type: CaseType.new(case_type)) }
     let(:step_name) { :case_type }
@@ -54,17 +45,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
       let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
 
-      context 'and there are no charges input yet' do
-        let(:charges_double) { double(any?: false, create!: 'charge') }
-
-        it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
-      end
-
-      context 'and there are already charges input' do
-        let(:charges_double) { double(any?: true) }
-
-        it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
-      end
+      it { is_expected.to have_destination(:urn, :edit, id: crime_application) }
     end
 
     context 'and the application has no date stamp' do
@@ -83,17 +64,7 @@ RSpec.describe Decisions::CaseDecisionTree do
       context 'and case type is not "date stampable"' do
         let(:case_type) { CaseType::INDICTABLE.to_s }
 
-        context 'and there are no charges input yet' do
-          let(:charges_double) { double(any?: false, create!: 'charge') }
-
-          it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
-        end
-
-        context 'and there are already charges input' do
-          let(:charges_double) { double(any?: true) }
-
-          it { is_expected.to have_destination(:charges_summary, :edit, id: crime_application) }
-        end
+        it { is_expected.to have_destination(:urn, :edit, id: crime_application) }
       end
     end
   end
@@ -113,6 +84,13 @@ RSpec.describe Decisions::CaseDecisionTree do
   context 'when the step is `date_stamp`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :date_stamp }
+
+    it { is_expected.to have_destination(:urn, :edit, id: crime_application) }
+  end
+
+  context 'when the step is `urn`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :urn }
 
     context 'and there are no charges yet' do
       let(:charges_double) { double(any?: false, create!: 'charge') }

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -160,13 +160,13 @@ address_id: 'address')
     context 'and answer is `home_address`' do
       let(:correspondence_address_type) { CorrespondenceType::HOME_ADDRESS }
 
-      it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
+      it { is_expected.to have_destination('/steps/case/case_type', :edit, id: crime_application) }
     end
 
     context 'and answer is `providers_office_address`' do
       let(:correspondence_address_type) { CorrespondenceType::PROVIDERS_OFFICE_ADDRESS }
 
-      it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
+      it { is_expected.to have_destination('/steps/case/case_type', :edit, id: crime_application) }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Move URN step after the date stamp (i.e. after case type and/or appeal details).

Update task list so the case details task starts with the case type and not with the URN as it was until now.

For consistency, moved also the place where the URN shows in the review application page (and caused a bit of a mess in the tests, sorry).

Everything (except the order, that is) should continue working as before, nothing really has changed except the order of the steps.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-430

## Notes for reviewer

## How to manually test the feature
Start a new application and after the contact details, instead of taking you to the URN step, it will take you to the case type step. The date stamp logic remains, and after the date stamp (or for non date-stampable cases, after the case type) you will be taken to the URN page.

Task list also updated. Developer bypass for under 18 also updated.