### PR TITLE
[CRIMAPP-265] Add council tax page

### DIFF
--- a/app/controllers/steps/outgoings/council_tax_controller.rb
+++ b/app/controllers/steps/outgoings/council_tax_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(CouncilTaxForm, as: :council_tax)
       end
+
+      private
+
+      def additional_permitted_params
+        [:council_tax_amount_in_pounds]
+      end
     end
   end
 end

--- a/app/controllers/steps/outgoings/council_tax_controller.rb
+++ b/app/controllers/steps/outgoings/council_tax_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Outgoings
+    class CouncilTaxController < Steps::OutgoingsStepController
+      def edit
+        @form_object = CouncilTaxForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(CouncilTaxForm, as: :council_tax)
+      end
+    end
+  end
+end

--- a/app/forms/steps/outgoings/council_tax_form.rb
+++ b/app/forms/steps/outgoings/council_tax_form.rb
@@ -29,9 +29,9 @@ module Steps
       def council_tax_amount_in_pounds
         return unless council_tax_amount
 
-        amount_in_pence = council_tax_amount.dup
+        amount_in_pounds = council_tax_amount.dup / 100.0
 
-        amount_in_pence / 100.0
+        helpers.number_with_precision(amount_in_pounds, precision: 2)
       end
 
       private
@@ -50,6 +50,10 @@ module Steps
 
       def pays_council_tax?
         pays_council_tax&.yes?
+      end
+
+      def helpers
+        ActionController::Base.helpers
       end
     end
   end

--- a/app/forms/steps/outgoings/council_tax_form.rb
+++ b/app/forms/steps/outgoings/council_tax_form.rb
@@ -1,0 +1,40 @@
+module Steps
+  module Outgoings
+    class CouncilTaxForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :outgoings
+
+      attribute :pays_council_tax, :value_object, source: YesNoAnswer
+      attribute :council_tax_amount, :integer
+
+      validates_inclusion_of :pays_council_tax, in: :choices
+
+      validates :council_tax_amount,
+                presence: true,
+                numericality: { only_integer: true },
+                if: -> { pays_council_tax? }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        outgoings.update(
+          attributes.merge(attributes_to_reset)
+        )
+      end
+
+      def attributes_to_reset
+        {
+          'council_tax_amount' => (council_tax_amount if pays_council_tax?)
+        }
+      end
+
+      def pays_council_tax?
+        pays_council_tax&.yes?
+      end
+    end
+  end
+end

--- a/app/forms/steps/outgoings/council_tax_form.rb
+++ b/app/forms/steps/outgoings/council_tax_form.rb
@@ -4,23 +4,34 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :outgoings
 
-      PENCE_REGEXP = /\A\d+(\.\d{0,2})?\z/
-
       attribute :pays_council_tax, :value_object, source: YesNoAnswer
-      attribute :council_tax_amount, :string
+      attribute :council_tax_amount, :integer
 
       validates_inclusion_of :pays_council_tax, in: :choices
 
-      validates :council_tax_amount,
+      validates :council_tax_amount_in_pounds,
                 presence: true,
                 numericality: {
                   greater_than: 0,
                 },
-                format: { with: PENCE_REGEXP },
                 if: -> { pays_council_tax? }
 
       def choices
         YesNoAnswer.values
+      end
+
+      def council_tax_amount_in_pounds=(amount_in_pounds)
+        amount_in_pence = (amount_in_pounds.to_f * 100).round
+
+        self.council_tax_amount = amount_in_pence
+      end
+
+      def council_tax_amount_in_pounds
+        return unless council_tax_amount
+
+        amount_in_pence = council_tax_amount.dup
+
+        amount_in_pence / 100.0
       end
 
       private

--- a/app/forms/steps/outgoings/council_tax_form.rb
+++ b/app/forms/steps/outgoings/council_tax_form.rb
@@ -4,14 +4,19 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :outgoings
 
+      PENCE_REGEXP = /\A\d+(\.\d{0,2})?\z/
+
       attribute :pays_council_tax, :value_object, source: YesNoAnswer
-      attribute :council_tax_amount, :integer
+      attribute :council_tax_amount, :string
 
       validates_inclusion_of :pays_council_tax, in: :choices
 
       validates :council_tax_amount,
                 presence: true,
-                numericality: { only_integer: true },
+                numericality: {
+                  greater_than: 0,
+                },
+                format: { with: PENCE_REGEXP },
                 if: -> { pays_council_tax? }
 
       def choices

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -24,7 +24,8 @@ module Decisions
       when :delete_dependant
         edit_dependants
       when :dependants_finished
-        edit('/home', action: :index)
+        # TODO: link to next step when we have it
+        edit(:manage_without_income)
       when :manage_without_income
         # TODO: link to next step when we have it
         edit('/steps/outgoings/housing_payment_type')

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -3,6 +3,8 @@ module Decisions
     def destination
       case step_name
       when :housing_payment_type
+        edit(:council_tax)
+      when :council_tax
         # TODO: link to next step when we have it
         edit(:income_tax_rate)
       when :income_tax_rate

--- a/app/views/steps/income/lost_job_in_custody/edit.html.erb
+++ b/app/views/steps/income/lost_job_in_custody/edit.html.erb
@@ -3,26 +3,28 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-  <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+
     <%= govuk_error_summary(@form_object) %>
+
     <%= step_form @form_object do |f| %>
-        <%= f.govuk_radio_buttons_fieldset(:lost_job_in_custody, legend: { tag: 'h1', size: 'xl' }) do %>
-          <% @form_object.choices.each_with_index do |choice, index| %>
-            <% if choice.yes? %>
-              <%= f.govuk_radio_button :lost_job_in_custody, choice.value do %>
-                <%= f.govuk_date_field :date_job_lost, maxlength_enabled: true,
-                                       legend: {
-                                         text: t('.date_job_lost'),
-                                         size: 's', class: 'govuk-!-font-weight-regular'
-                                       } %>
-              <% end %>
-            <% else %>
-              <%= f.govuk_radio_button :lost_job_in_custody, choice.value, link_errors: index.zero? %>
+      <%= f.govuk_radio_buttons_fieldset(:lost_job_in_custody, legend: { tag: 'h1', size: 'xl' }) do %>
+        <% @form_object.choices.each_with_index do |choice, index| %>
+          <% if choice.yes? %>
+            <%= f.govuk_radio_button :lost_job_in_custody, choice.value do %>
+              <%= f.govuk_date_field :date_job_lost, maxlength_enabled: true,
+                                      legend: {
+                                        text: t('.date_job_lost'),
+                                        size: 's', class: 'govuk-!-font-weight-regular'
+                                      } %>
             <% end %>
+          <% else %>
+            <%= f.govuk_radio_button :lost_job_in_custody, choice.value, link_errors: index.zero? %>
           <% end %>
         <% end %>
+      <% end %>
 
-        <%= f.continue_button %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/outgoings/council_tax/edit.html.erb
+++ b/app/views/steps/outgoings/council_tax/edit.html.erb
@@ -12,7 +12,7 @@
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice.yes? %>
             <%= f.govuk_radio_button :pays_council_tax, choice.value do %>
-              <%= f.govuk_number_field :council_tax_amount,
+              <%= f.govuk_number_field :council_tax_amount_in_pounds,
                                        prefix_text: '£' %>
             <% end %>
           <% else %>

--- a/app/views/steps/outgoings/council_tax/edit.html.erb
+++ b/app/views/steps/outgoings/council_tax/edit.html.erb
@@ -1,0 +1,32 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:council_tax, legend: { tag: 'h1', size: 'xl' }) do %>
+        <% @form_object.choices.each_with_index do |choice, index| %>
+          <% if choice.yes? %>
+            <%= f.govuk_radio_button :pays_council_tax, choice.value do %>
+              <%= f.govuk_number_field :council_tax_amount,
+                                       prefix_text: '£',
+                                       inputmode: 'numeric',
+                                       legend: {
+                                         text: t('.council_tax_amount'),
+                                         size: 's', class: 'govuk-!-font-weight-regular'
+                                       } %>
+            <% end %>
+          <% else %>
+            <%= f.govuk_radio_button :pays_council_tax, choice.value, link_errors: index.zero? %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+    <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/outgoings/council_tax/edit.html.erb
+++ b/app/views/steps/outgoings/council_tax/edit.html.erb
@@ -13,8 +13,7 @@
           <% if choice.yes? %>
             <%= f.govuk_radio_button :pays_council_tax, choice.value do %>
               <%= f.govuk_number_field :council_tax_amount,
-                                       prefix_text: '£',
-                                       inputmode: 'numeric' %>
+                                       prefix_text: '£' %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :pays_council_tax, choice.value, link_errors: index.zero? %>

--- a/app/views/steps/outgoings/council_tax/edit.html.erb
+++ b/app/views/steps/outgoings/council_tax/edit.html.erb
@@ -14,11 +14,7 @@
             <%= f.govuk_radio_button :pays_council_tax, choice.value do %>
               <%= f.govuk_number_field :council_tax_amount,
                                        prefix_text: '£',
-                                       inputmode: 'numeric',
-                                       legend: {
-                                         text: t('.council_tax_amount'),
-                                         size: 's', class: 'govuk-!-font-weight-regular'
-                                       } %>
+                                       inputmode: 'numeric' %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :pays_council_tax, choice.value, link_errors: index.zero? %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -327,6 +327,13 @@ en:
           attributes:
             housing_payment_type:
               inclusion: Select which payment your client pays where they usually live
+        steps/outgoings/council_tax_form:
+          attributes:
+            pays_council_tax:
+              inclusion: Select yes if your client pays Council Tax where they usually live
+            council_tax_amount:
+              blank: Enter how much your client pays yearly
+              not_a_number: How much they pay yearly must be a number, like 50
         steps/outgoings/income_tax_rate_form:
           attributes:
             income_tax_rate_above_threshold:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -333,7 +333,8 @@ en:
               inclusion: Select yes if your client pays Council Tax where they usually live
             council_tax_amount:
               blank: Enter how much your client pays yearly
-              not_a_number: How much they pay yearly must be a number, like 50
+              greater_than: How much they pay yearly must be more than 0
+              invalid: How much they pay yearly must be a number, like 50
         steps/outgoings/income_tax_rate_form:
           attributes:
             income_tax_rate_above_threshold:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -65,6 +65,8 @@ en:
         manage_without_income: How does your client manage with no income?
       steps_outgoings_housing_payment_type_form:
         housing_payment_type: Which of these payments does your client pay where they usually live?
+      steps_outgoings_council_tax_form:
+        council_tax: Does your client pay Council Tax where they usually live?
 
     hint:
       steps_client_details_form:
@@ -257,6 +259,9 @@ en:
           mortgage: Mortgage
           board_lodgings: Board and lodgings
           none: My client does not pay any of these payments
+      steps_outgoings_council_tax_form:
+        pays_council_tax_options: *YESNO
+        council_tax_amount: How much do they pay yearly?
       steps_outgoings_income_tax_rate_form:
         income_tax_rate_above_threshold_options: *YESNO
       steps_outgoings_outgoings_more_than_income_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -261,7 +261,7 @@ en:
           none: My client does not pay any of these payments
       steps_outgoings_council_tax_form:
         pays_council_tax_options: *YESNO
-        council_tax_amount: How much do they pay yearly?
+        council_tax_amount_in_pounds: How much do they pay yearly?
       steps_outgoings_income_tax_rate_form:
         income_tax_rate_above_threshold_options: *YESNO
       steps_outgoings_outgoings_more_than_income_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -256,6 +256,9 @@ en:
       housing_payment_type:
         edit:
           page_title: Which of these payments does your client pay where they usually live?
+      council_tax:
+        edit:
+          page_title: Does your client pay Council Tax where they usually live?
       income_tax_rate:
         edit:
           page_title: In the last 2 years, has your client paid the 40% income tax rate?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,7 @@ Rails.application.routes.draw do
 
       namespace :outgoings, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
         edit_step :housing_payments_where_client_lives, alias: :housing_payment_type
+        edit_step :does_client_pay_council_tax, alias: :council_tax
         edit_step :has_client_paid_income_tax_rate, alias: :income_tax_rate
         edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
       end

--- a/db/migrate/20240103143020_add_council_tax_to_outgoings.rb
+++ b/db/migrate/20240103143020_add_council_tax_to_outgoings.rb
@@ -1,0 +1,6 @@
+class AddCouncilTaxToOutgoings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :outgoings, :pays_council_tax, :string
+    add_column :outgoings, :council_tax_amount, :integer
+  end
+end

--- a/db/migrate/20240103143020_add_council_tax_to_outgoings.rb
+++ b/db/migrate/20240103143020_add_council_tax_to_outgoings.rb
@@ -1,6 +1,6 @@
 class AddCouncilTaxToOutgoings < ActiveRecord::Migration[7.0]
   def change
     add_column :outgoings, :pays_council_tax, :string
-    add_column :outgoings, :council_tax_amount, :string
+    add_column :outgoings, :council_tax_amount, :integer
   end
 end

--- a/db/migrate/20240103143020_add_council_tax_to_outgoings.rb
+++ b/db/migrate/20240103143020_add_council_tax_to_outgoings.rb
@@ -1,6 +1,6 @@
 class AddCouncilTaxToOutgoings < ActiveRecord::Migration[7.0]
   def change
     add_column :outgoings, :pays_council_tax, :string
-    add_column :outgoings, :council_tax_amount, :integer
+    add_column :outgoings, :council_tax_amount, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_02_154904) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_03_143020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -168,6 +168,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_02_154904) do
     t.datetime "updated_at", null: false
     t.string "income_tax_rate_above_threshold"
     t.string "housing_payment_type"
+    t.string "pays_council_tax"
+    t.integer "council_tax_amount"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_03_143020) do
     t.string "income_tax_rate_above_threshold"
     t.string "housing_payment_type"
     t.string "pays_council_tax"
-    t.string "council_tax_amount"
+    t.integer "council_tax_amount"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,6 +129,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_03_143020) do
     t.string "ended_employment_within_three_months"
     t.string "client_has_dependants"
     t.string "has_savings"
+    t.string "payments", default: [], array: true
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 
@@ -169,7 +170,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_03_143020) do
     t.string "income_tax_rate_above_threshold"
     t.string "housing_payment_type"
     t.string "pays_council_tax"
-    t.integer "council_tax_amount"
+    t.string "council_tax_amount"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/outgoings/council_tax_controller_spec.rb
+++ b/spec/controllers/steps/outgoings/council_tax_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::CouncilTaxController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Outgoings::CouncilTaxForm,
+                  Decisions::OutgoingsDecisionTree
+end

--- a/spec/forms/steps/outgoings/council_tax_form_spec.rb
+++ b/spec/forms/steps/outgoings/council_tax_form_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::CouncilTaxForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      pays_council_tax:,
+      council_tax_amount:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, outgoings:) }
+  let(:outgoings) { Outgoings.new }
+
+  let(:pays_council_tax) { nil }
+  let(:council_tax_amount) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        form.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `pays_council_tax` is not provided' do
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:pays_council_tax, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `pays_council_tax` is not valid' do
+      let(:pays_council_tax) { 'maybe' }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:pays_council_tax, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `pays_council_tax` is valid' do
+      let(:pays_council_tax) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:pays_council_tax, :invalid)).to be(false)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :outgoings,
+                      expected_attributes: {
+                        'pays_council_tax' => YesNoAnswer::NO,
+                        'council_tax_amount' => nil
+                      }
+
+      context 'when `pays_council_tax` answer is no' do
+        context 'when a `council_tax_amount` was previously recorded' do
+          let(:council_tax_amount) { 100_000 }
+
+          it { is_expected.to be_valid }
+
+          it 'can make council_tax_amount field nil if no longer required' do
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['council_tax_amount']).to be_nil
+          end
+        end
+      end
+
+      context 'when `pays_council_tax` answer is yes' do
+        context 'when a `council_tax_amount` was previously recorded' do
+          let(:pays_council_tax) { YesNoAnswer::YES.to_s }
+          let(:council_tax_amount) { 100_000 }
+
+          it 'is valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :council_tax_amount,
+                :present
+              )
+            ).to be(false)
+          end
+
+          it 'cannot reset `council_tax_amount` as it is relevant' do
+            outgoings.update(pays_council_tax: YesNoAnswer::YES.to_s)
+
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['council_tax_amount']).to eq(council_tax_amount)
+          end
+        end
+
+        context 'when a `council_tax_amount` was not previously recorded' do
+          let(:pays_council_tax) { YesNoAnswer::YES.to_s }
+          let(:council_tax_amount) { 100_000 }
+
+          it 'is also valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :council_tax_amount,
+                :present
+              )
+            ).to be(false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/outgoings/council_tax_form_spec.rb
+++ b/spec/forms/steps/outgoings/council_tax_form_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
 
       context 'when `pays_council_tax` answer is no' do
         context 'when a `council_tax_amount` was previously recorded' do
-          let(:council_tax_amount) { 100_000 }
+          let(:council_tax_amount) { '1000' }
 
           it { is_expected.to be_valid }
 
@@ -82,7 +82,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
       context 'when `pays_council_tax` answer is yes' do
         context 'when a `council_tax_amount` was previously recorded' do
           let(:pays_council_tax) { YesNoAnswer::YES.to_s }
-          let(:council_tax_amount) { 100_000 }
+          let(:council_tax_amount) { '1000' }
 
           it 'is valid' do
             expect(form).to be_valid
@@ -104,7 +104,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
 
         context 'when a `council_tax_amount` was not previously recorded' do
           let(:pays_council_tax) { YesNoAnswer::YES.to_s }
-          let(:council_tax_amount) { 100_000 }
+          let(:council_tax_amount) { '1000' }
 
           it 'is also valid' do
             expect(form).to be_valid

--- a/spec/forms/steps/outgoings/council_tax_form_spec.rb
+++ b/spec/forms/steps/outgoings/council_tax_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
     {
       crime_application:,
       pays_council_tax:,
-      council_tax_amount:
+      council_tax_amount_in_pounds:
     }
   end
 
@@ -15,7 +15,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
   let(:outgoings) { Outgoings.new }
 
   let(:pays_council_tax) { nil }
-  let(:council_tax_amount) { nil }
+  let(:council_tax_amount_in_pounds) { nil }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -67,8 +67,12 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
                       }
 
       context 'when `pays_council_tax` answer is no' do
+        let(:pays_council_tax) { YesNoAnswer::NO.to_s }
+
         context 'when a `council_tax_amount` was previously recorded' do
-          let(:council_tax_amount) { '1000' }
+          before do
+            outgoings.update(council_tax_amount: 100_079)
+          end
 
           it { is_expected.to be_valid }
 
@@ -82,35 +86,38 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
       context 'when `pays_council_tax` answer is yes' do
         context 'when a `council_tax_amount` was previously recorded' do
           let(:pays_council_tax) { YesNoAnswer::YES.to_s }
-          let(:council_tax_amount) { '1000' }
+          let(:council_tax_amount_in_pounds) { 1000.79 }
+
+          before do
+            outgoings.update(pays_council_tax: YesNoAnswer::YES.to_s)
+            outgoings.update(council_tax_amount: 100_079)
+          end
 
           it 'is valid' do
             expect(form).to be_valid
             expect(
               form.errors.of_kind?(
-                :council_tax_amount,
+                :council_tax_amount_in_pounds,
                 :present
               )
             ).to be(false)
           end
 
           it 'cannot reset `council_tax_amount` as it is relevant' do
-            outgoings.update(pays_council_tax: YesNoAnswer::YES.to_s)
-
             attributes = form.send(:attributes_to_reset)
-            expect(attributes['council_tax_amount']).to eq(council_tax_amount)
+            expect(attributes['council_tax_amount']).to eq(100_079)
           end
         end
 
         context 'when a `council_tax_amount` was not previously recorded' do
           let(:pays_council_tax) { YesNoAnswer::YES.to_s }
-          let(:council_tax_amount) { '1000' }
+          let(:council_tax_amount_in_pounds) { 1000.79 }
 
           it 'is also valid' do
             expect(form).to be_valid
             expect(
               form.errors.of_kind?(
-                :council_tax_amount,
+                :council_tax_amount_in_pounds,
                 :present
               )
             ).to be(false)

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :dependants_finished }
 
-    it { is_expected.to have_destination('/home', :index, id: crime_application) }
+    it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
   end
 
   context 'when the step is `manage_without_income`' do

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
     let(:step_name) { :housing_payment_type }
 
     context 'has correct next step' do
+      it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `council_tax`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :council_tax }
+
+    context 'has correct next step' do
       it { is_expected.to have_destination(:income_tax_rate, :edit, id: crime_application) }
     end
   end


### PR DESCRIPTION
## Description of change
Add council tax page

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-265

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1057" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/af4665b6-d001-424c-97af-ef49779e5b80">

## How to manually test the feature

1. rails db:migrate
2. Start an application
3. Go to steps/outgoings/does_client_pay_council_tax
4. Check that submitting the form without selecting an option displays error 'Select yes if your client pays Council Tax where they usually live'
5. Check that submitting the form with Yes selected but no amount number input displays error 'Enter how much your client pays yearly'
6. Check that submitting with Yes selected and an amount input submits ok