### PR TITLE
Relabel homeless option on manage_no_income form, update ValueObject

### DIFF
--- a/app/value_objects/manage_without_income_type.rb
+++ b/app/value_objects/manage_without_income_type.rb
@@ -2,7 +2,7 @@ class ManageWithoutIncomeType < ValueObject
   VALUES = [
     FRIENDS_SOFA = new(:friends_sofa),
     FAMILY = new(:family),
-    HOMELESS = new(:homeless),
+    LIVING_ON_STREETS = new(:living_on_streets),
     CUSTODY = new(:custody),
     OTHER = new(:other),
   ].freeze

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -237,7 +237,7 @@ en:
         manage_without_income_options:
           friends_sofa: They sleep on a friend's sofa for free
           family: They stay with family for free
-          homeless: They are homeless
+          living_on_streets: They are living on the streets / homeless
           custody: They have been in custody for more than 3 months
           other: Other
         manage_other_details: Tell us how your client manages with no income

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,7 +162,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_07_202222) do
     t.date "date_job_lost"
     t.string "manage_without_income"
     t.string "manage_other_details"
-    t.string "income_above_threshold"
     t.string "employment_status", default: [], array: true
     t.string "ended_employment_within_three_months"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true

--- a/spec/value_objects/manage_without_income_type_spec.rb
+++ b/spec/value_objects/manage_without_income_type_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ManageWithoutIncomeType do
       expect(described_class.values.map(&:to_s)).to eq(%w[
                                                          friends_sofa
                                                          family
-                                                         homeless
+                                                         living_on_streets
                                                          custody
                                                          other
                                                        ])


### PR DESCRIPTION
## Description of change
QA modification request to update copy. 

Also updated ValueObject to more accurately match the meaning of the option.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-110

### Before changes:
![image](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/01585328-be78-4a26-91b9-a597db59ea52)

### After changes:
<img width="852" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/14016aad-26b5-4a1d-92a4-006cc1d028e0">


## How to manually test the feature
Start a new application
Go to /steps/income/how_does_client_manage_with_no_income