### PR TITLE
Remove unneeded webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,5 @@ group :test do
   gem 'rubocop-rspec', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
-  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,10 +418,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -476,7 +472,6 @@ DEPENDENCIES
   sprockets-rails
   uk_postcode
   web-console
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,8 +1,0 @@
-# Allow connections to webdriver urls
-#
-driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
-
-WebMock.disable_net_connect!(
-  allow_localhost: true,
-  allow: driver_urls,
-)


### PR DESCRIPTION
## Description of change
And cleanup Webmock initialiser as now there is nothing needed in it, the default is to `allow_localhost` anyways.

Note: we need to observe if this runs properly on CI. It `works on my machine ™`

