### PR TITLE
CRIMAP-362 provider can create draft PSE

### DIFF
--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -16,9 +16,6 @@ class CompletedApplicationsController < DashboardController
     )
   end
 
-  # TODO: this is WIP, can be tested by manually setting
-  # an application in the `returned` status.
-  # :nocov:
   def recreate
     usn = current_crime_application.reference
 
@@ -39,8 +36,13 @@ class CompletedApplicationsController < DashboardController
   end
 
   def create_pse
-    # TODO: implement functionality
-    redirect_to completed_crime_application_path(crime_application: current_crime_application)
+    pse_application = Pse::FindOrCreate.new(
+      initial_application: Adapters::JsonApplication.new(current_crime_application)
+    ).call
+
+    # Redirect to the check your answers (review) page
+    # of the newly created application
+    redirect_to edit_crime_application_path(pse_application)
   end
 
   private

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,4 +1,5 @@
 module Errors
   class InvalidSession < StandardError; end
   class ApplicationNotFound < StandardError; end
+  class ApplicationCannotReceivePse < StandardError; end
 end

--- a/app/models/concerns/type_of_application.rb
+++ b/app/models/concerns/type_of_application.rb
@@ -13,10 +13,21 @@ module TypeOfApplication
   end
 
   def initial?
-    ApplicationType.new(application_type) == ApplicationType::INITIAL
+    application_type?(:initial)
   end
 
   def returned?
     returned_at.present?
+  end
+
+  def post_submission_evidence?
+    application_type?(:post_submission_evidence)
+  end
+  alias pse? post_submission_evidence?
+
+  private
+
+  def application_type?(other_type)
+    ApplicationType.new(application_type) == ApplicationType.new(other_type)
   end
 end

--- a/app/models/concerns/type_of_application.rb
+++ b/app/models/concerns/type_of_application.rb
@@ -13,7 +13,7 @@ module TypeOfApplication
   end
 
   def initial?
-    application_type?(:initial)
+    application_type_eql?(:initial)
   end
 
   def returned?
@@ -21,13 +21,13 @@ module TypeOfApplication
   end
 
   def post_submission_evidence?
-    application_type?(:post_submission_evidence)
+    application_type_eql?(:post_submission_evidence)
   end
   alias pse? post_submission_evidence?
 
   private
 
-  def application_type?(other_type)
+  def application_type_eql?(other_type)
     ApplicationType.new(application_type) == ApplicationType.new(other_type)
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -2,6 +2,8 @@ class CrimeApplication < ApplicationRecord
   include TypeOfApplication
   include Passportable
 
+  attr_readonly :application_type
+
   has_one :case, dependent: :destroy
 
   has_one :applicant, dependent: :destroy
@@ -34,5 +36,5 @@ class CrimeApplication < ApplicationRecord
 
   # Before submitting the application we run a final
   # validation to ensure some key details are fulfilled
-  validates_with ApplicationFulfilmentValidator, on: :submission
+  validates_with ApplicationFulfilmentValidator, on: :submission, unless: :post_submission_evidence?
 end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -2,32 +2,44 @@ module Summary
   class HtmlPresenter
     attr_reader :crime_application
 
+    delegate :application_type, to: :crime_application
+
+    SECTIONS = {
+      initial: %i[
+        overview
+        client_details
+        contact_details
+        case_details
+        offences
+        codefendants
+        next_court_hearing
+        first_court_hearing
+        justification_for_legal_aid
+        passport_justification_for_legal_aid
+        employment_details
+        income_details
+        other_income_details
+        housing_payments
+        other_outgoings_details
+        supporting_evidence
+        legal_representative_details
+      ],
+      post_submission_evidence: %i[
+        overview
+        client_details
+        supporting_evidence
+        legal_representative_details
+      ]
+    }.freeze
+
     def initialize(crime_application:)
       @crime_application = Adapters::BaseApplication.build(crime_application)
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def sections
-      [
-        Sections::Overview.new(crime_application),
-        Sections::ClientDetails.new(crime_application),
-        Sections::ContactDetails.new(crime_application),
-        Sections::CaseDetails.new(crime_application),
-        Sections::Offences.new(crime_application),
-        Sections::Codefendants.new(crime_application),
-        Sections::NextCourtHearing.new(crime_application),
-        Sections::FirstCourtHearing.new(crime_application),
-        Sections::JustificationForLegalAid.new(crime_application),
-        Sections::PassportJustificationForLegalAid.new(crime_application),
-        Sections::EmploymentDetails.new(crime_application),
-        Sections::IncomeDetails.new(crime_application),
-        Sections::OtherIncomeDetails.new(crime_application),
-        Sections::HousingPayments.new(crime_application),
-        Sections::OtherOutgoingsDetails.new(crime_application),
-        Sections::SupportingEvidence.new(crime_application),
-        Sections::LegalRepresentativeDetails.new(crime_application),
-      ].select(&:show?)
+      SECTIONS.fetch(application_type.to_sym).map do |section|
+        Sections.const_get(section.to_s.camelize).new(crime_application)
+      end.select(&:show?)
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end
 end

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -41,6 +41,10 @@ module Summary
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
+      def editable?
+        crime_application.initial? && super
+      end
+
       private
 
       def applicant

--- a/app/presenters/task_list/collection.rb
+++ b/app/presenters/task_list/collection.rb
@@ -4,16 +4,23 @@ module TaskList
 
     delegate :size, to: :all_tasks
     delegate :tag, :safe_join, to: :view
+    delegate :application_type, to: :crime_application
 
     # Sections and tasks will show in the same order they are declared here
     # Implement each task logic in individual classes in `app/presenters/tasks`
-    SECTIONS = [
-      [:client_details,   [:client_details]],
-      [:case_details,     [:case_details, :ioj]],
-      [:means_assessment, [:income_assessment, :capital_assessment, :check_your_answers, :check_assessment_result]],
-      [:support_evidence, [:evidence_upload]],
-      [:review_confirm,   [:review, :declaration]],
-    ].freeze
+    SECTIONS = {
+      initial: [
+        [:client_details,   [:client_details]],
+        [:case_details,     [:case_details, :ioj]],
+        [:means_assessment, [:income_assessment, :capital_assessment, :check_your_answers, :check_assessment_result]],
+        [:support_evidence, [:evidence_upload]],
+        [:review_confirm,   [:review, :declaration]],
+      ],
+      post_submission_evidence: [
+        [:support_evidence, [:evidence_upload]],
+        [:review_confirm,   [:review, :confirm_and_submit]],
+      ]
+    }.freeze
 
     def initialize(view, crime_application:)
       @view = view
@@ -39,9 +46,13 @@ module TaskList
     end
 
     def collection
-      SECTIONS.map.with_index(1) do |(name, tasks), idx|
+      sections.map.with_index(1) do |(name, tasks), idx|
         Section.new(crime_application, name: name, tasks: tasks, index: idx)
       end
+    end
+
+    def sections
+      SECTIONS.fetch(application_type.to_sym)
     end
   end
 end

--- a/app/presenters/tasks/base_task.rb
+++ b/app/presenters/tasks/base_task.rb
@@ -1,3 +1,4 @@
+# pse_evidence_upload
 module Tasks
   class BaseTask
     include Routing

--- a/app/presenters/tasks/base_task.rb
+++ b/app/presenters/tasks/base_task.rb
@@ -1,4 +1,3 @@
-# pse_evidence_upload
 module Tasks
   class BaseTask
     include Routing

--- a/app/presenters/tasks/declaration.rb
+++ b/app/presenters/tasks/declaration.rb
@@ -9,7 +9,11 @@ module Tasks
     end
 
     def can_start?
-      fulfilled?(Ioj)
+      if crime_application.pse?
+        fulfilled?(EvidenceUpload)
+      else
+        fulfilled?(Ioj)
+      end
     end
 
     def in_progress?

--- a/app/presenters/tasks/evidence_upload.rb
+++ b/app/presenters/tasks/evidence_upload.rb
@@ -9,6 +9,8 @@ module Tasks
     end
 
     def can_start?
+      return true if crime_application.pse?
+
       fulfilled?(CaseDetails)
     end
 

--- a/app/presenters/tasks/review.rb
+++ b/app/presenters/tasks/review.rb
@@ -9,7 +9,11 @@ module Tasks
     end
 
     def can_start?
-      fulfilled?(Ioj)
+      if crime_application.pse?
+        fulfilled?(EvidenceUpload)
+      else
+        fulfilled?(Ioj)
+      end
     end
 
     # Once the Ioj task is fulfilled, this is always true

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -32,6 +32,8 @@ module Adapters
           )
         end
       end
+
+      alias usn reference
     end
   end
 end

--- a/app/services/evidence/requirements.rb
+++ b/app/services/evidence/requirements.rb
@@ -14,7 +14,7 @@ module Evidence
 
     def any?
       # Assume all PSE has evidence requirements for now. These may be defined
-      # bythe parent application at some point.
+      # by the parent application at some point.
       return true if crime_application.pse?
 
       [benefits?].any?

--- a/app/services/evidence/requirements.rb
+++ b/app/services/evidence/requirements.rb
@@ -13,6 +13,10 @@ module Evidence
     end
 
     def any?
+      # Assume all PSE has evidence requirements for now. These may be defined
+      # bythe parent application at some point.
+      return true if crime_application.pse?
+
       [benefits?].any?
     end
 

--- a/app/services/pse/find_or_create.rb
+++ b/app/services/pse/find_or_create.rb
@@ -1,0 +1,43 @@
+module Pse
+  class FindOrCreate
+    attr_reader :initial_application
+
+    def initialize(initial_application:)
+      @initial_application = initial_application
+    end
+
+    def call
+      raise Errors::ApplicationCannotReceivePse unless initial_application.can_receive_pse?
+
+      pse_application = CrimeApplication.find_by(usn:)
+
+      return pse_application if pse_application
+
+      CrimeApplication.create!(
+        usn:, parent_id:, application_type:, office_code:, applicant:
+      )
+    end
+
+    private
+
+    def applicant
+      Applicant.new(initial_application.applicant.serializable_hash)
+    end
+
+    def application_type
+      ApplicationType::POST_SUBMISSION_EVIDENCE
+    end
+
+    def office_code
+      initial_application.provider_details&.office_code
+    end
+
+    def usn
+      initial_application.reference
+    end
+
+    def parent_id
+      initial_application.id
+    end
+  end
+end

--- a/app/value_objects/application_type.rb
+++ b/app/value_objects/application_type.rb
@@ -1,5 +1,4 @@
 class ApplicationType < ValueObject
-  # NOTE: for MVP, all applications are "initial"
   VALUES = [
     INITIAL = new(:initial),
     POST_SUBMISSION_EVIDENCE = new(:post_submission_evidence),

--- a/app/value_objects/application_type.rb
+++ b/app/value_objects/application_type.rb
@@ -2,5 +2,6 @@ class ApplicationType < ValueObject
   # NOTE: for MVP, all applications are "initial"
   VALUES = [
     INITIAL = new(:initial),
+    POST_SUBMISSION_EVIDENCE = new(:post_submission_evidence),
   ].freeze
 end

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -3,7 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl">
+      <%= t(@crime_application.application_type, scope: [:tasklist, :heading_text]) %>
+    </h1>
 
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
       <%=t '.subheading' %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -25,6 +25,9 @@
               %>
             </th>
             <th scope="col" class="govuk-table__header"><%= t('.table_headings.reference') %></th>
+            <% if FeatureFlags.post_submission_evidence.enabled? %>
+              <th scope="col" class="govuk-table__header"><%= t('.table_headings.application_type') %></th>
+            <% end %>
             <th scope="col" class="govuk-table__header"><%= t('.table_headings.action') %></th>
           </tr>
         </thead>
@@ -41,6 +44,9 @@
               <td class="govuk-table__cell">
                 <%= app.reference %>
               </td>
+              <% if FeatureFlags.post_submission_evidence.enabled? %>
+                <td class="govuk-table__cell"><%= app.application_type.humanize %></td>
+              <% end %>
               <td class="govuk-table__cell">
                 <%= button_to confirm_destroy_crime_application_path(app), method: :get,
                   class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',

--- a/app/views/steps/submission/declaration/_initial.html.erb
+++ b/app/views/steps/submission/declaration/_initial.html.erb
@@ -1,0 +1,36 @@
+<h1 class="govuk-heading-xl">
+  Enter your details to confirm the following
+</h1>
+
+<p class="govuk-body">Your client agrees that:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>they’ve instructed your law firm to represent them</li>
+  <li>they’ve read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.laa_privacy_notice_url, target: '_blank', rel: 'noopener' %></li>
+  <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
+  <li>we can check their details with bank and credit reference agencies</li>
+  <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>
+  <li>the information they’ve given is complete and correct</li>
+  <li>they’ll report any changes to their financial situation immediately</li>
+</ul>
+
+<div class="govuk-warning-text govuk-!-margin-bottom-0">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    If your client gives wrong or incomplete information, does not report changes, or is found to have committed benefit fraud, they may:
+    <ul class="govuk-list govuk-list--bullet govuk-!-font-weight-bold">
+      <li>be prosecuted</li>
+      <li>need to pay a financial penalty</li>
+      <li>have their legal aid stopped and have to pay back the costs</li>
+    </ul>
+  </strong>
+</div>
+
+<p class="govuk-body">You agree that:</p>
+
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+  <li>you’ve explained to your client why they may have to pay towards legal aid and the consequences of not paying contributions on time or at all</li>
+  <li>you’ve obtained a signed declaration from your client</li>
+  <li>you’ve provided correct and complete information in this application</li>
+</ul>

--- a/app/views/steps/submission/declaration/_post_submission_evidence.html.erb
+++ b/app/views/steps/submission/declaration/_post_submission_evidence.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl">
+  Enter your details
+</h1>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -5,42 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl">
-      Enter your details to confirm the following
-    </h1>
-
-    <p class="govuk-body">Your client agrees that:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>they’ve instructed your law firm to represent them</li>
-      <li>they’ve read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.laa_privacy_notice_url, target: '_blank', rel: 'noopener' %></li>
-      <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
-      <li>we can check their details with bank and credit reference agencies</li>
-      <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>
-      <li>the information they’ve given is complete and correct</li>
-      <li>they’ll report any changes to their financial situation immediately</li>
-    </ul>
-
-    <div class="govuk-warning-text govuk-!-margin-bottom-0">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        If your client gives wrong or incomplete information, does not report changes, or is found to have committed benefit fraud, they may:
-        <ul class="govuk-list govuk-list--bullet govuk-!-font-weight-bold">
-          <li>be prosecuted</li>
-          <li>need to pay a financial penalty</li>
-          <li>have their legal aid stopped and have to pay back the costs</li>
-        </ul>
-      </strong>
-    </div>
-
-    <p class="govuk-body">You agree that:</p>
-
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-      <li>you’ve explained to your client why they may have to pay towards legal aid and the consequences of not paying contributions on time or at all</li>
-      <li>you’ve obtained a signed declaration from your client</li>
-      <li>you’ve provided correct and complete information in this application</li>
-    </ul>
+    <%= render partial: current_crime_application.application_type %>
 
     <%= render partial: 'fulfilment_errors',
                locals: { errors: @form_object.fulfilment_errors } if @form_object.fulfilment_errors.any? %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -9,6 +9,7 @@ en:
         applicant_name: Name
         created_at: Start date
         reference: Reference number
+        application_type: Type of application
         status: Status
         action: Action
       status:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -71,6 +71,9 @@ en:
         housing_payment_type: Which of these payments does your client pay where they usually live?
       steps_outgoings_council_tax_form:
         council_tax: Does your client pay Council Tax where they usually live?
+      steps_evidence_additional_information_form:
+        add_additional_information: Do you need to add any more information to this application? 
+        
 
     hint:
       steps_client_details_form:
@@ -279,6 +282,9 @@ en:
         how_manage: How does your client manage if their outgoings are more than their income?
       steps_evidence_upload_form:
         upload_files: Upload files
+      steps_evidence_additional_information_form:
+        add_additional_information_options: *YESNO
+        additional_information: Enter details that will help us process this application 
       steps_submission_declaration_form:
         legal_rep_first_name: First name
         legal_rep_last_name: Last name

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -305,6 +305,9 @@ en:
         unavailable: ClamAV Scan Service unavailable
         not_installed: "ClamAV Scan Error - clamdscan package must be installed and executable. Exception: %{message}"
         timeout: "ClamAV file scan breached %{timeout} second, scan abandoned"
+      additional_information:
+        edit:
+          page_title: Additional information 
 
     submission:
       review:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -267,5 +267,8 @@ en:
 
       # BEGIN supporting evidence section
       supporting_evidence:
-        question: "File name"
+        question: File name
+      additional_information:
+        question: Additional information 
+        absence_answer: *absence_none
       # END supporting evidence section

--- a/config/locales/en/tasklist.yml
+++ b/config/locales/en/tasklist.yml
@@ -1,6 +1,9 @@
 ---
 en:
   tasklist:
+    heading_text:
+      initial: Make a new application
+      post_submission_evidence: Submit supporting evidence for a previously submitted application
     heading:
       client_details: About your client
       case_details: About the case
@@ -8,6 +11,7 @@ en:
       support_evidence: Supporting evidence
       review_confirm: Review and confirm
     task:
+      additional_information: Additional information
       client_details: Client details
       case_details: Case details
       ioj: Justification for legal aid
@@ -16,8 +20,10 @@ en:
       check_your_answers: Check your answers
       check_assessment_result: Check means assessment result
       evidence_upload: Upload evidence
+      pse_evidence_upload: Upload post submission evidence
       review: Review the application
       declaration: Confirm declaration and submit application
+      confirm_and_submit: Confirm and submit application
     status:
       completed: Completed
       in_progress: In progress

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,7 +168,7 @@ Rails.application.routes.draw do
         edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
       end
 
-      namespace :evidence, constraints: -> (_) { FeatureFlags.evidence_upload.enabled? } do
+      namespace :evidence do
         edit_step :upload
       end
 

--- a/db/migrate/20240118155035_add_application_type_to_crime_applications.rb
+++ b/db/migrate/20240118155035_add_application_type_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddApplicationTypeToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :application_type, :string, null: false, default: ApplicationType::INITIAL.to_s
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_17_132250) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_18_155035) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_17_132250) do
     t.uuid "parent_id"
     t.string "means_passport", default: [], array: true
     t.string "is_means_tested"
+    t.string "application_type", default: "initial", null: false
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end
@@ -132,7 +133,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_17_132250) do
     t.string "ended_employment_within_three_months"
     t.string "client_has_dependants"
     t.string "has_savings"
-    t.string "payments", default: [], array: true
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -97,7 +97,12 @@ describe Summary::HtmlPresenter do
         let(:crime_application) { datastore_application }
 
         let(:expected_sections) do
-          %w[Overview ClientDetails SupportingEvidence LegalRepresentativeDetails]
+          %w[
+            Overview
+            ClientDetails
+            SupportingEvidence
+            LegalRepresentativeDetails
+          ]
         end
 
         it { is_expected.to match_array(expected_sections) }

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -5,80 +5,103 @@ require 'rails_helper'
 # as that is tested individually in each of the sections specs.
 #
 describe Summary::HtmlPresenter do
-  subject { described_class.new(crime_application:) }
+  subject(:presenter) { described_class.new(crime_application:) }
+
+  let(:database_application) do
+    instance_double(CrimeApplication, applicant: double, case: double, ioj: double, status: :in_progress,
+                    income: double, outgoings: double, documents: double, application_type: application_type)
+  end
+
+  let(:datastore_application) do
+    JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge('application_type' => application_type)
+  end
 
   describe '#sections' do
+    subject(:sections) { presenter.sections.map { |s| s.class.name.demodulize } }
+
     before do
       allow_any_instance_of(
         Summary::Sections::BaseSection
       ).to receive(:show?).and_return(true)
     end
 
-    context 'for a database application' do
-      let(:crime_application) do
-        instance_double(CrimeApplication, applicant: double, case: double, ioj: double, status: :in_progress,
-                        income: double, outgoings: double, documents: double)
+    context 'when an initial application' do
+      let(:application_type) { 'initial' }
+
+      context 'for an "in progress" database application' do
+        let(:crime_application) { database_application }
+
+        let(:expected_sections) do
+          %w[
+            ClientDetails
+            ContactDetails
+            CaseDetails
+            Offences
+            Codefendants
+            NextCourtHearing
+            FirstCourtHearing
+            JustificationForLegalAid
+            PassportJustificationForLegalAid
+            EmploymentDetails
+            IncomeDetails
+            OtherIncomeDetails
+            HousingPayments
+            OtherOutgoingsDetails
+            SupportingEvidence
+          ]
+        end
+
+        it { is_expected.to match_array(expected_sections) }
       end
 
-      # rubocop:disable RSpec/ExampleLength
-      it 'has the right sections in the right order' do
-        expect(
-          subject.sections
-        ).to match_instances_array(
-          [
-            Summary::Sections::ClientDetails,
-            Summary::Sections::ContactDetails,
-            Summary::Sections::CaseDetails,
-            Summary::Sections::Offences,
-            Summary::Sections::Codefendants,
-            Summary::Sections::NextCourtHearing,
-            Summary::Sections::FirstCourtHearing,
-            Summary::Sections::JustificationForLegalAid,
-            Summary::Sections::PassportJustificationForLegalAid,
-            Summary::Sections::EmploymentDetails,
-            Summary::Sections::IncomeDetails,
-            Summary::Sections::OtherIncomeDetails,
-            Summary::Sections::HousingPayments,
-            Summary::Sections::OtherOutgoingsDetails,
-            Summary::Sections::SupportingEvidence,
+      context 'for a "submitted" datastore application' do
+        let(:crime_application) { datastore_application }
+
+        let(:expected_sections) do
+          %w[
+            Overview
+            ClientDetails
+            ContactDetails
+            CaseDetails
+            Offences
+            Codefendants
+            NextCourtHearing
+            FirstCourtHearing
+            JustificationForLegalAid
+            PassportJustificationForLegalAid
+            EmploymentDetails
+            IncomeDetails
+            OtherIncomeDetails
+            HousingPayments
+            OtherOutgoingsDetails
+            SupportingEvidence
+            LegalRepresentativeDetails
           ]
-        )
+        end
+
+        it { is_expected.to match_array(expected_sections) }
       end
-      # rubocop:enable RSpec/ExampleLength
     end
 
-    context 'for a completed application (API response)' do
-      let(:crime_application) do
-        JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    context 'when a PSE application' do
+      let(:application_type) { 'post_submission_evidence' }
+
+      context 'for an "in progress" database application' do
+        let(:crime_application) { database_application }
+        let(:expected_sections) { %w[ClientDetails SupportingEvidence] }
+
+        it { is_expected.to match_array(expected_sections) }
       end
 
-      # rubocop:disable RSpec/ExampleLength
-      it 'has the right sections in the right order' do
-        expect(
-          subject.sections
-        ).to match_instances_array(
-          [
-            Summary::Sections::Overview,
-            Summary::Sections::ClientDetails,
-            Summary::Sections::ContactDetails,
-            Summary::Sections::CaseDetails,
-            Summary::Sections::Offences,
-            Summary::Sections::Codefendants,
-            Summary::Sections::NextCourtHearing,
-            Summary::Sections::FirstCourtHearing,
-            Summary::Sections::JustificationForLegalAid,
-            Summary::Sections::PassportJustificationForLegalAid,
-            Summary::Sections::EmploymentDetails,
-            Summary::Sections::IncomeDetails,
-            Summary::Sections::OtherIncomeDetails,
-            Summary::Sections::HousingPayments,
-            Summary::Sections::OtherOutgoingsDetails,
-            Summary::Sections::SupportingEvidence,
-            Summary::Sections::LegalRepresentativeDetails,
-          ]
-        )
+      context 'for a "submitted" datastore application' do
+        let(:crime_application) { datastore_application }
+
+        let(:expected_sections) do
+          %w[Overview ClientDetails SupportingEvidence LegalRepresentativeDetails]
+        end
+
+        it { is_expected.to match_array(expected_sections) }
       end
-      # rubocop:enable RSpec/ExampleLength
     end
   end
 end

--- a/spec/presenters/task_list/collection_spec.rb
+++ b/spec/presenters/task_list/collection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TaskList::Collection do
   subject { described_class.new(view, crime_application:) }
 
   let(:name) { :foobar_task }
-  let(:crime_application) { double }
+  let(:crime_application) { double application_type: 'initial' }
 
   describe 'collection of sections' do
     it 'has the `client_details` section' do

--- a/spec/presenters/tasks/declaration_spec.rb
+++ b/spec/presenters/tasks/declaration_spec.rb
@@ -24,24 +24,48 @@ RSpec.describe Tasks::Declaration do
   end
 
   describe '#can_start?' do
-    # We assume the completeness of the Ioj here, as
-    # their statuses are tested in its own spec, no need to repeat
-    before do
-      allow(
-        subject
-      ).to receive(:fulfilled?).with(Tasks::Ioj).and_return(ioj_fulfilled)
+    context 'when an initial application' do
+      # We assume the completeness of the Ioj here, as
+      # their statuses are tested in its own spec, no need to repeat
+      before do
+        allow(
+          subject
+        ).to receive(:fulfilled?).with(Tasks::Ioj).and_return(ioj_fulfilled)
+      end
+
+      context 'when the Ioj task has been completed' do
+        let(:ioj_fulfilled) { true }
+
+        it { expect(subject.can_start?).to be(true) }
+      end
+
+      context 'when the Ioj task has not been completed yet' do
+        let(:ioj_fulfilled) { false }
+
+        it { expect(subject.can_start?).to be(false) }
+      end
     end
 
-    context 'when the Ioj task has been completed' do
-      let(:ioj_fulfilled) { true }
+    context 'when a post submission evidence application' do
+      before do
+        crime_application.application_type = ApplicationType::POST_SUBMISSION_EVIDENCE
 
-      it { expect(subject.can_start?).to be(true) }
-    end
+        allow(
+          subject
+        ).to receive(:fulfilled?).with(Tasks::EvidenceUpload).and_return(evidence_uploaded?)
+      end
 
-    context 'when the Ioj task has not been completed yet' do
-      let(:ioj_fulfilled) { false }
+      context 'when supporting evidence has been uploaded' do
+        let(:evidence_uploaded?) { true }
 
-      it { expect(subject.can_start?).to be(false) }
+        it { expect(subject.can_start?).to be(true) }
+      end
+
+      context 'when supporting evidence has not been uploaded' do
+        let(:evidence_uploaded?) { false }
+
+        it { expect(subject.can_start?).to be(false) }
+      end
     end
   end
 

--- a/spec/presenters/tasks/evidence_upload_spec.rb
+++ b/spec/presenters/tasks/evidence_upload_spec.rb
@@ -44,7 +44,11 @@ RSpec.describe Tasks::EvidenceUpload do
       allow(
         subject
       ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details_fulfilled)
+
+      allow(crime_application).to receive(:pse?).and_return(pse?)
     end
+
+    let(:pse?) { false }
 
     context 'when the Case Details task has been completed' do
       let(:case_details_fulfilled) { true }
@@ -56,6 +60,12 @@ RSpec.describe Tasks::EvidenceUpload do
       let(:case_details_fulfilled) { false }
 
       it { expect(subject.can_start?).to be(false) }
+
+      context 'but the application is pse' do
+        let(:pse?) { true }
+
+        it { expect(subject.can_start?).to be(true) }
+      end
     end
   end
 

--- a/spec/requests/dashboard_lists_spec.rb
+++ b/spec/requests/dashboard_lists_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Dashboard', :authorized do
             assert_select 'a', count: 1, text: 'John Doe'
             assert_select 'td.govuk-table__cell:nth-of-type(1)', '15 Oct 2022'
             assert_select 'td.govuk-table__cell:nth-of-type(2)', /[[:digit:]]/
-            assert_select 'td.govuk-table__cell:nth-of-type(3)' do
+            assert_select 'td.govuk-table__cell:nth-of-type(4)' do
               assert_select 'button.govuk-button', count: 2, text: 'Delete'
             end
           end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe 'Dashboard', :authorized do
         assert_select 'button.govuk-button', count: 1, text: 'Upload post submission evidence'
       end
 
+      it 'creates a new PSE application and shows the task list' do
+        expect do
+          post create_pse_completed_crime_application_path(application_fixture_id)
+        end.to change(CrimeApplication.where(parent_id: application_fixture_id), :count).from(0).to(1)
+
+        expect(response).to have_http_status(:redirect)
+        follow_redirect!
+
+        assert_select 'h1', 'Submit supporting evidence for a previously submitted application'
+        assert_select 'p', 'You have completed 0 of 3 sections.'
+
+        assert_select 'h3:contains("Reference number") + p', '6000001'
+        assert_select 'h3:contains("First name") + p', 'Kit'
+        assert_select 'h3:contains("Last name") + p', 'Pound'
+      end
+
       context 'when PSE feature flag is not enabled' do
         before do
           allow(FeatureFlags).to receive(:post_submission_evidence) {

--- a/spec/services/evidence/requirements_spec.rb
+++ b/spec/services/evidence/requirements_spec.rb
@@ -18,18 +18,28 @@ RSpec.describe Evidence::Requirements do
     before do
       # `benefits?` method is tested separated
       allow(subject).to receive(:benefits?).and_return(benefits)
+      allow(crime_application).to receive(:pse?).and_return(pse?)
     end
 
     context 'there are some evidence requirements' do
+      let(:pse?) { false }
       let(:benefits) { true }
 
       it { expect(subject.any?).to be(true) }
     end
 
     context 'there are no evidence requirements' do
+      let(:pse?) { false }
       let(:benefits) { false }
 
       it { expect(subject.any?).to be(false) }
+    end
+
+    context 'when the application is PSE' do
+      let(:pse?) { true }
+      let(:benefits) { false }
+
+      it { expect(subject.any?).to be(true) }
     end
   end
 

--- a/spec/services/pse/find_or_create_spec.rb
+++ b/spec/services/pse/find_or_create_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Pse::FindOrCreate do
+  subject(:service) { described_class.new(initial_application:) }
+
+  let(:initial_application) do
+    instance_double(Adapters::Structs::CrimeApplication, reference:, id:, applicant:, provider_details:)
+  end
+
+  let(:reference) { 1_000_023 }
+  let(:id) { SecureRandom.uuid }
+  let(:applicant) { instance_double(Adapters::Structs::Applicant, serializable_hash: {}) }
+  let(:provider_details) { double(office_code: 'An0Fi5') }
+
+  describe '#call' do
+    context 'when initial_application cannot receive pse' do
+      before do
+        allow(initial_application).to receive(:can_receive_pse?).and_return(false)
+      end
+
+      it 'raises Errors::ApplicationCannotReceivePse' do
+        expect { service.call }.to raise_error(Errors::ApplicationCannotReceivePse)
+      end
+    end
+
+    context 'when initial_application can receive pse' do
+      let(:existing_pse) { nil }
+
+      before do
+        allow(initial_application).to receive(:can_receive_pse?).and_return(true)
+        allow(CrimeApplication).to receive(:find_by).with(usn: reference).and_return(existing_pse)
+      end
+
+      it 'creates a new CrimeApplication record with the expected attributes' do
+        expect(CrimeApplication).to receive(:create!).with(
+          usn: reference,
+          parent_id: id,
+          office_code: 'An0Fi5',
+          applicant: an_instance_of(Applicant),
+          application_type: ApplicationType::POST_SUBMISSION_EVIDENCE
+        )
+
+        service.call
+      end
+
+      context 'when `in_progress` PSE for the initial application exists' do
+        let(:existing_pse) { instance_double(CrimeApplication) }
+
+        it 'returns the in progress PSE' do
+          expect(CrimeApplication).not_to receive(:create!)
+
+          expect(service.call).to eq existing_pse
+        end
+      end
+    end
+  end
+end

--- a/spec/value_objects/application_type_spec.rb
+++ b/spec/value_objects/application_type_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationType do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(
-        %w[initial]
+        %w[initial post_submission_evidence]
       )
     end
   end


### PR DESCRIPTION
## Description of change
Provider can now create draft PSE.

## Link to relevant ticket
[CRIMAPP-362](https://dsdmoj.atlassian.net/browse/CRIMAPP-362)

## Notes for reviewer

This feature enables the creation and review of a draft PSE application. Notably, it does not include submission to the datastore, which is part of another ticket. The design an copy in this feature are under review.

The additional information/notes section has been removed from this PSE, as it is now part of a separate feature for all application types. The additional information section will be added to PSE when that work is completed.

## Screenshots of changes (if applicable)

### Before changes:
<img width="1020" alt="Screenshot 2024-01-24 at 15 55 18" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/c6c11f71-e3f0-4285-b1c7-371ee78b80ba">


### After changes:


<img width="1016" alt="Screenshot 2024-01-24 at 15 54 32" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/4737c745-5688-489b-bbfc-f41f8d29a39d">

<img width="728" alt="Screenshot 2024-01-24 at 15 54 48" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/46a2c632-96d9-4e85-b2e2-dd65435352a2">

<img width="657" alt="Screenshot 2024-01-24 at 15 54 56" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/2411ab90-e2c2-4eca-bb32-026a3ccc636b">
<img width="992" alt="Screenshot 2024-01-24 at 15 54 14" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/b55c22e4-96d2-41a2-815d-7554f8062f0d">

## How to manually test the feature


[CRIMAPP-362]: https://dsdmoj.atlassian.net/browse/CRIMAPP-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


