### PR TITLE
CRIMAPP-210 rehydrate property

### DIFF
--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -9,7 +9,7 @@ module Summary
         income.present? && super
       end
 
-      def answers
+      def answers # rubocop:disable  Metrics/MethodLength
         [
           Components::ValueAnswer.new(
             :income_above_threshold, income.income_above_threshold,
@@ -18,6 +18,10 @@ module Summary
           Components::ValueAnswer.new(
             :has_frozen_income_or_assets, income.has_frozen_income_or_assets,
             change_path: edit_steps_income_frozen_income_savings_assets_path
+          ),
+          Components::ValueAnswer.new(
+            :client_owns_property, income.client_owns_property,
+            change_path: edit_steps_income_client_owns_property_path
           ),
         ].select(&:show?)
       end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -201,6 +201,10 @@ en:
         question: Does your client have any income, savings or assets under a restraint or freezing order?
         answers:
           <<: *YESNO
+      client_owns_property:
+        question: Does your client own their home, or any other land or property?
+        answers:
+          <<: *YESNO
       # END income details section
 
       # BEGIN other sources of income details section

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -15,7 +15,8 @@ describe Summary::Sections::IncomeDetails do
     instance_double(
       Income,
       income_above_threshold: 'no',
-      has_frozen_income_or_assets: 'no'
+      has_frozen_income_or_assets: 'no',
+      client_owns_property: 'no'
     )
   end
 
@@ -45,16 +46,26 @@ describe Summary::Sections::IncomeDetails do
     context 'when there are income details' do
       it 'has the correct rows' do
         expect(answers.count).to eq(2)
+
+        # £12,475
         expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answers[0].question).to eq(:income_above_threshold)
         expect(answers[0].change_path).to match('applications/12345/steps/income/clients_income_before_tax')
         expect(answers[0].value).to eq('no')
+
+        # freezing order
         expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answers[1].question).to eq(:has_frozen_income_or_assets)
         expect(answers[1].change_path).to match(
           'applications/12345/steps/income/income_savings_assets_under_restraint_freezing_order'
         )
         expect(answers[1].value).to eq('no')
+
+        # client has property or land?
+        expect(answers[2]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[2].question).to eq(:client_owns_property)
+        expect(answers[2].change_path).to match('applications/12345/steps/income/does_client_own_home_land_property')
+        expect(answers[2].value).to eq('no')
       end
     end
   end

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -45,7 +45,7 @@ describe Summary::Sections::IncomeDetails do
 
     context 'when there are income details' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(2)
+        expect(answers.count).to eq(3)
 
         # £12,475
         expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -47,26 +47,26 @@ describe Summary::Sections::IncomeDetails do
       it 'has the correct rows' do
         expect(answers.count).to eq(3)
 
-        # £12,475
-        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[0].question).to eq(:income_above_threshold)
-        expect(answers[0].change_path).to match('applications/12345/steps/income/clients_income_before_tax')
-        expect(answers[0].value).to eq('no')
+        income_details_yes_no_row_check(0,
+                                        :income_above_threshold,
+                                        'clients_income_before_tax')
 
-        # freezing order
-        expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[1].question).to eq(:has_frozen_income_or_assets)
-        expect(answers[1].change_path).to match(
-          'applications/12345/steps/income/income_savings_assets_under_restraint_freezing_order'
-        )
-        expect(answers[1].value).to eq('no')
+        income_details_yes_no_row_check(1,
+                                        :has_frozen_income_or_assets,
+                                        'income_savings_assets_under_restraint_freezing_order')
 
-        # client has property or land?
-        expect(answers[2]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[2].question).to eq(:client_owns_property)
-        expect(answers[2].change_path).to match('applications/12345/steps/income/does_client_own_home_land_property')
-        expect(answers[2].value).to eq('no')
+        income_details_yes_no_row_check(2,
+                                        :client_owns_property,
+                                        'does_client_own_home_land_property')
       end
     end
+  end
+
+  def income_details_yes_no_row_check(index, step, path) # rubocop:disable Metrics/AbcSize
+    full_path = "applications/12345/steps/income/#{path}"
+    expect(answers[index]).to be_an_instance_of(Summary::Components::ValueAnswer)
+    expect(answers[index].question).to eq(step)
+    expect(answers[index].change_path).to match(full_path)
+    expect(answers[index].value).to eq('no')
   end
 end


### PR DESCRIPTION
## Description of change

Adds "Does your client own their home, or any other land or property?" answer to the CYA page

## Link to relevant ticket

## Screenshots of changes (if applicable)

### After changes:
<img width="707" alt="Screenshot 2023-12-13 at 16 36 41" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/b716c624-4964-416c-9cf5-2f9f7eec39c1">


## How to manually test the feature
- create new application
- go through inital application stages
- click on the dev tools to go to the income pages answer in the following way:
1. What is your client's employment status? -> My Client is not working -> No
2. £12,475 a year before tax? -> No
3. assets under a restraint or freezing order? -> No
4. Does your client own their home, or any other land or property? -> No
5. Does your client have any savings or investments? -> No
6. Does your client have any dependants? -> No
7. How does your client manage with no income? -> select any
8. Continue should take you back to application list
9. Click on the application and go to "Review the application" in the task list
10. Scroll to income section, you should see the new "Does your client own their home, or any other land or property?" Question in the section.
11. Submit the application, then send it back, go to CYA page and check that it still shows there and that it has rehydrated correcly.
12. change its value and and go back to CYA to check that it reflected there too.



