### PR TITLE
CRIMAP-596 ClamAV in a separate container PoC

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,3 +6,4 @@
 
 brew 'adr-tools'
 brew 'yarn'
+brew 'clamav'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --update \
   postgresql15-dev \
   tzdata \
   yarn \
+  clamav-clamdscan \
   gcompat
 
 FROM base AS dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'savon'
 # Monitoring
 gem 'prometheus_exporter'
 
+# Virus scan with ClamAV
+gem 'clamby', '1.6.10'
+
 # Exceptions notifications
 gem 'sentry-rails'
 gem 'sentry-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    clamby (1.6.10)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -443,6 +444,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  clamby (= 1.6.10)
   dartsass-rails (~> 0.5.0)
   debug
   devise (~> 4.8)

--- a/app/services/datastore/documents/upload.rb
+++ b/app/services/datastore/documents/upload.rb
@@ -14,6 +14,10 @@ module Datastore
       def call
         return false if document.s3_object_key.present?
 
+        # TODO: PoC - move this to a separate service object
+        # On scan, annotate document with `infected`, `clean`, etc.
+        # return false if Clamby.virus?(document.tempfile.path)
+
         Rails.error.handle(fallback: -> { false }) do
           presign_upload = DatastoreApi::Requests::Documents::PresignUpload.new(
             usn:, expires_in:

--- a/config/clamd/clamd.docker.conf
+++ b/config/clamd/clamd.docker.conf
@@ -1,0 +1,2 @@
+TCPAddr clamav
+TCPSocket 3310

--- a/config/clamd/clamd.local.conf
+++ b/config/clamd/clamd.local.conf
@@ -1,0 +1,2 @@
+TCPAddr localhost
+TCPSocket 3310

--- a/config/clamd/clamd.production.conf
+++ b/config/clamd/clamd.production.conf
@@ -1,2 +1,2 @@
-TCPAddr clamav-svc-tbd
+TCPAddr clamav-service-production
 TCPSocket 3310

--- a/config/clamd/clamd.production.conf
+++ b/config/clamd/clamd.production.conf
@@ -1,0 +1,2 @@
+TCPAddr clamav-svc-tbd
+TCPSocket 3310

--- a/config/clamd/clamd.staging.conf
+++ b/config/clamd/clamd.staging.conf
@@ -1,0 +1,2 @@
+TCPAddr clamav-svc-tbd
+TCPSocket 3310

--- a/config/clamd/clamd.staging.conf
+++ b/config/clamd/clamd.staging.conf
@@ -1,2 +1,2 @@
-TCPAddr clamav-svc-tbd
+TCPAddr clamav-service-staging
 TCPSocket 3310

--- a/config/clamd/clamd.staging2.conf
+++ b/config/clamd/clamd.staging2.conf
@@ -1,0 +1,2 @@
+TCPAddr clamav-service-staging.laa-apply-for-criminal-legal-aid-staging.svc.cluster.local
+TCPSocket 3310

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+def clamd_config_file
+  filename = ENV.fetch('CLAMD_CONF_FILENAME', 'clamd.local.conf')
+  File.join(File.dirname(__FILE__), '..', 'clamd', filename)
+end
+
+Clamby.configure(
+  {
+    check: false,
+    daemonize: true,
+    config_file: clamd_config_file,
+    output_level: 'medium', # one of 'off', 'low', 'medium', 'high'
+    fdpass: true,
+    stream: true,
+    error_clamscan_missing: true,
+    error_clamscan_client_error: true,
+    error_file_missing: true,
+  }
+)

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -13,6 +13,7 @@ data:
   SESSION_TIMEOUT_MINUTES: "60"
   REAUTHENTICATE_AFTER_MINUTES: "1440"
   ENABLE_PROMETHEUS_EXPORTER: "true"
+  CLAMD_CONF_FILENAME: "clamd.production.conf"
   DATASTORE_API_ROOT: http://service-production.laa-criminal-applications-datastore-production.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   LAA_PORTAL_IDP_METADATA_URL: https://portal.legalservices.gov.uk/oamfed/idp/metadata

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -13,6 +13,7 @@ data:
   SESSION_TIMEOUT_MINUTES: "1440"
   REAUTHENTICATE_AFTER_MINUTES: "2880"
   ENABLE_PROMETHEUS_EXPORTER: "true"
+  CLAMD_CONF_FILENAME: "clamd.staging.conf"
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
 

--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -1,10 +1,24 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clamav-signatures
+  namespace: laa-apply-for-criminal-legal-aid-staging
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: anything
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clamav-staging
   namespace: laa-apply-for-criminal-legal-aid-staging
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 2
   minReadySeconds: 10
   strategy:
@@ -21,15 +35,38 @@ spec:
         app: apply-for-criminal-legal-aid-clamav-staging
         tier: backend
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - apply-for-criminal-legal-aid-clamav-staging
+            topologyKey: kubernetes.io/hostname
       securityContext:
-        fsGroup: 1000
+        # Change to 100 if using official clamav image
+        fsGroup: 1001
+        runAsUser: 1001
+        runAsGroup: 1001
+      volumes:
+      - name: clamav-signatures
+        persistentVolumeClaim:
+          claimName: clamav-signatures
       containers:
       - name: clamav
-        image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+        # NOTE: temporarily until clamav publishes an official unprivileged
+        # docker image (non-root) we use a forked version to run on k8s
+        # https://github.com/Cisco-Talos/clamav/issues/478
+        image: dradoaica/clamav-openshift:1.1
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 3310
             protocol: TCP
+        volumeMounts:
+          - mountPath: "/var/lib/clamav"
+            name: clamav-signatures
         resources:
           requests:
             cpu: 25m
@@ -47,3 +84,18 @@ spec:
             port: 3310
           initialDelaySeconds: 30
           periodSeconds: 60
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clamav-service-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+  labels:
+    app: apply-for-criminal-legal-aid-clamav-staging
+spec:
+  ports:
+  - port: 3310
+    name: clamav
+    targetPort: 3310
+  selector:
+    app: apply-for-criminal-legal-aid-clamav-staging

--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clamav-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-clamav-staging
+  template:
+    metadata:
+      labels:
+        app: apply-for-criminal-legal-aid-clamav-staging
+        tier: backend
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: clamav
+        image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 3310
+            protocol: TCP
+        resources:
+          requests:
+            cpu: 25m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 3Gi
+        readinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        livenessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 30
+          periodSeconds: 60

--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -97,12 +97,12 @@ spec:
     - alert: CrimeApply-TrivyVulns
       expr: >-
         sum(trivy_image_vulnerabilities{namespace=~"^laa-apply-for-criminal-legal-aid.*", severity=~"Critical|High"} > 0) 
-        by (namespace, image_tag, severity)
+        by (namespace, image_repository, image_tag, severity)
       for: 1h
       labels:
         severity: laa-crime-apply-alerts
       annotations:
-        message: Image `{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.severity }} vulnerabilities.
+        message: Image `{{ $labels.image_repository }}:{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.severity }} vulnerabilities.
         dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/trivy_starboard_operator123/trivy-operator-image-vulnerability?orgId=1&from=now-24h&to=now&var-namespace={{ $labels.namespace }}
 
     - alert: CrimeApply-PrometheusExporterFailure

--- a/config/kubernetes/staging/service.yml
+++ b/config/kubernetes/staging/service.yml
@@ -27,18 +27,3 @@ spec:
     targetPort: 9394
   selector:
     app: apply-for-criminal-legal-aid-web-staging
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: clamav-service-staging
-  namespace: laa-apply-for-criminal-legal-aid-staging
-  labels:
-    app: apply-for-criminal-legal-aid-clamav-staging
-spec:
-  ports:
-  - port: 3310
-    name: clamav
-    targetPort: 3310
-  selector:
-    app: apply-for-criminal-legal-aid-clamav-staging

--- a/config/kubernetes/staging/service.yml
+++ b/config/kubernetes/staging/service.yml
@@ -27,3 +27,18 @@ spec:
     targetPort: 9394
   selector:
     app: apply-for-criminal-legal-aid-web-staging
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clamav-service-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+  labels:
+    app: apply-for-criminal-legal-aid-clamav-staging
+spec:
+  ports:
+  - port: 3310
+    name: clamav
+    targetPort: 3310
+  selector:
+    app: apply-for-criminal-legal-aid-clamav-staging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@
 #
 version: '3'
 
+volumes:
+  clamav-signatures:
+
 services:
   db:
     image: postgres:15.2-alpine
@@ -12,9 +15,11 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   clamav:
-    image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+    image: clamav/clamav:stable_base
     ports:
       - "3310:3310"
+    volumes:
+      - clamav-signatures:/var/lib/clamav
 
   web:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 
+  clamav:
+    image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+    ports:
+      - "3310:3310"
+
   web:
     build: .
     environment:
@@ -28,6 +33,7 @@ services:
       DISABLE_HTTPS: "1"
       BC_USE_DEV_MOCK: "true"
       OMNIAUTH_TEST_MODE: "true"
+      CLAMD_CONF_FILENAME: "clamd.docker.conf"
     ports:
       - "3000:3000" # puma server (rails app)
       - "9394:9394" # prometheus exporter `/metrics` endpoint


### PR DESCRIPTION
## Description of change
Just a PoC to validate assumption we can have ClamAV and signatures in a container while communicating with it through the TCP socket and the `clamdscan` CLI tool.

Using HMPPS docker image because it is already pre-configured and works out of the box but we can use any other. https://github.com/ministryofjustice/hmpps-utility-container-images/tree/main/hmpps-clamav

Using the most bare bones gem I could find for it, Clamby.

Only "tricky" thing is we have to provide individual config files dependent on environment. The port does not change but the address will, and couldn't find a nice way to do this via ENV variables, as `clamdscan` expects as input a config file.

Not done kubernetes production yet, until we validate this can work on staging (TCP connectivity mainly).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-596

## Notes for reviewer

## How to manually test the feature
1. Run the clamav container `docker-compose up clamav`
2. If you don't have clamav locally (required for `clamdscan` to work) run `brew bundle` or `brew install clamav`
3. Run an Apply rails console `rails c`
4. Try to scan some files:
```
irb(main):002:0> Clamby.virus?('README.md')
/projects/laa-apply-for-criminal-legal-aid/README.md: OK
=> false
```

You can uncomment in the `Datastore::Documents::Upload` the code to perform a scan too. That is just for demo purposes, and to test we can stream to the scanner a tempfile. Final scan code should reside in a separate class and be resilient to errors/exceptions etc.