### PR TITLE
CRIMAP-651 Skip attack-sqli check on production

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -25,6 +25,7 @@ metadata:
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change

Update production ingress to be the same as staging.
Prevent sql injection false positives on the rails session cookie

## Link to relevant ticket
[CRIMAP-651](https://dsdmoj.atlassian.net/browse/CRIMAP-651)

## Notes for reviewer
This has been on staging for a couple of days without any reported issues.

False positives on the session cookie have been causing 403 errors. Here we use tags rather than id to prevent the offending rules being applied to the rails session cookie.  After testing on staging, this change will need to be applied to the production ingress.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-651]: https://dsdmoj.atlassian.net/browse/CRIMAP-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ