### PR TITLE
Remove `benefit_type` step feature flag

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,10 +104,8 @@ Rails.application.routes.draw do
         edit_step :details
         edit_step :has_nino
         show_step :nino_exit
-        if FeatureFlags.benefit_type_step.enabled?
-          edit_step :benefit_type
-          show_step :benefit_exit
-        end
+        edit_step :benefit_type
+        show_step :benefit_exit
         edit_step :benefit_check_result
         edit_step :retry_benefit_check
         edit_step :contact_details

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,10 +3,6 @@ feature_flags:
     local: true
     staging: true
     production: false
-  benefit_type_step:
-    local: true
-    staging: true
-    production: false
   u18_means_passport:
     local: true
     staging: true


### PR DESCRIPTION
## Description of change
In the event we want to release this.

As part of this PR I've also re-wired the logic for retrying the DWP check when it fails due to connectivity or unhandled exceptions, so it does not go again to the benefit type page, and instead just re-try the DWP check as intended.

## How to manually test the feature
No changes other than removing the feat flag and fixing the retry DWP check. To test it locally, point the DWP checker to an invalid endpoint for instance, and run the DWP check. It would present the "retry" page, and when clicking the retry button it will retry the DWP instead of taking provider back to benefit type page.