### PR TITLE
CRIMAP-616 evidence upload bug patch

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,6 +1,6 @@
 class FileUploadValidator < ActiveModel::Validator
   MIN_FILE_SIZE = 5 # KB
-  MAX_FILE_SIZE = 20 # MB
+  MAX_FILE_SIZE = 10 # MB
 
   ALLOWED_CONTENT_TYPES = %w[
     application/msword

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -21,7 +21,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecRequestBodyLimit 1048576
+      SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Document, type: :model do
       end
 
       context 'file is too big' do
-        let(:attributes) { super().merge(file_size: 21.megabytes) }
+        let(:attributes) { super().merge(file_size: 11.megabytes) }
 
         it 'has a validation error on the field' do
           expect(subject).not_to be_valid(:criteria)
@@ -63,7 +63,7 @@ RSpec.describe Document, type: :model do
       end
 
       context 'more than one error' do
-        let(:attributes) { super().merge(content_type: 'text/unknown', file_size: 21.megabytes) }
+        let(:attributes) { super().merge(content_type: 'text/unknown', file_size: 11.megabytes) }
 
         it 'has a validation error on all invalid fields' do
           expect(subject).not_to be_valid(:criteria)
@@ -84,7 +84,7 @@ RSpec.describe Document, type: :model do
       end
 
       context 'when some criteria also has failed' do
-        let(:attributes) { super().merge(file_size: 21.megabytes) }
+        let(:attributes) { super().merge(file_size: 11.megabytes) }
 
         it 'has a validation error on all invalid fields' do
           expect(subject).not_to be_valid(:storage)

--- a/spec/requests/evidence_upload_spec.rb
+++ b/spec/requests/evidence_upload_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Evidence upload page', authorized: true do
     too_big_err_file = Document.create_from_file(file:, crime_application:)
     too_big_err_file.update(
       filename: 'too_big.pdf',
-      file_size: 21.megabytes
+      file_size: 11.megabytes
     )
 
     too_small_err_file = Document.create_from_file(file:, crime_application:)


### PR DESCRIPTION
## Description of change
This PR fixes a bug on staging where files larger than 1MB were not uploading and errors were not being presented to the user. It was discovered that this was due to a modsec file upload limit which was set to 1MB. 

Two changes have been made. Apply's file upload limit has been decreased from 20MB to 10MB to match eForms. And the modsec upload limit has been increased to 15MB. This is slightly above our file size limit to act as a buffer to account for the increased number of http envelopes and storage needed to transport a 10MB file.

This has been tested on staging and fixes the issue. Screen recording below. 

## Link to relevant ticket
[CRIMAP-616](https://dsdmoj.atlassian.net/browse/CRIMAP-616)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
An example of the original issue can be found in [this slack thread](https://mojdt.slack.com/archives/C03JS4V9TPU/p1695114001626169) 

### After changes:
**Uploading a file within the 10MB file limit** 

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/86a7f220-c005-473d-b316-686bf83d4d42

**Uploading a file bigger than the 10MB file limit (note this is demoed in local environment as the file limit has not changed in staging)**

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/a876d502-6b2d-4b91-a52c-edb09a5a001e


## How to manually test the feature


[CRIMAP-616]: https://dsdmoj.atlassian.net/browse/CRIMAP-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ