### PR TITLE
CRIMAP-505 Add `pwits` to offence synonyms list

### DIFF
--- a/config/data/offence_synonyms.yml
+++ b/config/data/offence_synonyms.yml
@@ -7,5 +7,7 @@ offence_synonyms:
   synonyms: [cbo]
 - regex: !ruby/regexp /grievous bodily harm/i
   synonyms: [gbh]
+- regex: !ruby/regexp /possess with intent to supply/i
+  synonyms: [pwits]
 - regex: !ruby/regexp /section 18/i
   synonyms: [s18]


### PR DESCRIPTION
## Description of change
This will return 10 offences all related to "possess with intent to supply ..."

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-505

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="723" alt="Screenshot 2023-07-24 at 17 44 44" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/8582054d-6b5e-48fb-be3c-f4be64ef487d">

## How to manually test the feature
Note there is no need to finalise the acronym, just by typing a few letters of it will find results, but I added the full acronym as it is clearer this way.