### PR TITLE
CRIMAP-529 Add MOJ javascript and dropzone

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,10 @@
 //= link_tree ../images
+//= link_tree ../builds
+
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
-//= link_tree ../builds
+
 //= link_tree ../../../node_modules/govuk-frontend/govuk/assets
+//= link_tree ../../../node_modules/@ministryofjustice/frontend/moj/assets
+
+//= link jquery/dist/jquery.js

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -19,3 +19,7 @@
 // Sortable table
 // https://design-patterns.service.justice.gov.uk/components/sortable-table/
 @import "@ministryofjustice/frontend/moj/components/sortable-table/sortable-table";
+
+// Multi-file upload
+// https://design-patterns.service.justice.gov.uk/components/multi-file-upload/
+@import "@ministryofjustice/frontend/moj/components/multi-file-upload/multi-file-upload";

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,0 +1,22 @@
+# :nocov:
+class DocumentsController < ApplicationController
+  before_action :check_crime_application_presence
+
+  respond_to :html, :json, :js
+
+  def create
+    respond_with do |format|
+      format.html do
+        redirect_to edit_steps_evidence_upload_path
+      end
+      format.json do
+        render json: {}, status: :created
+      end
+    end
+  end
+
+  def download; end
+
+  def destroy; end
+end
+# :nocov:

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,10 +12,21 @@ if ($cookieBanner) {
   new Cbc($cookieBanner).init()
 }
 
+// Dropzone initialisation through MOJ frontend
+import MOJFrontend from '@ministryofjustice/frontend'
+if (window.jQuery) {
+  const $dzContainer = $('.moj-multi-file-upload')
+
+  new MOJFrontend.MultiFileUpload({
+    container: $dzContainer,
+    uploadUrl: $dzContainer.closest('form').attr('action'),
+    deleteUrl: '/ajax-delete-url' // TBC
+  })
+}
+
 // NOTE: suggestions input component not yet part of GOV.UK frontend
 // https://github.com/alphagov/govuk-frontend/pull/2453
 import Input from "local/suggestions"
-
 const $inputs = document.querySelectorAll('[data-module="govuk-input"]')
 if ($inputs) {
   for (let i = 0; i < $inputs.length; i++) {
@@ -24,7 +35,6 @@ if ($inputs) {
 }
 
 import accessibleAutocomplete from 'accessible-autocomplete'
-
 const $acElements = document.querySelectorAll('[data-module="accessible-autocomplete"]')
 if ($acElements) {
   for (let i = 0; i < $acElements.length; i++) {

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -1,26 +1,45 @@
 <% title t('.page_title') %>
 <% step_header %>
 
+<% content_for(:head) do %>
+  <%= javascript_include_tag 'jquery', async: true, nonce: true %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div>
-      <h1 class="govuk-heading-xl"><%=t('.heading') %></h1>
+    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
-      <p class="govuk-body">Use this page to provide:</p>
+    <p class="govuk-body">Use this page to provide:</p>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li>evidence your client gets a passporting benefit</li>
-        <li>evidence of your client's income and outgoings</li>
-        <li>evidence of your client's capital</li>
-        <li>any other supporting evidence, like a freezing order or charge sheet</li>
-      </ul>
-    </div>
+    <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-5">
+      <li>evidence your client gets a passporting benefit</li>
+      <li>evidence of your client's income and outgoings</li>
+      <li>evidence of your client's capital</li>
+      <li>any other supporting evidence, like a freezing order or charge sheet</li>
+    </ul>
 
-    <%= step_form @form_object, multipart: true do |f| %>
-      <%= f.govuk_file_field :upload_files, label: { size: 'm' }, multiple: true %>
-      <%= f.button t('.upload_file_button'),
-                   class: 'govuk-button govuk-button--secondary moj-multi-file-upload__button',
-                   data: { module: 'govuk-button' } %>
+    <%= form_for @form_object, html: { id: 'dz-evidence-upload-form' },
+                 url: crime_application_documents_path,
+                 method: :post, multipart: true do |f| %>
+      <div class="moj-multi-file-upload">
+        <div class="moj-multi-file-upload__upload">
+          <%= f.govuk_file_field :documents, multiple: true, label: { size: 'm' },
+                                 class: 'govuk-file-upload moj-multi-file-upload__input' %>
+
+          <%= f.button t('.upload_file_button'),
+                       class: 'govuk-button govuk-button--secondary moj-multi-file-upload__button',
+                       data: { module: 'govuk-button' } %>
+        </div>
+
+        <div class="moj-multi-file__uploaded-files ">
+          <h2 class="govuk-heading-m">Files added</h2>
+          <div class="govuk-summary-list moj-multi-file-upload__list">
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+    <%= step_form @form_object, html: { class: 'govuk-!-padding-top-5' } do |f| %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,3 +4,6 @@ pin "application", preload: true
 pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@4.6.0/govuk-esm/all.mjs"
 pin_all_from "app/javascript/local", under: "local"
 pin "accessible-autocomplete", to: "https://ga.jspm.io/npm:accessible-autocomplete@2.0.4/dist/accessible-autocomplete.min.js"
+pin "dropzone", to: "https://ga.jspm.io/npm:dropzone@6.0.0-beta.2/dist/dropzone.mjs"
+pin "just-extend", to: "https://ga.jspm.io/npm:just-extend@5.1.1/index.esm.js"
+pin "@ministryofjustice/frontend", to: "https://ga.jspm.io/npm:@ministryofjustice/frontend@1.8.0/moj/all.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,14 @@ Rails.application.routes.draw do
   resources :crime_applications, except: [:show, :new, :update], path: 'applications' do
     get :confirm_destroy, on: :member
 
+    member do
+      resources :documents, only: [:create, :destroy],
+                param: :document_id, as: 'crime_application_documents',
+                constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
+        get :download, on: :member
+      end
+    end
+
     scope :completed, as: :completed, controller: :completed_applications do
       get :index, on: :collection
       get :show, on: :member

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "laa-apply-for-criminal-legal-aid",
   "private": "true",
   "dependencies": {
-    "@ministryofjustice/frontend": "1.6.6",
-    "govuk-frontend": "4.6.0"
+    "@ministryofjustice/frontend": "1.8.0",
+    "dropzone": "^6.0.0-beta.2",
+    "govuk-frontend": "4.6.0",
+    "jquery": "^3.6.0"
   },
   "scripts": {
-    "postinstall": "bin/importmap pin govuk-frontend@4.6.0"
+    "postinstall": "bin/importmap pin govuk-frontend@4.6.0 @ministryofjustice/frontend@1.8.0 dropzone@6.0.0-beta.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,41 @@
 # yarn lockfile v1
 
 
-"@ministryofjustice/frontend@1.6.6":
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.6.6.tgz#120b117a796f3c297b3f05d4dba62568d66554e7"
-  integrity sha512-fbU3NEMmSmR0h8t4cSlhdl5c+Mc+cR94Or19R1ipGxfrnpmQpiN/Yc6h61n2pIMZBR5DIYvlO1GkDopVPS5qQw==
+"@ministryofjustice/frontend@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.8.0.tgz#2d1372c689e6da95efe07a11d5ff99d83be2f445"
+  integrity sha512-N4791HcFoqJNLNrK6EN4oMaTJjeFp9ileavCpXkda3qvpEWQByxZUsOd6sDA69FuLRpB6jBFL2C2bqfYbcTdqg==
   dependencies:
     govuk-frontend "^3.0.0 || ^4.0.0"
     moment "^2.27.0"
+
+"@swc/helpers@^0.2.13":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.2.14.tgz#20288c3627442339dd3d743c944f7043ee3590f0"
+  integrity sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA==
+
+dropzone@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-6.0.0-beta.2.tgz#098be8fa84bdc08674cf0b74f4c889e2679083d6"
+  integrity sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==
+  dependencies:
+    "@swc/helpers" "^0.2.13"
+    just-extend "^5.0.0"
 
 govuk-frontend@4.6.0, "govuk-frontend@^3.0.0 || ^4.0.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.6.0.tgz#662b41f7c468bb5468441218c720f0b31c948cbd"
   integrity sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==
+
+jquery@^3.6.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.0.tgz#fe2c01a05da500709006d8790fe21c8a39d75612"
+  integrity sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==
+
+just-extend@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-5.1.1.tgz#4f33b1fc719964f816df55acc905776694b713ab"
+  integrity sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ==
 
 moment@^2.27.0:
   version "2.29.4"


### PR DESCRIPTION
## Description of change
Add all the stuff needed to render an MOJ multi-upload component (dropzone behind the scenes).

Note in order to do this we now have to add to the application the MOJ javascript plus dropzone dependencies.

I'm raising this PR just to have it all set, but is obviously not functional, and I doubt it can be functional out of the box without modifying MOJ javascript because for once, the JS is not propagating the authenticity token and I don't see a way to configure this, meaning only way to propagate the token is to modify the javascript.

My opinion is we shouldn't be using MOJ component, which couples us to their javascript (and requires jQuery nonetheless) and instead code our own JS handling and apply our own styling (which can be the same as the MOJ styling if we wish).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-529

## Notes for reviewer
In order to avoid having jQuery loaded globally in each of the pages in the application, I'm only loading it ad-hoc in the evidence upload page (`javascript_include_tag`).

## Screenshots of changes (if applicable)
<img width="664" alt="Screenshot 2023-08-15 at 11 26 46" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/f5b383f6-9b80-4d68-a25d-3559cac95fc6">

## How to manually test the feature
Checkout, run `yarn`, run `rails assets:clobber && rails dartsass:build` and restart server. Go to the evidence upload and the drop zone should be "functional" and the styling look like the one on MOJ component page.