### PR TITLE
Discern between invalid session and invalid token errors

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -4,7 +4,9 @@ module ErrorHandling
   included do
     rescue_from Exception do |exception|
       case exception
-      when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
+      when ActionController::InvalidAuthenticityToken
+        redirect_to unauthenticated_errors_path
+      when Errors::InvalidSession
         redirect_to invalid_session_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -5,7 +5,7 @@ module ErrorHandling
     rescue_from Exception do |exception|
       case exception
       when ActionController::InvalidAuthenticityToken
-        redirect_to unauthenticated_errors_path
+        redirect_to invalid_token_errors_path
       when Errors::InvalidSession
         redirect_to invalid_session_errors_path
       when Errors::ApplicationNotFound

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,6 +3,10 @@ class ErrorsController < UnauthenticatedController
     respond_with_status(:ok)
   end
 
+  def invalid_token
+    respond_with_status(:bad_request)
+  end
+
   def application_not_found
     respond_with_status(:not_found)
   end

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -12,10 +12,9 @@ module Providers
     end
 
     def failure
-      raise if $ERROR_INFO.is_a?(ActionController::InvalidAuthenticityToken)
-
-      Rails.error.report($ERROR_INFO, handled: true)
-      redirect_to unhandled_errors_path
+      # Let the application generic error handling deal with the
+      # exception. Refer to `controllers/concerns/error_handling.rb`
+      raise
     end
 
     private

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -12,6 +12,8 @@ module Providers
     end
 
     def failure
+      raise if $ERROR_INFO.is_a?(ActionController::InvalidAuthenticityToken)
+
       Rails.error.report($ERROR_INFO, handled: true)
       redirect_to unhandled_errors_path
     end

--- a/app/views/errors/invalid_token.en.html.erb
+++ b/app/views/errors/invalid_token.en.html.erb
@@ -1,0 +1,17 @@
+<% title 'There is a problem with your request' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Sorry, there is a problem with your request
+    </h1>
+
+    <p class="govuk-body">
+      You can go back, refresh the page, and try again.
+    </p>
+
+    <p class="govuk-body">
+      <%= link_to 'Contact us', about_contact_path %> if this problem continues.
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   resource :errors, only: [] do
     get :application_not_found
     get :invalid_session
+    get :invalid_token
     get :unhandled
     get :unauthenticated
     get :reauthenticate

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ApplicationController do
 
   context 'Exceptions handling' do
     context 'ActionController::InvalidAuthenticityToken' do
-      it 'does not report the exception, and redirects to the unauthenticated error page' do
+      it 'does not report the exception, and redirects to the error page' do
         routes.draw { get 'invalid_token' => 'anonymous#invalid_token' }
 
         expect(Rails.error).not_to receive(:report)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,12 +2,24 @@ require 'rails_helper'
 
 RSpec.describe ApplicationController do
   controller do
+    def invalid_token = raise(ActionController::InvalidAuthenticityToken)
     def invalid_session = raise(Errors::InvalidSession)
     def application_not_found = raise(Errors::ApplicationNotFound)
     def another_exception = raise(StandardError)
   end
 
   context 'Exceptions handling' do
+    context 'ActionController::InvalidAuthenticityToken' do
+      it 'does not report the exception, and redirects to the unauthenticated error page' do
+        routes.draw { get 'invalid_token' => 'anonymous#invalid_token' }
+
+        expect(Rails.error).not_to receive(:report)
+
+        get :invalid_token
+        expect(response).to redirect_to(unauthenticated_errors_path)
+      end
+    end
+
     context 'Errors::InvalidSession' do
       it 'does not report the exception, and redirect to the error page' do
         routes.draw { get 'invalid_session' => 'anonymous#invalid_session' }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ApplicationController do
         expect(Rails.error).not_to receive(:report)
 
         get :invalid_token
-        expect(response).to redirect_to(unauthenticated_errors_path)
+        expect(response).to redirect_to(invalid_token_errors_path)
       end
     end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe 'Error pages' do
     end
   end
 
+  context 'invalid token' do
+    it 'renders the expected page and has expected status code' do
+      get '/errors/invalid_token'
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
   context 'application not found' do
     it 'renders the expected page and has expected status code' do
       get '/errors/application_not_found'

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -170,18 +170,10 @@ RSpec.describe 'Sign in user journey' do
     before do
       allow(OmniAuth.config).to receive(:test_mode).and_return(false)
       allow_any_instance_of(LaaPortal::SamlSetup).to receive(:setup).and_raise(StandardError)
-
-      allow(Rails.error).to receive(:report)
-
-      start_button.click
     end
 
-    it 'reports the exception and redirects to the unhandled error page' do
-      expect(Rails.error).to have_received(:report).with(
-        an_instance_of(StandardError), hash_including(handled: true)
-      )
-
-      expect(current_url).to match(unhandled_errors_path)
+    it 're-raises the exception for handling by the `ApplicationController`' do
+      expect { start_button.click }.to raise_error(StandardError)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Omniauth authentication could fail due to an invalid authenticity token. For instance, by re-submitting the same form twice. In this scenario we were redirecting to the unhandled error page, which is not correct and confusing to the user.

Now we just let `InvalidAuthenticityToken` exceptions bubble up, so it can be rescued and handled accordingly within the generic error handling block.

Also previously we were bunching together the invalid session and the authenticity token errors, but they are not really the same and to a user's point of view, showing the invalid session error when the error was produced by an invalid authenticity token (forgery protection) might be confusing as we tell them:

"For your security, we signed you out
This is because you were inactive for 48 hours."

Now each error is separate and the `InvalidAuthenticityToken` will redirect to a different error page with a more lax error message and instruct users to go back, reload and retry.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-459

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
When produced in omniauth flow:
<img width="799" alt="Screenshot 2023-07-19 at 11 49 35" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/ba0424dc-e64a-4d10-afdf-f53b68878a51">

When produced anywhere else:
<img width="777" alt="Screenshot 2023-07-19 at 13 57 45" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/b7a01216-a9eb-4a23-bec7-178c4b3ed1e6">

### After changes:
<img width="809" alt="Screenshot 2023-07-20 at 10 29 54" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/7f900397-f088-4333-866f-968396ac09d9">

## How to manually test the feature
Sign in, go back and click Sign in again. Without the changes in this PR, you will get an unhandled error page. With the changes in this page, you will get a "Sorry, there is a problem with your request" page.

As part of the steps journey: start an application, and when in a step form, edit the page and change the form param `authenticity_token` and submit to produce an `InvalidAuthenticityToken` exception. It shows the "Sorry, there is a problem with your request" page.