### PR TITLE
CRIMAP-576 Add `has_benefit_evidence` page

### DIFF
--- a/app/controllers/steps/client/evidence_exit_controller.rb
+++ b/app/controllers/steps/client/evidence_exit_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Client
+    class EvidenceExitController < Steps::ClientStepController
+      def show; end
+    end
+  end
+end

--- a/app/controllers/steps/client/has_benefit_evidence_controller.rb
+++ b/app/controllers/steps/client/has_benefit_evidence_controller.rb
@@ -2,18 +2,12 @@ module Steps
   module Client
     class HasBenefitEvidenceController < Steps::ClientStepController
       def edit
-        @form_object = HasBenefitEvidenceForm.new(
-          crime_application: current_crime_application
+        @form_object = HasBenefitEvidenceForm.build(
+          current_crime_application
         )
       end
 
       def update
-        expected_evidence = current_crime_application.expected_evidence || []
-
-        expected_evidence << 'passporting_benefit' if expected_evidence.exclude?('passporting_benefit')
-
-        current_crime_application.update(expected_evidence:)
-
         update_and_advance(HasBenefitEvidenceForm, as: :has_benefit_evidence)
       end
     end

--- a/app/controllers/steps/client/has_benefit_evidence_controller.rb
+++ b/app/controllers/steps/client/has_benefit_evidence_controller.rb
@@ -1,0 +1,21 @@
+module Steps
+  module Client
+    class HasBenefitEvidenceController < Steps::ClientStepController
+      def edit
+        @form_object = HasBenefitEvidenceForm.new(
+          crime_application: current_crime_application
+        )
+      end
+
+      def update
+        expected_evidence = current_crime_application.expected_evidence || []
+
+        expected_evidence << 'passporting_benefit' if expected_evidence.exclude?('passporting_benefit')
+
+        current_crime_application.update(expected_evidence:)
+
+        update_and_advance(HasBenefitEvidenceForm, as: :has_benefit_evidence)
+      end
+    end
+  end
+end

--- a/app/forms/steps/client/has_benefit_evidence_form.rb
+++ b/app/forms/steps/client/has_benefit_evidence_form.rb
@@ -1,9 +1,11 @@
 module Steps
   module Client
     class HasBenefitEvidenceForm < Steps::BaseFormObject
-      attribute :has_benefit_evidence, :value_object, source: YesNoAnswer
+      include Steps::HasOneAssociation
+      has_one_association :applicant
 
-      validates_inclusion_of :has_benefit_evidence, in: :choices
+      attribute :has_benefit_evidence, :value_object, source: YesNoAnswer
+      validates :has_benefit_evidence, inclusion: { in: :choices }
 
       def choices
         YesNoAnswer.values
@@ -12,7 +14,9 @@ module Steps
       private
 
       def persist!
-        true
+        applicant.update(
+          attributes
+        )
       end
     end
   end

--- a/app/forms/steps/client/has_benefit_evidence_form.rb
+++ b/app/forms/steps/client/has_benefit_evidence_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Client
+    class HasBenefitEvidenceForm < Steps::BaseFormObject
+      attribute :has_benefit_evidence, :value_object, source: YesNoAnswer
+
+      validates_inclusion_of :has_benefit_evidence, in: :choices
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        true
+      end
+    end
+  end
+end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -15,6 +15,8 @@ module Decisions
         determine_dwp_result_page
       when :benefit_check_result
         after_dwp_check
+      when :has_benefit_evidence
+        after_has_benefit_evidence
       when :contact_details
         after_contact_details
       else
@@ -66,6 +68,14 @@ module Decisions
 
     def after_dwp_check
       start_address_journey(HomeAddress)
+    end
+
+    def after_has_benefit_evidence
+      if form_object.has_benefit_evidence.yes?
+        start_address_journey(HomeAddress)
+      else
+        show(:evidence_exit)
+      end
     end
 
     def after_contact_details

--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -22,7 +22,9 @@ module Decisions
     end
 
     def after_confirm_details
-      if form_object.confirm_details.yes?
+      if form_object.confirm_details.yes? && FeatureFlags.evidence_upload.enabled?
+        edit('steps/client/has_benefit_evidence')
+      elsif form_object.confirm_details.yes?
         show(:benefit_check_result_exit)
       else
         edit('steps/client/details')

--- a/app/views/steps/client/evidence_exit/show.html.erb
+++ b/app/views/steps/client/evidence_exit/show.html.erb
@@ -1,0 +1,4 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<%= render partial: 'shared/eforms_redirect' %>

--- a/app/views/steps/client/has_benefit_evidence/edit.html.erb
+++ b/app/views/steps/client/has_benefit_evidence/edit.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+        <%= f.govuk_collection_radio_buttons :has_benefit_evidence, @form_object.choices,
+                                             :value, inline: false,
+                                             legend: { tag: 'h1', size: 'xl', text: t(
+                                               '.heading', benefit_type: t(
+                                                 current_crime_application.applicant.benefit_type,
+                                                 scope: 'helpers.label.steps_client_benefit_type_form.benefit_type_options'
+                                               )
+                                             ) } %>
+
+        <%= f.continue_button(secondary: false) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/client/has_benefit_evidence/edit.html.erb
+++ b/app/views/steps/client/has_benefit_evidence/edit.html.erb
@@ -1,9 +1,10 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
+
     <%= step_form @form_object do |f| %>
         <%= f.govuk_collection_radio_buttons :has_benefit_evidence, @form_object.choices,
                                              :value, inline: false,
@@ -14,7 +15,7 @@
                                                )
                                              ) } %>
 
-        <%= f.continue_button(secondary: false) %>
+        <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -68,6 +68,10 @@ en:
           attributes:
             benefit_type:
               inclusion: Select a benefit type
+        steps/client/has_benefit_evidence_form:
+          attributes:
+            has_benefit_evidence:
+              inclusion: Select yes if you have evidence of your client's benefit
         steps/client/contact_details_form:
           attributes:
             telephone_number:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -66,6 +66,10 @@ en:
         nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       steps_client_benefit_type_form:
         benefit_type: This will help us review your application. It will not affect the DWP check.
+      steps_client_has_benefit_evidence_form:
+        has_benefit_evidence: This can be a letter from DWP or JobCentre Plus, or an image from a government app showing your client's name and their benefit details.
+        has_benefit_evidence_options:
+          'yes': You'll need to upload evidence at the end of this application
       steps_client_contact_details_form:
         telephone_number: For example, 01632 960 001 or +44 808 157 0192
       steps_address_lookup_form:
@@ -126,6 +130,8 @@ en:
           esa: Income-related Employment and Support Allowance (ESA)
           income_support: Income Support
           none: My client does not get any of these passporting benefits
+      steps_client_has_benefit_evidence_form:
+        has_benefit_evidence_options: *YESNO
       steps_client_contact_details_form:
         telephone_number: Telephone number (optional)
         correspondence_address_type_options:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -51,6 +51,13 @@ en:
         edit:
           page_title: Benefit check result
           heading: DWP records show that your client receives a passporting benefit
+      has_benefit_evidence:
+        edit:
+          page_title: Client's passporting benefit evidence
+          heading: Do you have evidence your client gets %{benefit_type}?
+      evidence_exit:
+        show:
+          page_title: Use eForms for this application
       retry_benefit_check:
         edit:
           page_title: Unable to connect to DWP

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,10 @@ Rails.application.routes.draw do
         show_step :benefit_exit
         edit_step :benefit_check_result
         edit_step :retry_benefit_check
+        if FeatureFlags.evidence_upload.enabled?
+          edit_step :has_benefit_evidence
+          show_step :evidence_exit
+        end
         edit_step :contact_details
       end
 

--- a/db/migrate/20230929171846_add_expected_evidence_field.rb
+++ b/db/migrate/20230929171846_add_expected_evidence_field.rb
@@ -1,0 +1,5 @@
+class AddExpectedEvidenceField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :expected_evidence, :string, array: true, default: []
+  end
+end

--- a/db/migrate/20230929171846_add_expected_evidence_field.rb
+++ b/db/migrate/20230929171846_add_expected_evidence_field.rb
@@ -1,5 +1,0 @@
-class AddExpectedEvidenceField < ActiveRecord::Migration[7.0]
-  def change
-    add_column :crime_applications, :expected_evidence, :string, array: true, default: []
-  end
-end

--- a/db/migrate/20231005102741_add_has_benefit_evidence_attribute.rb
+++ b/db/migrate/20231005102741_add_has_benefit_evidence_attribute.rb
@@ -1,0 +1,5 @@
+class AddHasBenefitEvidenceAttribute < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :has_benefit_evidence, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_29_171846) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_05_102741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -79,7 +79,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_171846) do
     t.jsonb "provider_details", default: {}, null: false
     t.uuid "parent_id"
     t.string "means_passport", default: [], array: true
-    t.string "expected_evidence", default: [], array: true
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
@@ -142,6 +141,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_171846) do
     t.string "correspondence_address_type"
     t.boolean "passporting_benefit"
     t.string "benefit_type"
+    t.string "has_benefit_evidence"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_29_140740) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_29_171846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_140740) do
     t.jsonb "provider_details", default: {}, null: false
     t.uuid "parent_id"
     t.string "means_passport", default: [], array: true
+    t.string "expected_evidence", default: [], array: true
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end

--- a/spec/controllers/steps/client/evidence_exit_controller_spec.rb
+++ b/spec/controllers/steps/client/evidence_exit_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::EvidenceExitController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/controllers/steps/client/has_benefit_evidence_controller_spec.rb
+++ b/spec/controllers/steps/client/has_benefit_evidence_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::HasBenefitEvidenceController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Client::HasBenefitEvidenceForm, Decisions::ClientDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::Client::HasBenefitEvidenceForm
+end

--- a/spec/forms/steps/client/has_benefit_evidence_form_spec.rb
+++ b/spec/forms/steps/client/has_benefit_evidence_form_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Client::HasBenefitEvidenceForm do
+  subject { described_class.new }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `has_benefit_evidence` is not provided' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:has_benefit_evidence, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `confirm_result` is provided' do
+      it 'returns true' do
+        subject.choices.each do |choice|
+          subject.has_benefit_evidence = choice
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/client/has_benefit_evidence_form_spec.rb
+++ b/spec/forms/steps/client/has_benefit_evidence_form_spec.rb
@@ -1,18 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::HasBenefitEvidenceForm do
-  subject { described_class.new }
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
+      record: applicant_record,
+    }.merge(
+      form_attributes
+    )
+  end
+
+  let(:form_attributes) do
+    { has_benefit_evidence: }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
+  let(:applicant_record) { Applicant.new }
+  let(:has_benefit_evidence) { 'yes' }
 
   describe '#choices' do
     it 'returns the possible choices' do
       expect(
         subject.choices
-      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+      ).to eq(YesNoAnswer.values)
     end
   end
 
   describe '#save' do
     context 'when `has_benefit_evidence` is not provided' do
+      let(:has_benefit_evidence) { '' }
+
       it 'returns false' do
         expect(subject.save).to be(false)
       end
@@ -23,12 +42,26 @@ RSpec.describe Steps::Client::HasBenefitEvidenceForm do
       end
     end
 
-    context 'when `confirm_result` is provided' do
-      it 'returns true' do
-        subject.choices.each do |choice|
-          subject.has_benefit_evidence = choice
-          expect(subject.save).to be(true)
-        end
+    context 'when `has_benefit_evidence` is not valid' do
+      let(:has_benefit_evidence) { 'maybe' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:has_benefit_evidence, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(applicant_record).to receive(:update).with(
+          { 'has_benefit_evidence' => YesNoAnswer::YES }
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
       end
     end
   end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -127,6 +127,32 @@ RSpec.describe Decisions::ClientDecisionTree do
     end
   end
 
+  context 'when the step is `has_benefit_evidence`' do
+    let(:form_object) { double('FormObject', applicant:, has_benefit_evidence:) }
+    let(:step_name) { :has_benefit_evidence }
+
+    context 'and the answer is `yes`' do
+      let(:has_benefit_evidence) { YesNoAnswer::YES }
+
+      before do
+        allow(
+          Address
+        ).to receive(:find_or_create_by).with(person: applicant).and_return('address')
+      end
+
+      it {
+        expect(subject).to have_destination('/steps/address/lookup', :edit, id: crime_application,
+address_id: 'address')
+      }
+    end
+
+    context 'and the answer is `no`' do
+      let(:has_benefit_evidence) { YesNoAnswer::NO }
+
+      it { is_expected.to have_destination(:evidence_exit, :show, id: crime_application) }
+    end
+  end
+
   context 'when the step is `retry_benefit_check`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :retry_benefit_check }

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -39,7 +39,19 @@ RSpec.describe Decisions::DWPDecisionTree do
     context 'and the answer is `yes`' do
       let(:confirm_details) { YesNoAnswer::YES }
 
-      it { is_expected.to have_destination(:benefit_check_result_exit, :show, id: crime_application) }
+      context 'and the evidence upload feature flag enabled' do
+        it { is_expected.to have_destination('steps/client/has_benefit_evidence', :edit, id: crime_application) }
+      end
+
+      context 'and the evidence upload feature flag is disabled' do
+        before do
+          allow(FeatureFlags).to receive(:evidence_upload) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
+        end
+
+        it { is_expected.to have_destination(:benefit_check_result_exit, :show, id: crime_application) }
+      end
     end
 
     context 'and the answer is `no`' do


### PR DESCRIPTION
## Description of change
If benefit check fails, details are correct, user can register that they have evidence they intend to upload later
Adds virtual attribute, only needed locally in apply to resurface later at evidence upload step.

FYI I have also removed the feature flag for the benefit type page - So this would make it a live service change on deploy to prod.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-576

## Notes for reviewer
As I am away this week, please feel free to commit any changes and merge as needed! I'm not precious!

## Screenshots of changes (if applicable)

### Before changes:

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/287006df-15c8-4241-8eed-2d2143a84460


### After changes:

Uploading Hasevidence.mov…


## How to manually test the feature
