### PR TITLE
Resolve postgres related Trivy vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER LAA Crime Apply Team
 
 # dependencies required both at runtime and build time
 RUN apk add --update \
-  postgresql-dev \
+  postgresql15-dev \
   tzdata \
   yarn \
   gcompat


### PR DESCRIPTION
## Description of change
The `postgresql-dev` package used in the Dockerfile was outdated, now that we are running postgres 15.x (locally, CI and also cloud platform through RDS).

This ensure alpine build the image using latest versions of the postgres libraries.

## Link to relevant ticket
More info in slack thread
https://mojdt.slack.com/archives/C056U956ESH/p1692175607705879