### PR TITLE
CRIMAP-576 Link evidence upload to wider journey

### DIFF
--- a/app/presenters/tasks/evidence_upload.rb
+++ b/app/presenters/tasks/evidence_upload.rb
@@ -1,0 +1,29 @@
+module Tasks
+  class EvidenceUpload < BaseTask
+    def path
+      edit_steps_evidence_upload_path
+    end
+
+    def not_applicable?
+      Evidence::Requirements.new(crime_application).none?
+    end
+
+    def can_start?
+      fulfilled?(CaseDetails)
+    end
+
+    def in_progress?
+      documents.any?
+    end
+
+    def completed?
+      documents.stored.any?
+    end
+
+    private
+
+    def documents
+      @documents ||= crime_application.documents
+    end
+  end
+end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -108,23 +108,18 @@ module Decisions
       end
     end
 
-    # NOTE: for MVP, this is the last step of the application,
-    # however post-MVP there will be means assessment steps,
-    # unless the applicant has been passported. As this is not
-    # yet implemented, for now both branches behave the same.
-    # However before submission we perform a validation to
-    # ensure applicant is means-passported (array is not empty).
-    #
-    # rubocop:disable Style/IdenticalConditionalBranches,Lint/DuplicateBranch
+    # rubocop:disable Lint/DuplicateBranch
     def after_ioj
       if Passporting::MeansPassporter.new(current_crime_application).call
         edit('/steps/submission/review')
+      elsif Evidence::Requirements.new(current_crime_application).any?
+        edit('/steps/evidence/upload')
       else
         # TODO: post-MVP implement means assessment steps
         edit('/steps/submission/review')
       end
     end
-    # rubocop:enable Style/IdenticalConditionalBranches, Lint/DuplicateBranch
+    # rubocop:enable Lint/DuplicateBranch
 
     def edit_new_charge
       charge = case_charges.create!

--- a/app/services/evidence/requirements.rb
+++ b/app/services/evidence/requirements.rb
@@ -1,0 +1,35 @@
+module Evidence
+  class Requirements
+    attr_reader :crime_application
+
+    # NOTE: we don't have enough detail yet on how best to implement this.
+    # The assumption is, along the journey, there will be "check-points" or
+    # questions that will make certain evidence mandatory. For now we only
+    # have one question that will trigger the evidence upload page.
+    # This class is just a simple wrapper to start with.
+
+    def initialize(crime_application)
+      @crime_application = crime_application
+    end
+
+    def any?
+      [benefits?].any?
+    end
+
+    def none?
+      !any?
+    end
+
+    def benefits?
+      YesNoAnswer.new(
+        applicant&.has_benefit_evidence.to_s
+      ).yes?
+    end
+
+    private
+
+    def applicant
+      @applicant ||= crime_application.applicant
+    end
+  end
+end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -22,7 +22,7 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
   def perform_validations
     errors = []
 
-    unless Passporting::MeansPassporter.new(record).call || has_evidence?
+    unless Passporting::MeansPassporter.new(record).call || evidence_present?
       errors << [
         :means_passport, :blank, { change_path: edit_steps_client_details_path }
       ]
@@ -41,7 +41,7 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
     record.ioj.present? && record.ioj.types.any?
   end
 
-  def has_evidence?
+  def evidence_present?
     record.documents.stored.any?
   end
 

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -22,7 +22,7 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
   def perform_validations
     errors = []
 
-    unless Passporting::MeansPassporter.new(record).call
+    unless Passporting::MeansPassporter.new(record).call || has_evidence?
       errors << [
         :means_passport, :blank, { change_path: edit_steps_client_details_path }
       ]
@@ -39,6 +39,10 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
 
   def ioj_present?
     record.ioj.present? && record.ioj.types.any?
+  end
+
+  def has_evidence?
+    record.documents.stored.any?
   end
 
   def add_errors(errors)

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -7,20 +7,24 @@
 
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
-    <p class="govuk-body govuk-!-margin-bottom-1">Use this page to provide:</p>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <%= t('.explanation') %>
+    </p>
 
+    <%# TODO: dynamic list depending on evidence requirements %>
     <ul class="govuk-list govuk-list--bullet">
       <li>evidence your client gets a passporting benefit</li>
-      <li>evidence of your client's income and outgoings</li>
-      <li>evidence of your client's capital</li>
-      <li>any other supporting evidence, like a freezing order or charge sheet</li>
     </ul>
 
-    <p class="govuk-body">All evidence must be from the last 3 months.</p>
+    <p class="govuk-body">
+      <%= t('.recent_docs') %>
+    </p>
 
     <h2 class="govuk-heading-m">
       <%= t('.upload_files_heading') %>
-      <span class="govuk-caption-m govuk-!-padding-top-2"><%= t('.upload_files_info', max_size: FileUploadValidator::MAX_FILE_SIZE) %></span>
+      <span class="govuk-caption-m govuk-!-padding-top-2">
+        <%= t('.upload_files_info', max_size: FileUploadValidator::MAX_FILE_SIZE) %>
+      </span>
     </h2>
 
     <%= form_for @form_object, html: { id: 'dz-evidence-upload-form', class: 'dropzone' },

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -199,6 +199,8 @@ en:
         edit:
           page_title: Upload supporting evidence
           heading: Upload supporting evidence
+          explanation: "Use this page to provide:"
+          recent_docs: All evidence must be from the last 3 months.
           upload_file_button: Upload file
           upload_files_heading: Upload files
           upload_files_info: The maximum file size is %{max_size}MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF.

--- a/spec/presenters/tasks/evidence_upload_spec.rb
+++ b/spec/presenters/tasks/evidence_upload_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::EvidenceUpload do
+  subject { described_class.new(crime_application:) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      documents: documents,
+    )
+  end
+
+  let(:documents) { [] }
+
+  describe '#path' do
+    it { expect(subject.path).to eq('/applications/12345/steps/evidence/upload') }
+  end
+
+  describe '#not_applicable?' do
+    before do
+      allow_any_instance_of(
+        Evidence::Requirements
+      ).to receive(:none?).and_return(no_evidence_required)
+    end
+
+    context 'when evidence is deemed required' do
+      let(:no_evidence_required) { false }
+
+      it { expect(subject.not_applicable?).to be(false) }
+    end
+
+    context 'when evidence is deemed not required' do
+      let(:no_evidence_required) { true }
+
+      it { expect(subject.not_applicable?).to be(true) }
+    end
+  end
+
+  describe '#can_start?' do
+    # We assume the completeness of the Case Details here, as
+    # their statuses are tested in its own spec, no need to repeat
+    before do
+      allow(
+        subject
+      ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details_fulfilled)
+    end
+
+    context 'when the Case Details task has been completed' do
+      let(:case_details_fulfilled) { true }
+
+      it { expect(subject.can_start?).to be(true) }
+    end
+
+    context 'when the Case Details task has not been completed yet' do
+      let(:case_details_fulfilled) { false }
+
+      it { expect(subject.can_start?).to be(false) }
+    end
+  end
+
+  describe '#in_progress?' do
+    context 'when there are any documents' do
+      let(:documents) { ['doc'] }
+
+      it { expect(subject.in_progress?).to be(true) }
+    end
+
+    context 'when there are no documents yet' do
+      let(:documents) { [] }
+
+      it { expect(subject.in_progress?).to be(false) }
+    end
+  end
+
+  describe '#completed?' do
+    let(:documents) { double(stored: scoped_documents) }
+
+    context 'when there are any stored documents' do
+      let(:scoped_documents) { ['stored_doc'] }
+
+      it { expect(subject.completed?).to be(true) }
+    end
+
+    context 'when there are no stored documents yet' do
+      let(:scoped_documents) { [] }
+
+      it { expect(subject.completed?).to be(false) }
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -296,18 +296,33 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:step_name) { :ioj }
 
     before do
-      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(means_passported)
+      allow_any_instance_of(
+        Passporting::MeansPassporter
+      ).to receive(:call).and_return(means_passported)
+
+      allow_any_instance_of(
+        Evidence::Requirements
+      ).to receive(:any?).and_return(evidence_required)
     end
 
     context 'and the application is means-passported' do
       let(:means_passported) { true }
+      let(:evidence_required) { false }
 
       it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
+    end
+
+    context 'and the application requires evidence upload' do
+      let(:means_passported) { false }
+      let(:evidence_required) { true }
+
+      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
     end
 
     # TODO: means test journey to be implemented
     context 'and the application is not means-passported' do
       let(:means_passported) { false }
+      let(:evidence_required) { false }
 
       it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
     end

--- a/spec/services/evidence/requirements_spec.rb
+++ b/spec/services/evidence/requirements_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe Evidence::Requirements do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
+
+  let(:applicant) do
+    instance_double(
+      Applicant,
+      has_benefit_evidence:
+    )
+  end
+
+  let(:has_benefit_evidence) { nil }
+
+  describe '#any?' do
+    before do
+      # `benefits?` method is tested separated
+      allow(subject).to receive(:benefits?).and_return(benefits)
+    end
+
+    context 'there are some evidence requirements' do
+      let(:benefits) { true }
+
+      it { expect(subject.any?).to be(true) }
+    end
+
+    context 'there are no evidence requirements' do
+      let(:benefits) { false }
+
+      it { expect(subject.any?).to be(false) }
+    end
+  end
+
+  describe '#none?' do
+    it 'returns false if `#any?` is true' do
+      expect(subject).to receive(:any?).and_return(true)
+      expect(subject.none?).to be(false)
+    end
+
+    it 'returns true if `#any?` is false' do
+      expect(subject).to receive(:any?).and_return(false)
+      expect(subject.none?).to be(true)
+    end
+  end
+
+  describe '#benefits?' do
+    subject { described_class.new(crime_application).benefits? }
+
+    context 'when `applicant` ni `nil`' do
+      let(:applicant) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when `has_benefit_evidence` is `nil`' do
+      let(:has_benefit_evidence) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when `has_benefit_evidence` is `no`' do
+      let(:has_benefit_evidence) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when `has_benefit_evidence` is `yes`' do
+      let(:has_benefit_evidence) { YesNoAnswer::YES.to_s }
+
+      it { is_expected.to be(true) }
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Create the task implementation, in the task list.

A basic wrapper to hold the logic on whether evidence is needed or not, and which types. This for now is up in the air so I've done it as basic as possible.

Link the evidence upload page to the journey, post IoJ, depending on the value of the previously asked question "has_benefit_evidence"

Modify the fulfilment validator because now it will be possible to have non means passported applications, but with evidence supplied.

No datastore/schema/rehydration yet.

Some unknowns yet to be confirmed/decided.

Note all this still remains behind feat flag, so nothing will show on production even if we release.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-576

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="688" alt="Screenshot 2023-10-06 at 16 05 30" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/687910/d3a4a4a9-a241-47bd-9489-3fce9290aba8">

## How to manually test the feature
Run a DWP check that comes up without benefit, answer YES to the question about having evidence. Then proceed all the way to the end, where after the IoJ you will see the upload evidence page.
Also the task in the task list will show either not applicable, in progress or completed, depending on the state of the application.