### PR TITLE
Add flat file for inactive offices

### DIFF
--- a/app/lib/laa_portal/saml_strategy.rb
+++ b/app/lib/laa_portal/saml_strategy.rb
@@ -15,7 +15,7 @@ module LaaPortal
             info: {
               email: 'provider@example.com',
               roles: 'EFORMS,EFORMS_eFormsAuthor,CRIMEAPPLY',
-              office_codes: '1A123B:2A555X',
+              office_codes: '1A123B:2A555X:3B345C:4C567D',
             }
           )
         )

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -23,7 +23,7 @@ class Provider < ApplicationRecord
           email: auth.info.email,
           description: auth.info.description,
           roles: auth.info.roles,
-          office_codes: auth.info.office_codes,
+          office_codes: active_office_codes(auth)
         )
 
         ensure_default_office(record)
@@ -43,6 +43,10 @@ class Provider < ApplicationRecord
           record.office_codes.first unless record.multiple_offices?
         )
       )
+    end
+
+    def active_office_codes(auth)
+      Providers::ActiveOfficeChecker.new(auth.info).active_office_codes
     end
   end
 end

--- a/app/services/providers/active_office_checker.rb
+++ b/app/services/providers/active_office_checker.rb
@@ -1,0 +1,27 @@
+module Providers
+  class ActiveOfficeChecker
+    attr_reader :auth_info
+
+    def initialize(auth_info)
+      @auth_info = auth_info
+    end
+
+    def active_office_codes
+      if inactive_office_codes && auth_info.office_codes.size > 1
+        calculate_active_office_codes
+      else
+        auth_info.office_codes
+      end
+    end
+
+    private
+
+    def calculate_active_office_codes
+      auth_info.office_codes - inactive_office_codes
+    end
+
+    def inactive_office_codes
+      Rails.configuration.x.inactive_offices.inactive_office_codes
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,5 +62,9 @@ module LaaApplyForCriminalLegalAid
     config.x.gatekeeper= config_for(
       :gatekeeper, env: ENV.fetch('ENV_NAME', 'localhost')
     )
+
+    config.x.inactive_offices = config_for(
+      :inactive_offices, env: ENV.fetch('ENV_NAME', 'localhost')
+    )
   end
 end

--- a/config/inactive_offices.yml
+++ b/config/inactive_offices.yml
@@ -1,0 +1,25 @@
+# List of providers office codes that are inactive.
+#
+# Temporary solution to allow us to onboard over the next few months.
+# Plan is to build an API to glean this info from other systems, but
+# in the intrim this this was agreed as a way to continue onboarding.
+#
+# This is used by Provider::ActiveOfficeChecker to filter out inactive
+# offices from the array that Crime Apply receives from the portal auth_info
+#
+# This happens after the Provider::Gatekeeper has filtered out providers
+# that have not been onboarded yet in Providers::OmniauthCallbacksController.
+#
+#
+localhost:
+  inactive_office_codes:
+    - 3B345C
+    - 4C567D
+
+staging:
+  inactive_office_codes:
+    - 0N290J
+
+production:
+  inactive_office_codes:
+

--- a/config/inactive_offices.yml
+++ b/config/inactive_offices.yml
@@ -18,7 +18,7 @@ localhost:
 
 staging:
   inactive_office_codes:
-    - 0N290J
+    - 0A719G
 
 production:
   inactive_office_codes:

--- a/spec/services/providers/active_office_checker_spec.rb
+++ b/spec/services/providers/active_office_checker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Providers::ActiveOfficeChecker do
       context 'inactive codes are not in office code list' do
         let(:inactive_office_codes) { %w[3C345D 4C777Z] }
 
-        it 'returns the an unaltered office code list' do
+        it 'returns an unaltered office code list' do
           active_codes = %w[1A123B 2A555X 2B234C 3B666Y]
           expect(subject.active_office_codes).to match(active_codes)
         end

--- a/spec/services/providers/active_office_checker_spec.rb
+++ b/spec/services/providers/active_office_checker_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Providers::ActiveOfficeChecker do
+  subject { described_class.new(auth_info) }
+
+  let(:auth_info) do
+    double(
+      office_codes:,
+    )
+  end
+
+  let(:office_codes) { %w[1A123B 2A555X 2B234C 3B666Y] }
+  let(:inactive_office_codes) { %w[2B234C 3B666Y] }
+
+  describe '#active_office_codes' do
+    before do
+      allow(subject)
+        .to receive(:inactive_office_codes)
+        .and_return(inactive_office_codes)
+    end
+
+    context 'multi-code office' do
+      it 'returns a list of active office codes' do
+        active_codes = %w[1A123B 2A555X]
+        expect(subject.active_office_codes).to match(active_codes)
+      end
+
+      context 'inactive codes are not in office code list' do
+        let(:inactive_office_codes) { %w[3C345D 4C777Z] }
+
+        it 'returns the an unaltered office code list' do
+          active_codes = %w[1A123B 2A555X 2B234C 3B666Y]
+          expect(subject.active_office_codes).to match(active_codes)
+        end
+      end
+
+      context 'inactive office codes is nil (i.e. nothing on a given key in the flat file)' do
+        let(:inactive_office_codes) { nil }
+
+        it 'returns the full list of codes' do
+          active_codes = %w[1A123B 2A555X 2B234C 3B666Y]
+          expect(subject.active_office_codes).to match(active_codes)
+        end
+
+        context 'when there is a provider with only one office code' do
+          let(:office_codes) { %w[1A123B] }
+
+          it 'returns that one code' do
+            active_codes = %w[1A123B]
+            expect(subject.active_office_codes).to match(active_codes)
+          end
+        end
+      end
+    end
+
+    context 'single code office' do
+      let(:office_codes) { %w[1A123B] }
+
+      it 'returns one office' do
+        active_codes = %w[1A123B]
+
+        expect(subject).not_to receive(:calculate_active_office_codes)
+        expect(subject.active_office_codes).to match(active_codes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
An implementation using a flat file as an interim solution to filter out inactive office codes from the portal.

Idea her is to test on staging and then I will raise another PR with the inactive prod codes and deploy this again.

**The flow of this is:**

1. sign in is user attempts sign-in from portal 
2. callback in `OmniauthCallbacksController` checks they are allowlisted/enrolled with the `Providers::GateKeeper`
3. the `saml` method is called in the controller which in turn calls `Provider.from_omniauth` method with the `auth_hash`
4. `from_omniauth` finds or initialises a new provider, or updates them if they are already present
5. In the update statement, the `active_office_codes` method calls the new `ActiveOfficeChecker` service which filters our inactive offices based on the flatfile.
6. Inactive offices should then not show for newly logged in providers provided they are added to the flatfile.

I have also checked the way that the prometheus logs are collated and I think they should still work, [essentially they just call the `.office_codes` method on the `Providers` class](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/blob/4cace39fa81d5c248a6db7f851965056220eb15c/app/lib/prometheus_metrics/collectors/offices_count_collector.rb#L14C2-L14C2), which is [updated as a provider signs into the system.](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/blob/4cace39fa81d5c248a6db7f851965056220eb15c/app/models/provider.rb#L21C1-L21C1) So the metric should reflect "live" offices as we would expect it to.

## Link to relevant ticket
[CRIMAP-566](https://dsdmoj.atlassian.net/browse/CRIMAP-566)

## How to manually test the feature

You can see in the LaaPortal::SamlStrategy that I have added some more codes the the `mock_auth` these extra codes are added to the `inactive_offices.yml` so are filtered out, this means you should not see these codes as selectable locally. You can remove the codes from he `yml` file and reload the app and you should see these codes appear.

As you change this you should also see them update in the `office_codes` method of the Provider record in you're local database.

Please also test that you can go through the application e2e and there are no downstream affects of this change. 

[CRIMAP-566]: https://dsdmoj.atlassian.net/browse/CRIMAP-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ