### PR TITLE
CRIMAPP-385 Content change

### DIFF
--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -148,7 +148,7 @@ en:
       has_case_concluded:
         edit:
           page_title: Has the case concluded?
-          date_case_concluded: When did the case conclude?
+          date_case_concluded: Enter when the case concluded
       charges:
         edit:
           page_title: What has your client been charged with?

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -95,7 +95,7 @@ en:
         answers:
           <<: *YESNO
       date_case_concluded:
-        question: When did the case concluded?
+        question: Enter when the case concluded
       case_type:
         question: Case type
         answers:


### PR DESCRIPTION
## Description of change

Change "Has the case concluded?" date description
Before: When did the case conclude?
After: Enter when the case concluded

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-385

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1056" alt="Screenshot 2024-01-24 at 13 55 11" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/16d0df1f-e923-4e9d-a9e0-4936658142b9">

### After changes:
<img width="1119" alt="Screenshot 2024-01-24 at 13 53 41" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/c848a494-eaef-4a0e-adf6-3e28324cabdb">

## How to manually test the feature
