### PR TITLE
Remove MAAT ID field from appeal with changes page

### DIFF
--- a/app/views/steps/client/appeal_details/edit.en.html.erb
+++ b/app/views/steps/client/appeal_details/edit.en.html.erb
@@ -14,7 +14,7 @@
                             label: { size: 's' } if @form_object.appeal_with_changes? %>
 
       <%= f.govuk_text_field :appeal_maat_id, autocomplete: 'off', width: 'one-third',
-                             extra_letter_spacing: true, label: { size: 's' } %>
+                             extra_letter_spacing: true, label: { size: 's' } unless @form_object.appeal_with_changes? %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -142,7 +142,7 @@ en:
           appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
       steps_client_appeal_details_form:
         appeal_maat_id: Previous MAAT ID (optional)
-        appeal_with_changes_details: What has changed in your client’s financial circumstances?v
+        appeal_with_changes_details: What has changed in your client’s financial circumstances?
       steps_client_has_nino_form:
         nino: Enter your client’s National Insurance number
       steps_client_benefit_type_form:


### PR DESCRIPTION
## Description of change
Remove MAAT ID field from appeal with changes page

## Link to relevant ticket
Ticket has been deleted as it was created after I completed this PR, and I said it was done. 

Designs have now been updated to appear like it has already been done. 
https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?type=design&node-id=9182%3A66774&mode=design&t=ul8sC0nTj8KLZdwZ-1

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/1dd29aa3-eba2-4043-89a3-2c3e796db337)

### After changes:
![image](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/367ce887-03c8-4974-bc44-540e9e0cff57)

## How to manually test the feature
Start an application
Fill in client details
Click Save and continue
Select Appeal to crown court with changes in financial circumstances
Click Save and continue
Check screen reflects designs