### PR TITLE
CRIMAP-439 Ensure enter key triggers main submit action

### DIFF
--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -5,7 +5,7 @@
 module FormBuilderHelper
   def continue_button(primary: :save_and_continue, secondary: :save_and_come_back_later,
                       primary_opts: {}, secondary_opts: {})
-    submit_button(primary, primary_opts) do
+    submit_button(primary, primary_opts.merge(data: { 'main-action': true })) do
       submit_button(secondary, secondary_opts.merge(secondary: true, name: 'commit_draft')) if secondary
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -56,6 +56,15 @@ for (let i = 0; i < $elements.length; i++) {
   new PrintAction($elements[i]).init()
 }
 
+// Duplicate "main" submit and place it hidden higher than others
+// in the DOM hierarchy, so pressing `enter` key picks this one
+// Used in forms with secondary submit actions in between
+import MultiActionForm from "local/multi-action-form"
+const $forms = document.querySelectorAll('form[data-module="multi-action-form"]')
+for (let i = 0; i < $forms.length; i++) {
+  new MultiActionForm($forms[i]).init()
+}
+
 // Google analytics additional tracking
 // Keep this at the bottom of this file
 import GAEvents from "local/ga-events"

--- a/app/javascript/local/multi-action-form.js
+++ b/app/javascript/local/multi-action-form.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function MultiActionForm($form) {
+  this.$form = $form
+  this.$mainActionSelector = '.govuk-button-group button[data-main-action="true"]'
+}
+
+MultiActionForm.prototype.init = function() {
+  const $submit = this.$form.querySelector(this.$mainActionSelector)
+
+  if ($submit) {
+    let $clonedSubmit = $submit.cloneNode(true)
+
+    // Hide this button completely, including screen-readers
+    $clonedSubmit.setAttribute('class', 'govuk-visually-hidden')
+    $clonedSubmit.setAttribute('aria-hidden', 'true')
+    $clonedSubmit.setAttribute('tabindex', '-1')
+
+    this.$form.prepend($clonedSubmit)
+  }
+}
+
+export default MultiActionForm

--- a/app/views/steps/address/lookup/edit.html.erb
+++ b/app/views/steps/address/lookup/edit.html.erb
@@ -9,7 +9,7 @@
 
     <h1 class="govuk-heading-xl"><%=t @form_object.heading %></h1>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { module: 'multi-action-form' } do |f| %>
       <%= f.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third' %>
 
       <p class="govuk-body govuk-!-margin-bottom-2">

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -9,7 +9,7 @@
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { module: 'multi-action-form' } do |f| %>
       <% suggestions_id = f.field_id(:offence_name, :field, :suggestions).tr('_', '-') %>
 
       <%= f.govuk_text_field :offence_name, label: { size: 'm' },

--- a/app/views/steps/case/codefendants/edit.html.erb
+++ b/app/views/steps/case/codefendants/edit.html.erb
@@ -9,7 +9,7 @@
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { module: 'multi-action-form' } do |f| %>
       <%= f.fields_for :codefendants do |c| %>
         <% index = c.index + 1 %>
 

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe FormBuilderHelper, type: :helper do
   end
 
   describe '#continue_button' do
+    # rubocop:disable Layout/LineLength
     context 'when there is no secondary action' do
       let(:expected_markup) do
         '<button type="submit" formnovalidate="formnovalidate" class="govuk-button" ' \
-          'data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>'
+          'data-module="govuk-button" data-prevent-double-click="true" data-main-action="true">Save and continue</button>'
       end
 
       it 'outputs only the continue button' do
@@ -30,7 +31,7 @@ RSpec.describe FormBuilderHelper, type: :helper do
       let(:expected_markup) do
         '<div class="govuk-button-group">' \
           '<button type="submit" formnovalidate="formnovalidate" class="govuk-button" ' \
-          'data-module="govuk-button" data-prevent-double-click="true">Save and continue</button>' \
+          'data-module="govuk-button" data-prevent-double-click="true" data-main-action="true">Save and continue</button>' \
           '<button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--secondary" ' \
           'data-module="govuk-button" data-prevent-double-click="true" name="commit_draft">' \
           'Save and come back later</button></div>'
@@ -42,6 +43,7 @@ RSpec.describe FormBuilderHelper, type: :helper do
         ).to eq(expected_markup)
       end
     end
+    # rubocop:enable Layout/LineLength
 
     context 'button text can be customised' do
       before do


### PR DESCRIPTION
## Description of change
Default browser behaviour when user focus in a form input, like a text field, and they press enter, is to submit the form.

This usually works just fine, as there is only one submit per form or the main submit comes before the others.

However, in some steps, like the postcode lookup, there is more than 1 submit action and the browser picks the first one in order of appearance in the DOM, which might not be the one that actually performs the “save and continue” (or the postcode search in this case).

This works around this behaviour in a progressive enhancement way with a bit of JS, by cloning the main submit action and positioning it (hidden, even for screen-readers) right at the top of the form so `enter key` picks this one always.

Only forms tagged with "data-multi-action-form=true" will have this progressive enhancement applied, as there is no need to do this with other forms.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-439

## Notes for reviewer

## How to manually test the feature
Observe previous behaviour (without the changes in this PR) in steps. Enter key will not act same as "save and continue".
- postcode lookup
- offences page
- codefendants page

With the changes in this PR, when focus is in a text input in any of those pages, and pressing `enter` key, the form will be submitted, same behaviour as if the user clicks the "green button / save and continue".