### PR TITLE
Add restriction to dob that raises error if applicant under 10

### DIFF
--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -12,7 +12,8 @@ module Steps
       validates_presence_of :first_name,
                             :last_name
 
-      validates :date_of_birth, presence: true, multiparam_date: true
+      validates :date_of_birth, presence: true,
+                multiparam_date: { restrict_past_under_ten_years: true }
 
       private
 

--- a/app/validators/multiparam_date_validator.rb
+++ b/app/validators/multiparam_date_validator.rb
@@ -5,6 +5,7 @@ class MultiparamDateValidator < ActiveModel::EachValidator
     earliest_year: 1900,
     latest_year: 2050,
     allow_past: true,
+    restrict_past_under_ten_years: false,
     allow_future: false,
   }.freeze
 
@@ -57,15 +58,17 @@ class MultiparamDateValidator < ActiveModel::EachValidator
   # the future, or a date is very far in the past (potential user typo).
   # This kind of validations can be configured passing an options hash
   # when declaring the validation in the attribute.
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def validate_config_constraints(date)
     add_error(:past_not_allowed) unless config[:allow_past] || Time.zone.today <= date
     add_error(:future_not_allowed) unless config[:allow_future] || Time.zone.today >= date
 
     add_error(:year_too_late) if date.year > config[:latest_year]
     add_error(:year_too_early) if date.year < config[:earliest_year]
+
+    add_error(:client_under_ten) if config[:restrict_past_under_ten_years] && (date.beginning_of_day > 10.years.ago)
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def add_error(error)
     record.errors.add(attribute, error)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -37,6 +37,7 @@ en:
               year_too_late: Date of birth is too far in the future
               year_too_early: Date of birth is too far in the past
               future_not_allowed: Date of birth must be in the past
+              client_under_ten: Your client must be aged 10 or over to have been charged in England and Wales
         steps/client/has_nino_form:
           attributes:
             nino:

--- a/spec/forms/steps/case/appeal_details_form_spec.rb
+++ b/spec/forms/steps/case/appeal_details_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Steps::Case::AppealDetailsForm do
 
       it_behaves_like 'a multiparam date validation',
                       attribute_name: :appeal_lodged_date,
-                      allow_past: true, allow_future: false
+                      restrict_past_under_ten_years: false
     end
 
     context 'when case type is `appeal_to_crown_court_with_changes`' do
@@ -45,7 +45,7 @@ RSpec.describe Steps::Case::AppealDetailsForm do
 
       it_behaves_like 'a multiparam date validation',
                       attribute_name: :appeal_lodged_date,
-                      allow_past: true, allow_future: false
+                      restrict_past_under_ten_years: false
     end
 
     context 'previous MAAT ID format' do

--- a/spec/forms/steps/case/offence_date_fieldset_form_spec.rb
+++ b/spec/forms/steps/case/offence_date_fieldset_form_spec.rb
@@ -20,14 +20,16 @@ RSpec.describe Steps::Case::OffenceDateFieldsetForm do
       it { is_expected.to validate_presence_of(:date_from) }
 
       it_behaves_like 'a multiparam date validation',
-                      attribute_name: :date_from
+                      attribute_name: :date_from,
+                      restrict_past_under_ten_years: false
     end
 
     describe '#date_to' do
       it { is_expected.not_to validate_presence_of(:date_to) }
 
       it_behaves_like 'a multiparam date validation',
-                      attribute_name: :date_to
+                      attribute_name: :date_to,
+                      restrict_past_under_ten_years: false
     end
 
     context '`date_to` is before `date_from`' do

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Steps::Client::DetailsForm do
       first_name: 'John',
       last_name: 'Doe',
       other_names: nil,
-      date_of_birth: Date.yesterday,
+      date_of_birth: 20.years.ago.to_date,
     }
   end
 
@@ -34,7 +34,8 @@ RSpec.describe Steps::Client::DetailsForm do
 
     context 'date_of_birth' do
       it_behaves_like 'a multiparam date validation',
-                      attribute_name: :date_of_birth
+                      attribute_name: :date_of_birth,
+                      restrict_past_under_ten_years: true
     end
 
     context 'when validations pass' do
@@ -50,7 +51,7 @@ RSpec.describe Steps::Client::DetailsForm do
                             'first_name' => 'John',
                             'last_name' => 'Smith',
                             'other_names' => nil,
-                            'date_of_birth' => Date.yesterday,
+                            'date_of_birth' => 20.years.ago.to_date,
                             :has_nino => nil,
                             :nino => nil,
                             :passporting_benefit => nil,
@@ -58,7 +59,7 @@ RSpec.describe Steps::Client::DetailsForm do
         end
 
         context 'date_of_birth' do
-          let(:date_of_birth) { Date.new(2008, 11, 22) }
+          let(:date_of_birth) { 20.years.ago.to_date }
           let(:form_attributes) { super().merge(date_of_birth:) }
 
           it_behaves_like 'a has-one-association form',
@@ -67,7 +68,7 @@ RSpec.describe Steps::Client::DetailsForm do
                             'first_name' => 'John',
                             'last_name' => 'Doe',
                             'other_names' => nil,
-                            'date_of_birth' => Date.new(2008, 11, 22),
+                            'date_of_birth' => 20.years.ago.to_date,
                             :has_nino => nil,
                             :nino => nil,
                             :passporting_benefit => nil,
@@ -88,7 +89,7 @@ RSpec.describe Steps::Client::DetailsForm do
               'first_name' => 'Johnny',
               'last_name' => 'Doe',
               'other_names' => nil,
-              'date_of_birth' => Date.yesterday,
+              'date_of_birth' => 20.years.ago.to_date,
             }
           ).and_return(true)
 

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -161,13 +161,33 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
   end
 
   context 'when date is in the past' do
+    # `true` is the validator default unless passing a different config
     let(:date) { Date.yesterday }
 
-    # `true` is the validator default unless passing a different config
     if options.fetch(:allow_past, true)
-      it 'allows past dates' do
-        expect(subject).to be_valid
-        expect(subject.errors.added?(attribute_name, :past_not_allowed)).to be(false)
+      if options.fetch(:restrict_past_under_ten_years, true)
+        context 'when dob is less than 10 years ago' do
+          let(:date) { 10.years.ago.to_date + 1.day }
+
+          it 'does not allow past dates under 10 years ago' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.added?(attribute_name, :client_under_ten)).to be(true)
+          end
+        end
+
+        context 'when dob is more than 10 years ago' do
+          let(:date) { 10.years.ago.to_date }
+
+          it 'allows past dates over 10 years ago' do
+            expect(subject).to be_valid
+            expect(subject.errors.added?(attribute_name, :client_under_ten)).to be(false)
+          end
+        end
+      else
+        it 'allows past dates' do
+          expect(subject).to be_valid
+          expect(subject.errors.added?(attribute_name, :past_not_allowed)).to be(false)
+        end
       end
     else
       it 'does not allow past dates' do


### PR DESCRIPTION
## Description of change
Client cannot be under age 10 - below this age, children cannot be held criminally responsible. 

MAAT has a validation whereby trying to save application details with a DoB that means the applicant is under the age of 10 it errors. Crime Apply should replicate this error to prevent incompatible data reaching MAAT, but rather to raise an error with the provider as they input the DoB to get them to check the DoB for errors

Adds validation that input date results in the client being 10 years old or older. Adds an error if not and raises this to the user

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-451
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="753" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/d5d891be-c522-4aba-93ed-7480ad856c66">


## How to manually test the feature
Start an application and fill client details with a date of birth more recent than 18/07/2013 - e.g. 01/08/2013