### PR TITLE
[CRIMAP-66] Remove routing restrictions for evidence upload

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,10 +109,8 @@ Rails.application.routes.draw do
         show_step :benefit_exit
         edit_step :benefit_check_result
         edit_step :retry_benefit_check
-        if FeatureFlags.evidence_upload.enabled?
-          edit_step :has_benefit_evidence
-          show_step :evidence_exit
-        end
+        edit_step :has_benefit_evidence
+        show_step :evidence_exit
         edit_step :contact_details
       end
 
@@ -151,7 +149,7 @@ Rails.application.routes.draw do
         edit_step :clients_income_before_tax, alias: :income_before_tax
       end
 
-      namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
+      namespace :evidence do
         edit_step :upload
       end
 


### PR DESCRIPTION
## Description of change
Removes restriction to access the /steps/evidence/upload URL in all environments

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66

## Notes for reviewer
Do all the routes restrictions need removing?


## How to manually test the feature
Create an application and append /steps/evidence/upload to the URL