### PR TITLE
[CRIMAP-66] Re-instate Evidence Upload Feature Flag, remain disabled in production

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,8 +109,10 @@ Rails.application.routes.draw do
         show_step :benefit_exit
         edit_step :benefit_check_result
         edit_step :retry_benefit_check
-        edit_step :has_benefit_evidence
-        show_step :evidence_exit
+        if FeatureFlags.evidence_upload.enabled?
+          edit_step :has_benefit_evidence
+          show_step :evidence_exit
+        end
         edit_step :contact_details
       end
 
@@ -149,7 +151,7 @@ Rails.application.routes.draw do
         edit_step :clients_income_before_tax, alias: :income_before_tax
       end
 
-      namespace :evidence do
+      namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
         edit_step :upload
       end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,7 +18,7 @@ feature_flags:
   evidence_upload:
     local: true
     staging: true
-    production: false
+    production: true
   means_journey:
     local: true
     staging: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,7 +18,7 @@ feature_flags:
   evidence_upload:
     local: true
     staging: true
-    production: true
+    production: false
   means_journey:
     local: true
     staging: true


### PR DESCRIPTION
## Description of change
Re-instate Evidence Upload Feature Flag

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66

## Notes for reviewer
Reinstates the feature flag, production still not enabled

