### PR TITLE
[CRIMAPP-116] Rehydrate/Show employment details in CYA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.15'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.16'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b2413e18e0961a1e65414dbf8928a151268555be
-  tag: v1.0.15
+  revision: 718bb48b7808592555cb351a7b44fec0652f9c16
+  tag: v1.0.16
   specs:
     laa-criminal-legal-aid-schemas (1.0.15)
       dry-schema (~> 1.13)

--- a/app/presenters/summary/sections/employment_details.rb
+++ b/app/presenters/summary/sections/employment_details.rb
@@ -9,8 +9,18 @@ module Summary
         income.present? && super
       end
 
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
         [
+          Components::ValueAnswer.new(
+            # TODO: Handle array of employment_statuses when designs for employed available
+            :employment_status, income.employment_status.first,
+            change_path: edit_steps_income_employment_status_path
+          ),
+          Components::ValueAnswer.new(
+            :ended_employment_within_three_months, income.ended_employment_within_three_months,
+            change_path: edit_steps_income_employment_status_path
+          ),
           Components::ValueAnswer.new(
             :lost_job_in_custody, income.lost_job_in_custody,
             change_path: edit_steps_income_lost_job_in_custody_path
@@ -21,6 +31,7 @@ module Summary
           ),
         ].select(&:show?)
       end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       private
 

--- a/app/services/adapters/structs/income_details.rb
+++ b/app/services/adapters/structs/income_details.rb
@@ -1,10 +1,18 @@
 module Adapters
   module Structs
     class IncomeDetails < BaseStructAdapter
+      def employment_status
+        # TODO: Handle this having multiple employment status' when we get designs for employed
+        employment_type || []
+      end
+
       def serializable_hash(options = {})
         super(
           options.merge(
-            methods: []
+            methods: [:employment_status],
+            # `employment_type` is the name for employment_status
+            # in the datastore, we don't use it
+            except: [:employment_type]
           )
         )
       end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -175,6 +175,14 @@ en:
       # END passport justification for legal aid section
 
       # BEGIN employment details section
+      employment_status:
+        question: What is your client’s employment status?
+        answers:
+          'not_working': My client is not working
+      ended_employment_within_three_months:
+        question: Has your client ended employment in the last 3 months?
+        answers:
+          <<: *YESNO
       lost_job_in_custody:
         question: Did your client lose their job as a result of being in custody?
         answers:

--- a/spec/presenters/summary/sections/employment_details_spec.rb
+++ b/spec/presenters/summary/sections/employment_details_spec.rb
@@ -14,6 +14,8 @@ describe Summary::Sections::EmploymentDetails do
   let(:income) do
     instance_double(
       Income,
+      employment_status: ['not_working'],
+      ended_employment_within_three_months: 'yes',
       lost_job_in_custody: 'yes',
       date_job_lost: Date.new(2023, 11, 20),
     )
@@ -44,15 +46,23 @@ describe Summary::Sections::EmploymentDetails do
 
     context 'when there are income details' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(2)
+        expect(answers.count).to eq(4)
         expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[0].question).to eq(:lost_job_in_custody)
-        expect(answers[0].change_path).to match('applications/12345/steps/income/did_client_lose_job_being_in_custody')
-        expect(answers[0].value).to eq('yes')
-        expect(answers[1]).to be_an_instance_of(Summary::Components::DateAnswer)
-        expect(answers[1].question).to eq(:date_job_lost)
-        expect(answers[1].change_path).to match('applications/12345/steps/income/did_client_lose_job_being_in_custody')
-        expect(answers[1].value).to eq(Date.new(2023, 11, 20))
+        expect(answers[0].question).to eq(:employment_status)
+        expect(answers[0].change_path).to match('applications/12345/steps/income/what_is_clients_employment_status')
+        expect(answers[0].value).to eq('not_working')
+        expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[1].question).to eq(:ended_employment_within_three_months)
+        expect(answers[1].change_path).to match('applications/12345/steps/income/what_is_clients_employment_status')
+        expect(answers[1].value).to eq('yes')
+        expect(answers[2]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[2].question).to eq(:lost_job_in_custody)
+        expect(answers[2].change_path).to match('applications/12345/steps/income/did_client_lose_job_being_in_custody')
+        expect(answers[2].value).to eq('yes')
+        expect(answers[3]).to be_an_instance_of(Summary::Components::DateAnswer)
+        expect(answers[3].question).to eq(:date_job_lost)
+        expect(answers[3].change_path).to match('applications/12345/steps/income/did_client_lose_job_being_in_custody')
+        expect(answers[3].value).to eq(Date.new(2023, 11, 20))
       end
     end
   end

--- a/spec/services/adapters/structs/income_details_spec.rb
+++ b/spec/services/adapters/structs/income_details_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe Adapters::Structs::IncomeDetails do
         subject.serializable_hash
       ).to match(
         a_hash_including(
-          'income_above_threshold' => 'yes',
+          'employment_status' => ['not_working'],
+          'ended_employment_within_three_months' => 'yes',
           'lost_job_in_custody' => 'yes',
           'date_job_lost' => Date.new(2023, 9, 1),
+          'income_above_threshold' => 'yes',
         )
       )
     end
@@ -23,6 +25,8 @@ RSpec.describe Adapters::Structs::IncomeDetails do
         subject.serializable_hash.keys
       ).to match_array(
         %w[
+          employment_status
+          ended_employment_within_three_months
           income_above_threshold
           lost_job_in_custody
           date_job_lost


### PR DESCRIPTION
## Description of change
Show employment details in CYA
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-116
## Notes for reviewer
Designs are presumed based on the design on interim CYAs [here](https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?type=design&node-id=8959%3A130668&mode=design&t=zL5fWCdmRelppqV4-1)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="754" alt="Screenshot 2023-12-04 at 17 47 19" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/8331a3d9-4bd9-4a95-ad98-d4f706dac06e">

## How to manually test the feature

1. bundle install
2. Create a new application, fill all details but DO NOT SUBMIT
3. Go to /steps/income/what_is_clients_employment_status (now also in dev tools)
4. Select 'My client is not working', Select 'Yes'
5. Hit Save and continue
6. Select 'Yes', Enter 1/11/2023
8. Hit Save and continue
9. Select 'No' for £12,475
10. Hit Save and continue
11. Select 'No' for Freezing order
12. Hit Save and continue
13. Select 'No' for Freezing order
14. Hit Save and continue
15. Select 'No' for Own home
16. Hit Save and continue
13. Select 'No' for Dependants
14. Hit Save and continue
15. Select 'Other' Enter some text for manage no income
16. Hit Save and continue
17. Reopen that application
18. Go to Review the application - check table correct and matches designs and copy
19. Submit application - confirm submits ok
20. Hit View completed application - check table correct and matches designs and copy