### PR TITLE
Add new start page copy for means assessment journey

### DIFF
--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -13,7 +13,7 @@
       Use this service to apply for criminal legal aid in ongoing cases. The application will be means tested.
       </p>
       <p class="govuk-body">
-      Your client has a partner.
+      Your client cannot have a partner.
       </p>
       <p class="govuk-body">
       They must be one of the following:

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -8,20 +8,41 @@
       <%= service_name %>
     </h1>
 
-    <p class="govuk-body">
+    <% if FeatureFlags.means_journey.enabled? %>
+      <p class="govuk-body">
+      Use this service to apply for criminal legal aid in ongoing cases. The application will be means tested.
+      </p>
+      <p class="govuk-body">
+      Your client has a partner.
+      </p>
+      <p class="govuk-body">
+      They must be one of the following:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>receiving a passporting benefit, like Universal Credit</li>
+        <li>not working</li>
+      </ul>
+
+      <p class="govuk-body">
+        <%= link_to 'Use eForms for all other applications', Settings.eforms_url %>.
+      </p>
+    <% else %>
+      <p class="govuk-body">
       Use this service to apply for criminal legal aid if:
-    </p>
+      </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the case is ongoing</li>
-      <li>you know your client’s National Insurance number (if they are 18 years old or over)</li>
-      <li>your client does not have a partner</li>
-      <li>your client receives a passporting benefit, including Universal Credit</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the case is ongoing</li>
+        <li>you know your client’s National Insurance number (if they are 18 years old or over)</li>
+        <li>your client does not have a partner</li>
+        <li>your client receives a passporting benefit, including Universal Credit</li>
+      </ul>
 
-    <p class="govuk-body">
+      <p class="govuk-body">
       Use <%= link_to 'eForms', Settings.eforms_url %> for all other applications.
-    </p>
+      </p>
+    <% end %>
 
     <%= button_to provider_saml_omniauth_authorize_path, method: :post,
                   class: 'govuk-button govuk-button--start govuk-!-margin-top-4', form_class: 'app-button--start',


### PR DESCRIPTION
## Description of change

Updates start page copy to match means journey designs.

Is behind feature flag awaiting wider means journey release. Once this has happend, PR can be raised to remove the defunct copy when the feature flag is removed.

## Link to relevant ticket

[CRIMAP-722](https://dsdmoj.atlassian.net/browse/CRIMAP-722)

## Notes for reviewer

Please see ticket for figma designs and double check that the copy is the same.

## Screenshots of changes (if applicable)

### Before changes:
<img width="836" alt="Screenshot 2023-11-02 at 14 28 17" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/cbf57b97-d1ae-4b9f-a9dd-5ddb4c8c3855">

### After changes:
<img width="805" alt="Screenshot 2023-11-02 at 14 27 46" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/83fb29d8-facb-499c-82d4-d508a5e4fa96">


## How to manually test the feature
- make sure your meanse journey feature flag is on so as to see the new copy on the start page.
- check copy etc.
- set the feature flag to false --> then make sure current non-means copy shows instead.


[CRIMAP-722]: https://dsdmoj.atlassian.net/browse/CRIMAP-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ