### PR TITLE
Fix method missing in healthcheck

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -24,10 +24,13 @@ Rails.application.configure do
     }.compact_blank
   end
 
+  # Important: the `controller` might not be a full-featured
+  # `ApplicationController` but instead a `BareApplicationController`
+  # so careful what methods you assume exist! :wink:
   config.lograge.custom_payload do |controller|
     {
       provider_id: controller.current_provider.to_param,
-      office_code: controller.current_office_code,
+      office_code: controller.current_provider&.selected_office_code,
     }
   end
 end


### PR DESCRIPTION
## Description of change
On the back of previous PR #445.

This is the second time we've been bitten by this. Maybe some smoke test will be required, will think of something.

For now, fixing this by calling the warden exposed method instead of the helper controller method.

And added a cautionary comment.

