### PR TITLE
Fix error deleting document in non js upload form

### DIFF
--- a/app/controllers/steps/evidence/upload_controller.rb
+++ b/app/controllers/steps/evidence/upload_controller.rb
@@ -18,11 +18,12 @@ module Steps
 
         document = current_crime_application.documents.find(params['document_id'])
 
-        @flash = if Datastore::Documents::Delete.new(document:, log_context:).call
-                   { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
-                 else
-                   { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
-                 end
+        if Datastore::Documents::Delete.new(document:, log_context:).call
+          @flash = { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }
+          document.destroy
+        else
+          @flash = { alert: t('steps.evidence.upload.edit.delete.failure', file_name: document.filename) }
+        end
 
         :delete_document
       end

--- a/app/services/datastore/documents/delete.rb
+++ b/app/services/datastore/documents/delete.rb
@@ -12,7 +12,7 @@ module Datastore
         return true unless deletable?
 
         Rails.error.handle(fallback: -> { false }, context: context, severity: :error) do
-          document.destroy if DatastoreApi::Requests::Documents::Delete.new(object_key:).call
+          DatastoreApi::Requests::Documents::Delete.new(object_key:).call
           Rails.logger.info "Document successfully deleted. Object key: #{document.s3_object_key}"
           true
         end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -21,10 +21,10 @@ en:
         document:
           attributes:
             file_size:
-              too_small: File must be bigger than %{min_size}KB
-              too_big: File must be smaller than %{max_size}MB
+              too_small: File could not be uploaded – file must be bigger than %{min_size}KB
+              too_big: File could not be uploaded – file must be smaller than %{max_size}MB
             content_type:
-              invalid: File must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF
+              invalid: File could not be uploaded – file must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF
             s3_object_key:
               blank: File could not be uploaded – try again
             scan_status:

--- a/spec/controllers/steps/evidence/upload_controller_spec.rb
+++ b/spec/controllers/steps/evidence/upload_controller_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
     let(:crime_application) { CrimeApplication.create }
     let(:document) { crime_application.documents.create({ filename: 'test.pdf' }) }
 
+    before do
+      document
+    end
+
     context 'deleting a document' do
       it 'has the expected step name' do
         allow_any_instance_of(Datastore::Documents::Delete).to receive(:call).and_return(true)
@@ -19,7 +23,8 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
           flash: { success: 'You deleted test.pdf' }
         )
 
-        put :update, params: { id: crime_application, document_id: document }
+        expect { put :update, params: { id: crime_application, document_id: document } }
+          .to change { crime_application.reload.documents.size }.from(1).to(0)
       end
 
       it 'is has the correct flash message when delete is unsuccessful' do
@@ -32,7 +37,8 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
           flash: { alert: 'test.pdf could not be deleted – try again' }
         )
 
-        put :update, params: { id: crime_application, document_id: document }
+        expect { put :update, params: { id: crime_application, document_id: document } }
+          .to(not_change { crime_application.reload.documents.size })
       end
     end
 

--- a/spec/services/datastore/documents/delete_spec.rb
+++ b/spec/services/datastore/documents/delete_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Datastore::Documents::Delete do
       end
 
       it 'returns true' do
-        expect(document).to receive(:destroy)
         expect(subject.call).to be(true)
       end
     end


### PR DESCRIPTION
Fixes a bug spotted where files that did not upload to s3 were unable to be deleted in the non JS evidence upload form.

Also agreed to amend error messages to be clearer about upload status in the non JS form, so it is clear that files that have an error message did not upload and won't be submitted with the application (see screenshot below)

## Description of change

## Link to relevant ticket
[CRIMAPP-236](https://dsdmoj.atlassian.net/browse/CRIMAPP-236)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
**Bug - deleted file has been deleted but remains in uploaded files table**
<img width="1233" alt="Screenshot 2023-11-17 at 15 38 11" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/9fa6525b-c017-451d-ac4f-e7b73300f793">


### After changes:
**Deleted file has been deleted and is no longer in uploaded files table**

<img width="1233" alt="Screenshot 2023-11-20 at 10 36 04" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/118fdd7e-714d-4ffc-b1b3-3c1713d98e78">

**Error messages have been appended with file 'File could not be uploaded' to be clearer that they have not been uploaded (non js form only)**
<img width="1233" alt="Screenshot 2023-11-20 at 10 35 19" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/83b4e9f4-d916-4dbd-b0c7-9df6554f5852">
## How to manually test the feature


[CRIMAPP-236]: https://dsdmoj.atlassian.net/browse/CRIMAPP-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ