### PR TITLE
CRIMAP-460 Minor tweaks to logging

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -10,11 +10,9 @@ Rails.application.config.filter_parameters += [
   # Attributes relating to an application
   # It does partial matching (i.e. `telephone_number` is covered by `phone`)
   :address_line,
-  :city,
-  :country,
+  :appeal_with_changes_details,
   :date_of_birth,
   :description,
-  :details,
   :email,
   :first_name,
   :justification,

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -27,6 +27,7 @@ Rails.application.configure do
   config.lograge.custom_payload do |controller|
     {
       provider_id: controller.current_provider.to_param,
+      office_code: controller.current_office_code,
     }
   end
 end


### PR DESCRIPTION
## Description of change
In the `filter_parameter_logging` we had `details` which is a too broad term that was hindering some logs unnecessarily.

For instance, whole steps like `contact_details`, `address_details`, `appeal_details` or `hearing_details` where being filtered, however there are attributes we don't need to filter in those.

Also city and country are not PII and can be left unfiltered.

Added the signed in provider selected `office_code` to each log trace for better debug purposes.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-460

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
```
Processing by Steps::Address::DetailsController#update as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]", "steps_address_details_form"=>"[FILTERED]", "id"=>"a22f89c2-49eb-40e7-9dd3-395a35177e7c", "address_id"=>"5b21cfa2-1103-4e3d-adde-9f7a74fc27ff"}
```

### After changes:
```
Processing by Steps::Address::DetailsController#update as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]", "steps_address_details_form"=>{"address_line_one"=>"[FILTERED]", "address_line_two"=>"[FILTERED]", "city"=>"city", "country"=>"country", "postcode"=>"[FILTERED]"}, "id"=>"a22f89c2-49eb-40e7-9dd3-395a35177e7c", "address_id"=>"5b21cfa2-1103-4e3d-adde-9f7a74fc27ff"}
```

## How to manually test the feature
Can be tested locally, in the server logs. For the `lograge` custom payload the application needs to be running in production mode (docker-compose can be used, for example).