### PR TITLE
[CRIMAPP-205] Serialize freezing order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.14'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.15'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b48032e21aad43524712cafc81c2f34bfe5d051a
-  tag: v1.0.14
+  revision: b2413e18e0961a1e65414dbf8928a151268555be
+  tag: v1.0.15
   specs:
-    laa-criminal-legal-aid-schemas (1.0.13)
+    laa-criminal-legal-aid-schemas (1.0.15)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -12,6 +12,7 @@ module SubmissionSerializer
                 json.ended_employment_within_three_months income.ended_employment_within_three_months
                 json.lost_job_in_custody income.lost_job_in_custody
                 json.date_job_lost income.date_job_lost
+                json.has_frozen_income_or_assets income.has_frozen_income_or_assets
                 json.manage_without_income income.manage_without_income
                 json.manage_other_details income.manage_other_details
               end

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
         ended_employment_within_three_months: 'yes',
         lost_job_in_custody: 'yes',
         date_job_lost: '2023-10-01',
+        has_frozen_income_or_assets: 'yes',
         manage_without_income: 'other',
         manage_other_details: 'Another way that they manage'
       )
@@ -30,6 +31,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
             ended_employment_within_three_months: 'yes',
             lost_job_in_custody: 'yes',
             date_job_lost: '2023-10-01',
+            has_frozen_income_or_assets: 'yes',
             manage_without_income: 'other',
             manage_other_details: 'Another way that they manage'
           }
@@ -49,6 +51,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
         ended_employment_within_three_months: nil,
         lost_job_in_custody: nil,
         date_job_lost: nil,
+        has_frozen_income_or_assets: nil,
         manage_without_income: nil,
         manage_other_details: nil
       )
@@ -63,6 +66,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
             ended_employment_within_three_months: nil,
             lost_job_in_custody: nil,
             date_job_lost: nil,
+            has_frozen_income_or_assets: nil,
             manage_without_income: nil,
             manage_other_details: nil,
           }


### PR DESCRIPTION
N.B. Merge https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/559 and https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/564 first
## Description of change
Serialize has_frozen_income_or_assets 
Bump schema to v1.0.15
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-205

## How to manually test the feature
bundle install 
update schema on datastore to v1.0.15 and bundle 
Create a new application, fill all details but DO NOT SUBMIT
Go to /steps/income/what_is_clients_employment_status
Select 'My client is not working', Select 'No'
Click Save and continue
Reopen that application
Go to /steps/income/clients_income_before_tax
Select 'Yes'
Click Save and continue
Reopen that application
Go to /steps/income/income_savings_assets_under_restraint_freezing_order
Click Save and continue
Reopen that application
Click Confirm declaration and submit application
Click Save and submit
Make sure it succeeds