### PR TITLE
[CRIMAPP-219] Add housing payment to CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -22,6 +22,7 @@ module Summary
         Sections::EmploymentDetails.new(crime_application),
         Sections::IncomeDetails.new(crime_application),
         Sections::OtherIncomeDetails.new(crime_application),
+        Sections::HousingPayments.new(crime_application),
         Sections::OtherOutgoingsDetails.new(crime_application),
         Sections::SupportingEvidence.new(crime_application),
         Sections::LegalRepresentativeDetails.new(crime_application),

--- a/app/presenters/summary/sections/housing_payments.rb
+++ b/app/presenters/summary/sections/housing_payments.rb
@@ -1,0 +1,24 @@
+module Summary
+  module Sections
+    class HousingPayments < Sections::BaseSection
+      def show?
+        outgoings.present? && super
+      end
+
+      def answers
+        [
+          Components::ValueAnswer.new(
+            :housing_payment_type, outgoings.housing_payment_type,
+            change_path: edit_steps_outgoings_housing_payment_type_path
+          ),
+        ].select(&:show?)
+      end
+
+      private
+
+      def outgoings
+        @outgoings ||= crime_application.outgoings
+      end
+    end
+  end
+end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -23,6 +23,7 @@ en:
       employment_details: Employment
       income_details: Income
       other_income_details: Other sources of income
+      housing_payments: Housing Payments
       other_outgoings_details: Other outgoings
       supporting_evidence: Supporting evidence
 
@@ -225,6 +226,16 @@ en:
         #TODO: Question title has no design and needs to be checked/updated when designs are finalized
         question: Details
       # END other sources of income details section
+
+      # BEGIN housing payments section
+      housing_payment_type:
+        question: Which of these payments does your client pay where they usually live?
+        answers:
+          rent: Rent
+          mortgage: Mortgage
+          board_lodgings: Board and lodgings
+          none: None
+      # END housing payments section
 
       # BEGIN other outgoings details section
       income_tax_rate_above_threshold:

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -38,6 +38,7 @@ describe Summary::HtmlPresenter do
             Summary::Sections::EmploymentDetails,
             Summary::Sections::IncomeDetails,
             Summary::Sections::OtherIncomeDetails,
+            Summary::Sections::HousingPayments,
             Summary::Sections::OtherOutgoingsDetails,
             Summary::Sections::SupportingEvidence,
           ]
@@ -70,6 +71,7 @@ describe Summary::HtmlPresenter do
             Summary::Sections::EmploymentDetails,
             Summary::Sections::IncomeDetails,
             Summary::Sections::OtherIncomeDetails,
+            Summary::Sections::HousingPayments,
             Summary::Sections::OtherOutgoingsDetails,
             Summary::Sections::SupportingEvidence,
             Summary::Sections::LegalRepresentativeDetails,

--- a/spec/presenters/summary/sections/housing_payments_spec.rb
+++ b/spec/presenters/summary/sections/housing_payments_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Summary::Sections::HousingPayments do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      outgoings: outgoings,
+    )
+  end
+
+  let(:outgoings) do
+    instance_double(
+      Outgoings,
+      housing_payment_type: 'rent'
+    )
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:housing_payments) }
+  end
+
+  describe '#show?' do
+    context 'when there is a housing_payments' do
+      it 'shows this section' do
+        expect(subject.show?).to be(true)
+      end
+    end
+
+    context 'when there is no housing_payments' do
+      let(:outgoings) { nil }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    context 'when there are outgoings details' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:housing_payment_type)
+        expect(answers[0].change_path)
+          .to match('applications/12345/steps/outgoings/housing_payments_where_client_lives')
+        expect(answers[0].value).to eq('rent')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add housing payment to CYA
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-219
## Notes for reviewer

## Screenshots of changes (if applicable)

### After changes:
<img width="742" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/f95f22de-5734-4852-bc12-7078afb117ec">

## How to manually test the feature

1. Create a new application, fill all details but DO NOT SUBMIT
2. Go to /steps/income/what_is_clients_employment_status (now also in dev tools)
3. Select 'My client is not working', Select 'No'
4. Hit Save and continue
5. Select 'No' for £12,475
6. Hit Save and continue
7. Select 'No' for Freezing order
8. Hit Save and continue
9. Select 'No' for Land/property
10. Hit Save and continue
11. Select 'No' for Savings
12. Hit Save and continue
13. Select 'No' for Dependants
14. Hit Save and continue
15. Select any for How manage
16. Hit Save and continue
17. Select any for Housing Payment
18. Hit Save and continue
19. Select 'No' for Council tax
20. Hit Save and continue
21. Select 'No' for Income more than outgoings
22. Hit Save and continue
23. Reopen that application
24. Go to Review the application - check table correct and matches designs and copy
25. Submit application - confirm submits ok
26. Hit View completed application - check table correct and matches designs and copy
27. Open Review
28. Find that application and return to provider
29. Open Apply
30. Find that application in returned tab and check table, click to update, check table, check resubmitting works