### PR TITLE
CRIMAP-651 Skip attack-sqli check on session cookie

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -25,6 +25,7 @@ metadata:
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
Prevent sql injection false positives on the rails session cookie

## Link to relevant ticket

[CRIMAP-651](https://dsdmoj.atlassian.net/browse/CRIMAP-651)

## Notes for reviewer
We've identified a number of attack-sqli false +ve on the rails session cookie and confirmed this PR's changes work. After testing on staging, this change will need to be applied to the production ingress.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
