### PR TITLE
CRIMAP-506 Providers prometheus custom collector

### DIFF
--- a/app/lib/prometheus_metrics/applications_count_collector.rb
+++ b/app/lib/prometheus_metrics/applications_count_collector.rb
@@ -4,10 +4,10 @@ module PrometheusMetrics
     # Prometheus monitoring service on kubernetes will scrape
     # the `/metrics` endpoint frequently (every 15s), but these
     # custom metrics don't require such precision.
-    # We cache (in-memory) for 5 minutes the results.
+    # We cache (in-memory) for a few minutes the results.
     #
     def expires_in
-      5.minutes
+      2.minutes
     end
 
     def type

--- a/app/lib/prometheus_metrics/collectors.rb
+++ b/app/lib/prometheus_metrics/collectors.rb
@@ -1,5 +1,6 @@
 module PrometheusMetrics
   module Collectors
     require_relative 'applications_count_collector'
+    require_relative 'providers_count_collector'
   end
 end

--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -8,7 +8,8 @@ module PrometheusMetrics
     SERVER_BINDING_PORT = 9394
 
     CUSTOM_COLLECTORS = [
-      PrometheusMetrics::ApplicationsCountCollector
+      PrometheusMetrics::ApplicationsCountCollector,
+      PrometheusMetrics::ProvidersCountCollector,
     ].freeze
 
     # :nocov:

--- a/app/lib/prometheus_metrics/providers_count_collector.rb
+++ b/app/lib/prometheus_metrics/providers_count_collector.rb
@@ -1,0 +1,72 @@
+module PrometheusMetrics
+  class ProvidersCountCollector < PrometheusExporter::Server::TypeCollector
+    #
+    # Prometheus monitoring service on kubernetes will scrape
+    # the `/metrics` endpoint frequently (every 15s), but these
+    # custom metrics don't require such precision.
+    # We cache (in-memory) for a few minutes the results.
+    #
+    def expires_in
+      5.minutes
+    end
+
+    def type
+      'providers'.freeze
+    end
+
+    def metrics
+      [
+        enrolled_count,
+        multi_office_count,
+        disengaged_count,
+        idle_count,
+      ]
+    end
+
+    private
+
+    def counter
+      PrometheusExporter::Metric::Counter.new(
+        'crime_apply_providers_count', 'Number of providers by status'
+      )
+    end
+
+    def enrolled_count
+      result = Rails.cache.fetch(__method__, expires_in:) { Provider.count }
+
+      gauge = counter
+      gauge.observe(result, status: 'enrolled')
+      gauge
+    end
+
+    def multi_office_count
+      result = Rails.cache.fetch(__method__, expires_in:) do
+        Provider.where('array_length(office_codes, 1) > ?', 1).count
+      end
+
+      gauge = counter
+      gauge.observe(result, status: 'multi_office')
+      gauge
+    end
+
+    def disengaged_count
+      result = Rails.cache.fetch(__method__, expires_in:) do
+        Provider.where("(settings ->> 'legal_rep_first_name') is null").count
+      end
+
+      gauge = counter
+      gauge.observe(result, status: 'disengaged')
+      gauge
+    end
+
+    def idle_count
+      result = Rails.cache.fetch(__method__, expires_in:) do
+        Provider.where(['current_sign_in_at < ?', 1.week.ago]).count
+      end
+
+      gauge = counter
+      gauge.observe(result, status: 'idle')
+      gauge
+    end
+  end
+end

--- a/config/kubernetes/staging/grafana-applications.yml
+++ b/config/kubernetes/staging/grafana-applications.yml
@@ -37,7 +37,7 @@ data:
       "editable": false,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 82,
+      "id": 54,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -494,6 +494,451 @@ data:
           ],
           "title": "Applications by status",
           "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 12
+          },
+          "id": 62,
+          "panels": [],
+          "title": "Crime Apply Providers",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Providers that have access to the service and have signed in at least once",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "purple",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 13
+          },
+          "id": 63,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.4",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(1, ruby_crime_apply_providers_count{status=\"enrolled\", namespace=\"$namespace\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "ENROLLED",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Providers with more than one office",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "blue",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 4,
+            "y": 13
+          },
+          "id": 64,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.4",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(1, ruby_crime_apply_providers_count{status=\"multi_office\", namespace=\"$namespace\"})",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "MULTI OFFICE",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Providers that have not signed any declaration yet (no submissions), even if they have used the service",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 8,
+            "y": 13
+          },
+          "id": 65,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.4",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(1, ruby_crime_apply_providers_count{status=\"disengaged\", namespace=\"$namespace\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "DISENGAGED",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Providers that have not signed in to the service for a long period of time",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 12,
+            "y": 13
+          },
+          "id": 66,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.4",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(1, ruby_crime_apply_providers_count{status=\"idle\", namespace=\"$namespace\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "IDLE (> 1 WEEK)",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "blue",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "enrolled"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "multi_office"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "disengaged"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "idle"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 0,
+            "y": 16
+          },
+          "id": 67,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.5.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "round(avg(ruby_crime_apply_providers_count{namespace=\"$namespace\"}) by (status))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{status}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Providers by status",
+          "type": "timeseries"
         }
       ],
       "refresh": "1m",
@@ -601,6 +1046,6 @@ data:
       "timezone": "browser",
       "title": "LAA Crime Apply / Applications Dashboard",
       "uid": "crime-applications-dashboard",
-      "version": 3,
+      "version": 4,
       "weekStart": "monday"
     }

--- a/spec/lib/prometheus_metrics/applications_count_collector_spec.rb
+++ b/spec/lib/prometheus_metrics/applications_count_collector_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 describe PrometheusMetrics::ApplicationsCountCollector do
   subject { described_class.new }
 
-  let(:expires_in) { 5.minutes }
+  let(:expires_in) { 2.minutes }
   let(:type) { 'crime_applications' }
 
   describe '#expires_in' do

--- a/spec/lib/prometheus_metrics/providers_count_collector_spec.rb
+++ b/spec/lib/prometheus_metrics/providers_count_collector_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# Very light-touch smoke test as there is no point in having these
+# too elaborated, as metrics will probably change frequently
+#
+describe PrometheusMetrics::ProvidersCountCollector do
+  subject { described_class.new }
+
+  let(:expires_in) { 5.minutes }
+  let(:type) { 'providers' }
+
+  describe '#expires_in' do
+    it { expect(subject.expires_in).to eq(expires_in) }
+  end
+
+  describe '#type' do
+    it { expect(subject.type).to eq(type) }
+  end
+
+  describe '#metrics' do
+    before do
+      # rubocop:disable RSpec/MessageChain
+      allow(Provider).to receive(:count).and_return(10)
+      allow(Provider).to receive_message_chain(:where, :count).and_return(5, 2, 1)
+      # rubocop:enable RSpec/MessageChain
+    end
+
+    it 'calls the expected methods to gather metrics' do
+      expect(
+        subject.metrics.map(&:data)
+      ).to contain_exactly(
+        { { status: 'enrolled' } => 10 },
+        { { status: 'multi_office' } => 5 },
+        { { status: 'disengaged' } => 2 },
+        { { status: 'idle' } => 1 },
+      )
+    end
+
+    it 'uses Rails cache' do
+      expect(
+        Rails.cache
+      ).to receive(:fetch).with(:enrolled_count, expires_in:).and_return(10)
+
+      # testing just one, all counters behave the same
+      subject.send(:enrolled_count)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Similar to the existing applications collector, this new collector will expose a few basic metrics about providers as they are being enrolled and use our service.

Added a new panel and widgets to the existing Grafana dashboard so all is in one place.

Note until the collector is deployed, the dashboard will show no data.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-503

## Notes for reviewer

## How to manually test the feature
Metrics can be observed in the local /metrics endpoint when enabling prometheus exporter via ENV variables.