### PR TITLE
Tweak docker-compose

### DIFF
--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -4,9 +4,6 @@ module PrometheusMetrics
     require_relative 'collectors'
 
     DEFAULT_PREFIX = 'ruby_'.freeze
-    SERVER_BINDING_HOST = '0.0.0.0'.freeze
-    SERVER_BINDING_PORT = 9394
-
     CUSTOM_COLLECTORS = [
       PrometheusMetrics::Collectors::ApplicationsCountCollector,
       PrometheusMetrics::Collectors::ProvidersCountCollector,
@@ -30,7 +27,7 @@ module PrometheusMetrics
     # exporter process separately (`bundle exec prometheus_exporter`)
     def self.start_server
       server = PrometheusExporter::Server::WebServer.new(
-        bind: SERVER_BINDING_HOST, port: SERVER_BINDING_PORT,
+        bind: '0.0.0.0', port: ENV.fetch('PROMETHEUS_EXPORTER_PORT', 9394).to_i,
         verbose: ENV.fetch('PROMETHEUS_EXPORTER_VERBOSE', 'false').inquiry.true?
       )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ services:
       RAILS_ENV: production
       DATABASE_URL: postgresql://postgres@db/laa-apply-for-criminal-legal-aid
       SECRET_KEY_BASE: f22760a0bd78a9191ba4c247e23a281cb251461cdba6b5215043ca11b694d734
-      ENABLE_PROMETHEUS_EXPORTER: "true"
+      DATASTORE_API_ROOT: http://host.docker.internal:3003
+      DATASTORE_API_AUTH_SECRET: foobar
+      ENABLE_PROMETHEUS_EXPORTER: "false" # can be enabled for quick tests
+      PROMETHEUS_EXPORTER_PORT: 9394
       RAILS_SERVE_STATIC_FILES: "1"
       RAILS_LOG_TO_STDOUT: "1"
       DATABASE_SSLMODE: disable


### PR DESCRIPTION
## Description of change
With the objective of being able to run all 3 services (apply, review and datastore) at the same time as docker containers, some tweaks are needed.

Prometheus exporter port was hardcoded, it needs to be different in each container otherwise it will clash. Also by default now is disabled as most of the time we will never need it locally, but can be enabled for quick tests.

Added the datastore dummy credentials and endpoint (it works wether datastore is running also in a container, or on the host machine, assuming it's running in port 3003).

## How to manually test the feature
`docker-compose up` will no longer run prometheus exporter. If datastore is up and running in port 3003, Apply container will be able to talk to datastore too.