### PR TITLE
Add did_client_lose_job_being_in_custody step

### DIFF
--- a/app/controllers/steps/income/lost_job_in_custody_controller.rb
+++ b/app/controllers/steps/income/lost_job_in_custody_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Income
+    class LostJobInCustodyController < Steps::IncomeStepController
+      def edit
+        @form_object = LostJobInCustodyForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(LostJobInCustodyForm, as: :lost_job_in_custody)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/income_step_controller.rb
+++ b/app/controllers/steps/income_step_controller.rb
@@ -1,4 +1,3 @@
-# :nocov:
 module Steps
   class IncomeStepController < BaseStepController
     private
@@ -8,4 +7,3 @@ module Steps
     end
   end
 end
-# :nocov:

--- a/app/forms/steps/income/lost_job_in_custody_form.rb
+++ b/app/forms/steps/income/lost_job_in_custody_form.rb
@@ -1,0 +1,40 @@
+module Steps
+  module Income
+    class LostJobInCustodyForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :applicant
+
+      attribute :lost_job_in_custody, :value_object, source: YesNoAnswer
+      attribute :date_job_lost, :multiparam_date
+
+      validates_inclusion_of :lost_job_in_custody, in: :choices
+
+      validates :date_job_lost,
+                multiparam_date: true,
+                presence: true,
+                if: -> { lost_job_in_custody? }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        applicant.update(
+          attributes.merge(attributes_to_reset)
+        )
+      end
+
+      def attributes_to_reset
+        {
+          'date_job_lost' => (date_job_lost if lost_job_in_custody?)
+        }
+      end
+
+      def lost_job_in_custody?
+        lost_job_in_custody&.yes?
+      end
+    end
+  end
+end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -2,10 +2,9 @@ module Decisions
   class IncomeDecisionTree < BaseDecisionTree
     def destination
       case step_name
-      # :nocov:
-      when :x
-        edit(:y)
-      # :nocov:
+      when :lost_job_in_custody
+        # TODO: link to next step when we have it
+        show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end

--- a/app/views/steps/income/lost_job_in_custody/edit.html.erb
+++ b/app/views/steps/income/lost_job_in_custody/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+        <%= f.govuk_radio_buttons_fieldset(:lost_job_in_custody, legend: { tag: 'h1', size: 'xl' }) do %>
+          <% @form_object.choices.each_with_index do |choice, index| %>
+            <% if choice == YesNoAnswer::YES %>
+              <%= f.govuk_radio_button :lost_job_in_custody, choice.value do %>
+                <%= f.govuk_date_field :date_job_lost, maxlength_enabled: true,
+                                       legend: {
+                                         text: t('.date_job_lost',),
+                                         size: 's'
+                                       } %>
+              <% end %>
+            <% else %>
+              <%= f.govuk_radio_button :lost_job_in_custody, choice.value, link_errors: index.zero? %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -227,6 +227,18 @@ en:
               blank: Enter details on why it is in the interest of another person that your client is represented
             other_justification:
               blank: Enter details on why your client should get legal aid
+        steps/income/lost_job_in_custody_form:
+          attributes:
+            lost_job_in_custody:
+              inclusion: Select yes if your client lost their job as a result of being in custody
+            date_job_lost: 
+              blank: Date job was lost cannot be blank
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date job was lost is too far in the past
+              future_not_allowed: Date job was lost cannot be in the future
         steps/submission/declaration_form:
           attributes:
             legal_rep_first_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -57,6 +57,8 @@ en:
         is_first_court_hearing: Did this court also hear the first hearing?
       steps_case_ioj_form:
         types: Why should your client get legal aid?
+      steps_income_lost_job_in_custody_form:
+        lost_job_in_custody: Did your client lose their job as a result of being in custody?
 
     hint:
       steps_client_details_form:
@@ -99,6 +101,8 @@ en:
         expert_examination_justification: *ioj_justification_hint
         interest_of_another_justification: *ioj_justification_hint
         other_justification: *ioj_justification_hint
+      steps_income_lost_job_in_custody_form:
+        date_job_lost: For example, 27 3 2007
       steps_evidence_upload_form:
         #TODO update max file size and overall limit
         upload_files: The maximum file size is XMB. Files must be a JPG, BMP, PNG, TIF or PDF.
@@ -211,6 +215,8 @@ en:
           expert_examination: The proceedings may involve expert cross-examination of a prosecution witness (whether an expert or not)
           interest_of_another: It is in the interests of another person (such as the person making a complaint or other witness) that they are represented
           other: Other
+      steps_income_lost_job_in_custody_form:
+        lost_job_in_custody_options: *YESNO
       steps_evidence_upload_form:
         upload_files: Upload files
       steps_submission_declaration_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -125,6 +125,7 @@ en:
             applicant:
               home_address: Enter your client’s home address
               correspondence_address: Enter your client’s correspondence address
+    
     case:
       urn:
         edit:
@@ -194,6 +195,14 @@ en:
       ioj:
         edit:
           page_title: Why should your client get legal aid?
+    
+    income:
+      caption: Income assessment
+      lost_job_in_custody:
+        edit:
+          page_title: Did client lose job being in custody?
+          date_job_lost: Date job was lost
+
     evidence:
       upload:
         edit:
@@ -214,6 +223,7 @@ en:
             failure: "%{file_name} could not be deleted – try again"
         uploaded_file:
           remove_button: Delete
+    
     submission:
       review:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 def edit_step(name, opts = {}, &block)
   resource name,
            only: opts.fetch(:only, [:edit, :update]),
-           controller: name,
+           controller: opts.fetch(:alias, name),
+           as: opts.fetch(:alias, name),
            path_names: { edit: '' } do; block.call if block_given?; end
 end
 
@@ -140,6 +141,10 @@ Rails.application.routes.draw do
         edit_step :first_court_hearing
         edit_step :ioj_passport
         edit_step :ioj
+      end
+
+      namespace :income, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
+        edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody
       end
 
       namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do

--- a/db/migrate/20231023200153_add_lost_job_in_custody_to_people.rb
+++ b/db/migrate/20231023200153_add_lost_job_in_custody_to_people.rb
@@ -1,0 +1,6 @@
+class AddLostJobInCustodyToPeople < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :lost_job_in_custody, :string
+    add_column :people, :date_job_lost, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_11_224721) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_200153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_224721) do
     t.jsonb "provider_details", default: {}, null: false
     t.uuid "parent_id"
     t.string "means_passport", default: [], array: true
+    t.string "expected_evidence", default: [], array: true
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
@@ -150,6 +151,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_224721) do
     t.boolean "passporting_benefit"
     t.string "benefit_type"
     t.string "has_benefit_evidence"
+    t.string "lost_job_in_custody"
+    t.string "date_job_lost"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/income/lost_job_in_custody_controller_spec.rb
+++ b/spec/controllers/steps/income/lost_job_in_custody_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::LostJobInCustodyController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Income::LostJobInCustodyForm, Decisions::IncomeDecisionTree
+end

--- a/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
+++ b/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::LostJobInCustodyForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      lost_job_in_custody:,
+      date_job_lost:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
+  let(:applicant_record) { Applicant.new }
+
+  let(:lost_job_in_custody) { nil }
+  let(:date_job_lost) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        form.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `lost_job_in_custody` is not provided' do
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:lost_job_in_custody, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `lost_job_in_custody` is not valid' do
+      let(:lost_job_in_custody) { 'maybe' }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:lost_job_in_custody, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `lost_job_in_custody` is valid' do
+      let(:lost_job_in_custody) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:lost_job_in_custody, :invalid)).to be(false)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :applicant,
+                      expected_attributes: {
+                        'lost_job_in_custody' => YesNoAnswer::NO,
+                        'date_job_lost' => nil
+                      }
+
+      context 'when `lost_job_in_custody` answer is no' do
+        context 'when a `date_job_lost` was previously recorded' do
+          let(:date_job_lost) { 1.month.ago.to_date }
+
+          it { is_expected.to be_valid }
+
+          it 'can make date_job_lost field nil if no longer required' do
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['date_job_lost']).to be_nil
+          end
+        end
+      end
+
+      context 'when `lost_job_in_custody` answer is yes' do
+        context 'when a `date_job_lost` was previously recorded' do
+          let(:lost_job_in_custody) { YesNoAnswer::YES.to_s }
+          let(:date_job_lost) { 1.month.ago.to_date }
+
+          it 'is valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :date_job_lost,
+                :present
+              )
+            ).to be(false)
+          end
+
+          it 'cannot reset `date_job_lost` as it is relevant' do
+            applicant_record.update(lost_job_in_custody: YesNoAnswer::YES.to_s)
+
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['date_job_lost']).to eq(date_job_lost)
+          end
+        end
+
+        context 'when a `date_job_lost` was not previously recorded' do
+          let(:lost_job_in_custody) { YesNoAnswer::YES.to_s }
+          let(:date_job_lost) { 1.month.ago.to_date }
+
+          it 'is also valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :date_job_lost,
+                :present
+              )
+            ).to be(false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -3,5 +3,27 @@ require 'rails_helper'
 RSpec.describe Decisions::IncomeDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      id: 'uuid',
+    )
+  end
+
+  before do
+    allow(
+      form_object
+    ).to receive(:crime_application).and_return(crime_application)
+  end
+
   it_behaves_like 'a decision tree'
+
+  context 'when the step is `lost_job_in_custody`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :lost_job_in_custody }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Add new step behind feature flag
Add to income decision tree, but not in flow yet
Add route with alias, controller, form and errors

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-683

## Screenshots of changes (if applicable)
<img width="938" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/5b630933-a23f-47b0-98ae-9fc219f2d477">

## How to manually test the feature
run `rails db:migrate`
Start a new application 
Go to /steps/income/did_client_lose_job_being_in_custody