### PR TITLE
HOTFIX: Application without income details can be serialised.

### DIFF
--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -5,7 +5,7 @@ module SubmissionSerializer
         Jbuilder.new do |json|
           json.means_details do
             json.income_details do
-              json.income_above_threshold crime_application.income_details.income_above_threshold
+              json.income_above_threshold crime_application.income_details&.income_above_threshold
             end
           end
         end


### PR DESCRIPTION
## Description of change

## Link to relevant ticket
https://ministryofjustice.sentry.io/alerts/rules/details/143747/?alert=7266&environment=production&notification_uuid=cd926de7-e22d-4c5f-aff7-c95d737d5054&referrer=metric_alert_slack

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
