### PR TITLE
CRIMAP-598 First court hearing selection

### DIFF
--- a/app/forms/steps/case/hearing_details_form.rb
+++ b/app/forms/steps/case/hearing_details_form.rb
@@ -6,17 +6,35 @@ module Steps
 
       attribute :hearing_court_name, :string
       attribute :hearing_date, :multiparam_date
+      attribute :is_first_court_hearing, :value_object, source: FirstHearingAnswer
 
       validates :hearing_court_name, presence: true
       validates :hearing_date, presence: true,
                 multiparam_date: { allow_past: false, allow_future: true }
 
+      validates :is_first_court_hearing, inclusion: { in: :choices }
+
+      def choices
+        FirstHearingAnswer.values
+      end
+
       private
 
       def persist!
         kase.update(
-          attributes
+          attributes.merge(
+            # The following are dependent attributes that need to be reset
+            attributes_to_reset
+          )
         )
+      end
+
+      def attributes_to_reset
+        return {} if is_first_court_hearing.no?
+
+        {
+          first_court_hearing_name: nil,
+        }
       end
     end
   end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -30,6 +30,8 @@ module Decisions
         edit(:hearing_details)
       when :hearing_details
         after_hearing_details
+      when :first_court_hearing
+        ioj_or_passported
       when :ioj, :ioj_passport
         after_ioj
       else
@@ -91,6 +93,14 @@ module Decisions
     end
 
     def after_hearing_details
+      if form_object.is_first_court_hearing.no?
+        edit(:first_court_hearing)
+      else
+        ioj_or_passported
+      end
+    end
+
+    def ioj_or_passported
       if Passporting::IojPassporter.new(current_crime_application).call
         edit(:ioj_passport)
       else

--- a/app/views/steps/case/hearing_details/edit.html.erb
+++ b/app/views/steps/case/hearing_details/edit.html.erb
@@ -14,6 +14,8 @@
 
       <%= f.govuk_date_field :hearing_date, maxlength_enabled: true %>
 
+      <%= f.govuk_collection_radio_buttons :is_first_court_hearing, @form_object.choices, :value %>
+
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -193,6 +193,8 @@ en:
               invalid_year: Enter a valid year
               year_too_late: Date of next hearing is too far in the future
               past_not_allowed: Date of next hearing must be today or in the future
+            is_first_court_hearing:
+              inclusion: Select yes if this court also heard the first hearing
         steps/case/first_court_hearing_form:
           attributes:
             first_court_hearing_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -54,6 +54,7 @@ en:
           conflict_of_interest: Is there a conflict of interest with this co-defendant?
       steps_case_hearing_details_form:
         hearing_date: Date of next hearing
+        is_first_court_hearing: Did this court also hear the first hearing?
       steps_case_ioj_form:
         types: Why should your client get legal aid?
 
@@ -176,6 +177,9 @@ en:
           conflict_of_interest_options: *YESNO
       steps_case_hearing_details_form:
         hearing_court_name: Court name
+        is_first_court_hearing_options:
+          <<: *YESNO
+          no_hearing_yet: There has not been a hearing yet
       steps_case_first_court_hearing_form:
         first_court_hearing_name: Where was the first court hearing?
       steps_case_ioj_form:

--- a/spec/forms/steps/case/hearing_details_form_spec.rb
+++ b/spec/forms/steps/case/hearing_details_form_spec.rb
@@ -6,17 +6,45 @@ RSpec.describe Steps::Case::HearingDetailsForm do
   let(:arguments) do
     {
       crime_application: crime_application,
-    hearing_court_name: 'Cardiff Court',
-    hearing_date: Date.tomorrow,
+      hearing_court_name: 'Cardiff Court',
+      hearing_date: Date.tomorrow,
+      is_first_court_hearing: is_first_court_hearing,
     }
   end
 
   let(:crime_application) { instance_double(CrimeApplication) }
+  let(:is_first_court_hearing) { FirstHearingAnswer::YES.to_s }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([FirstHearingAnswer::YES, FirstHearingAnswer::NO, FirstHearingAnswer::NO_HEARING_YET])
+    end
+  end
 
   describe '#save' do
     context 'validations' do
       it { is_expected.to validate_presence_of(:hearing_court_name) }
       it { is_expected.to validate_presence_of(:hearing_date) }
+
+      context 'when `is_first_court_hearing` is not provided' do
+        let(:is_first_court_hearing) { '' }
+
+        it 'has a validation error on the field' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:is_first_court_hearing, :inclusion)).to be(true)
+        end
+      end
+
+      context 'when `is_first_court_hearing` is not valid' do
+        let(:is_first_court_hearing) { 'foobar' }
+
+        it 'has a validation error on the field' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:is_first_court_hearing, :inclusion)).to be(true)
+        end
+      end
     end
 
     context 'hearing_date' do
@@ -25,13 +53,31 @@ RSpec.describe Steps::Case::HearingDetailsForm do
                       allow_past: false, allow_future: true
     end
 
+    # rubocop:disable Style/HashSyntax
     context 'when validations pass' do
-      it_behaves_like 'a has-one-association form',
-                      association_name: :case,
-                      expected_attributes: {
-                        'hearing_court_name' => 'Cardiff Court',
-                        'hearing_date' => Date.tomorrow,
-                      }
+      context 'when it is the first court hearing it resets dependent attributes' do
+        it_behaves_like 'a has-one-association form',
+                        association_name: :case,
+                        expected_attributes: {
+                          'hearing_court_name' => 'Cardiff Court',
+                          'hearing_date' => Date.tomorrow,
+                          'is_first_court_hearing' => FirstHearingAnswer::YES,
+                          first_court_hearing_name: nil,
+                        }
+      end
+
+      context 'when it is not the first court hearing' do
+        let(:is_first_court_hearing) { FirstHearingAnswer::NO.to_s }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :case,
+                        expected_attributes: {
+                          'hearing_court_name' => 'Cardiff Court',
+                          'hearing_date' => Date.tomorrow,
+                          'is_first_court_hearing' => FirstHearingAnswer::NO,
+                        }
+      end
     end
+    # rubocop:enable Style/HashSyntax
   end
 end


### PR DESCRIPTION
## Description of change
Follow-up to PR #493 to expose the radio options in the existing hearing details page, for the provider to select whether the first hearing court is the same as the next hearing court and logic to move to next page.

Includes validation as well as logic to delete previous answer if the provider changes the radio selection.

This is now part of the wider journey, but there is not Check Your Answer yet, that will be part of the next PR. Also missing submission to datastore/rehydration.

This is not behind a feature flag as I'm hoping to finish it soonish enough to be able to test and release as is a minor iteration on current form.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-598

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="612" alt="Screenshot 2023-10-02 at 11 08 51" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/6e44f09a-acfe-4728-88b5-82f20971dd98">
<img width="577" alt="Screenshot 2023-10-02 at 11 09 35" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/06eb6e49-0e30-4b70-8551-8bbd24b7c6cc">

## How to manually test the feature
In any application go to the hearing details step, you should see the new radio options. It has validation. Selecting anything other than 'No' will proceed as usual. If selecting 'Yes', it will go to the new page to enter first court hearing and then proceed as normal.