### PR TITLE
CRIMAP-435 Remove `hmcts_common_platform` gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,6 @@ gem 'importmap-rails'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
-gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', tag: 'v0.2.0'
-
 gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/ministryofjustice/hmcts_common_platform.git
-  revision: f45aa2fddd05e238493c0c3e202de309ae93acb4
-  tag: v0.2.0
-  specs:
-    hmcts_common_platform (0.1.0)
-
-GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
   revision: 867f6dbcc8c646b08c19994cfbf19bf672acbec8
   specs:
@@ -455,7 +448,6 @@ DEPENDENCIES
   erb_lint
   faraday (~> 2.7)
   govuk_design_system_formbuilder (~> 4.0.0)
-  hmcts_common_platform!
   importmap-rails
   jbuilder (~> 2.11.5)
   kaminari

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -12,6 +12,10 @@ class Case < ApplicationRecord
     end
   end
 
+  composed_of :hearing_court, class_name: 'Court',
+              mapping: %i[hearing_court_name name],
+              constructor: :find_by_name, allow_nil: true
+
   private
 
   def initialise_dates(charge)

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -1,27 +1,11 @@
 class Court
-  def initialize(name:)
-    @name = name
-  end
+  include CsvQueryable
 
-  attr_reader :name
+  csv_filepath Rails.root.join('config/data/courts.csv')
 
-  class << self
-    # TODO: we still need to confirm which courts to list.
-    #
-    # In the meantime use the CourtCentre csv from hmcts_common_platform gem
-    # and filters by oucode_l1_code to produce a list of magistrates' and crown courts.
-    #
-    def all
-      @all ||= begin
-        oucode_l1_code = %w[B C]
+  csv_attributes :code, :name
 
-        rows = HmctsCommonPlatform::Reference::CourtCentre.csv.select do |cc|
-          oucode_l1_code.include? cc['oucode_l1_code']
-        end
-
-        rows.map { |r| new(name: r['oucode_l3_name']) }
-            .sort_by(&:name)
-      end
-    end
+  def self.find_by_name(name)
+    find_by(name:)
   end
 end

--- a/config/data/courts.csv
+++ b/config/data/courts.csv
@@ -1,0 +1,251 @@
+code,name
+B,Aberystwyth Magistrates' Court
+B,Aldershot Magistrates' Court
+B,Amersham Magistrates' Court
+C,Aylesbury Crown Court
+B,Banbury Magistrates' Court
+B,Barkingside Magistrates' Court
+B,Barnsley Magistrates' Court
+B,Barnstaple Magistrates' Court
+B,Barrow-in-Furness Magistrates' Court
+C,Basildon Crown Court
+B,Basildon Magistrates' Court
+B,Basingstoke Magistrates' Court
+B,Bath Magistrates' Court
+B,Bedford Magistrates' Court
+B,Berwick-upon-Tweed Magistrates' Court
+B,Beverley Magistrates' Court
+B,Bexley Magistrates' Court
+C,Birmingham Crown Court
+B,Birmingham Magistrates' Court
+B,Blackburn Magistrates' Court
+C,Blackfriars Crown Court
+B,Blackpool Magistrates' Court
+B,Bodmin Magistrates' Court
+B,Bolton Combined Court Centre
+C,Bolton Crown Court
+B,Boston Magistrates' Court
+B,Bournemouth Combined Court
+C,Bournemouth Crown Court
+C,Bradford Crown Court
+B,Bradford Magistrates' Court
+B,Bridlington Magistrates' Court
+B,Brighton Magistrates' Court
+C,Bristol Crown Court
+B,Bristol Magistrates' Court
+B,Bromley Magistrates' Court
+C,Burnley Crown Court
+B,Burnley Magistrates' Court
+C,Caernarfon Crown Court
+B,Caernarfon Magistrates' Court
+B,Camberwell Green Magistrates' Court
+C,Cambridge Crown Court
+B,Cambridge Magistrates' Court
+B,Cannock Magistrates' Court
+C,Canterbury Crown Court
+B,Canterbury Magistrates' Court
+C,Cardiff Crown Court
+B,Cardiff Magistrates' Court
+C,Carlisle Crown Court
+B,Carlisle Magistrates' Court
+C,Central Criminal Court
+C,Chelmsford Crown Court
+B,Chelmsford Magistrates' Court
+B,Cheltenham Magistrates' Court
+C,Chester Crown Court
+B,Chester Magistrates' Court
+B,Chesterfield Magistrates' Court
+C,Chichester Crown Court
+B,Chorley Magistrates' Court
+B,Cirencester Magistrates' Court
+B,City of London Magistrates' Court
+B,Colchester Magistrates' Court
+C,Court of Appeal
+C,Coventry Crown Court
+B,Coventry Magistrates' Court
+B,Crawley Magistrates' Court
+B,Crewe Magistrates' Court
+C,Croydon Crown Court
+B,Croydon Magistrates' Court
+B,Cwmbran Magistrates' Court
+B,Darlington Magistrates' Court
+C,Derby Crown Court
+B,Derby Justice Centre (aka Derby St Mary Adult)
+C,Doncaster Crown Court
+B,Doncaster Magistrates' Court
+B,Dudley Magistrates' Court
+C,Durham Crown Court
+B,Ealing Magistrates' Court
+B,Eastbourne Magistrates' Court
+C,Exeter Crown Court
+B,Exeter Magistrates' Court
+B,Folkestone Magistrates' Court
+B,Gateshead Magistrates' Court
+C,Gloucester Crown Court
+C,Great Grimsby Crown Court
+B,Great Yarmouth Magistrates' Court
+B,Grimsby Magistrates' Court
+C,Guildford Crown Court
+B,Guildford Magistrates' Court
+B,Harrogate Magistrates' Court
+C,Harrow Crown Court
+B,Hastings Magistrates' Court
+B,Hatfield Magistrates' Court
+B,Haverfordwest Magistrates' Court
+B,Hendon Magistrates' Court
+C,Hereford Crown Court
+B,Herefordshire Magistrates' Court
+B,Highbury Corner Magistrates' Court
+B,Horsham Magistrates' Court
+B,Huddersfield Magistrates' Court
+B,Hull Magistrates' Court
+B,Huntingdon Magistrates' Court
+C,Inner London Crown Court
+C,Ipswich Crown Court
+B,Ipswich Magistrates' Court
+B,Isle of Wight Magistrates' Court
+C,Isleworth Crown Court
+B,Kidderminster Magistrates' Court
+C,King's Lynn Crown Court
+C,Kingston upon Thames Crown Court
+C,Kingston-upon-Hull Crown Court
+C,Lancaster Crown Court
+B,Lancaster Magistrates' Court
+B,Lavender Hill Magistrates' Court
+B,Leamington Spa Magistrates' Court
+C,Leeds Crown Court
+B,Leeds Magistrates' Court
+C,Leicester Crown Court
+B,Leicester Magistrates' Court
+C,Lewes Crown Court
+C,Lincoln Crown Court
+B,Lincoln Magistrates' Court
+C,Liverpool Crown Court
+B,Liverpool Magistrates' Court
+B,Llandrindod Wells Magistrates' Court
+B,Llandudno Magistrates' Court
+B,Llanelli Magistrates' Court
+B,Loughborough Magistrates' Court
+C,Luton Crown Court
+B,Luton Magistrates' Court
+B,Maidenhead Courthouse
+C,Maidstone Crown Court
+B,Maidstone Magistrates' Court
+B,Manchester City Magistrates' Court
+C,Manchester Crown Court
+B,Mansfield Magistrates' Court
+B,Margate Magistrates' Court
+B,Medway Magistrates' Court
+C,Merthyr Tydfil Crown Court
+B,Merthyr Tydfil Magistrates' Court
+B,Milton Keynes Magistrates' Court
+C,Minshull Street Manchester Crown Court
+C,Mold Crown Court
+B,Mold Magistrates' Court
+B,Newcastle Magistrates' Court
+C,Newcastle upon Tyne Crown Court
+B,Newcastle upon Tyne Magistrates' Court
+C,Newport (I.O.W.) Crown Court
+C,Newport (South Wales) Crown Court
+B,Newport Magistrates' Court
+B,Newport Magistrates' Court (Crown Court Bldg)
+B,Newton Abbot Magistrates' Court
+B,Newton Aycliffe Magistrates' Court
+B,North Shields Magistrates' Court
+B,North Somerset Magistrates' Court
+B,North Staffordshire Justice Centre
+B,Northallerton Magistrates' Court
+C,Northampton Crown Court
+B,Northampton Magistrates' Court
+C,Norwich Crown Court
+B,Norwich Magistrates' Court
+C,Nottingham Crown Court
+B,Nottingham Magistrates' Court
+B,Nuneaton Magistrates' Court
+C,Oxford Crown Court
+B,Oxford Magistrates' Court
+C,Peterborough Crown Court
+B,Peterborough Magistrates' Court
+B,Peterlee Magistrates' Court
+C,Plymouth Crown Court
+B,Plymouth Magistrates' Court
+B,Poole Magistrates' Court
+C,Portsmouth Crown Court
+B,Portsmouth Magistrates' Court
+C,Preston Crown Court
+B,Preston Magistrates' Court
+C,Reading Crown Court
+B,Reading Magistrates' Court
+B,Redditch Magistrates' Court
+B,Romford Magistrates' Court
+C,Salisbury Crown Court
+B,Salisbury Magistrates' Court
+B,Scarborough Magistrates' Court
+B,Sevenoaks Magistrates' Court
+C,Sheffield Crown Court
+B,Sheffield Magistrates' Court
+C,Shrewsbury Crown Court
+C,Shrewsbury Crown Court
+B,Skipton Magistrates' Court
+B,Slough Courthouse
+C,Snaresbrook Crown Court
+B,South East Northumberland Magistrates' Court (aka Bedlington MC)
+B,South Sefton Magistrates' Court
+B,South Shields Magistrates' Court
+C,Southampton Crown Court
+B,Southampton Magistrates' Court
+C,Southend Crown Court
+B,Southend-on-Sea Magistrates' Court
+C,Southwark Crown Court
+B,St George's Hall
+C,St. Albans Crown Court
+B,St. Albans Magistrates' Court
+C,Stafford Crown Court
+B,Staines Magistrates' Court
+B,Stevenage Magistrates' Court
+B,Stockport Magistrates' Court
+C,Stoke-on-Trent Crown Court
+B,Stratford Magistrates' Court
+B,Sunderland Magistrates' Court
+C,Swansea Crown Court
+B,Swansea Magistrates' Court
+C,Swindon Crown Court
+B,Swindon Magistrates' Court
+B,Tameside Magistrates' Court
+C,Taunton Crown Court
+B,Taunton Magistrates' Court
+C,Teesside Crown Court
+B,Teesside Magistrates' Court
+B,Telford Magistrates' Court
+B,Thames Magistrates' Court
+C,Truro Crown Court
+B,Truro Magistrates' Court
+B,Uxbridge Magistrates' Court
+B,Walsall Magistrates' Court
+B,Warrington Combined Court
+C,Warrington Crown Court
+C,Warwick Crown Court sitting at Leamington Spa
+B,Wellingborough Magistrates' Court
+B,Welshpool Magistrates' Court
+B,West Norfolk Magistrates' Court
+B,Westminster Magistrates' Court
+B,Weymouth Magistrates' Court
+B,Wigan Magistrates' Court
+B,Willesden Magistrates' Court
+B,Wimbledon Magistrates' Court
+B,Winchester Combined Court
+C,Winchester Crown Court
+B,Wirral Magistrates' Court
+C,Wolverhampton Crown Court
+B,Wolverhampton Magistrates' Court
+C,Wood Green Crown Court
+C,Woolwich Crown Court
+C,Worcester Crown Court
+B,Worcester Magistrates' Court
+B,Workington Magistrates' Court
+B,Worthing Magistrates' Court
+B,Wrexham Magistrates' Court
+B,Wycombe Magistrates' Court
+B,Yeovil Magistrates' Court
+C,York Crown Court
+B,York Magistrates' Court

--- a/config/data/courts.csv
+++ b/config/data/courts.csv
@@ -185,7 +185,6 @@ B,Sevenoaks Magistrates' Court
 C,Sheffield Crown Court
 B,Sheffield Magistrates' Court
 C,Shrewsbury Crown Court
-C,Shrewsbury Crown Court
 B,Skipton Magistrates' Court
 B,Slough Courthouse
 C,Snaresbrook Crown Court

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -5,6 +5,29 @@ RSpec.describe Case, type: :model do
 
   let(:attributes) { {} }
 
+  describe '#hearing_court' do
+    let(:attributes) { { hearing_court_name: court_name } }
+
+    context 'for a known court' do
+      let(:court_name) { 'Croydon Crown Court' }
+
+      it { expect(subject.hearing_court).not_to be_nil }
+      it { expect(subject.hearing_court.name).to eq(court_name) }
+    end
+
+    context 'for an unknown court' do
+      let(:court_name) { 'Foobar Court' }
+
+      it { expect(subject.hearing_court).to be_nil }
+    end
+
+    context 'for a blank court' do
+      let(:court_name) { '' }
+
+      it { expect(subject.hearing_court).to be_nil }
+    end
+  end
+
   describe '`charges` relationship' do
     subject(:charges) do
       described_class.create(

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -11,8 +11,12 @@ RSpec.describe Court, type: :model do
   describe '.all' do
     subject(:all) { described_class.all }
 
+    it 'returns all courts' do
+      expect(all.size).to eq(249)
+    end
+
     it 'returns required courts as expected' do
-      digest_of_expected_court_names = '4cdc39a4fa9cfe2aeb4984fe1dbab5d1'
+      digest_of_expected_court_names = '2783b31a61666a79b810dc8ef95c61d1'
 
       expect(Digest::MD5.hexdigest(all.map(&:name).join)).to eq digest_of_expected_court_names
     end

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Court, type: :model do
+  describe '.find_by_name' do
+    it 'is shorthand for `.find_by`' do
+      expect(described_class).to receive(:find_by).with(name: 'Foobar')
+      described_class.find_by(name: 'Foobar')
+    end
+  end
+
   describe '.all' do
     subject(:all) { described_class.all }
 


### PR DESCRIPTION
## Description of change
Based on some recent conversations, and the fact the repo for `hmcts_common_platform` is archived and apparently unmaintained and outdated, one immediate easy thing we can do is bring over the (simplified) CSV file and use the same approach we used for offences.

Functionally everything should continue working as before, and we have more flexibility to update or tweak the CSV file to add/remove or rename courts.

In the future we can plan to move to an API based approach using FaCT.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-435
Slack thread:
https://mojdt.slack.com/archives/C02AFLHGK9S/p1689069962130059

## How to manually test the feature
Go to the hearing court page, and play around.