### PR TITLE
Patch: fix evidence delete functionality

### DIFF
--- a/app/controllers/steps/evidence/upload_controller.rb
+++ b/app/controllers/steps/evidence/upload_controller.rb
@@ -18,11 +18,12 @@ module Steps
 
         document = current_crime_application.documents.find(params['document_id'])
 
-        @flash = if Datastore::Documents::Delete.new(document:, log_context:).call
-                   { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
-                 else
-                   { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
-                 end
+        if Datastore::Documents::Delete.new(document:, log_context:).call
+          @flash = { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
+          document.destroy
+        else
+          @flash = { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
+        end
 
         :delete_document
       end


### PR DESCRIPTION
Adds back in a line of code to delete documents from the datastore that was accidentally deleted in yesterday's[ logging PR](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/522/files#diff-c8e8604fbd874ead2602a128f806c0a5c5fe9e3d12cb5924dddd216169f3e4d3L23) (my bad!). Evidence upload functionality has been tested locally and the rest is functioning as expected. 

## Description of change

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1287" alt="Screenshot 2023-10-31 at 16 50 32" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/1da65517-9c3b-45b0-ae25-5ef71bf4613d">

### After changes:
<img width="1287" alt="Screenshot 2023-10-31 at 16 51 07" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/61b0fd04-617f-458c-9d7d-6274ae4efab9">

## How to manually test the feature
