### PR TITLE
[CRIMAPP-228] Add other outgoings details to CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -22,6 +22,7 @@ module Summary
         Sections::EmploymentDetails.new(crime_application),
         Sections::IncomeDetails.new(crime_application),
         Sections::OtherIncomeDetails.new(crime_application),
+        Sections::OtherOutgoingsDetails.new(crime_application),
         Sections::SupportingEvidence.new(crime_application),
         Sections::LegalRepresentativeDetails.new(crime_application),
       ].select(&:show?)

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -17,6 +17,10 @@ module Summary
         'steps/submission/shared/section'
       end
 
+      def name
+        self.class.name.split('::').last.underscore.to_sym
+      end
+
       # May be overridden in subclasses to hide/show if appropriate
       def show?
         answers.any?

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class CaseDetails < Sections::BaseSection
-      def name
-        :case_details
-      end
-
       def show?
         kase.present? && super
       end

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class ClientDetails < Sections::BaseSection
-      def name
-        :client_details
-      end
-
       def show?
         applicant.present? && super
       end

--- a/app/presenters/summary/sections/codefendants.rb
+++ b/app/presenters/summary/sections/codefendants.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class Codefendants < Sections::BaseSection
-      def name
-        :codefendants
-      end
-
       def show?
         kase.present? && super
       end

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class ContactDetails < Sections::BaseSection
-      def name
-        :contact_details
-      end
-
       def show?
         applicant.present? && super
       end

--- a/app/presenters/summary/sections/employment_details.rb
+++ b/app/presenters/summary/sections/employment_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class EmploymentDetails < Sections::BaseSection
-      def name
-        :employment_details
-      end
-
       def show?
         income.present? && super
       end

--- a/app/presenters/summary/sections/first_court_hearing.rb
+++ b/app/presenters/summary/sections/first_court_hearing.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class FirstCourtHearing < Sections::BaseSection
-      def name
-        :first_court_hearing
-      end
-
       def show?
         kase.present? && super
       end

--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class IncomeDetails < Sections::BaseSection
-      def name
-        :income_details
-      end
-
       def show?
         income.present? && super
       end

--- a/app/presenters/summary/sections/justification_for_legal_aid.rb
+++ b/app/presenters/summary/sections/justification_for_legal_aid.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class JustificationForLegalAid < Sections::BaseSection
-      def name
-        :justification_for_legal_aid
-      end
-
       def show?
         ioj.present? && super
       end

--- a/app/presenters/summary/sections/legal_representative_details.rb
+++ b/app/presenters/summary/sections/legal_representative_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class LegalRepresentativeDetails < Sections::BaseSection
-      def name
-        :legal_representative_details
-      end
-
       def show?
         !crime_application.in_progress? && super
       end

--- a/app/presenters/summary/sections/next_court_hearing.rb
+++ b/app/presenters/summary/sections/next_court_hearing.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class NextCourtHearing < Sections::BaseSection
-      def name
-        :next_court_hearing
-      end
-
       def show?
         kase.present? && super
       end

--- a/app/presenters/summary/sections/offences.rb
+++ b/app/presenters/summary/sections/offences.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class Offences < Sections::BaseSection
-      def name
-        :offences
-      end
-
       def show?
         crime_application.case.present? && super
       end

--- a/app/presenters/summary/sections/other_income_details.rb
+++ b/app/presenters/summary/sections/other_income_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class OtherIncomeDetails < Sections::BaseSection
-      def name
-        :other_income_details
-      end
-
       def show?
         income.present? && super
       end

--- a/app/presenters/summary/sections/other_outgoings_details.rb
+++ b/app/presenters/summary/sections/other_outgoings_details.rb
@@ -1,0 +1,38 @@
+module Summary
+  module Sections
+    class OtherOutgoingsDetails < Sections::BaseSection
+      def name
+        :other_outgoings_details
+      end
+
+      def show?
+        outgoings.present? && super
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def answers
+        [
+          Components::ValueAnswer.new(
+            :income_tax_rate_above_threshold, outgoings.income_tax_rate_above_threshold,
+            change_path: edit_steps_outgoings_income_tax_rate_path
+          ),
+          Components::ValueAnswer.new(
+            :outgoings_more_than_income, outgoings.outgoings_more_than_income,
+            change_path: edit_steps_outgoings_outgoings_more_than_income_path
+          ),
+          Components::FreeTextAnswer.new(
+            :how_manage, outgoings.how_manage,
+            change_path: edit_steps_outgoings_outgoings_more_than_income_path
+          ),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def outgoings
+        @outgoings ||= crime_application.outgoings
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/other_outgoings_details.rb
+++ b/app/presenters/summary/sections/other_outgoings_details.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class OtherOutgoingsDetails < Sections::BaseSection
-      def name
-        :other_outgoings_details
-      end
-
       def show?
         outgoings.present? && super
       end

--- a/app/presenters/summary/sections/overview.rb
+++ b/app/presenters/summary/sections/overview.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class Overview < Sections::BaseSection
-      def name
-        :overview
-      end
-
       def show?
         !crime_application.in_progress? && super
       end

--- a/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
+++ b/app/presenters/summary/sections/passport_justification_for_legal_aid.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class PassportJustificationForLegalAid < Sections::BaseSection
-      def name
-        :passport_justification_for_legal_aid
-      end
-
       def answers
         [
           Components::ValueAnswer.new(

--- a/app/presenters/summary/sections/supporting_evidence.rb
+++ b/app/presenters/summary/sections/supporting_evidence.rb
@@ -1,10 +1,6 @@
 module Summary
   module Sections
     class SupportingEvidence < Sections::BaseSection
-      def name
-        :supporting_evidence
-      end
-
       def show?
         documents.present? && super
       end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -20,9 +20,9 @@ module Datastore
         applicant: applicant,
         case: case_with_ioj,
         income: income,
-        documents: parent.documents,
         dependants: dependants,
         outgoings: outgoings,
+        documents: parent.documents,
       )
     end
 

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -23,6 +23,7 @@ en:
       employment_details: Employment
       income_details: Income
       other_income_details: Other sources of income
+      other_outgoings_details: Other outgoings
       supporting_evidence: Supporting evidence
 
     questions:
@@ -224,6 +225,19 @@ en:
         #TODO: Question title has no design and needs to be checked/updated when designs are finalized
         question: Details
       # END other sources of income details section
+
+      # BEGIN other outgoings details section
+      income_tax_rate_above_threshold:
+        question: In the last 2 years, has your client paid the 40% income tax rate?
+        answers:
+          <<: *YESNO
+      outgoings_more_than_income:
+        question: Are your client’s outgoings more than their income?
+        answers:
+          <<: *YESNO
+      how_manage:
+        question: How does your client manage if their outgoings are more than their income?
+      # END other outgoings details section
 
       # BEGIN legal representative details section
       legal_rep_first_name:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,6 +129,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_184900) do
     t.string "ended_employment_within_three_months"
     t.string "client_has_dependants"
     t.string "has_savings"
+    t.string "payments", default: [], array: true
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -17,7 +17,7 @@ describe Summary::HtmlPresenter do
     context 'for a database application' do
       let(:crime_application) do
         instance_double(CrimeApplication, applicant: double, case: double, ioj: double, status: :in_progress,
-                        income: double, documents: double)
+                        income: double, outgoings: double, documents: double)
       end
 
       # rubocop:disable RSpec/ExampleLength
@@ -38,6 +38,7 @@ describe Summary::HtmlPresenter do
             Summary::Sections::EmploymentDetails,
             Summary::Sections::IncomeDetails,
             Summary::Sections::OtherIncomeDetails,
+            Summary::Sections::OtherOutgoingsDetails,
             Summary::Sections::SupportingEvidence,
           ]
         )
@@ -69,6 +70,7 @@ describe Summary::HtmlPresenter do
             Summary::Sections::EmploymentDetails,
             Summary::Sections::IncomeDetails,
             Summary::Sections::OtherIncomeDetails,
+            Summary::Sections::OtherOutgoingsDetails,
             Summary::Sections::SupportingEvidence,
             Summary::Sections::LegalRepresentativeDetails,
           ]

--- a/spec/presenters/summary/sections/other_outgoings_details_spec.rb
+++ b/spec/presenters/summary/sections/other_outgoings_details_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Summary::Sections::OtherOutgoingsDetails do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      outgoings: outgoings,
+    )
+  end
+
+  let(:outgoings) do
+    instance_double(
+      Outgoings,
+      income_tax_rate_above_threshold: 'no',
+      outgoings_more_than_income: 'yes',
+      how_manage: 'An example of how they manage'
+    )
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:other_outgoings_details) }
+  end
+
+  describe '#show?' do
+    context 'when there is an outgoings_details' do
+      it 'shows this section' do
+        expect(subject.show?).to be(true)
+      end
+    end
+
+    context 'when there is no outgoings_details' do
+      let(:outgoings) { nil }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    context 'when there are outgoings details' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(3)
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:income_tax_rate_above_threshold)
+        expect(answers[0].change_path)
+          .to match('applications/12345/steps/outgoings/has_client_paid_income_tax_rate')
+        expect(answers[0].value).to eq('no')
+        expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[1].question).to eq(:outgoings_more_than_income)
+        expect(answers[1].change_path)
+          .to match('applications/12345/steps/outgoings/are_clients_outgoings_more_than_income')
+        expect(answers[1].value).to eq('yes')
+        expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answers[2].question).to eq(:how_manage)
+        expect(answers[2].change_path)
+          .to match('applications/12345/steps/outgoings/are_clients_outgoings_more_than_income')
+        expect(answers[2].value).to eq('An example of how they manage')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Rehydrate/add other outgoings details to CYA
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-228

Designs assumed based on https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?type=design&node-id=8963%3A132484&mode=design&t=nO6xIcvVLqvY7Fvi-1

## Screenshots of changes (if applicable)

### After changes:
<img width="746" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/76e85f4b-d3ad-4df0-85cb-1636129c79c5">


## How to manually test the feature

1. Make sure schema is at v1.0.22 here and on the datastore
2. Create a new application, fill all details but DO NOT SUBMIT
3. Go to /steps/income/what_is_clients_employment_status (now also in dev tools)
4. Select 'My client is not working', Select 'Yes'
5. Hit Save and continue
6. Select 'Yes', Enter 1/11/2023
7. Hit Save and continue
8. Select 'No' for £12,475
9. Hit Save and continue
10. Select 'No' for Freezing order
11. Hit Save and continue
12. Select 'No' for Freezing order
13. Hit Save and continue
14. Select 'No' for Own home
15. Hit Save and continue
16. Select 'No' for Dependants
17. Hit Save and continue
18. Select 'Other' Enter some text for manage no income
19. Hit Save and continue
20. Reopen that application
21. Go to /steps/outgoings/has_client_paid_income_tax_rate
22. Select 'No'
23. Hit Save and continue
24. Select 'Yes' for outgoings more than income
25. Input some text
26. Hit Save and continue
27. Go to Review the application - check table correct and matches designs and copy
28. Submit application - confirm submits ok
29. Hit View completed application - check table correct and matches designs and copy
30. Open Review
31. Find that application and return to provider
32. Open Apply
33. Find that application in returned tab and check table, click to update, check table, check resubmitting works