### PR TITLE
[CRIMAP-675] Update schema gem to v1.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.4'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.5'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 41045dd32b5f821ff4919a88fd31c9c7a91a7177
-  tag: v1.0.4
+  revision: 1e08dfd8e71f956b06c1f8684af3fa465271f624
+  tag: v1.0.5
   specs:
-    laa-criminal-legal-aid-schemas (1.0.4)
+    laa-criminal-legal-aid-schemas (1.0.5)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 


### PR DESCRIPTION
## Description of change
Allows Document to be created without any scan_status field

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-675
## Notes for reviewer
N/A

## How to manually test the feature
Retrieve an old application prior to evidence upload, perhaps change it. Should save without any errors.
