### PR TITLE
[CRIMAP-66] Increase ClamAV readiness, reduce replicas

### DIFF
--- a/config/kubernetes/production/deployment-clamav.yml
+++ b/config/kubernetes/production/deployment-clamav.yml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clamav-production
+  namespace: laa-apply-for-criminal-legal-aid-production
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  minReadySeconds: 15
+  serviceName: clamav
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-clamav-production
+  template:
+    metadata:
+      labels:
+        app: apply-for-criminal-legal-aid-clamav-production
+        tier: backend
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: clamav
+        image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 3310
+            protocol: TCP
+        volumeMounts:
+          - mountPath: /var/lib/clamav
+            name: clamav-signatures
+        resources:
+          requests:
+            cpu: 25m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 3Gi
+        readinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 600
+          periodSeconds: 120
+        livenessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 600
+          periodSeconds: 120
+  volumeClaimTemplates:
+  - metadata:
+      name: clamav-signatures
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clamav-service-production
+  namespace: laa-apply-for-criminal-legal-aid-production
+  labels:
+    app: apply-for-criminal-legal-aid-clamav-production
+spec:
+  ports:
+  - port: 3310
+    name: clamav
+    targetPort: 3310
+  selector:
+    app: apply-for-criminal-legal-aid-clamav-production

--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -4,7 +4,7 @@ metadata:
   name: clamav-staging
   namespace: laa-apply-for-criminal-legal-aid-staging
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 2
   minReadySeconds: 15
   serviceName: clamav
@@ -45,13 +45,13 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 3310
-          initialDelaySeconds: 30
-          periodSeconds: 60
+          initialDelaySeconds: 600
+          periodSeconds: 120
         livenessProbe:
           tcpSocket:
             port: 3310
-          initialDelaySeconds: 30
-          periodSeconds: 60
+          initialDelaySeconds: 600
+          periodSeconds: 120
   volumeClaimTemplates:
   - metadata:
       name: clamav-signatures


### PR DESCRIPTION
## Description of change
Increases the delay for the `readinessProbe` to give clamav more time to download in production, testing in staging first

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66

## Notes for reviewer
This was tested in staging and worked as expected.

Reduces replicas from 2 down to 1 for troubleshooting purposes.

