### PR TITLE
Add client owns property step + specs

### DIFF
--- a/app/controllers/steps/income/client_owns_property_controller.rb
+++ b/app/controllers/steps/income/client_owns_property_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Income
+    class ClientOwnsPropertyController < Steps::IncomeStepController
+      def edit
+        @form_object = ClientOwnsPropertyForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(ClientOwnsPropertyForm, as: :client_owns_property)
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/client_owns_property_form.rb
+++ b/app/forms/steps/income/client_owns_property_form.rb
@@ -1,0 +1,24 @@
+module Steps
+  module Income
+    class ClientOwnsPropertyForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :income_details
+
+      attribute :client_owns_property, :value_object, source: YesNoAnswer
+
+      validates_inclusion_of :client_owns_property, in: :choices
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        income_details.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -1,8 +1,6 @@
 module Decisions
-  # TODO: remove this rubocop opt out when
-  # branches are known and are therefore non-duplicate
-  # rubocop:disable Lint/DuplicateBranch
   class IncomeDecisionTree < BaseDecisionTree
+    # rubocop:disable Metrics/MethodLength
     def destination
       case step_name
       when :employment_status
@@ -11,8 +9,9 @@ module Decisions
         # TODO: link to next step when we have it
         edit(:manage_without_income)
       when :income_before_tax
-        # TODO: link to next step when we have it
-        show('/home', action: :index)
+        after_income_before_tax
+      when :client_owns_property
+        edit('/home', action: :index)
       when :manage_without_income
         # TODO: link to next step when we have it
         show('/home', action: :index)
@@ -20,7 +19,7 @@ module Decisions
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
-    # rubocop:enable Lint/DuplicateBranch
+    # rubocop:enable Metrics/MethodLength
 
     private
 
@@ -36,12 +35,25 @@ module Decisions
       end
     end
 
+    def after_income_before_tax
+      if income_below_threshold?
+        edit(:client_owns_property)
+      else
+        # TODO: once we have the next step
+        show('/home', action: :index)
+      end
+    end
+
     def not_working
       form_object.employment_status.include?(EmploymentStatus::NOT_WORKING.to_s)
     end
 
     def ended_employment_within_three_months
       form_object.ended_employment_within_three_months&.yes?
+    end
+
+    def income_below_threshold?
+      form_object.income_above_threshold.no?
     end
   end
 end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -36,6 +36,7 @@ module Decisions
     end
 
     def after_income_before_tax
+      # TODO: change when step before added
       if income_below_threshold?
         edit(:client_owns_property)
       else

--- a/app/views/steps/income/client_owns_property/edit.html.erb
+++ b/app/views/steps/income/client_owns_property/edit.html.erb
@@ -1,0 +1,19 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :client_owns_property, @form_object.choices,
+                                           :value, inline: false,
+                                           legend: { text: t('.client_owns_property'), tag: 'h1', size: 'xl' } do %>
+           <span class="govuk-caption-m govuk-!-margin-bottom-4">
+             <%= t('.client_owns_property_info') %>
+           </span>
+        <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -294,6 +294,10 @@ en:
           attributes:
             income_above_threshold:
               inclusion: Select yes if your client’s income is currently more than £12,475 a year before tax
+        steps/income/client_owns_property_form:
+          attributes:
+            client_owns_property:
+              inclusion: Select yes if your client owns their home, or any other land or property?
         steps/income/manage_without_income_form:
           attributes:
             manage_without_income:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -233,6 +233,8 @@ en:
         lost_job_in_custody_options: *YESNO
       steps_income_income_before_tax_form:
         income_above_threshold_options: *YESNO
+      steps_income_client_owns_property_form:
+        client_owns_property_options: *YESNO
       steps_income_manage_without_income_form:
         manage_without_income_options:
           friends_sofa: They sleep on a friend's sofa for free

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -216,7 +216,7 @@ en:
           income_above_threshold: Is your client's income currently more than £12,475 a year before tax?
       client_owns_property:
         edit:
-          page_title: Is your client's income currently more than £12,475 a year before tax?
+          page_title: Does your client own their home, or any other land or property?
           client_owns_property_info: Include land or property fully or partly owned, inside or outside the UK.
           client_owns_property: Does your client own their home, or any other land or property?
       manage_without_income:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -214,6 +214,11 @@ en:
           page_title: Is your client's income currently more than £12,475 a year before tax?
           income_above_threshold_info: Do not include any employment income if your client has lost their job or ended employment.
           income_above_threshold: Is your client's income currently more than £12,475 a year before tax?
+      client_owns_property:
+        edit:
+          page_title: Is your client's income currently more than £12,475 a year before tax?
+          client_owns_property_info: Include land or property fully or partly owned, inside or outside the UK.
+          client_owns_property: Does your client own their home, or any other land or property?
       manage_without_income:
         edit:
           page_title: How does client manage with no income?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
         edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody
         edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
         edit_step :clients_income_before_tax, alias: :income_before_tax
+        edit_step :does_client_own_home_land_property, alias: :client_owns_property
       end
 
       namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do

--- a/db/migrate/20231114162825_add_client_owns_property_to_income_details.rb
+++ b/db/migrate/20231114162825_add_client_owns_property_to_income_details.rb
@@ -1,0 +1,7 @@
+class AddClientOwnsPropertyToIncomeDetails < ActiveRecord::Migration[7.0]
+  def change
+    change_table :income_details do |t|
+      t.string :client_owns_property
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_14_075123) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_14_162825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_075123) do
     t.string "income_above_threshold"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "client_owns_property"
     t.index ["crime_application_id"], name: "index_income_details_on_crime_application_id"
   end
 

--- a/spec/controllers/steps/income/client_owns_property_controller_spec.rb
+++ b/spec/controllers/steps/income/client_owns_property_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::ClientOwnsPropertyController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Income::ClientOwnsPropertyForm, Decisions::IncomeDecisionTree
+end

--- a/spec/forms/steps/income/client_owns_property_form_spec.rb
+++ b/spec/forms/steps/income/client_owns_property_form_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::ClientOwnsPropertyForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      client_owns_property:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
+  let(:income_details) { instance_double(IncomeDetails) }
+
+  let(:client_owns_property) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `client_owns_property` is blank' do
+      let(:client_owns_property) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:client_owns_property, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `client_owns_property` is invalid' do
+      let(:client_owns_property) { 'invalid_selection' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:client_owns_property, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `client_owns_property` is valid' do
+      let(:client_owns_property) { YesNoAnswer::YES.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:client_owns_property, :invalid)).to be(false)
+      end
+
+      it 'updates the record' do
+        expect(income_details).to receive(:update)
+          .with({ 'client_owns_property' => YesNoAnswer::YES })
+          .and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :income_details,
+                      expected_attributes: {
+                        'client_owns_property' => YesNoAnswer::YES,
+                      }
+    end
+  end
+end

--- a/spec/forms/steps/income/client_owns_property_form_spec.rb
+++ b/spec/forms/steps/income/client_owns_property_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Steps::Income::ClientOwnsPropertyForm do
     context 'when `client_owns_property` is blank' do
       let(:client_owns_property) { '' }
 
-      it 'has is a validation error on the field' do
+      it 'has a validation error on the field' do
         expect(form).not_to be_valid
         expect(form.errors.of_kind?(:client_owns_property, :inclusion)).to be(true)
       end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -72,6 +72,27 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :income_before_tax }
 
+    context 'when income is above the threshold' do
+      before do
+        allow(form_object).to receive_messages(income_above_threshold: YesNoAnswer::YES)
+      end
+
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    end
+
+    context 'when income below the threshold' do
+      before do
+        allow(form_object).to receive_messages(income_above_threshold: YesNoAnswer::NO)
+      end
+
+      it { is_expected.to have_destination(:client_owns_property, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `client_owns_property`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :client_owns_property }
+
     context 'has correct next step' do
       it { is_expected.to have_destination('/home', :index, id: crime_application) }
     end


### PR DESCRIPTION
## Description of change

Adds "Apply: Add Does your client own their home, or any other land or property?" page into the application.

## Link to relevant ticket
[CRIMAPP-208](https://dsdmoj.atlassian.net/browse/CRIMAPP-208)

## Screenshots of changes (if applicable)

### After changes:

Page:
<img width="990" alt="Screenshot 2023-11-15 at 10 01 15" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/bd3f7d7a-dbb9-4c10-ba2a-d9bfdc850b38">

Errors:
<img width="999" alt="Screenshot 2023-11-15 at 10 00 28" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/eb2301e3-d4a9-4b40-9046-2ebbe030e1b4">


## How to manually test the feature
- create a case, get through the inital info page
- go to `/steps/income/clients_income_before_tax` click no
- this takes you to the next step (the one added in this PR): `/steps/income/does_client_own_home_land_property`
- try to submit without adding an answer - you should revcieve and error message.
- answer either yes or no --> it should then allow you to submit and will return you to the homepage pending further additions.

[CRIMAPP-208]: https://dsdmoj.atlassian.net/browse/CRIMAPP-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ