### PR TITLE
[CRIMAP-207] Rollback file upload restrictions for testing

### DIFF
--- a/app/javascript/local/dropzone-cfg.js
+++ b/app/javascript/local/dropzone-cfg.js
@@ -2,7 +2,7 @@
 
 import Dropzone from "dropzone"
 
-const MIN_FILE_SIZE = 5000 // Bytes = 5KB
+const MIN_FILE_SIZE = 1 // Bytes = 5KB, TODO: Temporarily disable CRIMAP-207, Reset to 5000
 const MAX_FILE_SIZE = 1000000 // Bytes = 10MB
 
 const ERR_GENERIC = 'could not be uploaded – try again'
@@ -11,7 +11,8 @@ const ERR_FILE_SIZE_TOO_SMALL = 'must be bigger than 5KB'
 const ERR_CONTENT_TYPE = 'must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF'
 const ALLOWED_CONTENT_TYPES = [
   // dropzone checks both the mimetype and the file extension so this list covers everything
-  '.doc', '.docx', '.rtf', '.odt', '.jpg', '.jpeg', '.bpm', '.png', '.tif', '.tiff', '.pdf',
+  // TODO: Temporarily disable CRIMAP-207, Reset to omit '.txt'
+  '.txt', '.doc', '.docx', '.rtf', '.odt', '.jpg', '.jpeg', '.bpm', '.png', '.tif', '.tiff', '.pdf',
   'application/pdf',
   'application/msword',
   'application/vnd.oasis.opendocument.text',

--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -27,7 +27,7 @@ class FileUploadValidator < ActiveModel::Validator
 
   private
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Style/GuardClause
+  # rubocop:disable Style/GuardClause
   def perform_validations
     unless record.content_type.in?(ALLOWED_CONTENT_TYPES)
       record.errors.add(
@@ -36,9 +36,10 @@ class FileUploadValidator < ActiveModel::Validator
     end
 
     if record.file_size < MIN_FILE_SIZE.kilobytes
-      record.errors.add(
-        :file_size, :too_small, min_size: MIN_FILE_SIZE
-      )
+      # TODO: Temporarily disable CRIMAP-207
+      # record.errors.add(
+      #   :file_size, :too_small, min_size: MIN_FILE_SIZE
+      # )
     end
 
     if record.file_size > MAX_FILE_SIZE.megabytes
@@ -47,5 +48,5 @@ class FileUploadValidator < ActiveModel::Validator
       )
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Style/GuardClause
+  # rubocop:enable Style/GuardClause
 end

--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,5 +1,5 @@
 class FileUploadValidator < ActiveModel::Validator
-  MIN_FILE_SIZE = 5 # KB
+  MIN_FILE_SIZE = 0 # KB, TODO: Temporarily disable CRIMAP-207, reset to 5
   MAX_FILE_SIZE = 10 # MB
 
   ALLOWED_CONTENT_TYPES = %w[

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Document, type: :model do
     end
 
     context 'criteria' do
-      context 'file is too small' do
+      context 'file is too small', skip: 'TODO: Temporarily disable CRIMAP-207' do
         let(:attributes) { super().merge(file_size: 3.kilobytes) }
 
         it 'has a validation error on the field' do

--- a/spec/requests/evidence_upload_spec.rb
+++ b/spec/requests/evidence_upload_spec.rb
@@ -72,12 +72,13 @@ RSpec.describe 'Evidence upload page', :authorized do
                           "Error: #{I18n.t('activerecord.errors.models.document.attributes.file_size.too_big',
                                            max_size: FileUploadValidator::MAX_FILE_SIZE)}"
           end
-          assert_select 'tr.govuk-table__row:nth-of-type(3)' do
-            assert_select 'span:nth-of-type(1)', 'too_small.pdf'
-            assert_select 'p:nth-of-type(1)',
-                          "Error: #{I18n.t('activerecord.errors.models.document.attributes.file_size.too_small',
-                                           min_size: FileUploadValidator::MIN_FILE_SIZE)}"
-          end
+          # TODO: Temporarily disable CRIMAP-207
+          # assert_select 'tr.govuk-table__row:nth-of-type(3)' do
+          #   assert_select 'span:nth-of-type(1)', 'too_small.pdf'
+          #   assert_select 'p:nth-of-type(1)',
+          #                 "Error: #{I18n.t('activerecord.errors.models.document.attributes.file_size.too_small',
+          #                                  min_size: FileUploadValidator::MIN_FILE_SIZE)}"
+          # end
         end
       end
 


### PR DESCRIPTION
## Description of change
Rollback file upload restrictions enough to test a test malicious file upload

## Link to relevant ticket


## Notes for reviewer
https://dsdmoj.atlassian.net/browse/CRIMAPP-207


## How to manually test the feature
1. Find an existing application in progress or create a new application, amend URL to look like https://staging-apply.com/applications/773bd241-6324-4fde-81b2-d48a94308d2a/steps/evidence/upload
2. Upload the malicious file and expect an error message