### PR TITLE
Bump datastore API client gem (v1.0.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'importmap-rails'
 gem 'bootsnap', require: false
 
 gem 'laa-criminal-applications-datastore-api-client',
-    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
+    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.0.0'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: 867f6dbcc8c646b08c19994cfbf19bf672acbec8
+  revision: c70ab780a2384fb156e9ded2213304cd2967254b
+  tag: v1.0.0
   specs:
-    laa-criminal-applications-datastore-api-client (0.1.0)
-      faraday (~> 2.6)
+    laa-criminal-applications-datastore-api-client (1.0.0)
+      faraday (~> 2.7)
       moj-simple-jwt-auth (~> 0.1.0)
 
 GIT
@@ -161,7 +162,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
-    faraday (2.7.9)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)


### PR DESCRIPTION
## Description of change
No functional changes, the gem dependencies have been refreshen and released as `v1.0.0`

Using the tagged version in the Gemfile, same as we do with the schemas gem, to avoid inadvertently introducing breaking changes when updating the bundle.

