### PR TITLE
[CRIMAP-246] Upgrade Schema to v1.0.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.10'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.11'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 36557b0a9c3973c41a8bb450285516f278606c3b
-  tag: v1.0.10
+  revision: cdbca6d1ff657a19df9f667192763d99c4d3c302
+  tag: v1.0.11
   specs:
-    laa-criminal-legal-aid-schemas (1.0.10)
+    laa-criminal-legal-aid-schemas (1.0.11)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Upgrade Schema to v1.0.11
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-246
## Notes for reviewer
Makes `income_details` optional
