### PR TITLE
CRIMAP-433 Bump schemas gem (return_details refactor)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.7.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: bf2bbf156ff4d89c815bea9dba1b3a1f0cbe96c0
-  tag: v0.6.0
+  revision: 5dae17e1af44335493dae6932b9257e8a9ba6b08
+  tag: v0.7.0
   specs:
-    laa-criminal-legal-aid-schemas (0.6.0)
+    laa-criminal-legal-aid-schemas (0.7.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
@@ -276,7 +276,7 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.3.0)
       nio4r (~> 2.0)
     racc (1.7.1)


### PR DESCRIPTION
## Description of change
It is required to use the latest schemas gem version as the `ReturnDetails` struct in versions `< 0.7.0` states `returned_at` attribute as mandatory presence, which the datastore will no longer be returning.

Note: Review will need to bump the version too due to the same reason.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-433

## Notes for reviewer

## How to manually test the feature
No functional changes, everything keep working as before.