### PR TITLE
CRIMAP-644 Show benefit type in CYA page

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -32,6 +32,7 @@ module DeveloperTools
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_has_nino_path(crime_application),
+          edit_steps_client_benefit_type_path(crime_application),
           edit_steps_client_benefit_check_result_path(crime_application),
         ]
       )
@@ -44,6 +45,7 @@ module DeveloperTools
       find_or_create_applicant(
         dob: rand(15..17).years.ago,
         nino: nil,
+        benefit_type: nil,
         passporting_benefit: nil,
       ).update(
         correspondence_address_type: CorrespondenceType::PROVIDERS_OFFICE_ADDRESS,
@@ -84,6 +86,7 @@ module DeveloperTools
           other_names: '',
           date_of_birth: overrides.fetch(:dob, details[:dob]),
           nino: overrides.fetch(:nino, details[:nino]),
+          benefit_type: overrides.fetch(:benefit_type, 'universal_credit'),
           passporting_benefit: overrides.fetch(:passporting_benefit, true),
         )
       end

--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -43,6 +43,7 @@ module Steps
         {
           has_nino: nil,
           nino: nil,
+          benefit_type: nil,
           passporting_benefit: nil,
         }
       end

--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -21,6 +21,7 @@ module Steps
         applicant.update(
           attributes.merge(
             # The following are dependent attributes that need to be reset
+            benefit_type: nil,
             passporting_benefit: nil,
           )
         )

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -38,7 +38,8 @@ module Summary
           ),
 
           Components::ValueAnswer.new(
-            :means_passporting, means_passported?
+            :passporting_benefit, applicant.benefit_type,
+            change_path: edit_steps_client_benefit_type_path
           ),
         ].select(&:show?)
       end
@@ -48,10 +49,6 @@ module Summary
 
       def applicant
         @applicant ||= crime_application.applicant
-      end
-
-      def means_passported?
-        crime_application.means_passport.any?
       end
     end
   end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -52,6 +52,15 @@ en:
         answers:
           'true': 'Yes'
           'false': 'No'
+      passporting_benefit:
+        question: Passporting benefit
+        answers:
+          universal_credit: Universal Credit
+          guarantee_pension: Guarantee Credit element of Pension Credit
+          jsa: Income-based Jobseeker’s Allowance (JSA)
+          esa: Income-related Employment and Support Allowance (ESA)
+          income_support: Income Support
+          none: None
       # END client details section
 
       # BEGIN contact details section

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Steps::Client::DetailsForm do
                             'date_of_birth' => 20.years.ago.to_date,
                             :has_nino => nil,
                             :nino => nil,
+                            :benefit_type => nil,
                             :passporting_benefit => nil,
                           }
         end
@@ -70,6 +71,7 @@ RSpec.describe Steps::Client::DetailsForm do
                             'date_of_birth' => 20.years.ago.to_date,
                             :has_nino => nil,
                             :nino => nil,
+                            :benefit_type => nil,
                             :passporting_benefit => nil,
                           }
         end

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Steps::Client::HasNinoForm do
                         association_name: :applicant,
                         expected_attributes: {
                           'nino' => 'NC123456A',
+                          :benefit_type => nil,
                           :passporting_benefit => nil,
                         }
       end

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -9,7 +9,6 @@ describe Summary::Sections::ClientDetails do
       to_param: '12345',
       client_has_partner: 'no',
       applicant: applicant,
-      means_passport: means_passport,
     )
   end
 
@@ -21,10 +20,11 @@ describe Summary::Sections::ClientDetails do
       other_names: '',
       date_of_birth: Date.new(1999, 1, 20),
       nino: '123456',
+      benefit_type: benefit_type,
     )
   end
 
-  let(:means_passport) { ['foobar'] }
+  let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
 
   describe '#name' do
     it { expect(subject.name).to eq(:client_details) }
@@ -78,13 +78,13 @@ describe Summary::Sections::ClientDetails do
       expect(answers[4].value).to eq('123456')
 
       expect(answers[5]).to be_an_instance_of(Summary::Components::ValueAnswer)
-      expect(answers[5].question).to eq(:means_passporting)
-      expect(answers[5].change_path).to be_nil
-      expect(answers[5].value).to be(true)
+      expect(answers[5].question).to eq(:passporting_benefit)
+      expect(answers[5].change_path).to match('applications/12345/steps/client/benefit_type')
+      expect(answers[5].value).to eq('universal_credit')
     end
 
-    context 'when there is no means passporting' do
-      let(:means_passport) { [] }
+    context 'when there is no `benefit_type` value' do
+      let(:benefit_type) { nil }
 
       it 'has the correct rows' do
         expect(answers.count).to eq(5)


### PR DESCRIPTION
## Description of change
Added the benefit type to the check your answer page, in place of the previous "Passporting benefit" essentially merging both rows into one as confirmed by content designer.

If the question is not asked (under 18s) then the row will not show up.

Ensured `benefit_type` attribute is reset in a couple places if some key details are changed, as this value is linked to the DWP benefit checker.

Feature is still being feature flag, need to be removed if we want this in production at some point in the future once QA'ed.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-644
Slack thread: https://mojdt.slack.com/archives/C03JS4V9TPU/p1696328705798759

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="759" alt="Screenshot 2023-10-03 at 14 33 09" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/b231361f-f869-49c0-896c-cf48c9264b36">

## How to manually test the feature
For under 18s this row will not show.
For over 18s, run through the DWP check successfully and reach the CYA page, you should see whatever benefit was selected from the list presented.