### PR TITLE
Removes relationship between IncomeDetails and Person

### DIFF
--- a/app/forms/steps/income/income_before_tax_form.rb
+++ b/app/forms/steps/income/income_before_tax_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class IncomeBeforeTaxForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details, through: :applicant
+      has_one_association :income_details
 
       # threshold being £12,475 as of Nov 2023
       attribute :income_above_threshold, :value_object, source: YesNoAnswer

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -5,6 +5,7 @@ class CrimeApplication < ApplicationRecord
 
   has_one :applicant, dependent: :destroy
   has_one :partner, dependent: :destroy
+  has_one :income_details, dependent: :destroy
 
   has_many :people, dependent: :destroy
   has_many :documents, dependent: :destroy
@@ -13,7 +14,6 @@ class CrimeApplication < ApplicationRecord
   has_one :ioj, through: :case
   has_many :addresses, through: :people
   has_many :codefendants, through: :case
-  has_many :income_details, through: :people
 
   enum status: ApplicationStatus.enum_values
 

--- a/app/models/income_details.rb
+++ b/app/models/income_details.rb
@@ -1,3 +1,3 @@
 class IncomeDetails < ApplicationRecord
-  belongs_to :person
+  belongs_to :crime_application
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,8 +8,6 @@ class Person < ApplicationRecord
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
   has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'
 
-  has_one :income_details, dependent: :destroy
-
   scope :with_name, -> { where.not(first_name: [nil, '']) }
 
   def home_address?

--- a/db/migrate/20231114075123_modify_income_details_to_ref_crime_application.rb
+++ b/db/migrate/20231114075123_modify_income_details_to_ref_crime_application.rb
@@ -1,0 +1,12 @@
+class ModifyIncomeDetailsToRefCrimeApplication < ActiveRecord::Migration[7.0]
+  def change
+    change_table :income_details do |t|
+      t.remove_foreign_key :people
+
+      # Ref crime_application rather than person
+      t.rename :person_id, :crime_application_id
+    end
+
+    add_foreign_key :income_details, :crime_applications, column: :crime_application_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_07_202222) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_14_075123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -107,11 +107,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_07_202222) do
   end
 
   create_table "income_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "person_id", null: false
+    t.uuid "crime_application_id", null: false
     t.string "income_above_threshold"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["person_id"], name: "index_income_details_on_person_id"
+    t.index ["crime_application_id"], name: "index_income_details_on_crime_application_id"
   end
 
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -192,7 +192,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_07_202222) do
   add_foreign_key "charges", "cases"
   add_foreign_key "codefendants", "cases"
   add_foreign_key "documents", "crime_applications"
-  add_foreign_key "income_details", "people"
+  add_foreign_key "income_details", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
   add_foreign_key "people", "crime_applications"

--- a/spec/forms/steps/income/income_before_tax_form_spec.rb
+++ b/spec/forms/steps/income/income_before_tax_form_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Steps::Income::IncomeBeforeTaxForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
-  let(:applicant) { instance_double(Applicant, income_details:) }
+  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
   let(:income_details) { instance_double(IncomeDetails) }
 
   let(:income_above_threshold) { nil }
@@ -59,6 +58,12 @@ RSpec.describe Steps::Income::IncomeBeforeTaxForm do
 
         expect(subject.save).to be(true)
       end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :income_details,
+                      expected_attributes: {
+                        'income_above_threshold' => YesNoAnswer::YES,
+                      }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Instead it makes it related to CrimeApplication. A CrimeApplication has_one income_details

This is an object that will eventually have the common income related data in relation to applicant/client and partner

## Link to relevant ticket
As part of discussions on [CRIMAPP-131](https://dsdmoj.atlassian.net/browse/CRIMAPP-131) we created this refactor.

## Notes for reviewer
This will create data issues if you apply the migration and have `IncomeDetails` <---> `Person` data in your DB due to its removal of foreign keys.

You will need to remove these records for the rollback to happen.

## How to manually test the feature
In the UI should work the same as [CRIMAP-676](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/531)


[CRIMAPP-131]: https://dsdmoj.atlassian.net/browse/CRIMAPP-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ