### PR TITLE
Refactor evidence data model removing bundle abstraction

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -7,7 +7,7 @@ class DocumentsController < ApplicationController
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def create
     document = Document.create_from_file(
-      file: file_from_params, bundle: current_document_bundle
+      file: file_from_params, crime_application: current_crime_application
     )
 
     Datastore::Documents::Upload.new(document:).call if document.valid?(:criteria)
@@ -34,10 +34,6 @@ class DocumentsController < ApplicationController
     edit_steps_evidence_upload_path(current_crime_application)
   end
 
-  def current_document_bundle
-    @current_document_bundle ||= DocumentBundle.find(document_bundle_id)
-  end
-
   # TODO: unify if possible the submission params
   # Currently XHR and HTML requests have different structure
   # Also needs proper error handling for non-JS version if user click
@@ -48,14 +44,6 @@ class DocumentsController < ApplicationController
     else
       params.fetch(:document)
     end
-  end
-
-  def document_bundle_id
-    params[:id]
-  end
-
-  def application_id
-    current_document_bundle.crime_application_id
   end
 end
 # :nocov:

--- a/app/controllers/steps/evidence/upload_controller.rb
+++ b/app/controllers/steps/evidence/upload_controller.rb
@@ -3,12 +3,12 @@ module Steps
     class UploadController < Steps::EvidenceStepController
       def edit
         @form_object = UploadForm.build(
-          document_bundle_record, crime_application: current_crime_application
+          current_crime_application
         )
       end
 
       def update
-        update_and_advance(UploadForm, record: document_bundle_record, as: step_name, flash: @flash)
+        update_and_advance(UploadForm, as: step_name, flash: @flash)
       end
 
       def step_name

--- a/app/controllers/steps/evidence_step_controller.rb
+++ b/app/controllers/steps/evidence_step_controller.rb
@@ -5,13 +5,5 @@ module Steps
     def decision_tree_class
       Decisions::EvidenceDecisionTree
     end
-
-    def document_bundle_record
-      @document_bundle_record ||= existing_bundles.find_or_initialize_by(submitted_at: nil).tap(&:save)
-    end
-
-    def existing_bundles
-      current_crime_application.document_bundles
-    end
   end
 end

--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -1,11 +1,13 @@
 module Steps
   module Evidence
     class UploadForm < Steps::BaseFormObject
-      alias_attribute :current_document_bundle, :record
+      # :nocov:
+      def documents
+        crime_application.documents.not_deleted
+      end
 
       private
 
-      # :nocov:
       def persist!
         true
       end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -7,7 +7,7 @@ class CrimeApplication < ApplicationRecord
   has_one :partner, dependent: :destroy
 
   has_many :people, dependent: :destroy
-  has_many :document_bundles, dependent: :destroy
+  has_many :documents, dependent: :destroy
 
   # Shortcuts through intermediate tables
   has_one :ioj, through: :case

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document < ApplicationRecord
-  belongs_to :document_bundle
+  belongs_to :crime_application
 
   # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
   default_scope { order(created_at: :asc) }
@@ -16,10 +16,11 @@ class Document < ApplicationRecord
   attr_accessor :tempfile
 
   scope :stored, -> { where.not(s3_object_key: nil) }
+  scope :not_deleted, -> { where(deleted_at: nil) }
 
-  def self.create_from_file(file:, bundle:)
+  def self.create_from_file(file:, crime_application:)
     create(
-      document_bundle: bundle,
+      crime_application: crime_application,
       filename: file.original_filename,
       content_type: file.content_type,
       file_size: file.tempfile.size,

--- a/app/models/document_bundle.rb
+++ b/app/models/document_bundle.rb
@@ -1,6 +1,0 @@
-class DocumentBundle < ApplicationRecord
-  belongs_to :crime_application
-  has_many :documents, dependent: :destroy
-
-  accepts_nested_attributes_for :documents, allow_destroy: true
-end

--- a/app/serializers/submission_serializer/sections/supporting_evidence.rb
+++ b/app/serializers/submission_serializer/sections/supporting_evidence.rb
@@ -3,20 +3,14 @@ module SubmissionSerializer
     class SupportingEvidence < Sections::BaseSection
       def to_builder
         Jbuilder.new do |json|
-          json.supporting_evidence Definitions::Document.generate(documents)
+          json.supporting_evidence Definitions::Document.generate(documents.stored)
         end
       end
 
       private
 
       def documents
-        # the upload page is not part of the flow yet so document bundles may not be initialised
-        if crime_application.document_bundles.first.nil?
-          @documents = {}
-        else
-          # we only want documents successfully uploaded to s3 to be serialised
-          @documents ||= crime_application.document_bundles.first.documents.stored
-        end
+        crime_application.documents
       end
     end
   end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -18,7 +18,7 @@ module Datastore
         means_passport: parent.means_passport,
         applicant: applicant,
         case: case_with_ioj,
-        document_bundles: [document_bundle]
+        documents: documents,
       )
     end
 
@@ -57,11 +57,11 @@ module Datastore
       )
     end
 
-    def document_bundle
-      documents = parent.supporting_evidence.map do |struct|
+    def documents
+      # TODO: Filter out deleted documents
+      parent.supporting_evidence.map do |struct|
         Document.new(struct.attributes)
       end
-      DocumentBundle.new(documents:)
     end
   end
 end

--- a/app/services/datastore/documents/upload.rb
+++ b/app/services/datastore/documents/upload.rb
@@ -43,7 +43,7 @@ module Datastore
       end
 
       def usn
-        document.document_bundle.crime_application.usn
+        document.crime_application.usn
       end
 
       def expires_in

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -1,9 +1,10 @@
 <% title t('.page_title') %>
 <% step_header %>
-<%= render partial: 'shared/flash_banner' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
     <p class="govuk-body govuk-!-margin-bottom-1">Use this page to provide:</p>
@@ -23,7 +24,7 @@
     </h2>
 
     <%= form_for @form_object, html: { id: 'dz-evidence-upload-form', class: 'dropzone' },
-                 url: bundle_documents_path(@form_object.current_document_bundle),
+                 url: crime_application_documents_path,
                  method: :post, multipart: true do |f| %>
 
       <%= f.button t('.choose_files_button'),
@@ -57,7 +58,7 @@
           </thead>
           <tbody class="govuk-table__body">
           <%= render partial: 'steps/evidence/upload/uploaded_file',
-                     collection: @form_object.current_document_bundle.documents, as: :document %>
+                     collection: @form_object.documents, as: :document %>
           </tbody>
         </table>
       </div>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -198,8 +198,8 @@ en:
           file_name: File name
           uploaded: Uploaded
           delete:
-            success: Document has been sucessfully deleted
-            failure: Document was not sucessfully deleted
+            success: Document has been successfully deleted
+            failure: Document was not successfully deleted
         uploaded_file:
           remove_button: Delete
     submission:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,18 +74,18 @@ Rails.application.routes.draw do
   resources :crime_applications, except: [:show, :new, :update], path: 'applications' do
     get :confirm_destroy, on: :member
 
+    member do
+      resources :documents, only: [:create, :destroy],
+                param: :document_id, as: 'crime_application_documents',
+                constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
+        get :download, on: :member
+      end
+    end
+
     scope :completed, as: :completed, controller: :completed_applications do
       get :index, on: :collection
       get :show, on: :member
       put :recreate, on: :member
-    end
-  end
-
-  # Documents upload handling
-  scope 'document_bundles/:id', as: 'bundle' do
-    resources :documents, only: [:create, :destroy], param: :document_id,
-              constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
-      get :download, on: :member
     end
   end
 

--- a/db/migrate/20230927100615_refactor_documents.rb
+++ b/db/migrate/20230927100615_refactor_documents.rb
@@ -1,0 +1,28 @@
+class RefactorDocuments < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :documents
+    drop_table :document_bundles
+
+    create_table :documents, id: :uuid do |t|
+      t.timestamps
+
+      t.datetime :submitted_at
+      t.datetime :deleted_at
+
+      t.references :crime_application, null: false, foreign_key: true, type: :uuid, index: true
+      t.jsonb :annotations, null: false, default: {}
+
+      t.string :s3_object_key
+      t.string :filename
+      t.string :file_category
+      t.string :content_type
+      t.integer :file_size
+    end
+  end
+
+  def down
+    # Just so it can perform the down in the previous migrations
+    # although note the code would have changed dramatically
+    create_table :document_bundles, id: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_19_153720) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_27_100615) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -81,25 +81,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_153720) do
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
 
-  create_table "document_bundles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "submitted_at"
-    t.uuid "crime_application_id", null: false
-    t.index ["crime_application_id"], name: "index_document_bundles_on_crime_application_id"
-  end
-
   create_table "documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "submitted_at"
     t.datetime "deleted_at"
-    t.uuid "document_bundle_id", null: false
+    t.uuid "crime_application_id", null: false
+    t.jsonb "annotations", default: {}, null: false
     t.string "s3_object_key"
     t.string "filename"
     t.string "file_category"
     t.string "content_type"
     t.integer "file_size"
-    t.index ["document_bundle_id"], name: "index_documents_on_document_bundle_id"
+    t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -172,8 +166,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_153720) do
   add_foreign_key "cases", "crime_applications"
   add_foreign_key "charges", "cases"
   add_foreign_key "codefendants", "cases"
-  add_foreign_key "document_bundles", "crime_applications"
-  add_foreign_key "documents", "document_bundles"
+  add_foreign_key "documents", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
   add_foreign_key "people", "crime_applications"

--- a/spec/controllers/steps/evidence/upload_controller_spec.rb
+++ b/spec/controllers/steps/evidence/upload_controller_spec.rb
@@ -3,40 +3,36 @@ require 'rails_helper'
 RSpec.describe Steps::Evidence::UploadController, type: :controller do
   it_behaves_like 'a generic step controller', Steps::Evidence::UploadForm, Decisions::EvidenceDecisionTree
   it_behaves_like 'a step that can be drafted', Steps::Evidence::UploadForm
+
   describe 'additional CRUD actions' do
-    include_context 'with an existing document'
+    let(:crime_application) { CrimeApplication.create }
+    let(:document) { crime_application.documents.create }
 
     context 'deleting a document' do
       it 'has the expected step name' do
-        document.save
-
         allow_any_instance_of(Datastore::Documents::Delete).to receive(:call).and_return(true)
 
         expect(
           subject
         ).to receive(:update_and_advance).with(
           Steps::Evidence::UploadForm, as: :delete_document,
-          flash: { success: 'Document has been sucessfully deleted' },
-          record: document.document_bundle
+          flash: { success: 'Document has been successfully deleted' }
         )
 
-        put :update, params: { id: bundle.crime_application, document_id: document.id }
+        put :update, params: { id: crime_application, document_id: document }
       end
 
       it 'is has the correct flash message when delete is unsuccessful' do
-        document.save
-
         allow_any_instance_of(Datastore::Documents::Delete).to receive(:call).and_return(false)
 
         expect(
           subject
         ).to receive(:update_and_advance).with(
           Steps::Evidence::UploadForm, as: :delete_document,
-          flash: { alert: 'Document was not sucessfully deleted' },
-          record: document.document_bundle
+          flash: { alert: 'Document was not successfully deleted' }
         )
 
-        put :update, params: { id: bundle.crime_application, document_id: document.id }
+        put :update, params: { id: crime_application, document_id: document }
       end
     end
 
@@ -45,10 +41,10 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
         expect(
           subject
         ).to receive(:update_and_advance).with(
-          Steps::Evidence::UploadForm, record: bundle, as: :upload_finished, flash: nil
+          Steps::Evidence::UploadForm, as: :upload_finished, flash: nil
         )
 
-        put :update, params: { id: bundle.crime_application, record: bundle }
+        put :update, params: { id: crime_application }
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe Document, type: :model do
       expect(
         described_class
       ).to receive(:create).with(
-        document_bundle: bundle,
+        crime_application: crime_application,
         filename: 'test.pdf',
         content_type: 'application/pdf',
         file_size: 14_077,
         tempfile: kind_of(Tempfile),
       )
 
-      described_class.create_from_file(file:, bundle:)
+      described_class.create_from_file(file:, crime_application:)
     end
   end
 
   describe 'validations' do
     let(:attributes) do
       {
-        document_bundle: bundle,
+        crime_application: crime_application,
         filename: 'test.pdf',
         content_type: 'application/pdf',
         file_size: 1.megabytes,

--- a/spec/requests/evidence_upload_spec.rb
+++ b/spec/requests/evidence_upload_spec.rb
@@ -2,28 +2,27 @@ require 'rails_helper'
 
 RSpec.describe 'Evidence upload page', authorized: true do
   before :all do
-    app = CrimeApplication.create
-    bundle = DocumentBundle.create(crime_application: app)
+    crime_application = CrimeApplication.create
     file = fixture_file_upload('uploads/test.pdf', 'application/pdf')
 
     # Successfully uploaded document
-    Document.create_from_file(file:, bundle:).update(
+    Document.create_from_file(file:, crime_application:).update(
       s3_object_key: '123/abcdef1234'
     )
 
-    too_big_err_file = Document.create_from_file(file:, bundle:)
+    too_big_err_file = Document.create_from_file(file:, crime_application:)
     too_big_err_file.update(
       filename: 'too_big.pdf',
       file_size: 21.megabytes
     )
 
-    too_small_err_file = Document.create_from_file(file:, bundle:)
+    too_small_err_file = Document.create_from_file(file:, crime_application:)
     too_small_err_file.update(
       filename: 'too_small.pdf',
       file_size: 2.kilobytes
     )
 
-    content_type_err_file = Document.create_from_file(file:, bundle:)
+    content_type_err_file = Document.create_from_file(file:, crime_application:)
     content_type_err_file.update(
       filename: 'invalid_content_type.pdf',
       content_type: 'video/mp4'
@@ -35,7 +34,7 @@ RSpec.describe 'Evidence upload page', authorized: true do
     content_type_err_file.valid?(:criteria)
 
     # Unsuccessful upload for any other reason (no s3 key)
-    Document.create_from_file(file:, bundle:).update(
+    Document.create_from_file(file:, crime_application:).update(
       filename: 'error.pdf'
     )
   end

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe SubmissionSerializer::Application do
     # in spec `services/application_submission_spec.rb`
 
     let(:kase) { Case.new }
-    let(:bundle) { DocumentBundle.new }
+    let(:documents_scope) { double(stored: [Document.new]) }
 
     before do
       allow(crime_application).to receive(:case).and_return(kase)
-      allow(crime_application).to receive(:document_bundles).and_return([bundle])
+      allow(crime_application).to receive(:documents).and_return(documents_scope)
     end
 
     it 'generates a serialized version of the application' do

--- a/spec/serializers/submission_serializer/sections/supporting_evidence_spec.rb
+++ b/spec/serializers/submission_serializer/sections/supporting_evidence_spec.rb
@@ -3,22 +3,19 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Sections::SupportingEvidence do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) do
-    document = instance_double(
+  let(:document) do
+    instance_double(
       Document,
       filename: 'test.pdf',
       s3_object_key: '123/abcdef1234',
       content_type: 'application/pdf',
       file_size: 12,
     )
+  end
 
-    bundle = instance_double(
-      DocumentBundle,
-      documents: double(stored: [document])
-    )
-
+  let(:crime_application) do
     instance_double(
-      CrimeApplication, document_bundles: [bundle]
+      CrimeApplication, documents: double(stored: [document])
     )
   end
 

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datastore::ApplicationRehydration do
         means_passport: an_instance_of(Array),
         applicant: an_instance_of(Applicant),
         case: an_instance_of(Case),
-        document_bundles: [an_instance_of(DocumentBundle)]
+        documents: all(be_a(Document)),
       )
 
       expect(

--- a/spec/support/shared_contexts/with_an_existing_document.rb
+++ b/spec/support/shared_contexts/with_an_existing_document.rb
@@ -1,7 +1,7 @@
 RSpec.shared_context 'with an existing document' do
-  let(:bundle) { DocumentBundle.create(crime_application: CrimeApplication.new(usn: 123)) }
+  let(:crime_application) { CrimeApplication.new(usn: 123) }
   let(:file) { fixture_file_upload('uploads/test.pdf', 'application/pdf') }
-  let(:attributes) { { document_bundle: bundle } }
+  let(:attributes) { { crime_application: } }
 
   let(:document) do
     Document.new(attributes)


### PR DESCRIPTION
## Description of change
Bit of a refactor before this becomes too entangled to remove the DocumentBundle intermediate table and abstraction as it seems is of no use and makes code a bit more convoluted and creates additional indirection.

To the best of my efforts everything should continue working as before, no changes to external URLs etc. have been made, and is all internal.

As part of this I've taken the opportunity to introduce in the Documents DB table 2 new attributes:

- `submitted_at` - can be populated on rehydration from a submitted application, and this can signalise which documents are already submitted and thus we shouldn't do a hard delete on S3 (just soft delete setting the `deleted_at` attribute)

- `annotations` - jsonb attribute that initially will be used for the virus scanner to annotate files that have been scanned and its result. Can be used for some additional functionality later on.

## Link to relevant ticket
This is part of the overall evidence upload work.

## Notes for reviewer

## Screenshots of changes (if applicable)
No visual changes.

## How to manually test the feature
Everything should keep working as before.