### PR TITLE
Replace cryptic Omniauth error flash alert

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -11,14 +11,15 @@ module Providers
       )
     end
 
+    def failure
+      Rails.error.report($ERROR_INFO, handled: true)
+      redirect_to unhandled_errors_path
+    end
+
     private
 
     def after_sign_in_path_for(_)
       Providers::OfficeRouter.call(current_provider)
-    end
-
-    def after_omniauth_failure_path_for(_)
-      unauthenticated_errors_path
     end
 
     def auth_hash

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -16,7 +16,7 @@ en:
       reauthenticate: ""
       unauthenticated: ""
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      failure: ""
       success: ""
     sessions:
       signed_in: ""

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -171,12 +171,17 @@ RSpec.describe 'Sign in user journey' do
       allow(OmniAuth.config).to receive(:test_mode).and_return(false)
       allow_any_instance_of(LaaPortal::SamlSetup).to receive(:setup).and_raise(StandardError)
 
+      allow(Rails.error).to receive(:report)
+
       start_button.click
     end
 
-    it 'redirects to the unauthenticated page' do
-      expect(current_url).to match(unauthenticated_errors_path)
-      expect(page).to have_content('Could not authenticate you')
+    it 'reports the exception and redirects to the unhandled error page' do
+      expect(Rails.error).to have_received(:report).with(
+        an_instance_of(StandardError), hash_including(handled: true)
+      )
+
+      expect(current_url).to match(unhandled_errors_path)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Although it should be very rare and edge case, there could be sometimes Portal authentication errors.

We were showing a rather obscure error message in a flash alert. This has now been replaced with the generic "unhandled" error page, and also we send the exception to Sentry so we are alerted.

More context on this slack thread:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1688989509642419

## Screenshots of changes (if applicable)

### Before changes:
<img width="851" alt="Screenshot 2023-07-10 at 12 41 10" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/c75d5e0f-4071-4e3a-ab18-b1e4d31080fc">

### After changes:
<img width="785" alt="Screenshot 2023-07-10 at 15 51 05" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/7b2370ea-5bed-4d64-a599-f6828d541a40">

## How to manually test the feature
It's rather difficult, you need to disable omniauth test mode, and configure Portal locally, then disable something that Portal except, for example `authn_requests_signed` in the file `LaaPortal::SamlSetup`