### PR TITLE
Reduce restrictions on URN validation

### DIFF
--- a/app/forms/steps/case/urn_form.rb
+++ b/app/forms/steps/case/urn_form.rb
@@ -4,7 +4,7 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :case
 
-      URN_REGEXP = /\A[0-9]{2}[A-Z]{2}[0-9]{7}\z/
+      URN_REGEXP = /\A[A-Z0-9]{6,20}\z/
 
       attribute :urn, :string
 

--- a/spec/forms/steps/case/urn_form_spec.rb
+++ b/spec/forms/steps/case/urn_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Steps::Case::UrnForm do
     end
 
     context 'when `urn` is invalid' do
-      let(:urn) { 'not a urn' }
+      let(:urn) { 'urn' }
 
       it 'has a validation error on the field' do
         expect(subject).not_to be_valid


### PR DESCRIPTION
## Description of change
URN field was raising validation errors on valid URNs. The rules we have been told are not correct, so we need to reduce restrictions given we now don't know what the specific format is.

Following suit of VCD, which has validations that URN is alphanumeric and fewer than 20 chars. This PR also sets a minimum of 6 chars, but otherwise the same as VCD
