### PR TITLE
Set `Cache-Control` response header to no-store

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,10 @@ class DashboardController < ApplicationController
   helper_method :in_progress_count, :returned_count, :sortable_columns
   delegate :returned_count, to: :application_counters
 
+  # Avoid the browser caching any of the dashboard pages so the
+  # back button after signing out can't load any sensitive details
+  before_action :no_store
+
   private
 
   # Implement in sub-controllers to narrow down allowed columns

--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -3,6 +3,10 @@ module Steps
     before_action :check_crime_application_presence
     before_action :update_navigation_stack, only: [:show, :edit]
 
+    # Avoid the browser caching any of the step pages so the
+    # back button after signing out can't load any sensitive details
+    before_action :no_store
+
     # :nocov:
     def show
       raise 'implement this action, if needed, in subclasses'


### PR DESCRIPTION
## Description of change
It avoids possibly exposing personal information when using the browser back button after the current session has been terminated.

This is similar to the [approach taken on Review](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/361) however instead of adding it to all controller actions, this is only set on those exposing possible personal information.

There are many other pages on Apply (all footer pages, and some others) that are not sensitive.

Note pragma header not set as is deprecated and no longer recommended. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma

## Link to relevant ticket

## Notes for reviewer
I'm not 100% sure this works well with Safari. Tested well in all other browsers including Firefox, Chrome, Opera and Edge.

## How to manually test the feature
Sign in, go to the dashboard, then go to submitted applications for instance, open one of those applications. Then while having it opened, sign out, then click the browser's back button, one or more times, you should not see the previous application details, and a page to sign in should be presented instead.