### PR TITLE
Serialize outgoings, with first attrs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.20'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.21'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ec72e9c9cc930a3c6eee3873fac717d855e7ab2a
-  tag: v1.0.20
+  revision: ed3974fdef335ba06096e214589a29546140b723
+  tag: v1.0.21
   specs:
-    laa-criminal-legal-aid-schemas (1.0.20)
+    laa-criminal-legal-aid-schemas (1.0.21)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -20,6 +20,14 @@ module SubmissionSerializer
                 json.manage_without_income income.manage_without_income
                 json.manage_other_details income.manage_other_details
               end
+
+              json.outgoings_details do
+                # TODO: Update to take array from outgoings payments when we get
+                # there - needs to default to []
+                json.outgoings []
+                json.outgoings_more_than_income outgoings&.outgoings_more_than_income
+                json.how_manage outgoings&.how_manage
+              end
             end
           end
         end
@@ -30,6 +38,10 @@ module SubmissionSerializer
 
       def income
         @income ||= crime_application.income
+      end
+
+      def outgoings
+        @outgoings ||= crime_application.outgoings
       end
     end
   end

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -19,6 +19,10 @@ module Adapters
         Structs::IncomeDetails.new(means_details.income_details)
       end
 
+      def outgoings
+        Structs::OutgoingsDetails.new(means_details.outgoings_details)
+      end
+
       def documents
         supporting_evidence.map do |struct|
           Document.new(

--- a/app/services/adapters/structs/outgoings_details.rb
+++ b/app/services/adapters/structs/outgoings_details.rb
@@ -1,0 +1,13 @@
+module Adapters
+  module Structs
+    class OutgoingsDetails < BaseStructAdapter
+      def serializable_hash(options = {})
+        super(
+          options.merge(
+            methods: []
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
     instance_double(
       CrimeApplication,
       income:,
+      outgoings:,
       dependants:
     )
   end
@@ -32,6 +33,14 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
       )
     end
 
+    let(:outgoings) do
+      instance_double(
+        Outgoings,
+        outgoings_more_than_income: 'yes',
+        how_manage: 'A description of how they manage'
+      )
+    end
+
     let(:json_output) do
       {
         means_details: {
@@ -47,6 +56,12 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
             has_savings: 'yes',
             manage_without_income: 'other',
             manage_other_details: 'Another way that they manage'
+          },
+          outgoings_details: {
+            # TODO: Outgoings array currently hardcoded in serializer
+            outgoings: [],
+            outgoings_more_than_income: 'yes',
+            how_manage: 'A description of how they manage'
           }
         }
       }.as_json
@@ -72,6 +87,14 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
       )
     end
 
+    let(:outgoings) do
+      instance_double(
+        Outgoings,
+        outgoings_more_than_income: nil,
+        how_manage: nil
+      )
+    end
+
     let(:json_output) do
       {
         means_details: {
@@ -87,6 +110,12 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
             has_savings: nil,
             manage_without_income: nil,
             manage_other_details: nil,
+          },
+          outgoings_details: {
+            # TODO: Outgoings array currently hardcoded in serializer
+            outgoings: [],
+            outgoings_more_than_income: nil,
+            how_manage: nil
           }
         }
       }.as_json

--- a/spec/services/adapters/structs/crime_application_spec.rb
+++ b/spec/services/adapters/structs/crime_application_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Adapters::Structs::CrimeApplication do
     end
   end
 
+  describe '#income' do
+    it 'returns the income struct' do
+      expect(subject.income).to be_a(Adapters::Structs::IncomeDetails)
+    end
+  end
+
+  describe '#outgoings' do
+    it 'returns the outgoings struct' do
+      expect(subject.outgoings).to be_a(Adapters::Structs::OutgoingsDetails)
+    end
+  end
+
   describe '#documents' do
     it 'returns documents' do
       expect(subject.documents).to all(be_a(Document))

--- a/spec/services/adapters/structs/outgoings_details_spec.rb
+++ b/spec/services/adapters/structs/outgoings_details_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Adapters::Structs::OutgoingsDetails do
+  subject { application_struct.outgoings }
+
+  let(:application_struct) { build_struct_application }
+
+  describe '#serializable_hash' do
+    it 'returns a serializable hash' do
+      expect(
+        subject.serializable_hash
+      ).to match(
+        a_hash_including(
+          'outgoings_more_than_income' => 'yes',
+          'how_manage' => 'A description of how they manage'
+        )
+      )
+    end
+
+    it 'contains all required attributes' do
+      expect(
+        subject.serializable_hash.keys
+      ).to match_array(
+        %w[
+          outgoings_more_than_income
+          how_manage
+        ]
+      )
+    end
+  end
+end

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -76,9 +76,15 @@ RSpec.describe Datastore::ApplicationSubmission do
       types: ['loss_of_liberty'],
       loss_of_liberty_justification: 'Details about loss of liberty.',
     )
+
     Income.create(
       crime_application: app,
       income_above_threshold: 'yes'
+    )
+
+    Outgoings.create(
+      crime_application: app,
+      outgoings_more_than_income: 'no'
     )
   end
 


### PR DESCRIPTION
## Description of change
Serialize outgoings, with first attrs

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-227
## Notes for reviewer
outgoings array is hardcoded as this ticket is not for that attribute, but the schema requires something. It will be an empty array if no options are selected (or maybe ['none']

## How to manually test the feature

1. `bundle install`
2. Create a new application, fill all details but DO NOT SUBMIT
3. Go to /steps/outgoings/are_clients_outgoings_more_than_income
4. Select 'Yes'
5. Enter some text in the text area
6. Click Save and continue
7. Reopen that application
8. Click Confirm declaration and submit application
9. Make sure submits ok
10. Click View completed application
11. Copy the UUID from the url
12. Run `rails c` in your datastore locally
13. Enter `a = CrimeApplication.find('UUID')`
14. Enter a.submitted_application
15. Make sure application has a means_details>outgoings_details