### PR TITLE
QA design/content fixes

### DIFF
--- a/app/controllers/steps/evidence/upload_controller.rb
+++ b/app/controllers/steps/evidence/upload_controller.rb
@@ -19,10 +19,10 @@ module Steps
         document = current_crime_application.documents.find(params['document_id'])
 
         if Datastore::Documents::Delete.new(document:).call
-          @flash = { success: t('steps.evidence.upload.edit.delete.success') }
+          @flash = { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
           document.destroy
         else
-          @flash = { alert: t('steps.evidence.upload.edit.delete.failure') }
+          @flash = { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
         end
 
         :delete_document

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -7,14 +7,10 @@
 
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <%= t('.explanation') %>
-    </p>
-
     <%# TODO: dynamic list depending on evidence requirements %>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>evidence your client gets a passporting benefit</li>
-    </ul>
+    <p class="govuk-body govuk-!-margin-bottom-2">
+      <%= t('.explanation') %> <%= 'evidence your client gets a passporting benefit.' %>
+    </p>
 
     <p class="govuk-body">
       <%= t('.recent_docs') %>
@@ -50,22 +46,24 @@
     <% end %>
 
     <%= step_form @form_object, html: { class: 'govuk-!-padding-top-5' } do |f| %>
-      <div class="app-multi-file__uploaded-files">
-        <h2 class="govuk-heading-m"> <%= t('.uploaded_files_heading') %></h2>
-        <p class="govuk-body"><%= t('.uploaded_files_info') %></p>
-        <table class="govuk-table">
-          <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header"><%= t('steps.evidence.upload.edit.file_name') %></th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-          <%= render partial: 'steps/evidence/upload/uploaded_file',
-                     collection: @form_object.documents, as: :document %>
-          </tbody>
-        </table>
-      </div>
+      <% if @form_object.documents.present? %>
+        <div class="app-multi-file__uploaded-files">
+          <h2 class="govuk-heading-m"> <%= t('.uploaded_files_heading') %></h2>
+          <p class="govuk-body"><%= t('.uploaded_files_info') %></p>
+          <table class="govuk-table">
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header"><%= t('steps.evidence.upload.edit.file_name') %></th>
+              <th scope="col" class="govuk-table__header"></th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            <%= render partial: 'steps/evidence/upload/uploaded_file',
+                       collection: @form_object.documents, as: :document %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -199,19 +199,19 @@ en:
         edit:
           page_title: Upload supporting evidence
           heading: Upload supporting evidence
-          explanation: "Use this page to provide:"
+          explanation: Use this page to provide
           recent_docs: All evidence must be from the last 3 months.
           upload_file_button: Upload file
           upload_files_heading: Upload files
           upload_files_info: The maximum file size is %{max_size}MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF.
           choose_files_button: Choose files
           uploaded_files_heading: Uploaded files
-          uploaded_files_info: When you submit this application, the caseworker will also get these files.
+          uploaded_files_info: When you submit this application, a caseworker will be able to access these files.
           file_name: File name
           uploaded: Uploaded
           delete:
-            success: Document has been successfully deleted
-            failure: Document was not successfully deleted
+            success: "You have deleted %{file_name}"
+            failure: "%{file_name} could not be deleted – try again"
         uploaded_file:
           remove_button: Delete
     submission:

--- a/spec/controllers/steps/evidence/upload_controller_spec.rb
+++ b/spec/controllers/steps/evidence/upload_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
           subject
         ).to receive(:update_and_advance).with(
           Steps::Evidence::UploadForm, as: :delete_document,
-          flash: { success: 'Document has been successfully deleted' }
+          flash: { success: I18n.t('steps.evidence.upload.edit.delete.success', file_name: document.filename).to_s }
         )
 
         put :update, params: { id: crime_application, document_id: document }
@@ -29,7 +29,7 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
           subject
         ).to receive(:update_and_advance).with(
           Steps::Evidence::UploadForm, as: :delete_document,
-          flash: { alert: 'Document was not successfully deleted' }
+          flash: { alert: I18n.t('steps.evidence.upload.edit.delete.failure', file_name: document.filename).to_s }
         )
 
         put :update, params: { id: crime_application, document_id: document }


### PR DESCRIPTION
## Description of change
Following QA of the evidence upload functionality, a few design/content fixes were requested
These are:

1. Hide the 'Uploaded files' section when nothing has been uploaded
2. Change 'Use this page to..' text from bullet list to "Use this page to provide evidence your client gets a passporting benefit.' 
3. The deleted success banner should say "You deleted [file name]"
4. The sentence under the 'Uploaded files' title should say 'When you submit this application, a caseworker will be able to access these files.'

## Link to relevant ticket
The requested design changes have been added to a comment on [CRIMAP-615](https://dsdmoj.atlassian.net/browse/CRIMAP-615)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/17994040-980c-425a-83c9-3d90f7a5ad3a

## How to manually test the feature
