### PR TITLE
Only show dev tools `return` button in development

### DIFF
--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -32,7 +32,7 @@
                           data: { module: 'govuk-button' } do; 'Destroy'; end %>
           <% end %>
 
-          <% if crime_application.submitted? %>
+          <% if crime_application.submitted? && Rails.env.development? %>
             <%= button_to mark_as_returned_developer_tools_crime_application_path, method: :put,
                           class: 'govuk-button govuk-button--warning govuk-!-margin-right-1',
                           data: { module: 'govuk-button' } do; 'Return application'; end %>


### PR DESCRIPTION
## Description of change
Change to go along with [datastore PR](https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/137) so on staging (where developer tools is active) the `return` functionality will not show as it can leave inconsistent or corrupted data in the datastore.

Leave it enabled for quick tests on local environments.

## How to manually test the feature
On staging the button will not show anymore 😿 