### PR TITLE
Update can_start? criteria for case_details 

### DIFF
--- a/app/presenters/tasks/case_details.rb
+++ b/app/presenters/tasks/case_details.rb
@@ -9,7 +9,7 @@ module Tasks
     end
 
     def can_start?
-      applicant.present? && crime_application.means_passported?
+      fulfilled?(ClientDetails)
     end
 
     # If we have a `case` record we consider this in progress

--- a/spec/presenters/tasks/case_details_spec.rb
+++ b/spec/presenters/tasks/case_details_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Tasks::CaseDetails do
   let(:applicant) { nil }
   let(:kase) { nil }
 
+  # We assume the completeness of the client details here, as
+  # their statuses are tested in its own spec, no need to repeat
+  let(:client_details_fulfilled) { true }
+
+  before do
+    allow(
+      subject
+    ).to receive(:fulfilled?).with(Tasks::ClientDetails).and_return(client_details_fulfilled)
+  end
+
   describe '#path' do
     it { expect(subject.path).to eq('/applications/12345/steps/case/case_type') }
   end
@@ -24,28 +34,14 @@ RSpec.describe Tasks::CaseDetails do
   end
 
   describe '#can_start?' do
-    context 'when there is no applicant record yet' do
-      it { expect(subject.can_start?).to be(false) }
+    context 'when the client details task has been completed' do
+      it { expect(subject.can_start?).to be(true) }
     end
 
-    context 'when there is an applicant record' do
-      let(:applicant) { double }
+    context 'when the client details task has not been completed yet' do
+      let(:client_details_fulfilled) { false }
 
-      before do
-        allow(crime_application).to receive(:means_passported?).and_return(means_passported)
-      end
-
-      context 'when applicant is means passported' do
-        let(:means_passported) { true }
-
-        it { expect(subject.can_start?).to be(true) }
-      end
-
-      context 'when applicant is not means passported' do
-        let(:means_passported) { false }
-
-        it { expect(subject.can_start?).to be(false) }
-      end
+      it { expect(subject.can_start?).to be(false) }
     end
   end
 


### PR DESCRIPTION
## Description of change

Update can_start? criteria for case_details  to require all client_detail steps to be completed first
Fixes a bug whereby a user could exit the journey after completing the DWP check then start Case details with no later prompt to complete client details.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-584
## Notes for reviewer
Plan to write a ticket to decide any plan to allow user to have multiple sections in progress at the same time

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Current = 
1. Start new application, complete up to DWP check
2. Click save and continue without filling in any address details
3. Dashboard shows Case Details available to start

Now = 
1. Start new application, complete up to DWP check
2. Click save and continue without filling in any address details
3. Dashboard shows Case Details NOT available to start