### PR TITLE
[CRIMAP-650] Perform document virus scan (backend only)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'savon'
 gem 'prometheus_exporter'
 
 # Virus scan with ClamAV
-gem 'clamby', '1.6.10'
+gem 'clamby', '1.6.10', require: false
 
 # Exceptions notifications
 gem 'sentry-rails'
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.3'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.4'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b2f94b5b4e952477435358d23f5f14fb38c87b0a
-  tag: v1.0.3
+  revision: 41045dd32b5f821ff4919a88fd31c9c7a91a7177
+  tag: v1.0.4
   specs:
-    laa-criminal-legal-aid-schemas (1.0.3)
+    laa-criminal-legal-aid-schemas (1.0.4)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/app/services/datastore/documents/scan.rb
+++ b/app/services/datastore/documents/scan.rb
@@ -1,0 +1,47 @@
+require 'clamby'
+
+# Performs virus scan using remote ClamAV scanning server
+module Datastore
+  module Documents
+    class Scan
+      include ::LaaCrimeSchemas::Types
+
+      attr_reader :document
+
+      def initialize(document:)
+        @document = document
+      end
+
+      def call
+        raise ArgumentError, 'Document not present' if document.nil?
+
+        document.update(
+          scan_status: scan_result,
+          scan_at: ::Time.current,
+          scan_provider: 'ClamAV'
+        )
+
+        success?
+      end
+
+      private
+
+      def success?
+        [VirusScanStatus['pass']].include? document.scan_status
+      end
+
+      def scan_result
+        Rails.error.handle(fallback: -> { VirusScanStatus['incomplete'] }) do
+          case Clamby.safe?(document.tempfile.path)
+          when true
+            VirusScanStatus['pass']
+          when false
+            VirusScanStatus['flagged']
+          else
+            VirusScanStatus['other']
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/datastore/documents/upload.rb
+++ b/app/services/datastore/documents/upload.rb
@@ -11,14 +11,14 @@ module Datastore
         @document = document
       end
 
-      def call
+      # TODO: 2023-10-6 document is persisted regardless of scan
+      # result due to incomplete UX
+      def call # rubocop:disable Metrics/AbcSize
         return false if document.s3_object_key.present?
 
-        # TODO: PoC - move this to a separate service object
-        # On scan, annotate document with `infected`, `clean`, etc.
-        # return false if Clamby.virus?(document.tempfile.path)
-
         Rails.error.handle(fallback: -> { false }) do
+          Scan.new(document:).call
+
           presign_upload = DatastoreApi::Requests::Documents::PresignUpload.new(
             usn:, expires_in:
           ).call

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'clamby'
+
 def clamd_config_file
   filename = ENV.fetch('CLAMD_CONF_FILENAME', 'clamd.local.conf')
   File.join(File.dirname(__FILE__), '..', 'clamd', filename)

--- a/db/migrate/20231011224721_add_scan_result_to_documents.rb
+++ b/db/migrate/20231011224721_add_scan_result_to_documents.rb
@@ -1,0 +1,31 @@
+require 'laa_crime_schemas'
+
+class AddScanResultToDocuments < ActiveRecord::Migration[7.0]
+  def up
+
+    supported_statuses = %w[awaiting pass flagged incomplete other]
+    statuses = (::LaaCrimeSchemas::Types::VirusScanStatus.values & supported_statuses)
+                  .map { |s| "'#{s}'" }
+                  .join(', ')
+
+    execute <<-SQL
+      CREATE TYPE virus_scan_status AS ENUM (#{statuses});
+    SQL
+
+    add_column :documents, :scan_provider, :string, default: nil
+    add_column :documents, :scan_status, :virus_scan_status, default: ::LaaCrimeSchemas::Types::VirusScanStatus['awaiting']
+    add_column :documents, :scan_output, :string, default: nil
+    add_column :documents, :scan_at, :datetime, default: nil
+  end
+
+  def down
+    remove_column :documents, :scan_provider
+    remove_column :documents, :scan_status
+    remove_column :documents, :scan_output
+    remove_column :documents, :scan_at
+
+    execute <<-SQL
+      DROP TYPE virus_scan_status;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_05_102741) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_11_224721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "virus_scan_status", ["awaiting", "pass", "flagged", "incomplete", "other"]
 
   create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -95,6 +99,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_05_102741) do
     t.string "file_category"
     t.string "content_type"
     t.integer "file_size"
+    t.string "scan_provider"
+    t.enum "scan_status", default: "awaiting", enum_type: "virus_scan_status"
+    t.string "scan_output"
+    t.datetime "scan_at"
     t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 

--- a/spec/services/datastore/documents/scan_spec.rb
+++ b/spec/services/datastore/documents/scan_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::Documents::Scan do
+  subject { described_class.new(document:) }
+
+  include_context 'with an existing document'
+
+  describe '#call' do
+    before do
+      subject.document.tempfile = file
+    end
+
+    context 'with any document' do
+      before { expect(Clamby).to receive(:safe?).and_return(false) }
+
+      it 'persists virus scan attributes' do
+        subject.call
+        document.reload
+
+        expect(subject.document.scan_at).to be_a Time
+        expect(subject.document.scan_status).to be_present
+        expect(subject.document.scan_provider).to eq 'ClamAV'
+      end
+    end
+
+    context 'with a safe file' do
+      before { expect(Clamby).to receive(:safe?).and_return(true) }
+
+      it 'returns true' do
+        expect(subject.call).to be true
+        expect(subject.document.scan_status).to eq 'pass'
+      end
+    end
+
+    context 'with an unsafe file' do
+      before { expect(Clamby).to receive(:safe?).and_return(false) }
+
+      it 'returns false' do
+        expect(subject.call).to be false
+        expect(subject.document.scan_status).to eq 'flagged'
+      end
+    end
+
+    context 'with a missing virus scanner' do
+      before { expect(Clamby).to receive(:safe?).and_raise(StandardError) }
+
+      it 'returns false' do
+        expect(subject.call).to be false
+        expect(subject.document.scan_status).to eq 'incomplete'
+      end
+    end
+
+    context 'with an undetermined result' do
+      before { expect(Clamby).to receive(:safe?).and_return(nil) }
+
+      it 'returns false' do
+        expect(subject.call).to be false
+        expect(subject.document.scan_status).to eq 'other'
+      end
+    end
+
+    context 'with a missing document' do
+      it 'returns false' do
+        expect { described_class.new(document: nil).call }.to raise_error ArgumentError
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Introduces backend virus scanning taking advantage of the new ClamAV server - does not show to the user.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-650

## Notes for reviewer
- this PR allows the file upload to continue even if ClamAV finds a virus (i.e. current behaviour is maintained)
- rationale is to allow ClamAV setup and usage to become operational in production prior to updating the UI and therefore reduce an avalanche of support issues

## Screenshots of changes (if applicable)
N/A

### Before changes:

### After changes:

## How to manually test the feature
