### PR TITLE
[CRIMAP-223/225/114] Outgoings 'Paid 40% Tax Rate'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.21'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.22'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ed3974fdef335ba06096e214589a29546140b723
-  tag: v1.0.21
+  revision: c9cb2408e024bc9dc437c21c888025a98e21f02f
+  tag: v1.0.22
   specs:
-    laa-criminal-legal-aid-schemas (1.0.21)
+    laa-criminal-legal-aid-schemas (1.0.22)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/controllers/steps/outgoings/income_tax_rate_controller.rb
+++ b/app/controllers/steps/outgoings/income_tax_rate_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Outgoings
+    class IncomeTaxRateController < Steps::OutgoingsStepController
+      def edit
+        @form_object = IncomeTaxRateForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(IncomeTaxRateForm, as: :income_tax_rate)
+      end
+    end
+  end
+end

--- a/app/forms/steps/outgoings/income_tax_rate_form.rb
+++ b/app/forms/steps/outgoings/income_tax_rate_form.rb
@@ -1,0 +1,24 @@
+module Steps
+  module Outgoings
+    class IncomeTaxRateForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :outgoings
+
+      attribute :income_tax_rate_above_threshold, :value_object, source: YesNoAnswer
+
+      validates_inclusion_of :income_tax_rate_above_threshold, in: :choices
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        outgoings.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -25,6 +25,7 @@ module SubmissionSerializer
                 # TODO: Update to take array from outgoings payments when we get
                 # there - needs to default to []
                 json.outgoings []
+                json.income_tax_rate_above_threshold outgoings&.income_tax_rate_above_threshold
                 json.outgoings_more_than_income outgoings&.outgoings_more_than_income
                 json.how_manage outgoings&.how_manage
               end

--- a/app/services/adapters/structs/outgoings_details.rb
+++ b/app/services/adapters/structs/outgoings_details.rb
@@ -4,7 +4,8 @@ module Adapters
       def serializable_hash(options = {})
         super(
           options.merge(
-            methods: []
+            methods: [],
+            except: [:outgoings],
           )
         )
       end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -22,6 +22,7 @@ module Datastore
         income: income,
         documents: parent.documents,
         dependants: dependants,
+        outgoings: outgoings,
       )
     end
 
@@ -77,6 +78,12 @@ module Datastore
 
     def client_has_dependants
       parent.means_details&.dependants&.any? ? YesNoAnswer::YES : YesNoAnswer::NO
+    end
+
+    def outgoings
+      return if parent.outgoings.blank?
+
+      Outgoings.new(parent.outgoings.serializable_hash)
     end
   end
 end

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -2,6 +2,8 @@ module Decisions
   class OutgoingsDecisionTree < BaseDecisionTree
     def destination
       case step_name
+      when :income_tax_rate
+        edit(:outgoings_more_than_income)
       when :outgoings_more_than_income
         # TODO: link to next step when we have it
         show('/home', action: :index)

--- a/app/views/steps/outgoings/income_tax_rate/edit.html.erb
+++ b/app/views/steps/outgoings/income_tax_rate/edit.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :income_tax_rate_above_threshold, @form_object.choices,
+                                           :value, inline: false,
+                                           legend: { text: t('.income_tax_rate_above_threshold'), tag: 'h1', size: 'xl' } do %>
+        <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -323,6 +323,10 @@ en:
               inclusion: Select how your client manages with no income
             manage_other_details:
               blank: Enter details on how your client manages with no income
+        steps/outgoings/income_tax_rate_form:
+          attributes:
+            income_tax_rate_above_threshold:
+              inclusion: Select yes if in the last 2 years, your client has paid the 40% income tax rate
         steps/outgoings/outgoings_more_than_income_form:
           attributes:
             outgoings_more_than_income:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -251,6 +251,8 @@ en:
           custody: They have been in custody for more than 3 months
           other: Other
         manage_other_details: Tell us how your client manages with no income
+      steps_outgoings_income_tax_rate_form:
+        income_tax_rate_above_threshold_options: *YESNO
       steps_outgoings_outgoings_more_than_income_form:
         outgoings_more_than_income_options: *YESNO
         how_manage: How does your client manage if their outgoings are more than their income?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -253,6 +253,10 @@ en:
 
     outgoings:
       caption: Outgoings assessment
+      income_tax_rate:
+        edit:
+          page_title: In the last 2 years, has your client paid the 40% income tax rate?
+          income_tax_rate_above_threshold: In the last 2 years, has your client paid the 40% income tax rate?
       outgoings_more_than_income:
         edit:
           page_title: Are your client’s outgoings more than their income?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
       end
 
       namespace :outgoings, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
+        edit_step :has_client_paid_income_tax_rate, alias: :income_tax_rate
         edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
       end
 

--- a/db/migrate/20231220184900_add_income_tax_above_threshold_to_outgoings.rb
+++ b/db/migrate/20231220184900_add_income_tax_above_threshold_to_outgoings.rb
@@ -1,0 +1,5 @@
+class AddIncomeTaxAboveThresholdToOutgoings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :outgoings, :income_tax_rate_above_threshold, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_18_162300) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_20_184900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -114,6 +114,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_162300) do
     t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 
+  create_table "income_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "payment_type"
+    t.integer "amount"
+    t.string "frequency"
+    t.string "details"
+    t.index ["crime_application_id"], name: "index_income_payments_on_crime_application_id"
+  end
+
   create_table "incomes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "income_above_threshold"
@@ -166,6 +177,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_162300) do
     t.string "how_manage"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "income_tax_rate_above_threshold"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 
@@ -214,6 +226,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_162300) do
   add_foreign_key "codefendants", "cases"
   add_foreign_key "dependants", "crime_applications"
   add_foreign_key "documents", "crime_applications"
+  add_foreign_key "income_payments", "crime_applications"
   add_foreign_key "incomes", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -114,17 +114,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_184900) do
     t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 
-  create_table "income_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "crime_application_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "payment_type"
-    t.integer "amount"
-    t.string "frequency"
-    t.string "details"
-    t.index ["crime_application_id"], name: "index_income_payments_on_crime_application_id"
-  end
-
   create_table "incomes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "income_above_threshold"
@@ -226,7 +215,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_184900) do
   add_foreign_key "codefendants", "cases"
   add_foreign_key "dependants", "crime_applications"
   add_foreign_key "documents", "crime_applications"
-  add_foreign_key "income_payments", "crime_applications"
   add_foreign_key "incomes", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"

--- a/spec/controllers/steps/outgoings/income_tax_rate_controller_spec.rb
+++ b/spec/controllers/steps/outgoings/income_tax_rate_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::IncomeTaxRateController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Outgoings::IncomeTaxRateForm,
+                  Decisions::OutgoingsDecisionTree
+end

--- a/spec/forms/steps/outgoings/income_tax_rate_form_spec.rb
+++ b/spec/forms/steps/outgoings/income_tax_rate_form_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::IncomeTaxRateForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      income_tax_rate_above_threshold:,
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, outgoings:) }
+  let(:outgoings) { instance_double(Outgoings) }
+
+  let(:income_tax_rate_above_threshold) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `income_tax_rate_above_threshold` is blank' do
+      let(:income_tax_rate_above_threshold) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:income_tax_rate_above_threshold, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `income_tax_rate_above_threshold` is invalid' do
+      let(:income_tax_rate_above_threshold) { 'invalid_selection' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:income_tax_rate_above_threshold, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `income_tax_rate_above_threshold` is valid' do
+      let(:income_tax_rate_above_threshold) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:income_tax_rate_above_threshold, :invalid)).to be(false)
+      end
+
+      it 'updates the record' do
+        expect(outgoings).to receive(:update)
+          .with({ 'income_tax_rate_above_threshold' => YesNoAnswer::NO })
+          .and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :outgoings,
+                      expected_attributes: {
+                        'income_tax_rate_above_threshold' => YesNoAnswer::NO,
+                      }
+    end
+  end
+end

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
     let(:outgoings) do
       instance_double(
         Outgoings,
+        income_tax_rate_above_threshold: 'no',
         outgoings_more_than_income: 'yes',
         how_manage: 'A description of how they manage'
       )
@@ -60,6 +61,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
           outgoings_details: {
             # TODO: Outgoings array currently hardcoded in serializer
             outgoings: [],
+            income_tax_rate_above_threshold: 'no',
             outgoings_more_than_income: 'yes',
             how_manage: 'A description of how they manage'
           }
@@ -90,6 +92,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
     let(:outgoings) do
       instance_double(
         Outgoings,
+        income_tax_rate_above_threshold: nil,
         outgoings_more_than_income: nil,
         how_manage: nil
       )
@@ -114,6 +117,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
           outgoings_details: {
             # TODO: Outgoings array currently hardcoded in serializer
             outgoings: [],
+            income_tax_rate_above_threshold: nil,
             outgoings_more_than_income: nil,
             how_manage: nil
           }

--- a/spec/services/adapters/structs/outgoings_details_spec.rb
+++ b/spec/services/adapters/structs/outgoings_details_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Adapters::Structs::OutgoingsDetails do
         subject.serializable_hash
       ).to match(
         a_hash_including(
+          'income_tax_rate_above_threshold' => 'no',
           'outgoings_more_than_income' => 'yes',
           'how_manage' => 'A description of how they manage'
         )
@@ -22,10 +23,15 @@ RSpec.describe Adapters::Structs::OutgoingsDetails do
         subject.serializable_hash.keys
       ).to match_array(
         %w[
+          income_tax_rate_above_threshold
           outgoings_more_than_income
           how_manage
         ]
       )
+    end
+
+    it 'omits outgoings array' do
+      expect(subject.serializable_hash.key?('outgoings')).to be false
     end
   end
 end

--- a/spec/services/datastore/application_rehydration_spec.rb
+++ b/spec/services/datastore/application_rehydration_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Datastore::ApplicationRehydration do
         income: an_instance_of(Income),
         documents: all(be_a(Document)),
         dependants: all(be_a(Dependant)),
+        outgoings: an_instance_of(Outgoings),
       )
 
       expect(

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
 
   it_behaves_like 'a decision tree'
 
+  context 'when the step is `income_tax_rate`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :income_tax_rate }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination(:outgoings_more_than_income, :edit, id: crime_application) }
+    end
+  end
+
   context 'when the step is `outgoings_more_than_income`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :outgoings_more_than_income }


### PR DESCRIPTION
## Description of change
Introduces new Outgoings form 'In the last 2 years, has your client paid the 40% income tax rate?'.

Introduces Outgoings rehydration.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-223
https://dsdmoj.atlassian.net/browse/CRIMAPP-225
https://dsdmoj.atlassian.net/browse/CRIMAPP-114 (Part)

## Notes for reviewer
- The `Outgoings` model breaks convention - it should be `Outgoing` singular. Does this matter?
- The rehydration of Outgoings omits the `outgoings` field which is not present in the Apply database, pending CRIMAP-98

## Screenshots of changes (if applicable)

### Before changes:
N/A
### After changes:
<img width="726" alt="Screenshot 2023-12-21 at 09 45 20" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/58def4d9-6b65-41c0-a184-b0c36cbc0eb2">


#### On error
<img width="707" alt="Screenshot 2023-12-21 at 09 49 13" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/6c376de7-f213-49b4-8905-018958beb321">

## How to manually test the feature
