### PR TITLE
Bump schemas gem to v1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.0.0'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.7.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5dae17e1af44335493dae6932b9257e8a9ba6b08
-  tag: v0.7.0
+  revision: 1c7d156ea6ddf0fb997706e3d59d66f4f102e0e7
+  tag: v1.0.0
   specs:
-    laa-criminal-legal-aid-schemas (0.7.0)
+    laa-criminal-legal-aid-schemas (1.0.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Adapters::Structs::Applicant do
         %w[
           first_name
           last_name
+          other_names
           date_of_birth
           nino
           correspondence_address_type


### PR DESCRIPTION
## Description of change
Just tweaked a test as `other_names` have been added to the fixture, it was missing.

No other changes were required.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-442

