### PR TITLE
[CRIMAP-66] Add clamav production service

### DIFF
--- a/config/kubernetes/production/deployment-clamav.yml
+++ b/config/kubernetes/production/deployment-clamav.yml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clamav-production
+  namespace: laa-apply-for-criminal-legal-aid-production
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  minReadySeconds: 15
+  serviceName: clamav
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-clamav-production
+  template:
+    metadata:
+      labels:
+        app: apply-for-criminal-legal-aid-clamav-production
+        tier: backend
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: clamav
+        image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 3310
+            protocol: TCP
+        volumeMounts:
+          - mountPath: /var/lib/clamav
+            name: clamav-signatures
+        resources:
+          requests:
+            cpu: 25m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 3Gi
+        readinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        livenessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 30
+          periodSeconds: 60
+  volumeClaimTemplates:
+  - metadata:
+      name: clamav-signatures
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clamav-service-production
+  namespace: laa-apply-for-criminal-legal-aid-production
+  labels:
+    app: apply-for-criminal-legal-aid-clamav-production
+spec:
+  ports:
+  - port: 3310
+    name: clamav
+    targetPort: 3310
+  selector:
+    app: apply-for-criminal-legal-aid-clamav-production


### PR DESCRIPTION
## Description of change
Adds Kubernetes StatefulSet deployment-clamav.yml to generate the production ClamAV service on port 3310

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66

## Notes for reviewer
Will need trial and error in production unfortunately. Currently replicates (working) staging settings. Environment variables needed for virus scanning are already in place in config_map.yml
