### PR TITLE
Refactor clamav deployment to use StatefulSet

### DIFF
--- a/config/clamd/clamd.staging2.conf
+++ b/config/clamd/clamd.staging2.conf
@@ -1,2 +1,0 @@
-TCPAddr clamav-service-staging.laa-apply-for-criminal-legal-aid-staging.svc.cluster.local
-TCPSocket 3310

--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -1,19 +1,5 @@
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: clamav-signatures
-  namespace: laa-apply-for-criminal-legal-aid-staging
-  annotations:
-    volume.alpha.kubernetes.io/storage-class: anything
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
----
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: clamav-staging
   namespace: laa-apply-for-criminal-legal-aid-staging
@@ -21,11 +7,11 @@ spec:
   replicas: 2
   revisionHistoryLimit: 2
   minReadySeconds: 10
-  strategy:
+  serviceName: clamav
+  updateStrategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 50%
-      maxSurge: 100%
   selector:
     matchLabels:
       app: apply-for-criminal-legal-aid-clamav-staging
@@ -35,25 +21,11 @@ spec:
         app: apply-for-criminal-legal-aid-clamav-staging
         tier: backend
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - apply-for-criminal-legal-aid-clamav-staging
-            topologyKey: kubernetes.io/hostname
       securityContext:
         # Change to 100 if using official clamav image
         fsGroup: 1001
         runAsUser: 1001
         runAsGroup: 1001
-      volumes:
-      - name: clamav-signatures
-        persistentVolumeClaim:
-          claimName: clamav-signatures
       containers:
       - name: clamav
         # NOTE: temporarily until clamav publishes an official unprivileged
@@ -65,7 +37,7 @@ spec:
           - containerPort: 3310
             protocol: TCP
         volumeMounts:
-          - mountPath: "/var/lib/clamav"
+          - mountPath: /var/lib/clamav
             name: clamav-signatures
         resources:
           requests:
@@ -84,6 +56,15 @@ spec:
             port: 3310
           initialDelaySeconds: 30
           periodSeconds: 60
+  volumeClaimTemplates:
+  - metadata:
+      name: clamav-signatures
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description of change
This ensures stickiness of persistent volumes on rollouts and scaling.

Delete unused file. We can access the service with the short name as it is inside the same namespace, no need to use the fully qualified name.

This is a follow-up to previous PR #490.
