### PR TITLE
[CRIMAPP-97] Move income detail columns from People to IncomeDetails table

### DIFF
--- a/app/forms/steps/income/client_owns_property_form.rb
+++ b/app/forms/steps/income/client_owns_property_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class ClientOwnsPropertyForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details
+      has_one_association :income
 
       attribute :client_owns_property, :value_object, source: YesNoAnswer
 
@@ -15,7 +15,7 @@ module Steps
       private
 
       def persist!
-        income_details.update(
+        income.update(
           attributes
         )
       end

--- a/app/forms/steps/income/employment_status_form.rb
+++ b/app/forms/steps/income/employment_status_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class EmploymentStatusForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :applicant
+      has_one_association :income_details
 
       attribute :employment_status, array: true, default: []
       attribute :ended_employment_within_three_months, :value_object, source: YesNoAnswer
@@ -36,7 +36,7 @@ module Steps
       end
 
       def persist!
-        applicant.update(
+        income_details.update(
           attributes.merge(attributes_to_reset)
         )
       end

--- a/app/forms/steps/income/employment_status_form.rb
+++ b/app/forms/steps/income/employment_status_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class EmploymentStatusForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details
+      has_one_association :income
 
       attribute :employment_status, array: true, default: []
       attribute :ended_employment_within_three_months, :value_object, source: YesNoAnswer
@@ -36,7 +36,7 @@ module Steps
       end
 
       def persist!
-        income_details.update(
+        income.update(
           attributes.merge(attributes_to_reset)
         )
       end

--- a/app/forms/steps/income/frozen_income_savings_assets_form.rb
+++ b/app/forms/steps/income/frozen_income_savings_assets_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class FrozenIncomeSavingsAssetsForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details
+      has_one_association :income
 
       attribute :has_frozen_income_or_assets, :value_object, source: YesNoAnswer
 
@@ -15,7 +15,7 @@ module Steps
       private
 
       def persist!
-        income_details.update(
+        income.update(
           attributes
         )
       end

--- a/app/forms/steps/income/income_before_tax_form.rb
+++ b/app/forms/steps/income/income_before_tax_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class IncomeBeforeTaxForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details
+      has_one_association :income
 
       # threshold being £12,475 as of Nov 2023
       attribute :income_above_threshold, :value_object, source: YesNoAnswer
@@ -16,7 +16,7 @@ module Steps
       private
 
       def persist!
-        income_details.update(
+        income.update(
           attributes
         )
       end

--- a/app/forms/steps/income/lost_job_in_custody_form.rb
+++ b/app/forms/steps/income/lost_job_in_custody_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class LostJobInCustodyForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details
+      has_one_association :income
 
       attribute :lost_job_in_custody, :value_object, source: YesNoAnswer
       attribute :date_job_lost, :multiparam_date
@@ -29,7 +29,7 @@ module Steps
       end
 
       def persist!
-        income_details.update(
+        income.update(
           attributes.merge(attributes_to_reset)
         )
       end

--- a/app/forms/steps/income/lost_job_in_custody_form.rb
+++ b/app/forms/steps/income/lost_job_in_custody_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class LostJobInCustodyForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :applicant
+      has_one_association :income_details
 
       attribute :lost_job_in_custody, :value_object, source: YesNoAnswer
       attribute :date_job_lost, :multiparam_date
@@ -29,7 +29,7 @@ module Steps
       end
 
       def persist!
-        applicant.update(
+        income_details.update(
           attributes.merge(attributes_to_reset)
         )
       end

--- a/app/forms/steps/income/manage_without_income_form.rb
+++ b/app/forms/steps/income/manage_without_income_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class ManageWithoutIncomeForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :income_details
+      has_one_association :income
 
       attribute :manage_without_income, :value_object, source: ManageWithoutIncomeType
       attribute :manage_other_details, :string
@@ -20,7 +20,7 @@ module Steps
       private
 
       def persist!
-        income_details.update(
+        income.update(
           attributes.merge(attributes_to_reset)
         )
       end

--- a/app/forms/steps/income/manage_without_income_form.rb
+++ b/app/forms/steps/income/manage_without_income_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     class ManageWithoutIncomeForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
-      has_one_association :applicant
+      has_one_association :income_details
 
       attribute :manage_without_income, :value_object, source: ManageWithoutIncomeType
       attribute :manage_other_details, :string
@@ -20,7 +20,7 @@ module Steps
       private
 
       def persist!
-        applicant.update(
+        income_details.update(
           attributes.merge(attributes_to_reset)
         )
       end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -5,7 +5,7 @@ class CrimeApplication < ApplicationRecord
 
   has_one :applicant, dependent: :destroy
   has_one :partner, dependent: :destroy
-  has_one :income_details, dependent: :destroy
+  has_one :income, dependent: :destroy
 
   has_many :people, dependent: :destroy
   has_many :documents, dependent: :destroy

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -1,0 +1,3 @@
+class Income < ApplicationRecord
+  belongs_to :crime_application
+end

--- a/app/models/income_details.rb
+++ b/app/models/income_details.rb
@@ -1,3 +1,0 @@
-class IncomeDetails < ApplicationRecord
-  belongs_to :crime_application
-end

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -21,7 +21,7 @@ module SubmissionSerializer
       end
 
       def lost_job_in_custody(json)
-        return unless crime_application&.income&.lost_job_in_custody
+        return unless crime_application.income&.lost_job_in_custody
 
         json.lost_job_in_custody crime_application.income.lost_job_in_custody
         json.date_job_lost crime_application.income.date_job_lost

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -15,16 +15,16 @@ module SubmissionSerializer
       private
 
       def income_above_threshold(json)
-        return unless crime_application.income_details
+        return unless crime_application.income
 
-        json.income_above_threshold crime_application.income_details.income_above_threshold
+        json.income_above_threshold crime_application.income.income_above_threshold
       end
 
       def lost_job_in_custody(json)
-        return unless crime_application&.income_details&.lost_job_in_custody
+        return unless crime_application&.income&.lost_job_in_custody
 
-        json.lost_job_in_custody crime_application.income_details.lost_job_in_custody
-        json.date_job_lost crime_application.income_details.date_job_lost
+        json.lost_job_in_custody crime_application.income.lost_job_in_custody
+        json.date_job_lost crime_application.income.date_job_lost
       end
     end
   end

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -21,10 +21,10 @@ module SubmissionSerializer
       end
 
       def lost_job_in_custody(json)
-        return unless crime_application.applicant&.lost_job_in_custody
+        return unless crime_application&.income_details&.lost_job_in_custody
 
-        json.lost_job_in_custody crime_application.applicant.lost_job_in_custody
-        json.date_job_lost crime_application.applicant.date_job_lost
+        json.lost_job_in_custody crime_application.income_details.lost_job_in_custody
+        json.date_job_lost crime_application.income_details.date_job_lost
       end
     end
   end

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -15,6 +15,10 @@ module Adapters
         Structs::InterestsOfJustice.new(interests_of_justice)
       end
 
+      def income
+        Structs::IncomeDetails.new(means_details.income_details)
+      end
+
       def documents
         supporting_evidence.map do |struct|
           Document.new(

--- a/app/services/adapters/structs/income_details.rb
+++ b/app/services/adapters/structs/income_details.rb
@@ -1,0 +1,13 @@
+module Adapters
+  module Structs
+    class IncomeDetails < BaseStructAdapter
+      def serializable_hash(options = {})
+        super(
+          options.merge(
+            methods: []
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -59,6 +59,8 @@ module Datastore
     end
 
     def income
+      return if parent.income.blank?
+
       Income.new(
         parent.income.serializable_hash
       )

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -18,7 +18,7 @@ module Datastore
         means_passport: parent.means_passport,
         applicant: applicant,
         case: case_with_ioj,
-        income_details: income_details,
+        income: income,
         documents: parent.documents,
       )
     end
@@ -58,8 +58,8 @@ module Datastore
       )
     end
 
-    def income_details
-      IncomeDetails.new(
+    def income
+      Income.new(
         parent.income.serializable_hash
       )
     end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -18,6 +18,7 @@ module Datastore
         means_passport: parent.means_passport,
         applicant: applicant,
         case: case_with_ioj,
+        income_details: income_details,
         documents: parent.documents,
       )
     end
@@ -39,13 +40,8 @@ module Datastore
       parent.date_stamp if CaseType.new(parent.case.case_type).date_stampable?
     end
 
-    # NOTE: Income Details implementation is WIP, hence hard-coded nillable fields
     def applicant
-      Applicant.new(
-        'lost_job_in_custody' => parent.means_details&.income_details&.lost_job_in_custody,
-        'date_job_lost' => parent.means_details&.income_details&.date_job_lost,
-        **parent.applicant.serializable_hash
-      )
+      Applicant.new(parent.applicant.serializable_hash)
     end
 
     def ioj
@@ -59,6 +55,12 @@ module Datastore
     def case_with_ioj
       Case.new(
         parent.case.serializable_hash.merge('ioj' => ioj)
+      )
+    end
+
+    def income_details
+      IncomeDetails.new(
+        parent.income.serializable_hash
       )
     end
   end

--- a/db/migrate/20231127115239_move_income_detail_columns_from_people_to_income_details.rb
+++ b/db/migrate/20231127115239_move_income_detail_columns_from_people_to_income_details.rb
@@ -1,0 +1,17 @@
+class MoveIncomeDetailColumnsFromPeopleToIncomeDetails < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :people, :lost_job_in_custody, :string
+    remove_column :people, :date_job_lost, :date
+    remove_column :people, :manage_without_income, :string
+    remove_column :people, :manage_other_details, :string
+    remove_column :people, :employment_status, :string, array: true, default: []
+    remove_column :people, :ended_employment_within_three_months, :string
+
+    add_column :income_details, :lost_job_in_custody, :string
+    add_column :income_details, :date_job_lost, :date, using: 'date_job_lost::date'
+    add_column :income_details, :manage_without_income, :string
+    add_column :income_details, :manage_other_details, :string
+    add_column :income_details, :employment_status, :string, array: true, default: []
+    add_column :income_details, :ended_employment_within_three_months, :string
+  end
+end

--- a/db/migrate/20231127163617_change_income_details_to_incomes.rb
+++ b/db/migrate/20231127163617_change_income_details_to_incomes.rb
@@ -1,0 +1,5 @@
+class ChangeIncomeDetailsToIncomes < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :income_details, :incomes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_16_154434) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_115239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -113,6 +113,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_154434) do
     t.datetime "updated_at", null: false
     t.string "client_owns_property"
     t.string "has_frozen_income_or_assets"
+    t.string "lost_job_in_custody"
+    t.date "date_job_lost"
+    t.string "manage_without_income"
+    t.string "manage_other_details"
+    t.string "employment_status", default: [], array: true
+    t.string "ended_employment_within_three_months"
     t.index ["crime_application_id"], name: "index_income_details_on_crime_application_id"
   end
 
@@ -160,12 +166,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_154434) do
     t.boolean "passporting_benefit"
     t.string "benefit_type"
     t.string "has_benefit_evidence"
-    t.string "lost_job_in_custody"
-    t.date "date_job_lost"
-    t.string "manage_without_income"
-    t.string "manage_other_details"
-    t.string "employment_status", default: [], array: true
-    t.string "ended_employment_within_three_months"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_27_115239) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_163617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -106,7 +106,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_115239) do
     t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 
-  create_table "income_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "incomes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "income_above_threshold"
     t.datetime "created_at", null: false
@@ -119,7 +119,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_115239) do
     t.string "manage_other_details"
     t.string "employment_status", default: [], array: true
     t.string "ended_employment_within_three_months"
-    t.index ["crime_application_id"], name: "index_income_details_on_crime_application_id"
+    t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 
   create_table "iojs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -194,7 +194,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_115239) do
   add_foreign_key "charges", "cases"
   add_foreign_key "codefendants", "cases"
   add_foreign_key "documents", "crime_applications"
-  add_foreign_key "income_details", "crime_applications"
+  add_foreign_key "incomes", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
   add_foreign_key "people", "crime_applications"

--- a/spec/forms/steps/income/client_owns_property_form_spec.rb
+++ b/spec/forms/steps/income/client_owns_property_form_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Steps::Income::ClientOwnsPropertyForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
-  let(:income_details) { instance_double(IncomeDetails) }
+  let(:crime_application) { instance_double(CrimeApplication, income:) }
+  let(:income) { instance_double(Income) }
 
   let(:client_owns_property) { nil }
 
@@ -52,7 +52,7 @@ RSpec.describe Steps::Income::ClientOwnsPropertyForm do
       end
 
       it 'updates the record' do
-        expect(income_details).to receive(:update)
+        expect(income).to receive(:update)
           .with({ 'client_owns_property' => YesNoAnswer::YES })
           .and_return(true)
 
@@ -60,7 +60,7 @@ RSpec.describe Steps::Income::ClientOwnsPropertyForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :income_details,
+                      association_name: :income,
                       expected_attributes: {
                         'client_owns_property' => YesNoAnswer::YES,
                       }

--- a/spec/forms/steps/income/employment_status_form_spec.rb
+++ b/spec/forms/steps/income/employment_status_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
-  let(:income_details) { IncomeDetails.new }
+  let(:crime_application) { instance_double(CrimeApplication, income:) }
+  let(:income) { Income.new }
 
   let(:employment_status) { [] }
   let(:ended_employment_within_three_months) { nil }
@@ -76,7 +76,7 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :income_details,
+                      association_name: :income,
                       expected_attributes: {
                         'employment_status' => [EmploymentStatus::EMPLOYED.to_s],
                         'ended_employment_within_three_months' => nil
@@ -111,7 +111,7 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
           end
 
           it 'cannot reset `date_job_lost` as it is relevant' do
-            income_details.update(employment_status: [EmploymentStatus::NOT_WORKING.to_s])
+            income.update(employment_status: [EmploymentStatus::NOT_WORKING.to_s])
 
             attributes = form.send(:attributes_to_reset)
             expect(attributes['ended_employment_within_three_months']).to eq(ended_employment_within_three_months)

--- a/spec/forms/steps/income/employment_status_form_spec.rb
+++ b/spec/forms/steps/income/employment_status_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
-  let(:applicant_record) { Applicant.new }
+  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
+  let(:income_details) { IncomeDetails.new }
 
   let(:employment_status) { [] }
   let(:ended_employment_within_three_months) { nil }
@@ -76,7 +76,7 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :applicant,
+                      association_name: :income_details,
                       expected_attributes: {
                         'employment_status' => [EmploymentStatus::EMPLOYED.to_s],
                         'ended_employment_within_three_months' => nil
@@ -111,7 +111,7 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
           end
 
           it 'cannot reset `date_job_lost` as it is relevant' do
-            applicant_record.update(employment_status: [EmploymentStatus::NOT_WORKING.to_s])
+            income_details.update(employment_status: [EmploymentStatus::NOT_WORKING.to_s])
 
             attributes = form.send(:attributes_to_reset)
             expect(attributes['ended_employment_within_three_months']).to eq(ended_employment_within_three_months)

--- a/spec/forms/steps/income/frozen_income_savings_assets_form_spec.rb
+++ b/spec/forms/steps/income/frozen_income_savings_assets_form_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Steps::Income::FrozenIncomeSavingsAssetsForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
-  let(:income_details) { instance_double(IncomeDetails) }
+  let(:crime_application) { instance_double(CrimeApplication, income:) }
+  let(:income) { instance_double(Income) }
 
   let(:has_frozen_income_or_assets) { nil }
 
@@ -52,7 +52,7 @@ RSpec.describe Steps::Income::FrozenIncomeSavingsAssetsForm do
       end
 
       it 'updates the record' do
-        expect(income_details).to receive(:update)
+        expect(income).to receive(:update)
           .with({ 'has_frozen_income_or_assets' => YesNoAnswer::YES })
           .and_return(true)
 
@@ -60,7 +60,7 @@ RSpec.describe Steps::Income::FrozenIncomeSavingsAssetsForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :income_details,
+                      association_name: :income,
                       expected_attributes: {
                         'has_frozen_income_or_assets' => YesNoAnswer::YES,
                       }

--- a/spec/forms/steps/income/income_before_tax_form_spec.rb
+++ b/spec/forms/steps/income/income_before_tax_form_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Steps::Income::IncomeBeforeTaxForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
-  let(:income_details) { instance_double(IncomeDetails) }
+  let(:crime_application) { instance_double(CrimeApplication, income:) }
+  let(:income) { instance_double(Income) }
 
   let(:income_above_threshold) { nil }
 
@@ -52,7 +52,7 @@ RSpec.describe Steps::Income::IncomeBeforeTaxForm do
       end
 
       it 'updates the record' do
-        expect(income_details).to receive(:update)
+        expect(income).to receive(:update)
           .with({ 'income_above_threshold' => YesNoAnswer::YES })
           .and_return(true)
 
@@ -60,7 +60,7 @@ RSpec.describe Steps::Income::IncomeBeforeTaxForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :income_details,
+                      association_name: :income,
                       expected_attributes: {
                         'income_above_threshold' => YesNoAnswer::YES,
                       }

--- a/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
+++ b/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
-  let(:income_details) { IncomeDetails.new }
+  let(:crime_application) { instance_double(CrimeApplication, income:) }
+  let(:income) { Income.new }
 
   let(:lost_job_in_custody) { nil }
   let(:date_job_lost) { nil }
@@ -60,7 +60,7 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :income_details,
+                      association_name: :income,
                       expected_attributes: {
                         'lost_job_in_custody' => YesNoAnswer::NO,
                         'date_job_lost' => nil
@@ -95,7 +95,7 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
           end
 
           it 'cannot reset `date_job_lost` as it is relevant' do
-            income_details.update(lost_job_in_custody: YesNoAnswer::YES.to_s)
+            income.update(lost_job_in_custody: YesNoAnswer::YES.to_s)
 
             attributes = form.send(:attributes_to_reset)
             expect(attributes['date_job_lost']).to eq(date_job_lost)

--- a/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
+++ b/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
-  let(:applicant_record) { Applicant.new }
+  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
+  let(:income_details) { IncomeDetails.new }
 
   let(:lost_job_in_custody) { nil }
   let(:date_job_lost) { nil }
@@ -60,7 +60,7 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :applicant,
+                      association_name: :income_details,
                       expected_attributes: {
                         'lost_job_in_custody' => YesNoAnswer::NO,
                         'date_job_lost' => nil
@@ -95,7 +95,7 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
           end
 
           it 'cannot reset `date_job_lost` as it is relevant' do
-            applicant_record.update(lost_job_in_custody: YesNoAnswer::YES.to_s)
+            income_details.update(lost_job_in_custody: YesNoAnswer::YES.to_s)
 
             attributes = form.send(:attributes_to_reset)
             expect(attributes['date_job_lost']).to eq(date_job_lost)

--- a/spec/forms/steps/income/manage_without_income_form_spec.rb
+++ b/spec/forms/steps/income/manage_without_income_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Income::ManageWithoutIncomeForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
-  let(:income_details) { IncomeDetails.new }
+  let(:crime_application) { instance_double(CrimeApplication, income:) }
+  let(:income) { Income.new }
 
   let(:manage_without_income) { nil }
   let(:manage_other_details) { nil }
@@ -46,7 +46,7 @@ RSpec.describe Steps::Income::ManageWithoutIncomeForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :income_details,
+                      association_name: :income,
                       expected_attributes: {
                         'manage_without_income' => ManageWithoutIncomeType::FAMILY,
                         'manage_other_details' => nil
@@ -67,7 +67,7 @@ RSpec.describe Steps::Income::ManageWithoutIncomeForm do
         end
 
         it 'cannot reset `manage_other_details` as it is relevant' do
-          income_details.update(manage_without_income: ManageWithoutIncomeType::OTHER.to_s)
+          income.update(manage_without_income: ManageWithoutIncomeType::OTHER.to_s)
 
           attributes = form.send(:attributes_to_reset)
           expect(attributes['manage_other_details']).to eq(manage_other_details)

--- a/spec/forms/steps/income/manage_without_income_form_spec.rb
+++ b/spec/forms/steps/income/manage_without_income_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Steps::Income::ManageWithoutIncomeForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, applicant: applicant_record) }
-  let(:applicant_record) { Applicant.new }
+  let(:crime_application) { instance_double(CrimeApplication, income_details:) }
+  let(:income_details) { IncomeDetails.new }
 
   let(:manage_without_income) { nil }
   let(:manage_other_details) { nil }
@@ -46,7 +46,7 @@ RSpec.describe Steps::Income::ManageWithoutIncomeForm do
       end
 
       it_behaves_like 'a has-one-association form',
-                      association_name: :applicant,
+                      association_name: :income_details,
                       expected_attributes: {
                         'manage_without_income' => ManageWithoutIncomeType::FAMILY,
                         'manage_other_details' => nil
@@ -67,7 +67,7 @@ RSpec.describe Steps::Income::ManageWithoutIncomeForm do
         end
 
         it 'cannot reset `manage_other_details` as it is relevant' do
-          applicant_record.update(manage_without_income: ManageWithoutIncomeType::OTHER.to_s)
+          income_details.update(manage_without_income: ManageWithoutIncomeType::OTHER.to_s)
 
           attributes = form.send(:attributes_to_reset)
           expect(attributes['manage_other_details']).to eq(manage_other_details)

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe SubmissionSerializer::Application do
     # in spec `services/application_submission_spec.rb`
 
     let(:kase) { Case.new }
-    let(:income_details) { IncomeDetails.new }
+    let(:income) { Income.new }
     let(:documents_scope) { double(stored: [Document.new]) }
 
     before do
       allow(crime_application).to receive_messages(case: kase, documents: documents_scope,
-                                                   income_details: income_details)
+                                                   income: income)
     end
 
     it 'generates a serialized version of the application' do

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -4,15 +4,14 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
   subject { described_class.new(crime_application) }
 
   let(:crime_application) do
-    instance_double(CrimeApplication, applicant: applicant, income_details: IncomeDetails.new)
+    instance_double(CrimeApplication, income_details:)
   end
 
   describe '#generate' do
-    let(:applicant) do
+    let(:income_details) do
       instance_double(
-        Applicant,
-        first_name: 'Max',
-        last_name: 'Mustermann',
+        IncomeDetails,
+        income_above_threshold: 'yes',
         lost_job_in_custody: 'yes',
         date_job_lost: '2023-10-01',
       )
@@ -22,7 +21,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
       {
         means_details: {
           income_details: {
-            income_above_threshold: nil,
+            income_above_threshold: 'yes',
             lost_job_in_custody: 'yes',
             date_job_lost: '2023-10-01',
           }
@@ -35,11 +34,10 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
 
   describe '#lost_job_in_custody' do
     context 'when lost_job_in_custody is nil' do
-      let(:applicant) do
+      let(:income_details) do
         instance_double(
-          Applicant,
-          first_name: 'Max',
-          last_name: 'Mustermann',
+          IncomeDetails,
+          income_above_threshold: 'yes',
           lost_job_in_custody: nil,
           date_job_lost: nil,
         )
@@ -49,7 +47,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
         {
           means_details: {
             income_details: {
-              income_above_threshold: nil,
+              income_above_threshold: 'yes'
             }
           }
         }.as_json

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
   subject { described_class.new(crime_application) }
 
   let(:crime_application) do
-    instance_double(CrimeApplication, income_details:)
+    instance_double(CrimeApplication, income:)
   end
 
   describe '#generate' do
-    let(:income_details) do
+    let(:income) do
       instance_double(
-        IncomeDetails,
+        Income,
         income_above_threshold: 'yes',
         lost_job_in_custody: 'yes',
         date_job_lost: '2023-10-01',
@@ -34,9 +34,9 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
 
   describe '#lost_job_in_custody' do
     context 'when lost_job_in_custody is nil' do
-      let(:income_details) do
+      let(:income) do
         instance_double(
-          IncomeDetails,
+          Income,
           income_above_threshold: 'yes',
           lost_job_in_custody: nil,
           date_job_lost: nil,

--- a/spec/services/adapters/structs/income_details_spec.rb
+++ b/spec/services/adapters/structs/income_details_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::IncomeDetails do
+  subject { application_struct.income }
+
+  let(:application_struct) { build_struct_application }
+
+  describe '#serializable_hash' do
+    it 'returns a serializable hash, including relationships' do
+      expect(
+        subject.serializable_hash
+      ).to match(
+        a_hash_including(
+          'income_above_threshold' => 'yes',
+          'lost_job_in_custody' => 'yes',
+          'date_job_lost' => Date.new(2023, 9, 1),
+        )
+      )
+    end
+
+    it 'contains all required attributes' do
+      expect(
+        subject.serializable_hash.keys
+      ).to match_array(
+        %w[
+          income_above_threshold
+          lost_job_in_custody
+          date_job_lost
+        ]
+      )
+    end
+  end
+end

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Datastore::ApplicationRehydration do
         means_passport: an_instance_of(Array),
         applicant: an_instance_of(Applicant),
         case: an_instance_of(Case),
+        income_details: an_instance_of(IncomeDetails),
         documents: all(be_a(Document)),
       )
 
@@ -45,7 +46,7 @@ RSpec.describe Datastore::ApplicationRehydration do
       ).and_call_original
 
       expect(
-        Applicant
+        IncomeDetails
       ).to receive(:new).with(
         hash_including(
           'lost_job_in_custody' => 'yes',

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datastore::ApplicationRehydration do
         means_passport: an_instance_of(Array),
         applicant: an_instance_of(Applicant),
         case: an_instance_of(Case),
-        income_details: an_instance_of(IncomeDetails),
+        income: an_instance_of(Income),
         documents: all(be_a(Document)),
       )
 
@@ -46,7 +46,7 @@ RSpec.describe Datastore::ApplicationRehydration do
       ).and_call_original
 
       expect(
-        IncomeDetails
+        Income
       ).to receive(:new).with(
         hash_including(
           'lost_job_in_custody' => 'yes',

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Datastore::ApplicationSubmission do
       types: ['loss_of_liberty'],
       loss_of_liberty_justification: 'Details about loss of liberty.',
     )
-    IncomeDetails.create(
+    Income.create(
       crime_application: app,
       income_above_threshold: 'yes'
     )

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Decisions::IncomeDecisionTree do
     instance_double(
       CrimeApplication,
       id: 'uuid',
-      income_details: income_details
+      income: income
     )
   end
 
-  let(:income_details) { instance_double(IncomeDetails, employment_status:) }
+  let(:income) { instance_double(Income, employment_status:) }
   let(:employment_status) { nil }
 
   before do

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Decisions::IncomeDecisionTree do
     instance_double(
       CrimeApplication,
       id: 'uuid',
-      applicant: applicant
+      income_details: income_details
     )
   end
 
-  let(:applicant) { instance_double(Applicant, employment_status:) }
+  let(:income_details) { instance_double(IncomeDetails, employment_status:) }
   let(:employment_status) { nil }
 
   before do


### PR DESCRIPTION
## Description of change
Move income detail columns from People to IncomeDetails table
Serialization and rehydration of income_above_threshold and lost_job

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-97

## How to manually test the feature

1. Run `bin/rails db:migrate RAILS_ENV=development`
2. Create a new application, fill all details but DO NOT SUBMIT
3. Go to /steps/income/clients_income_before_tax
4. Select 'Yes'
5. Hit Save and continue
6. Reopen that application
7. Go to Confirm declaration and submit application
8. Submit application 
9. Go to Review
10. Assign that application to your list
11. Return to provider for any reason
12. Go to Apply
13. Open application and select Update
14. Go to /steps/income/clients_income_before_tax - radio should be selected