### PR TITLE
Serialize housing payments, bump schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.23'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.24'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 0e3a390af6311054d94720d3300178db898b6ae4
-  tag: v1.0.23
+  revision: c0631e93ecc22b61344ebba88f1b3c2476409e9b
+  tag: v1.0.24
   specs:
-    laa-criminal-legal-aid-schemas (1.0.23)
+    laa-criminal-legal-aid-schemas (1.0.24)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/serializers/submission_serializer/sections/means_details.rb
+++ b/app/serializers/submission_serializer/sections/means_details.rb
@@ -24,6 +24,7 @@ module SubmissionSerializer
                 # TODO: Update to take array from outgoings payments when we get
                 # there - needs to default to []
                 json.outgoings []
+                json.housing_payment_type outgoings&.housing_payment_type
                 json.income_tax_rate_above_threshold outgoings&.income_tax_rate_above_threshold
                 json.outgoings_more_than_income outgoings&.outgoings_more_than_income
                 json.how_manage outgoings&.how_manage

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
     let(:outgoings) do
       instance_double(
         Outgoings,
+        housing_payment_type: 'mortgage',
         income_tax_rate_above_threshold: 'no',
         outgoings_more_than_income: 'yes',
         how_manage: 'A description of how they manage'
@@ -61,6 +62,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
           outgoings_details: {
             # TODO: Outgoings array currently hardcoded in serializer
             outgoings: [],
+            housing_payment_type: 'mortgage',
             income_tax_rate_above_threshold: 'no',
             outgoings_more_than_income: 'yes',
             how_manage: 'A description of how they manage'
@@ -92,6 +94,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
     let(:outgoings) do
       instance_double(
         Outgoings,
+        housing_payment_type: nil,
         income_tax_rate_above_threshold: nil,
         outgoings_more_than_income: nil,
         how_manage: nil
@@ -117,6 +120,7 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
           outgoings_details: {
             # TODO: Outgoings array currently hardcoded in serializer
             outgoings: [],
+            housing_payment_type: nil,
             income_tax_rate_above_threshold: nil,
             outgoings_more_than_income: nil,
             how_manage: nil

--- a/spec/services/adapters/structs/outgoings_details_spec.rb
+++ b/spec/services/adapters/structs/outgoings_details_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Adapters::Structs::OutgoingsDetails do
         subject.serializable_hash
       ).to match(
         a_hash_including(
+          'housing_payment_type' => 'rent',
           'income_tax_rate_above_threshold' => 'no',
           'outgoings_more_than_income' => 'yes',
           'how_manage' => 'A description of how they manage'
@@ -23,6 +24,7 @@ RSpec.describe Adapters::Structs::OutgoingsDetails do
         subject.serializable_hash.keys
       ).to match_array(
         %w[
+          housing_payment_type
           income_tax_rate_above_threshold
           outgoings_more_than_income
           how_manage


### PR DESCRIPTION
## Description of change
Serialize housing payments, bump schema
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-275

![image](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/6a4c4fd6-7e05-4e09-8af2-5fa7ec265df6)

1. `bundle install`
2. Set local datastore schema in Gemfile to tag: 'v1.0.24' `bundle install`
3. Create a new application, fill all details but DO NOT SUBMIT
4. Go to /steps/income/what_is_clients_employment_status
5. Select 'My client is not working', Select 'No'
6. Click Save and continue
7. Select 'No' to £12,475
8. Click Save and continue
9. Select 'No' to frozen assets
10. Click Save and continue
11. Select 'No' to property
12. Click Save and continue
13. Select 'No' to savings
14. Select 'No' to dependants
15. Click Save and continue
16. Select any for how manage
17. Click Save and continue
18. Select any for housing payment
19. Click Save and continue
20. Select no for 40%
21. Click Save and continue
22. Select no for outgoings more than income
23. Click Save and continue
24. Reopen that application
25. Click Confirm declaration and submit application
26. Make sure submits ok
27. Open a rails console in datastore and check sumbitted_application has the correct data recorded