### PR TITLE
Fix bug around deleting applications with documents

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -42,6 +42,6 @@ class CrimeApplicationsController < DashboardController
   end
 
   def log_context
-    LogContext.new(current_provider: current_provider, ip_address: request.remote_ip).to_h
+    LogContext.new(current_provider: current_provider, ip_address: request.remote_ip)
   end
 end

--- a/app/controllers/steps/evidence/upload_controller.rb
+++ b/app/controllers/steps/evidence/upload_controller.rb
@@ -18,12 +18,11 @@ module Steps
 
         document = current_crime_application.documents.find(params['document_id'])
 
-        if Datastore::Documents::Delete.new(document:, log_context:).call
-          @flash = { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
-          document.destroy
-        else
-          @flash = { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
-        end
+        @flash = if Datastore::Documents::Delete.new(document:, log_context:).call
+                   { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
+                 else
+                   { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
+                 end
 
         :delete_document
       end

--- a/app/services/datastore/documents/delete.rb
+++ b/app/services/datastore/documents/delete.rb
@@ -12,7 +12,7 @@ module Datastore
         return true unless deletable?
 
         Rails.error.handle(fallback: -> { false }, context: context, severity: :error) do
-          DatastoreApi::Requests::Documents::Delete.new(object_key:).call
+          document.destroy if DatastoreApi::Requests::Documents::Delete.new(object_key:).call
           Rails.logger.info "Document successfully deleted. Object key: #{document.s3_object_key}"
           true
         end

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -71,7 +71,7 @@ en:
       steps_client_has_benefit_evidence_form:
         has_benefit_evidence: This can be a letter from DWP or JobCentre Plus, or an image from a government app showing your client's name and their benefit details.
         has_benefit_evidence_options:
-          'yes': You'll need to upload evidence at the end of this application
+          'yes': You'll need to upload evidence at the end of this application.
       steps_client_contact_details_form:
         telephone_number: For example, 01632 960 001 or +44 808 157 0192
       steps_address_lookup_form:

--- a/spec/services/datastore/documents/delete_spec.rb
+++ b/spec/services/datastore/documents/delete_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Datastore::Documents::Delete do
       end
 
       it 'returns true' do
+        expect(document).to receive(:destroy)
         expect(subject.call).to be(true)
       end
     end
@@ -44,6 +45,7 @@ RSpec.describe Datastore::Documents::Delete do
       end
 
       it 'returns false' do
+        expect(document).not_to receive(:destroy)
         expect(subject.call).to be(false)
       end
     end


### PR DESCRIPTION
## Description of change

Fixes bug introduced in previous PR which meant it was not possible to delete a draft application which had supporting evidence. See sentry error [here](https://ministryofjustice.sentry.io/issues/4593077416/?alert_rule_id=14332616&alert_timestamp=1698849012915&alert_type=email&environment=staging&notification_uuid=310d9517-b09e-459b-a8de-284764ee884a&project=6587263&referrer=alert_email)

Also updates the delete service spec based on a previous PR where the `document.destroy` call was accidentally deleted, adds testing to ensure this is caught in the future: https://mojdt.slack.com/archives/C04TGATBWNL/p1698771504841059

Also adds a missing full stop to hint text (see screenshot below)

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1066" alt="Screenshot 2023-11-02 at 17 24 21" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/e2373792-3085-4094-a6cf-2cf7b64be0d2">

### After changes:
<img width="1066" alt="Screenshot 2023-11-02 at 17 24 37" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/9ae21c85-d004-4848-8cab-36e0348f86ff">

## How to manually test the feature
