### PR TITLE
BUGFIX: Fix back links for income/outgoings journey

### DIFF
--- a/app/views/steps/income/client_has_dependants/edit.html.erb
+++ b/app/views/steps/income/client_has_dependants/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/client_owns_property/edit.html.erb
+++ b/app/views/steps/income/client_owns_property/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/employment_status/edit.html.erb
+++ b/app/views/steps/income/employment_status/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/frozen_income_savings_assets/edit.html.erb
+++ b/app/views/steps/income/frozen_income_savings_assets/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/has_savings/edit.html.erb
+++ b/app/views/steps/income/has_savings/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/lost_job_in_custody/edit.html.erb
+++ b/app/views/steps/income/lost_job_in_custody/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/income/manage_without_income/edit.html.erb
+++ b/app/views/steps/income/manage_without_income/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/outgoings/outgoings_more_than_income/edit.html.erb
+++ b/app/views/steps/outgoings/outgoings_more_than_income/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header(path: crime_applications_path) %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Description of change

Fixes the back link for the income and new outgoings journeys. Was just a copy paste error. The `step_header` helper accepts a path as an overide which can be used on pages where the back link just needs to go back to the landing page or some other page when the user isn't in an application journey.

Issue was that we were passing `<% step_header(path: crime_applications_path) %>` on the steps and overriding the default behaviour of utilising the navigation stack to get the back link.

## Link to relevant ticket
n/a

## How to manually test the feature
- check back links on the current live journey they should be uneffected.
- start a new application, go past the initial client details page, then use dev tools sto start the income journey.
- go through the income journey, and after you submit each step click the back link, and make sure it takes you back to the last step you were on.
