### PR TITLE
Reorder and chain steps, add income path to dev tools

### DIFF
--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -7,15 +7,16 @@ module Decisions
         after_employment_status
       when :lost_job_in_custody
         # TODO: link to next step when we have it
-        edit(:manage_without_income)
+        edit(:income_before_tax)
       when :income_before_tax
         after_income_before_tax
       when :frozen_income_savings_assets
         after_frozen_income_savings_assets
+      when :client_owns_property
+        # TODO: link to next step when we have it
+        edit(:client_has_dependants)
       when :client_has_dependants
         after_client_has_dependants
-      when :client_owns_property
-        edit('/home', action: :index)
       when :manage_without_income
         # TODO: link to next step when we have it
         show('/home', action: :index)
@@ -32,9 +33,10 @@ module Decisions
         if ended_employment_within_three_months?
           edit(:lost_job_in_custody)
         else
-          show('/home', action: :index)
+          edit(:income_before_tax)
         end
       else
+        # TODO: Update exit page content to include unemployed
         show(:employed_exit)
       end
     end
@@ -44,7 +46,7 @@ module Decisions
         edit(:frozen_income_savings_assets)
       else
         # TODO: once we have the next step
-        show('/home', action: :index)
+        edit(:client_has_dependants)
       end
     end
 
@@ -53,13 +55,13 @@ module Decisions
         edit(:client_owns_property)
       else
         # TODO: once we have the next step
-        show('/home', action: :index)
+        edit(:client_has_dependants)
       end
     end
 
     def after_client_has_dependants
       # TODO: once we have the next step
-      show('/home', action: :index)
+      edit(:manage_without_income)
     end
 
     def not_working?

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -27,6 +27,9 @@
           <% end %>
 
           <% if crime_application.in_progress? %>
+             <%= button_to edit_steps_income_employment_status_path, method: :get,
+                          class: 'govuk-button govuk-!-margin-right-1',
+                          data: { module: 'govuk-button' } do; 'Income journey'; end %>
             <%= button_to developer_tools_crime_application_path, method: :delete,
                           class: 'govuk-button govuk-button--warning',
                           data: { module: 'govuk-button' } do; 'Destroy'; end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,11 +147,11 @@ Rails.application.routes.draw do
         edit_step :what_is_clients_employment_status, alias: :employment_status
         show_step :employed_exit
         edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody
-        edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
         edit_step :clients_income_before_tax, alias: :income_before_tax
         edit_step :income_savings_assets_under_restraint_freezing_order, alias: :frozen_income_savings_assets
         edit_step :does_client_own_home_land_property, alias: :client_owns_property
         edit_step :does_client_have_dependants, alias: :client_has_dependants
+        edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
       end
 
       namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
                                                  ended_employment_within_three_months: YesNoAnswer::NO)
         end
 
-        it { is_expected.to have_destination('/home', :index, id: crime_application) }
+        it { is_expected.to have_destination(:income_before_tax, :edit, id: crime_application) }
       end
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:step_name) { :lost_job_in_custody }
 
     context 'has correct next step' do
-      it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
+      it { is_expected.to have_destination(:income_before_tax, :edit, id: crime_application) }
     end
   end
 
@@ -77,7 +77,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
         allow(form_object).to receive_messages(income_above_threshold: YesNoAnswer::YES)
       end
 
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination(:client_has_dependants, :edit, id: crime_application) }
     end
 
     context 'when income below the threshold' do
@@ -98,7 +98,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
         allow(form_object).to receive_messages(has_frozen_income_or_assets: YesNoAnswer::YES)
       end
 
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination(:client_has_dependants, :edit, id: crime_application) }
     end
 
     context 'when they do not have frozen income or assets' do
@@ -115,22 +115,22 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:step_name) { :client_owns_property }
 
     context 'has correct next step' do
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
-    end
-  end
-
-  context 'when the step is `manage_without_income`' do
-    let(:form_object) { double('FormObject') }
-    let(:step_name) { :manage_without_income }
-
-    context 'has correct next step' do
-      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+      it { is_expected.to have_destination(:client_has_dependants, :edit, id: crime_application) }
     end
   end
 
   context 'when the step is `after_client_has_dependants`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :client_has_dependants }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `manage_without_income`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :manage_without_income }
 
     context 'has correct next step' do
       it { is_expected.to have_destination('/home', :index, id: crime_application) }


### PR DESCRIPTION
## Description of change
To help with manual testing, chain all income journey steps together, add a button in dev tools for Selenium to click to jump to the first page of the journey