### PR TITLE
CRIMAP-548 Add explicit 'no conflict' caption to CYA

### DIFF
--- a/app/presenters/summary/sections/codefendants.rb
+++ b/app/presenters/summary/sections/codefendants.rb
@@ -42,7 +42,7 @@ module Summary
         if YesNoAnswer.new(codefendant.conflict_of_interest).yes?
           [codefendant.full_name, I18n.t('summary.questions.conflict_of_interest_html')].join
         else
-          codefendant.full_name
+          [codefendant.full_name, I18n.t('summary.questions.no_conflict_of_interest_html')].join
         end
       end
     end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -105,7 +105,8 @@ en:
           <<: *YESNO
       codefendant_full_name:
         question: "Co-defendant %{index}"
-      conflict_of_interest_html: <span class="govuk-caption-m">Has a conflict of interest</span>
+      conflict_of_interest_html: <span class="govuk-caption-m">Conflict of interest</span>
+      no_conflict_of_interest_html: <span class="govuk-caption-m">No conflict of interest</span>
       # END codefendants section
 
       # BEGIN next court hearing section

--- a/spec/presenters/summary/sections/codefendants_spec.rb
+++ b/spec/presenters/summary/sections/codefendants_spec.rb
@@ -71,13 +71,13 @@ describe Summary::Sections::Codefendants do
       expect(answers[1]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[1].question).to eq(:codefendant_full_name)
       expect(answers[1].change_path).to match('applications/12345/steps/case/codefendants#codefendant_1')
-      expect(answers[1].value).to eq('John Doe<span class="govuk-caption-m">Has a conflict of interest</span>')
+      expect(answers[1].value).to eq('John Doe<span class="govuk-caption-m">Conflict of interest</span>')
       expect(answers[1].i18n_opts).to eq({ index: 1 })
 
       expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[2].question).to eq(:codefendant_full_name)
       expect(answers[2].change_path).to match('applications/12345/steps/case/codefendants#codefendant_2')
-      expect(answers[2].value).to eq('Jane Doe')
+      expect(answers[2].value).to eq('Jane Doe<span class="govuk-caption-m">No conflict of interest</span>')
       expect(answers[2].i18n_opts).to eq({ index: 2 })
     end
   end


### PR DESCRIPTION
## Description of change
Add explicit 'no conflict' caption to CYA so provider can see what has been input should they need to change it. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-548

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="742" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/b0f510ba-f03d-43fc-818c-f0518ac4cd72">

### After changes:
<img width="702" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/f375bf65-65dd-4249-83f1-fa43f38b5b21">

## How to manually test the feature
