### PR TITLE
Add savings yes/no answer to CYA page

### DIFF
--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -23,6 +23,10 @@ module Summary
             :client_owns_property, income.client_owns_property,
             change_path: edit_steps_income_client_owns_property_path
           ),
+          Components::ValueAnswer.new(
+            :has_savings, income.has_savings,
+            change_path: edit_steps_income_has_savings_path
+          ),
         ].select(&:show?)
       end
 

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -205,6 +205,10 @@ en:
         question: Does your client own their home, or any other land or property?
         answers:
           <<: *YESNO
+      has_savings:
+        question: Does your client have any savings or investments?
+        answers:
+          <<: *YESNO
       # END income details section
 
       # BEGIN other sources of income details section

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -16,7 +16,8 @@ describe Summary::Sections::IncomeDetails do
       Income,
       income_above_threshold: 'no',
       has_frozen_income_or_assets: 'no',
-      client_owns_property: 'no'
+      client_owns_property: 'no',
+      has_savings: 'no'
     )
   end
 
@@ -42,27 +43,39 @@ describe Summary::Sections::IncomeDetails do
 
   describe '#answers' do
     let(:answers) { subject.answers }
+    let(:rows) {
+      [
+        [
+          :income_above_threshold,
+          'clients_income_before_tax'
+        ],
+        [
+          :has_frozen_income_or_assets,
+          'income_savings_assets_under_restraint_freezing_order'
+        ],
+        [
+          :client_owns_property,
+          'does_client_own_home_land_property'
+        ],
+        [
+          :has_savings,
+          'does_client_have_savings_investments'
+        ]
+      ]
+    }
 
     context 'when there are income details' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(3)
+        expect(answers.count).to eq(rows.size)
 
-        income_details_yes_no_row_check(0,
-                                        :income_above_threshold,
-                                        'clients_income_before_tax')
-
-        income_details_yes_no_row_check(1,
-                                        :has_frozen_income_or_assets,
-                                        'income_savings_assets_under_restraint_freezing_order')
-
-        income_details_yes_no_row_check(2,
-                                        :client_owns_property,
-                                        'does_client_own_home_land_property')
+        rows.each_with_index do |row, i|
+          income_details_yes_no_row_check(*row, i)
+        end
       end
     end
   end
 
-  def income_details_yes_no_row_check(index, step, path) # rubocop:disable Metrics/AbcSize
+  def income_details_yes_no_row_check(step, path, index) # rubocop:disable Metrics/AbcSize
     full_path = "applications/12345/steps/income/#{path}"
     expect(answers[index]).to be_an_instance_of(Summary::Components::ValueAnswer)
     expect(answers[index].question).to eq(step)


### PR DESCRIPTION
## Description of change

Adds "Does your client have any savings or investments?" answer to the CYA page

## Link to relevant ticket
[CRIMAPP-213](https://dsdmoj.atlassian.net/browse/CRIMAPP-213)

## Screenshots of changes (if applicable)

### After changes:

<img width="689" alt="Screenshot 2023-12-15 at 09 49 08" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/13377553/44d8a139-ece3-48cb-90c3-6b25125c87d2">


## How to manually test the feature
- create new application
- go through inital application stages
- click on the dev tools to go to the income pages answer in the following way:
1. What is your client's employment status? -> My Client is not working -> No
2. £12,475 a year before tax? -> No
3. assets under a restraint or freezing order? -> No
4. Does your client own their home, or any other land or property? -> No
5. Does your client have any savings or investments? -> Yes
6. Does your client have any dependants? -> No
7. How does your client manage with no income? -> select any
8. Continue should take you back to application list
9. Click on the application and go to "Review the application" in the task list
10. Scroll to income section, you should see the new "Does your client have any savings or investments?" Question in the section.
11. Submit the application, then send it back, go to CYA page and check that it still shows there and that it has rehydrated correcly.
12. change its value and and go back to CYA to check that it reflected there too.




## How to manually test the feature


[CRIMAPP-213]: https://dsdmoj.atlassian.net/browse/CRIMAPP-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ