### PR TITLE
CRIMAP-462 Datastore health engine routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ gem 'importmap-rails'
 gem 'bootsnap', require: false
 
 gem 'laa-criminal-applications-datastore-api-client',
-    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.0.0'
+    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', ref: 'a873cfd',
+    require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'importmap-rails'
 gem 'bootsnap', require: false
 
 gem 'laa-criminal-applications-datastore-api-client',
-    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', ref: 'a873cfd',
+    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.1.0',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: a873cfd47eb6f14b5e90ed5f35e0d53a050a302b
-  ref: a873cfd
+  revision: 0707f4122553b3e72c85ea5df0a242d703fec00a
+  tag: v1.1.0
   specs:
     laa-criminal-applications-datastore-api-client (1.1.0)
       faraday (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: c70ab780a2384fb156e9ded2213304cd2967254b
-  tag: v1.0.0
+  revision: a873cfd47eb6f14b5e90ed5f35e0d53a050a302b
+  ref: a873cfd
   specs:
-    laa-criminal-applications-datastore-api-client (1.0.0)
+    laa-criminal-applications-datastore-api-client (1.1.0)
       faraday (~> 2.7)
       moj-simple-jwt-auth (~> 0.1.0)
 

--- a/config/initializers/datastore_client.rb
+++ b/config/initializers/datastore_client.rb
@@ -1,5 +1,3 @@
-require 'datastore_api'
-
 DatastoreApi.configure do |config|
   config.api_root = ENV.fetch('DATASTORE_API_ROOT', nil)
   config.api_path = '/api/v1'

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,9 +5,12 @@ Rails.application.configure do
   config.lograge.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.formatter = Lograge::Formatters::Logstash.new
 
+  # Reduce noise in the logs by ignoring the healthcheck actions
   config.lograge.ignore_actions = %w[
     HealthcheckController#show
     HealthcheckController#ping
+    DatastoreApi::HealthEngine::HealthcheckController#show
+    DatastoreApi::HealthEngine::HealthcheckController#ping
   ]
 
   config.lograge.custom_options = lambda do |event|

--- a/config/kubernetes/staging/grafana-rails-metrics.yml
+++ b/config/kubernetes/staging/grafana-rails-metrics.yml
@@ -217,7 +217,7 @@ data:
           "pluginVersion": "9.2.4",
           "targets": [
             {
-              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[60m]) * 60 * 60)",
+              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[60m]) * 60 * 60)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -387,7 +387,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (controller,action) (rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m])  > 0)\n/\navg by (controller,action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0) * 1000",
+              "expr": "avg by (controller,action) (rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m])  > 0)\n/\navg by (controller,action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0) * 1000",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -487,7 +487,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by (controller, action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\", controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "sum by (controller, action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\", controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{controller}}/{{action}}",
@@ -542,7 +542,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "max(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -552,7 +552,7 @@ data:
               "target": "carbon.*"
             },
             {
-              "expr": "max(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "max(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max SQL",
@@ -633,7 +633,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",status=~\"^[23].*\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m])) by (status) > 0",
+              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",status=~\"^[23].*\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m])) by (status) > 0",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{status}}",
@@ -718,7 +718,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "avg(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Avg Request",
@@ -726,7 +726,7 @@ data:
               "target": ""
             },
             {
-              "expr": "avg(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "avg(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'.*healthcheck|status',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Avg SQL",
@@ -1084,7 +1084,7 @@ data:
           ],
           "targets": [
             {
-              "expr": "topk(10,sum(rate(ruby_http_request_duration_seconds_count{namespace=~\"$namespace\",controller!~'healthcheck|status'}[1w]) * 3600 * 24) by (controller, action))",
+              "expr": "topk(10,sum(rate(ruby_http_request_duration_seconds_count{namespace=~\"$namespace\",controller!~'.*healthcheck|status'}[1w]) * 3600 * 24) by (controller, action))",
               "format": "table",
               "instant": true,
               "intervalFactor": 1,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ def show_step(name)
 end
 
 Rails.application.routes.draw do
+  mount DatastoreApi::HealthEngine::Engine => '/datastore'
+
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
 

--- a/spec/requests/datastore_healthcheck_spec.rb
+++ b/spec/requests/datastore_healthcheck_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Datastore healthcheck endpoints' do
+  describe 'Health endpoint' do
+    context 'success' do
+      before do
+        stub_request(:get, 'http://datastore-webmock/health')
+          .to_return(body: '{}')
+      end
+
+      it 'reports success' do
+        get '/datastore/health'
+        expect(response.body).to eq('{}')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'failure' do
+      before do
+        stub_request(:get, 'http://datastore-webmock/health')
+          .to_raise(StandardError)
+      end
+
+      it 'reports failure' do
+        get '/datastore/health'
+        expect(response.body).to eq('{"error":"Exception from WebMock"}')
+        expect(response).to have_http_status(:service_unavailable)
+      end
+    end
+  end
+
+  describe 'Ping endpoint' do
+    context 'success' do
+      before do
+        stub_request(:get, 'http://datastore-webmock/ping')
+          .to_return(body: '{}')
+      end
+
+      it 'reports success' do
+        get '/datastore/ping'
+        expect(response.body).to eq('{}')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'failure' do
+      before do
+        stub_request(:get, 'http://datastore-webmock/ping')
+          .to_raise(StandardError)
+      end
+
+      it 'reports failure' do
+        get '/datastore/ping'
+        expect(response.body).to eq('{"error":"Exception from WebMock"}')
+        expect(response).to have_http_status(:service_unavailable)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Use the datastore health rails engine on Apply to act as a proxy for the health and ping endpoints given the datastore is an internal service only accessible from the cluster.

Moved the `require 'datastore_api'` to the Gemfile declaration as otherwise it wasn't properly loading the engine, I think it may be because the name of the gem is different to the name of the lib require.

Note: the gem ref to be changed with the tag 1.1.0 when new tag is released.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-462

## Notes for reviewer

## How to manually test the feature
Spin up both, datastore and Apply, and from Apply, observe how `/datastore/ping` or `/datastore/health` reach the datastore. If datastore is down, those endpoints will return error.

Also:
```
$ rails routes | grep datastore
datastore_api_health_engine   /datastore   DatastoreApi::HealthEngine::Engine
health GET  /health(.:format) datastore_api/health_engine/healthcheck#show
  ping GET  /ping(.:format)   datastore_api/health_engine/healthcheck#ping
```