### PR TITLE
CRIMAP-647 Added new offence Intentional Strangulation

### DIFF
--- a/config/data/offences.csv
+++ b/config/data/offences.csv
@@ -311,3 +311,4 @@ PR52028,Bring / throw / convey a List 'B' prohibited article into / out of a pri
 TH68006A,"Attempt theft of pedal cycle (£30,000 or less)",CE Either Way,F,false
 TH68006A,"Attempt theft of pedal cycle (Over £30,000 up to £100,000)",CE Either Way,G,false
 TH68006A,"Attempt theft of pedal cycle (Over £100,000)",CE Either Way,K,false
+SC15005,"Intentional Strangulation",CE Either Way,B,false

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe Offence, type: :model do
 
     it 'returns all offences' do
       expect(subject).to all(be_a(described_class))
-      expect(subject.size).to eq(312)
+      expect(subject.size).to eq(313)
     end
 
     it 'keeps the same order as in the CSV file' do
       expect(subject.first.code).to eq('TH68010')
-      expect(subject.last.code).to eq('TH68006A')
+      expect(subject.last.code).to eq('SC15005')
     end
   end
 


### PR DESCRIPTION
## Description of change
Added new offence Intentional Strangulation to list of existing offences

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-647

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/106679087/a2ac4006-723e-4579-b6d1-5a2264ce6b48)

### After changes:
<img width="755" alt="Screenshot 2023-10-24 at 16 15 36" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/106679087/5c6b41f3-9bd7-4aa4-a7f7-c5fe5867b1e6">

<img width="761" alt="Screenshot 2023-10-24 at 16 16 51" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/106679087/f95c839c-57dd-4aa0-b159-dfc82c98aeda">

## How to manually test the feature
- User creates a new application in Apply
- User gets to 'What has your client been charged with?' page
- User clicks on offence box to add an offence and enters 'Intentional Strangulation'
- 'Intentional Strangulation' will appear in the list of offences