### PR TITLE
CRIMAP-599 Add first hearing court name page

### DIFF
--- a/app/controllers/steps/case/first_court_hearing_controller.rb
+++ b/app/controllers/steps/case/first_court_hearing_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class FirstCourtHearingController < Steps::CaseStepController
+      def edit
+        @form_object = FirstCourtHearingForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(FirstCourtHearingForm, as: :first_court_hearing)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/first_court_hearing_form.rb
+++ b/app/forms/steps/case/first_court_hearing_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Case
+    class FirstCourtHearingForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :case
+
+      attribute :first_court_hearing_name, :string
+      validates :first_court_hearing_name, presence: true
+
+      private
+
+      def persist!
+        kase.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/value_objects/first_hearing_answer.rb
+++ b/app/value_objects/first_hearing_answer.rb
@@ -1,0 +1,7 @@
+class FirstHearingAnswer < ValueObject
+  VALUES = [
+    YES = new(:yes),
+    NO = new(:no),
+    NO_HEARING_YET = new(:no_hearing_yet)
+  ].freeze
+end

--- a/app/views/steps/case/first_court_hearing/edit.en.html.erb
+++ b/app/views/steps/case/first_court_hearing/edit.en.html.erb
@@ -1,0 +1,16 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_select :first_court_hearing_name, Court.all, :name, :name,
+                                    data: { module: 'accessible-autocomplete' },
+                                    options: { include_blank: true }, label: { tag: 'h1', size: 'xl' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -193,6 +193,10 @@ en:
               invalid_year: Enter a valid year
               year_too_late: Date of next hearing is too far in the future
               past_not_allowed: Date of next hearing must be today or in the future
+        steps/case/first_court_hearing_form:
+          attributes:
+            first_court_hearing_name:
+              blank: Enter a court name
         steps/case/ioj_form:
           attributes:
             types:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -81,6 +81,8 @@ en:
       steps_case_hearing_details_form:
         hearing_court_name: For example, Cardiff Crown Court
         hearing_date: For example, 27 3 2024
+      steps_case_first_court_hearing_form:
+        first_court_hearing_name: For example, Bristol Magistrates Court
       steps_case_ioj_form:
         loss_of_liberty_justification: *ioj_justification_hint
         suspended_sentence_justification: *ioj_justification_hint
@@ -174,6 +176,8 @@ en:
           conflict_of_interest_options: *YESNO
       steps_case_hearing_details_form:
         hearing_court_name: Court name
+      steps_case_first_court_hearing_form:
+        first_court_hearing_name: Where was the first court hearing?
       steps_case_ioj_form:
         loss_of_liberty_justification: Loss of liberty justification
         suspended_sentence_justification: Suspended sentence justification

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -176,6 +176,9 @@ en:
         edit:
           page_title: Next hearing court details
           heading: Enter the details of the next court hearing
+      first_court_hearing:
+        edit:
+          page_title: First court hearing
       ioj_passport:
         edit:
           page_title: Passported on IoJ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,7 @@ Rails.application.routes.draw do
         edit_step :has_codefendants
         edit_step :codefendants
         edit_step :hearing_details
+        edit_step :first_court_hearing
         edit_step :ioj_passport
         edit_step :ioj
       end

--- a/db/migrate/20230929140740_add_first_court_hearing_attributes.rb
+++ b/db/migrate/20230929140740_add_first_court_hearing_attributes.rb
@@ -1,0 +1,6 @@
+class AddFirstCourtHearingAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :is_first_court_hearing, :string
+    add_column :cases, :first_court_hearing_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_27_100615) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_29_140740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -42,6 +42,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_27_100615) do
     t.string "has_codefendants"
     t.string "hearing_court_name"
     t.date "hearing_date"
+    t.string "is_first_court_hearing"
+    t.string "first_court_hearing_name"
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/case/first_court_hearing_controller_spec.rb
+++ b/spec/controllers/steps/case/first_court_hearing_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::FirstCourtHearingController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::FirstCourtHearingForm, Decisions::CaseDecisionTree
+end

--- a/spec/forms/steps/case/first_court_hearing_form_spec.rb
+++ b/spec/forms/steps/case/first_court_hearing_form_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::FirstCourtHearingForm do
+  subject { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
+      first_court_hearing_name: 'Cardiff Court',
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+
+  describe '#save' do
+    context 'validations' do
+      it { is_expected.to validate_presence_of(:first_court_hearing_name) }
+    end
+
+    context 'when validations pass' do
+      it_behaves_like 'a has-one-association form',
+                      association_name: :case,
+                      expected_attributes: {
+                        'first_court_hearing_name' => 'Cardiff Court',
+                      }
+    end
+  end
+end

--- a/spec/value_objects/first_hearing_answer_spec.rb
+++ b/spec/value_objects/first_hearing_answer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe FirstHearingAnswer do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w[yes no no_hearing_yet])
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Not yet linked to the wider journey, this is the first part of a few PRs to implement the gathering of the first hearing court name, determined by the provider answer to a series of radio options (not implemented in this PR).
Trying to raise smaller PRs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-598

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="722" alt="Screenshot 2023-10-02 at 08 40 41" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/ced16b08-5776-457d-b6fd-447ea05ebe89">
<img width="712" alt="Screenshot 2023-10-02 at 08 41 00" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/414313d0-c3e4-41c6-9b9e-24dad64fa5b8">
<img width="703" alt="Screenshot 2023-10-02 at 08 41 15" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/a740624e-49a7-4f17-952e-ac1db3cf96c0">

## How to manually test the feature
In order to view this page, as it is not part of the journey yet, start an application, go all the way to the court hearing step, and then enter URL manually: `applications/[uuid]/steps/case/first_court_hearing`
The submit will raise an error as there is no next page yet, but the page is functional.