### PR TITLE
CRIMAP-696 Add manage_no_income page

### DIFF
--- a/app/controllers/steps/income/manage_without_income_controller.rb
+++ b/app/controllers/steps/income/manage_without_income_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Income
+    class ManageWithoutIncomeController < Steps::IncomeStepController
+      def edit
+        @form_object = ManageWithoutIncomeForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(ManageWithoutIncomeForm, as: :manage_without_income)
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/manage_without_income_form.rb
+++ b/app/forms/steps/income/manage_without_income_form.rb
@@ -1,0 +1,39 @@
+module Steps
+  module Income
+    class ManageWithoutIncomeForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :applicant
+
+      attribute :manage_without_income, :value_object, source: ManageWithoutIncomeType
+      attribute :manage_other_details, :string
+
+      validates_inclusion_of :manage_without_income, in: :choices
+
+      validates :manage_other_details,
+                presence: true,
+                if: -> { manage_other? }
+
+      def choices
+        ManageWithoutIncomeType.values
+      end
+
+      private
+
+      def persist!
+        applicant.update(
+          attributes.merge(attributes_to_reset)
+        )
+      end
+
+      def attributes_to_reset
+        {
+          'manage_other_details' => (manage_other_details if manage_other?)
+        }
+      end
+
+      def manage_other?
+        manage_without_income&.other?
+      end
+    end
+  end
+end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -4,6 +4,9 @@ module Decisions
       case step_name
       when :lost_job_in_custody
         # TODO: link to next step when we have it
+        edit(:manage_without_income)
+      when :manage_without_income
+        # TODO: link to next step when we have it
         show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"

--- a/app/value_objects/manage_without_income_type.rb
+++ b/app/value_objects/manage_without_income_type.rb
@@ -1,0 +1,9 @@
+class ManageWithoutIncomeType < ValueObject
+  VALUES = [
+    FRIENDS_SOFA = new(:friends_sofa),
+    FAMILY = new(:family),
+    HOMELESS = new(:homeless),
+    CUSTODY = new(:custody),
+    OTHER = new(:other),
+  ].freeze
+end

--- a/app/views/steps/income/manage_without_income/edit.html.erb
+++ b/app/views/steps/income/manage_without_income/edit.html.erb
@@ -1,0 +1,25 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+        <%= f.govuk_radio_buttons_fieldset(:manage_without_income, legend: { tag: 'h1', size: 'xl' }) do %>
+          <% @form_object.choices.each_with_index do |choice, index| %>
+            <% if choice == ManageWithoutIncomeType::OTHER %>
+              <%= f.govuk_radio_button :manage_without_income, choice.value do %>
+                <% f.govuk_text_area :manage_other_details,
+                                     label: { size: 's' } %>
+              <% end %>
+            <% else %>
+              <%= f.govuk_radio_button :manage_without_income, choice.value, link_errors: index.zero? %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -231,7 +231,7 @@ en:
           attributes:
             lost_job_in_custody:
               inclusion: Select yes if your client lost their job as a result of being in custody
-            date_job_lost: 
+            date_job_lost:
               blank: Date job was lost cannot be blank
               invalid: Enter a valid date
               invalid_day: Enter a valid day
@@ -239,6 +239,12 @@ en:
               invalid_year: Enter a valid year
               year_too_early: Date job was lost is too far in the past
               future_not_allowed: Date job was lost cannot be in the future
+        steps/income/manage_without_income_form:
+          attributes:
+            manage_without_income:
+              inclusion: Select how your client manages with no income
+            manage_other_details:
+              blank: Enter details on how your client manages with no income
         steps/submission/declaration_form:
           attributes:
             legal_rep_first_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -59,6 +59,8 @@ en:
         types: Why should your client get legal aid?
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody: Did your client lose their job as a result of being in custody?
+      steps_income_manage_without_income_form:
+        manage_without_income: How does your client manage with no income?
 
     hint:
       steps_client_details_form:
@@ -103,9 +105,6 @@ en:
         other_justification: *ioj_justification_hint
       steps_income_lost_job_in_custody_form:
         date_job_lost: For example, 27 3 2007
-      steps_evidence_upload_form:
-        #TODO update max file size and overall limit
-        upload_files: The maximum file size is XMB. Files must be a JPG, BMP, PNG, TIF or PDF.
       steps_submission_declaration_form:
         legal_rep_telephone: For example, 01632 960 001 or +44 808 157 0192
 
@@ -217,6 +216,14 @@ en:
           other: Other
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
+      steps_income_manage_without_income_form:
+        manage_without_income_options:
+          friends_sofa: They sleep on a friend's sofa for free
+          family: They stay with family for free
+          homeless: They are homeless
+          custody: They have been in custody for more than 3 months
+          other: Other
+        manage_other_details: Tell us how your client manages with no income
       steps_evidence_upload_form:
         upload_files: Upload files
       steps_submission_declaration_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -82,7 +82,7 @@ en:
       benefit_check_result_exit:
         show:
           page_title: Use eForms for this application
-      
+
     address:
       lookup:
         edit:
@@ -125,7 +125,7 @@ en:
             applicant:
               home_address: Enter your client’s home address
               correspondence_address: Enter your client’s correspondence address
-    
+
     case:
       urn:
         edit:
@@ -195,13 +195,16 @@ en:
       ioj:
         edit:
           page_title: Why should your client get legal aid?
-    
+
     income:
       caption: Income assessment
       lost_job_in_custody:
         edit:
           page_title: Did client lose job being in custody?
           date_job_lost: Date job was lost
+      manage_without_income:
+        edit:
+          page_title: How does client manage with no income?
 
     evidence:
       upload:
@@ -223,7 +226,7 @@ en:
             failure: "%{file_name} could not be deleted – try again"
         uploaded_file:
           remove_button: Delete
-    
+
     submission:
       review:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
 
       namespace :income, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
         edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody
+        edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
       end
 
       namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do

--- a/db/migrate/20231025070727_manage_without_income_to_people.rb
+++ b/db/migrate/20231025070727_manage_without_income_to_people.rb
@@ -1,0 +1,6 @@
+class ManageWithoutIncomeToPeople < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :manage_without_income, :string
+    add_column :people, :manage_other_details, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_200153) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_25_070727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -83,7 +83,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_200153) do
     t.jsonb "provider_details", default: {}, null: false
     t.uuid "parent_id"
     t.string "means_passport", default: [], array: true
-    t.string "expected_evidence", default: [], array: true
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
@@ -153,6 +152,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_200153) do
     t.string "has_benefit_evidence"
     t.string "lost_job_in_custody"
     t.string "date_job_lost"
+    t.string "manage_without_income"
+    t.string "manage_other_details"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/income/manage_without_income_controller_spec.rb
+++ b/spec/controllers/steps/income/manage_without_income_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::ManageWithoutIncomeController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Income::ManageWithoutIncomeForm, Decisions::IncomeDecisionTree
+end

--- a/spec/forms/steps/income/manage_without_income_form_spec.rb
+++ b/spec/forms/steps/income/manage_without_income_form_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::ManageWithoutIncomeForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      manage_without_income:,
+      manage_other_details:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
+  let(:applicant_record) { Applicant.new }
+
+  let(:manage_without_income) { nil }
+  let(:manage_other_details) { nil }
+
+  describe '#save' do
+    context 'when `manage_without_income` is blank' do
+      let(:manage_without_income) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:manage_without_income, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `manage_without_income` is invalid' do
+      let(:manage_without_income) { 'invalid_selection' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:manage_without_income, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `manage_without_income` is valid' do
+      let(:manage_without_income) { ManageWithoutIncomeType::FAMILY.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:manage_without_income, :invalid)).to be(false)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :applicant,
+                      expected_attributes: {
+                        'manage_without_income' => ManageWithoutIncomeType::FAMILY,
+                        'manage_other_details' => nil
+                      }
+
+      context 'when selection is other' do
+        let(:manage_without_income) { ManageWithoutIncomeType::OTHER.to_s }
+        let(:manage_other_details) { 'details' }
+
+        it 'is valid' do
+          expect(form).to be_valid
+          expect(
+            form.errors.of_kind?(
+              :manage_other_details,
+              :present
+            )
+          ).to be(false)
+        end
+
+        it 'cannot reset `manage_other_details` as it is relevant' do
+          applicant_record.update(manage_without_income: ManageWithoutIncomeType::OTHER.to_s)
+
+          attributes = form.send(:attributes_to_reset)
+          expect(attributes['manage_other_details']).to eq(manage_other_details)
+        end
+      end
+
+      context 'when `manage_other_details` answer is not `other`' do
+        context 'when `manage_other_details` was previously recorded' do
+          let(:manage_other_details) { 'details' }
+
+          it { is_expected.to be_valid }
+
+          it 'can make manage_other_details field nil if no longer required' do
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['manage_other_details']).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:step_name) { :lost_job_in_custody }
 
     context 'has correct next step' do
+      it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `manage_without_income`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :manage_without_income }
+
+    context 'has correct next step' do
       it { is_expected.to have_destination('/home', :index, id: crime_application) }
     end
   end

--- a/spec/value_objects/manage_without_income_type_spec.rb
+++ b/spec/value_objects/manage_without_income_type_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ManageWithoutIncomeType do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w[
+                                                         friends_sofa
+                                                         family
+                                                         homeless
+                                                         custody
+                                                         other
+                                                       ])
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add new step behind feature flag
Add to income decision tree, but not in flow yet
Add route with alias, controller, form and errors

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-696

## Screenshots of changes (if applicable)
<img width="853" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/5e4efed3-39cc-4d80-8694-00166c4289cc">

<img width="828" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/b89aed33-48ae-4390-9d9b-84b14f6c6946">


## How to manually test the feature
run rails db:migrate
Start a new application
Go to /steps/income/how_does_client_manage_with_no_income