### PR TITLE
[CRIMAP-66] Update deployment-clamav.yml with manual entrypoint

### DIFF
--- a/config/kubernetes/production/deployment-clamav.yml
+++ b/config/kubernetes/production/deployment-clamav.yml
@@ -29,6 +29,7 @@ spec:
       - name: clamav
         image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
         imagePullPolicy: Always
+        command: ['/bin/sh', '-c', 'freshclam && clamd && touch startup.txt && clamdscan startup.txt']
         ports:
           - containerPort: 3310
             protocol: TCP
@@ -45,12 +46,12 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 3310
-          initialDelaySeconds: 600
+          initialDelaySeconds: 300
           periodSeconds: 120
         livenessProbe:
           tcpSocket:
             port: 3310
-          initialDelaySeconds: 600
+          initialDelaySeconds: 300
           periodSeconds: 120
   volumeClaimTemplates:
   - metadata:

--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -29,6 +29,7 @@ spec:
       - name: clamav
         image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
         imagePullPolicy: Always
+        command: ['/bin/sh', '-c', 'freshclam && clamd && touch startup.txt && clamdscan startup.txt']
         ports:
           - containerPort: 3310
             protocol: TCP
@@ -45,12 +46,12 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 3310
-          initialDelaySeconds: 600
+          initialDelaySeconds: 300
           periodSeconds: 120
         livenessProbe:
           tcpSocket:
             port: 3310
-          initialDelaySeconds: 600
+          initialDelaySeconds: 300
           periodSeconds: 120
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
## Description of change
Manually forces `freshclam` to run on container build because the [Dockerfile.freshclammed](https://github.com/ministryofjustice/hmpps-utility-container-images/tree/main/hmpps-clamav) doesn't seem to run 
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66
## Notes for reviewer
Already Deployed to staging via command line, requires creation in Staging as part of build pipeline and then into production

## How to manually test the feature
On staging create a new evidence upload

On production watch the k8s pods and then log into the pod and try a manual file scan.
