### PR TITLE
[CRIMAPP-206] Rehydrate/add freezing order to CYA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.16'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.17'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 718bb48b7808592555cb351a7b44fec0652f9c16
-  tag: v1.0.16
+  revision: 0a7e5a48f01958505b85741200131cd7ac49e922
+  tag: v1.0.17
   specs:
-    laa-criminal-legal-aid-schemas (1.0.15)
+    laa-criminal-legal-aid-schemas (1.0.17)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -15,6 +15,10 @@ module Summary
             :income_above_threshold, income.income_above_threshold,
             change_path: edit_steps_income_income_before_tax_path
           ),
+          Components::ValueAnswer.new(
+            :has_frozen_income_or_assets, income.has_frozen_income_or_assets,
+            change_path: edit_steps_income_frozen_income_savings_assets_path
+          ),
         ].select(&:show?)
       end
 

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -196,6 +196,10 @@ en:
         question: Is your client’s income currently more than £12,475 a year before tax?
         answers:
           <<: *YESNO
+      has_frozen_income_or_assets:
+        question: Does your client have any income, savings or assets under a restraint or freezing order?
+        answers:
+          <<: *YESNO
       # END income details section
 
       # BEGIN legal representative details section

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -14,7 +14,8 @@ describe Summary::Sections::IncomeDetails do
   let(:income) do
     instance_double(
       Income,
-      income_above_threshold: 'yes'
+      income_above_threshold: 'no',
+      has_frozen_income_or_assets: 'no'
     )
   end
 
@@ -43,11 +44,17 @@ describe Summary::Sections::IncomeDetails do
 
     context 'when there are income details' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(1)
+        expect(answers.count).to eq(2)
         expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answers[0].question).to eq(:income_above_threshold)
         expect(answers[0].change_path).to match('applications/12345/steps/income/clients_income_before_tax')
-        expect(answers[0].value).to eq('yes')
+        expect(answers[0].value).to eq('no')
+        expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[1].question).to eq(:has_frozen_income_or_assets)
+        expect(answers[1].change_path).to match(
+          'applications/12345/steps/income/income_savings_assets_under_restraint_freezing_order'
+        )
+        expect(answers[1].value).to eq('no')
       end
     end
   end

--- a/spec/services/adapters/structs/income_details_spec.rb
+++ b/spec/services/adapters/structs/income_details_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Adapters::Structs::IncomeDetails do
           'lost_job_in_custody' => 'yes',
           'date_job_lost' => Date.new(2023, 9, 1),
           'income_above_threshold' => 'yes',
+          'has_frozen_income_or_assets' => 'no',
+          'has_savings' => 'no',
         )
       )
     end
@@ -27,9 +29,11 @@ RSpec.describe Adapters::Structs::IncomeDetails do
         %w[
           employment_status
           ended_employment_within_three_months
-          income_above_threshold
           lost_job_in_custody
           date_job_lost
+          income_above_threshold
+          has_frozen_income_or_assets
+          has_savings
         ]
       )
     end


### PR DESCRIPTION
## Description of change
Rehydrate/add freezing order to CYA
## Link to relevant ticket

## Notes for reviewer
https://dsdmoj.atlassian.net/browse/CRIMAPP-206
## Screenshots of changes (if applicable)

### After changes:
<img width="738" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/982ee339-b452-42e0-a3be-56b92172509c">

## How to manually test the feature

1. bundle install
2. Set schema gem in datastore to v1.0.17 and bundle install
3. Create a new application, fill all details but DO NOT SUBMIT
4. Go to /steps/income/what_is_clients_employment_status (now also in dev tools)
5. Select 'My client is not working', Select 'Yes'
6. Hit Save and continue
7. Select 'Yes', Enter 1/11/2023
8. Hit Save and continue
9. Select 'No' for £12,475
10. Hit Save and continue
11. Select 'No' for Freezing order
12. Hit Save and continue
13. Select 'No' for Freezing order
14. Hit Save and continue
15. Select 'No' for Own home
16. Hit Save and continue
17. Select 'No' for Dependants
18. Hit Save and continue
19. Select 'Other' Enter some text for manage no income
20. Hit Save and continue
21. Reopen that application
22. Go to Review the application - check table correct and matches designs and copy
23. Submit application - confirm submits ok
24. Hit View completed application - check table correct and matches designs and copy
25. Open Review
26. Find that application and return to provider
27. Open Apply
28. Find that application in returned tab and check table, click to update, check table, check resubmitting works