### PR TITLE
Create outgoings table, add outgoings more than income page

### DIFF
--- a/app/controllers/steps/outgoings/outgoings_more_than_income_controller.rb
+++ b/app/controllers/steps/outgoings/outgoings_more_than_income_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Outgoings
+    class OutgoingsMoreThanIncomeController < Steps::OutgoingsStepController
+      def edit
+        @form_object = OutgoingsMoreThanIncomeForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(OutgoingsMoreThanIncomeForm, as: :outgoings_more_than_income)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/outgoings_step_controller.rb
+++ b/app/controllers/steps/outgoings_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class OutgoingsStepController < BaseStepController
+    private
+
+    def decision_tree_class
+      Decisions::OutgoingsDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/outgoings/outgoings_more_than_income_form.rb
+++ b/app/forms/steps/outgoings/outgoings_more_than_income_form.rb
@@ -1,0 +1,28 @@
+module Steps
+  module Outgoings
+    class OutgoingsMoreThanIncomeForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :outgoings
+
+      attribute :outgoings_more_than_income, :value_object, source: YesNoAnswer
+      attribute :how_manage, :string
+
+      validates_inclusion_of :outgoings_more_than_income, in: :choices
+      validates :how_manage,
+                presence: true,
+                if: -> { outgoings_more_than_income&.yes? }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        outgoings.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -6,6 +6,7 @@ class CrimeApplication < ApplicationRecord
   has_one :applicant, dependent: :destroy
   has_one :partner, dependent: :destroy
   has_one :income, dependent: :destroy
+  has_one :outgoings, dependent: :destroy
 
   has_many :people, dependent: :destroy
   has_many :documents, dependent: :destroy

--- a/app/models/outgoings.rb
+++ b/app/models/outgoings.rb
@@ -1,0 +1,3 @@
+class Outgoings < ApplicationRecord
+  belongs_to :crime_application
+end

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -1,0 +1,13 @@
+module Decisions
+  class OutgoingsDecisionTree < BaseDecisionTree
+    def destination
+      case step_name
+      when :outgoings_more_than_income
+        # TODO: link to next step when we have it
+        show('/home', action: :index)
+      else
+        raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+  end
+end

--- a/app/views/steps/income/lost_job_in_custody/edit.html.erb
+++ b/app/views/steps/income/lost_job_in_custody/edit.html.erb
@@ -8,7 +8,7 @@
     <%= step_form @form_object do |f| %>
         <%= f.govuk_radio_buttons_fieldset(:lost_job_in_custody, legend: { tag: 'h1', size: 'xl' }) do %>
           <% @form_object.choices.each_with_index do |choice, index| %>
-            <% if choice == YesNoAnswer::YES %>
+            <% if choice.yes? %>
               <%= f.govuk_radio_button :lost_job_in_custody, choice.value do %>
                 <%= f.govuk_date_field :date_job_lost, maxlength_enabled: true,
                                        legend: {

--- a/app/views/steps/outgoings/outgoings_more_than_income/edit.html.erb
+++ b/app/views/steps/outgoings/outgoings_more_than_income/edit.html.erb
@@ -1,0 +1,26 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+     <%= step_form @form_object do |f| %>
+        <%= f.govuk_radio_buttons_fieldset :outgoings_more_than_income, legend: { text: t('.outgoings_more_than_income'), tag: 'h1', size: 'xl' } do %>
+          <% @form_object.choices.each_with_index do |choice, index| %>
+            <% if choice == YesNoAnswer::YES %>
+              <%= f.govuk_radio_button :outgoings_more_than_income, choice.value do %>
+                <%= f.govuk_text_area :how_manage,
+                                      legend: {
+                                        size: 's', class: 'govuk-!-font-weight-regular'
+                                      } %>
+              <% end %>
+            <% else %>
+              <%= f.govuk_radio_button :outgoings_more_than_income, choice.value, link_errors: index.zero? %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/outgoings/outgoings_more_than_income/edit.html.erb
+++ b/app/views/steps/outgoings/outgoings_more_than_income/edit.html.erb
@@ -7,7 +7,7 @@
      <%= step_form @form_object do |f| %>
         <%= f.govuk_radio_buttons_fieldset :outgoings_more_than_income, legend: { text: t('.outgoings_more_than_income'), tag: 'h1', size: 'xl' } do %>
           <% @form_object.choices.each_with_index do |choice, index| %>
-            <% if choice == YesNoAnswer::YES %>
+            <% if choice.yes? %>
               <%= f.govuk_radio_button :outgoings_more_than_income, choice.value do %>
                 <%= f.govuk_text_area :how_manage,
                                       legend: {

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -323,6 +323,12 @@ en:
               inclusion: Select how your client manages with no income
             manage_other_details:
               blank: Enter details on how your client manages with no income
+        steps/outgoings/outgoings_more_than_income_form:
+          attributes:
+            outgoings_more_than_income:
+              inclusion: Select yes if your client’s outgoings are more than their income
+            how_manage:
+              blank: Enter how your client manages if their outgoings are more than their income
         steps/submission/declaration_form:
           attributes:
             legal_rep_first_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -63,6 +63,8 @@ en:
         lost_job_in_custody: Did your client lose their job as a result of being in custody?
       steps_income_manage_without_income_form:
         manage_without_income: How does your client manage with no income?
+      steps_outgoings_outgoings_more_than_income:
+        outgoings_more_than_income: Are your client’s outgoings more than their income?
 
     hint:
       steps_client_details_form:
@@ -249,6 +251,9 @@ en:
           custody: They have been in custody for more than 3 months
           other: Other
         manage_other_details: Tell us how your client manages with no income
+      steps_outgoings_outgoings_more_than_income_form:
+        outgoings_more_than_income_options: *YESNO
+        how_manage: How does your client manage if their outgoings are more than their income?
       steps_evidence_upload_form:
         upload_files: Upload files
       steps_submission_declaration_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -251,6 +251,13 @@ en:
         edit:
           page_title: How does client manage with no income?
 
+    outgoings:
+      caption: Outgoings assessment
+      outgoings_more_than_income:
+        edit:
+          page_title: Are your client’s outgoings more than their income?
+          outgoings_more_than_income: Are your client’s outgoings more than their income?
+
     evidence:
       upload:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,10 @@ Rails.application.routes.draw do
         edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
       end
 
+      namespace :outgoings, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
+        edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
+      end
+
       namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
         edit_step :upload
       end

--- a/db/migrate/20231218162300_create_outgoings.rb
+++ b/db/migrate/20231218162300_create_outgoings.rb
@@ -1,0 +1,12 @@
+class CreateOutgoings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :outgoings, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false, index: { unique: true }
+      
+      t.string :outgoings_more_than_income
+      t.string :how_manage
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_07_181336) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_18_162300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -160,6 +160,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_181336) do
     t.index ["charge_id"], name: "index_offence_dates_on_charge_id"
   end
 
+  create_table "outgoings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.string "outgoings_more_than_income"
+    t.string "how_manage"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
+  end
+
   create_table "people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -208,5 +217,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_181336) do
   add_foreign_key "incomes", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
+  add_foreign_key "outgoings", "crime_applications"
   add_foreign_key "people", "crime_applications"
 end

--- a/spec/controllers/steps/outgoings/outgoings_more_than_income_controller_spec.rb
+++ b/spec/controllers/steps/outgoings/outgoings_more_than_income_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::OutgoingsMoreThanIncomeController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Outgoings::OutgoingsMoreThanIncomeForm,
+                  Decisions::OutgoingsDecisionTree
+end

--- a/spec/forms/steps/outgoings/outgoings_more_than_income_form_spec.rb
+++ b/spec/forms/steps/outgoings/outgoings_more_than_income_form_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::OutgoingsMoreThanIncomeForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      outgoings_more_than_income:,
+      how_manage:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, outgoings:) }
+  let(:outgoings) { instance_double(Outgoings) }
+
+  let(:outgoings_more_than_income) { nil }
+  let(:how_manage) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `outgoings_more_than_income` is blank' do
+      let(:outgoings_more_than_income) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:outgoings_more_than_income, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `outgoings_more_than_income` is invalid' do
+      let(:outgoings_more_than_income) { 'invalid_selection' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:outgoings_more_than_income, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `outgoings_more_than_income` is `NO`' do
+      let(:outgoings_more_than_income) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:outgoings_more_than_income, :invalid)).to be(false)
+      end
+
+      it 'updates the record' do
+        expect(outgoings).to receive(:update)
+          .with({
+                  'outgoings_more_than_income' => YesNoAnswer::NO,
+            'how_manage' => nil
+                })
+          .and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :outgoings,
+                      expected_attributes: {
+                        'outgoings_more_than_income' => YesNoAnswer::NO,
+                        'how_manage' => nil
+                      }
+    end
+
+    context 'when `outgoings_more_than_income` is `YES`' do
+      let(:outgoings_more_than_income) { YesNoAnswer::YES.to_s }
+
+      context 'when `how_manage` is blank' do
+        it 'has is a validation error on the field' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:how_manage, :blank)).to be(true)
+        end
+      end
+
+      context 'when `how_manage` is not blank' do
+        let(:how_manage) { 'A description of of they manage' }
+
+        it 'there is no validation error on the field' do
+          expect(form).to be_valid
+          expect(form.errors.of_kind?(:how_manage, :blank)).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Decisions::OutgoingsDecisionTree do
+  subject { described_class.new(form_object, as: step_name) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      id: 'uuid',
+      outgoings: outgoings
+    )
+  end
+
+  let(:outgoings) { instance_double(Outgoings) }
+
+  before do
+    allow(
+      form_object
+    ).to receive(:crime_application).and_return(crime_application)
+  end
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `outgoings_more_than_income`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :outgoings_more_than_income }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Create outgoings table, add outgoings more than income page

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-226
## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="1064" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/dd317c19-e797-410a-97ff-06696de5e056">

## How to manually test the feature

1. rails db:migrate
2. start a new application
3. go to steps/outgoings/are_clients_outgoings_more_than_income
4. submit with no selection to check errors https://docs.google.com/spreadsheets/d/1gdDpuyqWO6MJgUT1SOy0nbHd8AAdp1YebBzh1WDG040/edit#gid=0&range=B58:B59
5. select yes and input no text, submit to check errors
6. enter text and submit to check submits and doesn't raise an error
