### PR TITLE
Remove benefit type from DWP confirm details page

### DIFF
--- a/app/controllers/steps/dwp/confirm_details_controller.rb
+++ b/app/controllers/steps/dwp/confirm_details_controller.rb
@@ -16,9 +16,12 @@ module Steps
       private
 
       def set_presenter
-        @client_details = Summary::Sections::ClientDetails.new(
-          current_crime_application, editable: false, headless: true
-        )
+        dwp_details_app = current_crime_application
+        dwp_details_app.applicant&.benefit_type = nil
+
+        @client_details = [Summary::Sections::ClientDetails.new(
+          dwp_details_app, editable: false, headless: true
+        )].select(&:show?)
       end
     end
   end

--- a/app/controllers/steps/dwp/confirm_details_controller.rb
+++ b/app/controllers/steps/dwp/confirm_details_controller.rb
@@ -16,11 +16,8 @@ module Steps
       private
 
       def set_presenter
-        dwp_details_app = current_crime_application
-        dwp_details_app.applicant&.benefit_type = nil
-
-        @client_details = [Summary::Sections::ClientDetails.new(
-          dwp_details_app, editable: false, headless: true
+        @dwp_client_details = [Summary::Sections::DWPClientDetails.new(
+          current_crime_application, editable: false, headless: true
         )].select(&:show?)
       end
     end

--- a/app/presenters/summary/sections/dwp_client_details.rb
+++ b/app/presenters/summary/sections/dwp_client_details.rb
@@ -1,0 +1,46 @@
+module Summary
+  module Sections
+    class DWPClientDetails < Sections::BaseSection
+      def show?
+        applicant.present? && super
+      end
+
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def answers
+        [
+          Components::FreeTextAnswer.new(
+            :first_name, applicant.first_name,
+            change_path: edit_steps_client_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :last_name, applicant.last_name,
+            change_path: edit_steps_client_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :other_names, applicant.other_names,
+            change_path: edit_steps_client_details_path, show: true
+          ),
+
+          Components::DateAnswer.new(
+            :date_of_birth, applicant.date_of_birth,
+            change_path: edit_steps_client_details_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :nino, applicant.nino,
+            change_path: edit_steps_client_has_nino_path
+          ),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      private
+
+      def applicant
+        @applicant ||= crime_application.applicant
+      end
+    end
+  end
+end

--- a/app/views/steps/dwp/confirm_details/edit.html.erb
+++ b/app/views/steps/dwp/confirm_details/edit.html.erb
@@ -7,7 +7,7 @@
 
     <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
 
-    <%= render @client_details %>
+    <%= render @dwp_client_details %>
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :confirm_details, @form_object.choices, :value,

--- a/spec/presenters/summary/sections/dwp_client_details_spec.rb
+++ b/spec/presenters/summary/sections/dwp_client_details_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+describe Summary::Sections::DWPClientDetails do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      client_has_partner: 'no',
+      applicant: applicant,
+    )
+  end
+
+  let(:applicant) do
+    instance_double(
+      Applicant,
+      first_name: 'first name',
+      last_name: 'last name',
+      other_names: '',
+      date_of_birth: Date.new(1999, 1, 20),
+      nino: '123456',
+      benefit_type: benefit_type,
+    )
+  end
+
+  let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:dwp_client_details) }
+  end
+
+  describe '#show?' do
+    context 'when there is an applicant' do
+      it 'shows this section' do
+        expect(subject.show?).to be(true)
+      end
+    end
+
+    context 'when there is no applicant' do
+      let(:applicant) { nil }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    it 'has the correct rows' do
+      expect(answers.count).to eq(5)
+
+      expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[0].question).to eq(:first_name)
+      expect(answers[0].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[0].value).to eq('first name')
+
+      expect(answers[1]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[1].question).to eq(:last_name)
+      expect(answers[1].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[1].value).to eq('last name')
+
+      expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[2].question).to eq(:other_names)
+      expect(answers[2].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[2].value).to eq('')
+
+      expect(answers[3]).to be_an_instance_of(Summary::Components::DateAnswer)
+      expect(answers[3].question).to eq(:date_of_birth)
+      expect(answers[2].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[3].value).to eq(Date.new(1999, 1, 20))
+
+      expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[4].question).to eq(:nino)
+      expect(answers[4].change_path).to match('applications/12345/steps/client/has_nino')
+      expect(answers[4].value).to eq('123456')
+    end
+
+    context 'when there is no `benefit_type` value' do
+      let(:benefit_type) { nil }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Remove benefit type from DWP confirm details page

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
