### PR TITLE
Increase custom prometheus collector resolution

### DIFF
--- a/app/lib/prometheus_metrics/applications_count_collector.rb
+++ b/app/lib/prometheus_metrics/applications_count_collector.rb
@@ -4,10 +4,10 @@ module PrometheusMetrics
     # Prometheus monitoring service on kubernetes will scrape
     # the `/metrics` endpoint frequently (every 15s), but these
     # custom metrics don't require such precision.
-    # We cache (in-memory) for 5 minutes the results.
+    # We cache (in-memory) for a few minutes the results.
     #
     def expires_in
-      5.minutes
+      2.minutes
     end
 
     def type

--- a/spec/lib/prometheus_metrics/applications_count_collector_spec.rb
+++ b/spec/lib/prometheus_metrics/applications_count_collector_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 describe PrometheusMetrics::ApplicationsCountCollector do
   subject { described_class.new }
 
-  let(:expires_in) { 5.minutes }
+  let(:expires_in) { 2.minutes }
   let(:type) { 'crime_applications' }
 
   describe '#expires_in' do


### PR DESCRIPTION
## Description of change
Funny enough our service allows to submit applications in such a speedy way that we had 1 application under the 5 minutes resolution.

Decreasing cache to 2 minutes, after all this are not heavy reports just simple counts on very few records.

This is for the applications grafana dashboard (started, in progress, date stamped...)
