### PR TITLE
Crimap 676 add income model and bf tax form

### DIFF
--- a/app/controllers/steps/income/income_before_tax_controller.rb
+++ b/app/controllers/steps/income/income_before_tax_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Income
+    class IncomeBeforeTaxController < Steps::IncomeStepController
+      def edit
+        @form_object = IncomeBeforeTaxForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(IncomeBeforeTaxForm, as: :income_before_tax)
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/income_before_tax_form.rb
+++ b/app/forms/steps/income/income_before_tax_form.rb
@@ -1,0 +1,25 @@
+module Steps
+  module Income
+    class IncomeBeforeTaxForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :income_details, through: :applicant
+
+      # threshold being £12,475 currently
+      attribute :income_above_threshold, :value_object, source: YesNoAnswer
+
+      validates_inclusion_of :income_above_threshold, in: :choices
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        income_details.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/income_before_tax_form.rb
+++ b/app/forms/steps/income/income_before_tax_form.rb
@@ -4,7 +4,7 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :income_details, through: :applicant
 
-      # threshold being £12,475 currently
+      # threshold being £12,475 as of Nov 2023
       attribute :income_above_threshold, :value_object, source: YesNoAnswer
 
       validates_inclusion_of :income_above_threshold, in: :choices

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -13,6 +13,7 @@ class CrimeApplication < ApplicationRecord
   has_one :ioj, through: :case
   has_many :addresses, through: :people
   has_many :codefendants, through: :case
+  has_many :income_details, through: :people
 
   enum status: ApplicationStatus.enum_values
 

--- a/app/models/income_detail.rb
+++ b/app/models/income_detail.rb
@@ -1,3 +1,0 @@
-class IncomeDetail < ApplicationRecord
-  belongs_to :person
-end

--- a/app/models/income_detail.rb
+++ b/app/models/income_detail.rb
@@ -1,0 +1,3 @@
+class IncomeDetail < ApplicationRecord
+  belongs_to :person
+end

--- a/app/models/income_details.rb
+++ b/app/models/income_details.rb
@@ -1,0 +1,3 @@
+class IncomeDetails < ApplicationRecord
+  belongs_to :person
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,7 +8,7 @@ class Person < ApplicationRecord
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
   has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'
 
-  has_one :income_details, foreign_key: :person_id, dependent: :destroy
+  has_one :income_details, dependent: :destroy
 
   scope :with_name, -> { where.not(first_name: [nil, '']) }
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,7 +8,7 @@ class Person < ApplicationRecord
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
   has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'
 
-  has_one :income_detail, foreign_key: :person_id, dependent: :destroy
+  has_one :income_details, foreign_key: :person_id, dependent: :destroy
 
   scope :with_name, -> { where.not(first_name: [nil, '']) }
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,6 +8,8 @@ class Person < ApplicationRecord
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
   has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'
 
+  has_one :income_detail, foreign_key: :person_id, dependent: :destroy
+
   scope :with_name, -> { where.not(first_name: [nil, '']) }
 
   def home_address?

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -7,9 +7,12 @@ module Decisions
       when :lost_job_in_custody
         # TODO: link to next step when we have it
         edit(:manage_without_income)
-      when :manage_without_income
+      when :income_before_tax
         # TODO: link to next step when we have it
         show('/home', action: :index)
+      when :manage_without_income
+        # TODO: link to next step when we have it
+        show('/', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -1,4 +1,7 @@
 module Decisions
+  # TODO: remove this rubocop opt out when
+  # branches are known and are therefore non-duplicate
+  # rubocop:disable Lint/DuplicateBranch
   class IncomeDecisionTree < BaseDecisionTree
     def destination
       case step_name
@@ -12,11 +15,12 @@ module Decisions
         show('/home', action: :index)
       when :manage_without_income
         # TODO: link to next step when we have it
-        show('/', action: :index)
+        show('/home', action: :index)
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
+    # rubocop:enable Lint/DuplicateBranch
 
     private
 

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -1,0 +1,17 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :income_above_threshold, @form_object.choices,
+                                           :value, inline: false,
+                                           legend: { text: t('.income_above_threshold'), tag: 'h1' , size: 'xl' } do %>
+          <p><%= t('.income_above_threshold_info') %></p>
+        <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -9,7 +9,9 @@
       <%= f.govuk_collection_radio_buttons :income_above_threshold, @form_object.choices,
                                            :value, inline: false,
                                            legend: { text: t('.income_above_threshold'), tag: 'h1', size: 'xl' } do %>
-          <p><%= t('.income_above_threshold_info') %></p>
+           <span class="govuk-caption-m govuk-!-margin-bottom-4">
+             <%= t('.income_above_threshold_info') %>
+           </span>
         <% end %>
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -8,7 +8,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :income_above_threshold, @form_object.choices,
                                            :value, inline: false,
-                                           legend: { text: t('.income_above_threshold'), tag: 'h1' , size: 'xl' } do %>
+                                           legend: { text: t('.income_above_threshold'), tag: 'h1', size: 'xl' } do %>
           <p><%= t('.income_above_threshold_info') %></p>
         <% end %>
       <%= f.continue_button %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -287,6 +287,10 @@ en:
               invalid_year: Enter a valid year
               over_three_months_ago: Date they lost their job must be within the last 3 months
               future_not_allowed: Date they lost their job must be today or in the past
+        steps/income/income_before_tax_form:
+          attributes:
+            income_above_threshold:
+              inclusion: Select yes if your client’s income is currently more than £12,475 a year before tax
         steps/income/manage_without_income_form:
           attributes:
             manage_without_income:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -231,6 +231,8 @@ en:
         ended_employment_within_three_months_options: *YESNO
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
+      steps_income_income_before_tax_form:
+        income_above_threshold_options: *YESNO
       steps_income_manage_without_income_form:
         manage_without_income_options:
           friends_sofa: They sleep on a friend's sofa for free

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -62,8 +62,8 @@ en:
         edit:
           page_title: Unable to connect to DWP
           heading: Sorry there was a problem connecting to DWP
-          explanation: We cannot connect to the DWP service to check if your client receives a passporting benefit. 
-          use_eforms: You can try again later, or use eforms which will allow you to self-certify that your client does receive a passporting benefit. 
+          explanation: We cannot connect to the DWP service to check if your client receives a passporting benefit.
+          use_eforms: You can try again later, or use eforms which will allow you to self-certify that your client does receive a passporting benefit.
           saved_answers: We have saved your answers.
       contact_details:
         edit:
@@ -209,6 +209,11 @@ en:
         edit:
           page_title: Did your client lose their job as a result of being in custody?
           date_job_lost: When did they lose their job?
+      income_before_tax:
+        edit:
+          page_title: Is your client's income currently more than £12,475 a year before tax?
+          income_above_threshold_info: Do not include any employment income if your client has lost their job or ended employment.
+          income_above_threshold: Is your client's income currently more than £12,475 a year before tax?
       manage_without_income:
         edit:
           page_title: How does client manage with no income?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Rails.application.routes.draw do
         show_step :employed_exit
         edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody
         edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
+        edit_step :clients_income_before_tax, alias: :income_before_tax
       end
 
       namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do

--- a/db/migrate/20231107202222_create_income_details.rb
+++ b/db/migrate/20231107202222_create_income_details.rb
@@ -1,0 +1,13 @@
+class CreateIncomeDetails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :income_details, id: :uuid do |t|
+      t.uuid :person_id, null: false
+      t.string :income_above_threshold
+
+      t.timestamps
+    end
+
+    add_index :income_details, :person_id
+    add_foreign_key :income_details, :people, column: :person_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_03_123725) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_07_202222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -106,6 +106,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_123725) do
     t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 
+  create_table "income_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "person_id", null: false
+    t.string "income_above_threshold"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id"], name: "index_income_details_on_person_id"
+  end
+
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "types", default: [], array: true
     t.text "loss_of_liberty_justification"
@@ -154,6 +162,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_123725) do
     t.date "date_job_lost"
     t.string "manage_without_income"
     t.string "manage_other_details"
+    t.string "income_above_threshold"
     t.string "employment_status", default: [], array: true
     t.string "ended_employment_within_three_months"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
@@ -184,6 +193,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_123725) do
   add_foreign_key "charges", "cases"
   add_foreign_key "codefendants", "cases"
   add_foreign_key "documents", "crime_applications"
+  add_foreign_key "income_details", "people"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
   add_foreign_key "people", "crime_applications"

--- a/spec/controllers/steps/income/income_before_tax_controller_spec.rb
+++ b/spec/controllers/steps/income/income_before_tax_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::IncomeBeforeTaxController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Income::IncomeBeforeTaxForm, Decisions::IncomeDecisionTree
+end

--- a/spec/forms/steps/income/income_before_tax_form_spec.rb
+++ b/spec/forms/steps/income/income_before_tax_form_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Steps::Income::IncomeBeforeTaxForm do
       it 'passes validation' do
         expect(form.errors.of_kind?(:income_above_threshold, :invalid)).to be(false)
       end
+
+      it 'updates the record' do
+        expect(income_details).to receive(:update)
+          .with({ 'income_above_threshold' => YesNoAnswer::YES })
+          .and_return(true)
+
+        expect(subject.save).to be(true)
+      end
     end
   end
 end

--- a/spec/forms/steps/income/income_before_tax_form_spec.rb
+++ b/spec/forms/steps/income/income_before_tax_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::IncomeBeforeTaxForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      income_above_threshold:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
+  let(:applicant) { instance_double(Applicant, income_details:) }
+  let(:income_details) { instance_double(IncomeDetails) }
+
+  let(:income_above_threshold) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `income_above_threshold` is blank' do
+      let(:income_above_threshold) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:income_above_threshold, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `income_above_threshold` is invalid' do
+      let(:income_above_threshold) { 'invalid_selection' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:income_above_threshold, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `income_above_threshold` is valid' do
+      let(:income_above_threshold) { YesNoAnswer::YES.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:income_above_threshold, :invalid)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe Decisions::IncomeDecisionTree do
     end
   end
 
+  context 'when the step is `income_before_tax`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :income_before_tax }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    end
+  end
+
   context 'when the step is `manage_without_income`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :manage_without_income }


### PR DESCRIPTION
## Description of change

Adds the "clients_income_before_tax"  to the income journey.

Also adds a new `IncomeDetails` object that we can use going forward to collect income related information in subsequent steps.

the relationship to crime_application is:

`crime_application.applicant.income_details`

i.e. it is a relationship through the applicant, but this is defined on the `Person` model so should be ameanable to `Partner` when the time comes to add those steps in as well. 

## Link to relevant ticket
[CRIMAP-676](https://dsdmoj.atlassian.net/browse/CRIMAP-676)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
n/a

### After changes:
<img width="878" alt="Screenshot 2023-11-08 at 17 02 48" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/25876378-9899-4565-b6c4-762d467a3b2c">

## How to manually test the feature
- Start an application and go through the first step so you enter client details.
- then head to `applications/<application id>/steps/income/clients_income_before_tax`
- try to submitt the form without aswering the question, you should get a validation error in this case.

You could also test the API functions correctly in the Rails console.

After creating the application locally run:
- `rails c` to open the console
- then you can see the relationships working as such

```
# i.e. the latest applicant - the one you just created
a = Applicant.last

# get their (albeit limited at the moment) income details
icd = a.income_details

# get current application from applicant
c = applicant.crime_application

# there is a convenience method to return all income_details related to a crime application
c.income_details 
>>>  [ <array of income details records> ]
```

[CRIMAP-676]: https://dsdmoj.atlassian.net/browse/CRIMAP-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ