### PR TITLE
Replace prometheus 'severity' label to prevent collision

### DIFF
--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -94,6 +94,26 @@ spec:
         message: Namespace `{{ $labels.exported_namespace }}` is serving 5XX responses.
         dashboard_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/?_g=(time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.request_path),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.kubernetes_namespace,negate:!f,params:(query:{{ $labels.exported_namespace }}),type:phrase),query:(match_phrase:(log_processed.kubernetes_namespace:{{ $labels.exported_namespace }}))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.status,negate:!f,params:(gte:500,lt:600),type:range),range:(log_processed.status:(gte:500,lt:600)))),index:'8a728bc0-00eb-11ec-9062-27aa363b66a2')
 
+    - alert: CrimeApply-TrivyVulns
+      expr: >-
+        sum by (namespace, image_repository, image_tag, trivy_severity) (
+          label_replace(
+            trivy_image_vulnerabilities{namespace=~"^laa-apply-for-criminal-legal-aid.*",severity=~"Critical|High"}
+          >
+            0,
+          "trivy_severity",
+          "$1",
+          "severity",
+          "(.*)"
+          )
+        )
+      for: 1h
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Image `{{ $labels.image_repository }}:{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.trivy_severity }} vulnerabilities.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/trivy_starboard_operator123/trivy-operator-image-vulnerability?orgId=1&from=now-24h&to=now&var-namespace={{ $labels.namespace }}
+
     - alert: CrimeApply-PrometheusExporterFailure
       expr: >-
         ruby_collector_working{namespace=~"^laa-apply-for-criminal-legal-aid.*"} != 1


### PR DESCRIPTION
## Description of change
Rename severity label in prometheus rule to prevent CP labelset collision.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
