### PR TITLE
CRIMAP-636 Implement end-of-journey fulfilment validations

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -135,3 +135,11 @@ $app-blue-button-colour: govuk-colour("blue");
   padding-top: govuk-spacing(2);
   border-top: 1px solid $govuk-border-colour;
 }
+
+.app-declaration__fulfilment-errors {
+  @include govuk-media-query($from: tablet) {
+    .govuk-grid-column-one-third {
+      text-align: right;
+    }
+  }
+}

--- a/app/lib/logger_error_subscriber.rb
+++ b/app/lib/logger_error_subscriber.rb
@@ -2,6 +2,6 @@
 # new Rails error reporting API (i.e. `Rails.error.handle`, etc.)
 class LoggerErrorSubscriber
   def report(error, *)
-    Rails.logger.error [error, error.backtrace.first].join("\n")
+    Rails.logger.error [error.class, error, error.backtrace&.first].join("\n")
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -25,4 +25,8 @@ class CrimeApplication < ApplicationRecord
                  :legal_rep_first_name,
                  :legal_rep_last_name,
                  :legal_rep_telephone
+
+  # Before submitting the application we run a final
+  # validation to ensure some key details are fulfilled
+  validates_with ApplicationFulfilmentValidator, on: :submission
 end

--- a/app/presenters/fulfilment_errors_presenter.rb
+++ b/app/presenters/fulfilment_errors_presenter.rb
@@ -1,0 +1,24 @@
+class FulfilmentErrorsPresenter
+  FulfilmentError = Struct.new(:attribute, :message, :error, :change_path, keyword_init: true)
+
+  attr_writer :errors
+
+  def initialize(crime_application)
+    @errors = crime_application.errors
+  end
+
+  def errors
+    @errors.map { |error| build_error(error) }
+  end
+
+  private
+
+  def build_error(error)
+    FulfilmentError.new(
+      attribute: error.attribute,
+      message: error.message,
+      error: error.details[:error],
+      change_path: error.details[:change_path],
+    )
+  end
+end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -101,22 +101,20 @@ module Decisions
     # NOTE: for MVP, this is the last step of the application,
     # however post-MVP there will be means assessment steps,
     # unless the applicant has been passported. As this is not
-    # yet implemented, and for MVP we only let means passported
-    # applicants, raise an exception (this should NOT happen but
-    # in case it happens, we get alerted).
+    # yet implemented, for now both branches behave the same.
+    # However before submission we perform a validation to
+    # ensure applicant is means-passported (array is not empty).
     #
-    # rubocop:disable Style/GuardClause
+    # rubocop:disable Style/IdenticalConditionalBranches,Lint/DuplicateBranch
     def after_ioj
       if Passporting::MeansPassporter.new(current_crime_application).call
         edit('/steps/submission/review')
       else
         # TODO: post-MVP implement means assessment steps
-        # For MVP, this branch should not be reachable, and if
-        # we end up here, we want to know about it (Sentry)
-        raise InvalidStep, 'application is not means-passported'
+        edit('/steps/submission/review')
       end
     end
-    # rubocop:enable Style/GuardClause
+    # rubocop:enable Style/IdenticalConditionalBranches, Lint/DuplicateBranch
 
     def edit_new_charge
       charge = case_charges.create!

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -1,0 +1,49 @@
+class ApplicationFulfilmentValidator < ActiveModel::Validator
+  include Routing
+
+  attr_reader :record
+
+  def validate(record)
+    @record = record
+
+    errors = perform_validations
+    add_errors(errors)
+  end
+
+  # Used by the `Routing` module to build the urls
+  def default_url_options
+    { id: record }
+  end
+
+  private
+
+  # More validations can be added here
+  # Errors, when more than one, will maintain the order
+  def perform_validations
+    errors = []
+
+    unless Passporting::MeansPassporter.new(record).call
+      errors << [
+        :means_passport, :blank, { change_path: edit_steps_client_details_path }
+      ]
+    end
+
+    unless Passporting::IojPassporter.new(record).call || ioj_present?
+      errors << [
+        :ioj_passport, :blank, { change_path: edit_steps_case_ioj_path }
+      ]
+    end
+
+    errors
+  end
+
+  def ioj_present?
+    record.ioj.present? && record.ioj.types.any?
+  end
+
+  def add_errors(errors)
+    errors.each do |(attr, type, opts)|
+      record.errors.add(attr, type, **opts)
+    end
+  end
+end

--- a/app/views/steps/submission/declaration/_fulfilment_errors.html.erb
+++ b/app/views/steps/submission/declaration/_fulfilment_errors.html.erb
@@ -1,0 +1,23 @@
+<a id="steps-submission-declaration-form-crime-application-field-error"></a>
+
+<div class="app-declaration__fulfilment-errors govuk-form-group govuk-form-group--error govuk-!-margin-top-8">
+  <span class="govuk-error-message">
+    <%=t '.heading' %>
+  </span>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <ul class="govuk-list">
+        <% errors.each do |error| %>
+          <li><%= error.message %></li>
+        <% end %>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%# We only show the change link in the first error, in case there are more than one %>
+      <%= link_to t('.change_link'), errors.first.change_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink govuk-body-m',
+                  data: { ga_category: 'declaration', ga_label: "fulfilment error: #{errors.first.attribute}" } %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -42,6 +42,9 @@
       <li>you’ve provided correct and complete information in this application</li>
     </ul>
 
+    <%= render partial: 'fulfilment_errors',
+               locals: { errors: @form_object.fulfilment_errors } if @form_object.fulfilment_errors.any? %>
+
     <%= step_form @form_object do |f| %>
       <%= f.govuk_fieldset legend: { text: t('.legal_representative_legend') } do %>
         <%= f.govuk_text_field :legal_rep_first_name, autocomplete: 'off', width: 'three-quarters' %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -10,6 +10,13 @@ en:
   activerecord:
     errors:
       models:
+        # fulfillment validation errors
+        crime_application:
+          attributes:
+            means_passport:
+              blank: Applicant is not passported on means
+            ioj_passport:
+              blank: Justification for legal aid needs to be completed
         # evidence upload data model
         document:
           attributes:
@@ -219,3 +226,6 @@ en:
             legal_rep_telephone:
               blank: Enter a telephone number
               invalid: Enter a telephone number in the correct format
+            # fulfillment validation errors
+            crime_application:
+              invalid: Some application details are missing

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -211,6 +211,9 @@ en:
         edit:
           page_title: Declaration
           legal_representative_legend: Legal representative
+        fulfilment_errors:
+          heading: You need to complete the following information before the application can be submitted
+          change_link: Change
       confirmation:
         show:
           page_title: Application submitted

--- a/spec/presenters/fulfilment_errors_presenter_spec.rb
+++ b/spec/presenters/fulfilment_errors_presenter_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe FulfilmentErrorsPresenter do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { CrimeApplication.new }
+
+  describe '#errors' do
+    context 'when there are no errors' do
+      it 'returns an empty collection' do
+        expect(subject.errors).to be_empty
+      end
+    end
+
+    context 'when there are errors' do
+      before do
+        # Add a couple fake errors as an example (the attributes must exist)
+        crime_application.errors.add(:means_passport, :blank, change_path: 'steps/foo/bar')
+        crime_application.errors.add(:ioj_passport, :blank, change_path: 'steps/xyz')
+      end
+
+      it 'returns a collection of errors' do
+        expect(subject.errors).to be_an_instance_of(Array)
+      end
+
+      context 'returned errors' do
+        context 'first error' do
+          let(:error) { subject.errors[0] }
+
+          it 'contains all the information needed' do
+            expect(error.attribute).to eq(:means_passport)
+            expect(error.message).to eq('Applicant is not passported on means')
+            expect(error.error).to eq(:blank)
+            expect(error.change_path).to eq('steps/foo/bar')
+          end
+        end
+
+        context 'second error' do
+          let(:error) { subject.errors[1] }
+
+          it 'contains all the information needed' do
+            expect(error.attribute).to eq(:ioj_passport)
+            expect(error.message).to eq('Justification for legal aid needs to be completed')
+            expect(error.error).to eq(:blank)
+            expect(error.change_path).to eq('steps/xyz')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -279,20 +279,15 @@ RSpec.describe Decisions::CaseDecisionTree do
       allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(means_passported)
     end
 
-    context 'and the means passporter was not triggered' do
-      let(:means_passported) { false }
+    context 'and the application is means-passported' do
+      let(:means_passported) { true }
 
-      it 'raises an error' do
-        expect {
-          subject.destination
-        }.to raise_error(
-          Decisions::BaseDecisionTree::InvalidStep, 'application is not means-passported'
-        )
-      end
+      it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
     end
 
-    context 'and the means passporter was triggered' do
-      let(:means_passported) { true }
+    # TODO: means test journey to be implemented
+    context 'and the application is not means-passported' do
+      let(:means_passported) { false }
 
       it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
     end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+module Test
+  CrimeApplicationValidatable = Struct.new(:ioj, keyword_init: true) do
+    include ActiveModel::Validations
+    validates_with ApplicationFulfilmentValidator
+
+    def to_param
+      '12345'
+    end
+  end
+end
+
+RSpec.describe ApplicationFulfilmentValidator, type: :model do
+  subject { Test::CrimeApplicationValidatable.new(arguments) }
+
+  let(:arguments) do
+    {
+      ioj:,
+    }
+  end
+
+  let(:ioj) { instance_double(Ioj, types: ioj_types) }
+  let(:ioj_types) { [] }
+
+  context 'MeansPassporter validation' do
+    before do
+      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(means_result)
+
+      # stub the other validation
+      allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(true)
+    end
+
+    context 'when the application is means-passported' do
+      let(:means_result) { true }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when the application is not means-passported' do
+      let(:means_result) { false }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:means_passport, :blank)).to be(true)
+        expect(subject.errors.first.details[:change_path]).to eq('/applications/12345/steps/client/details')
+      end
+    end
+  end
+
+  context 'IojPassporter validation' do
+    before do
+      allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(ioj_result)
+
+      # stub the other validation
+      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
+    end
+
+    context 'when the application is ioj-passported' do
+      let(:ioj_result) { true }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when the application is not ioj-passported' do
+      let(:ioj_result) { false }
+
+      context 'and there are no IoJ reasons' do
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:ioj_passport, :blank)).to be(true)
+          expect(subject.errors.first.details[:change_path]).to eq('/applications/12345/steps/case/ioj')
+        end
+      end
+
+      context 'and there are IoJ reasons' do
+        let(:ioj_types) { [:foo, :bar] }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Due to the loosely coupled nature of the step-by-step architecture where, as much as possible, each step is isolated from others and perform their own validations, and branching out can produce many different paths for a user, there may be rare situations (or by malice) where some important details of the application are not properly calculated.

Majority of these problems are caught by the JSON schema validation at point of submission, however there is not a proper user interface to present these errors.

This PR introduces the concept of "fulfilment validation" that happens at point of submission (technically right after declaration is signed) and raise any issues that hopefully can be recovered from by re-running some of the steps.

The validator allows to introduce further validations in the future, but for now we are focusing on the "passporters" (IoJ and Means).

If a problem is found, we present an error to the user. The error and design is TBD, in this PR most of the work is backend, but to "see something" I've added the errors to the page with some placeholder copy.

We also report to Sentry the problems to be alerted and take further measures if this is a reoccurring problem. Again is important to note the rare nature of these issues (unless tampering on purpose with the form).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-636

Slack convo:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1695656457701139

## Notes for reviewer
* As stated, copy is placeholder and possibly design may change.
* The "Change" link takes the provider to a meaningful page if possible. So for instance for the means passport it takes them to the Client Details page, and for the IoJ passport it takes them to IoJ page.
* At the moment there are 2 validations (ioj passport and means passport). If both fail we present 2 errors. In the future we could introduce more validations. We can decide if we want to show all errors or just one error, the first one, as in the end the provider will be able to action only one at a time (with the Change link).

## Screenshots of changes (if applicable)
<img width="756" alt="Screenshot 2023-09-27 at 10 06 22" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/5f4141ea-54cb-40fc-8daa-2b0196221743">
<img width="811" alt="Screenshot 2023-09-26 at 16 29 14" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/75fc1f49-5929-48ff-baea-bb213e48d0ca">

## How to manually test the feature
Use instructions provided by @arthurashman on slack:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1695634016744189