### PR TITLE
Show DWP bypass in Dev post case type move

### DIFF
--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -16,7 +16,7 @@
         <p>Speed up some common application actions</p>
 
         <div class="govuk-button-group">
-          <% if crime_application.in_progress? && crime_application.case.nil? %>
+          <% if crime_application.in_progress? && crime_application.case&.charges&.empty? %>
             <%= button_to bypass_dwp_developer_tools_crime_application_path, method: :put,
                           class: 'govuk-button govuk-!-margin-right-1',
                           data: { module: 'govuk-button' } do; 'Bypass DWP'; end %>


### PR DESCRIPTION
## Description of change
Adds DWP bypass back in post the case type move.

Does a check on charge as this is the next mandatory data point we can use to remove it when it is not relevant.

No strong feelings either way - guess it could get more crowded if we add more buttons etc.

## How to manually test the feature
- DWP bypass button should be back now when you start the case.
- it will disappear on the offences page as its not relevant after the DWP page of the journey