### PR TITLE
CRIMAPP-314  Add "Has the court remanded your client in custody" page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.34'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.35'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: f5f16a0410f91e1669a3897dde841ea7f5fb036b
-  tag: v1.0.34
+  revision: 921152079407aa334c1e879210a593d2a3b405b8
+  tag: v1.0.35
   specs:
-    laa-criminal-legal-aid-schemas (1.0.34)
+    laa-criminal-legal-aid-schemas (1.0.35)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/controllers/steps/case/is_client_remanded_controller.rb
+++ b/app/controllers/steps/case/is_client_remanded_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Case
+    class IsClientRemandedController < Steps::CaseStepController
+      def edit
+        @form_object = IsClientRemandedForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(IsClientRemandedForm, as: :is_client_remanded)
+      end
+    end
+  end
+end

--- a/app/forms/steps/case/is_client_remanded_form.rb
+++ b/app/forms/steps/case/is_client_remanded_form.rb
@@ -1,0 +1,40 @@
+module Steps
+  module Case
+    class IsClientRemandedForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :case
+
+      attribute :is_client_remanded, :value_object, source: YesNoAnswer
+      attribute :date_client_remanded, :multiparam_date
+
+      validates_inclusion_of :is_client_remanded, in: :choices
+
+      validates :date_client_remanded,
+                multiparam_date: true,
+                presence: true,
+                if: -> { client_remanded? }
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      private
+
+      def persist!
+        self.case.update(
+          attributes.merge(attributes_to_reset)
+        )
+      end
+
+      def attributes_to_reset
+        {
+          'date_client_remanded' => (date_client_remanded if client_remanded?)
+        }
+      end
+
+      def client_remanded?
+        is_client_remanded&.yes?
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -46,6 +46,17 @@ module Summary
             show: case_concluded?,
             change_path: edit_steps_case_has_case_concluded_path,
           ),
+
+          Components::ValueAnswer.new(
+            :is_client_remanded, kase.is_client_remanded,
+            change_path: edit_steps_case_is_client_remanded_path
+          ),
+
+          Components::DateAnswer.new(
+            :date_client_remanded, kase.date_client_remanded,
+            show: client_remanded?,
+            change_path: edit_steps_case_is_client_remanded_path
+          ),
         ].select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
@@ -58,6 +69,10 @@ module Summary
 
       def case_concluded?
         kase.has_case_concluded == 'yes' && !kase.date_case_concluded.nil?
+      end
+
+      def client_remanded?
+        kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
       end
     end
   end

--- a/app/serializers/submission_serializer/sections/case_details.rb
+++ b/app/serializers/submission_serializer/sections/case_details.rb
@@ -9,6 +9,8 @@ module SubmissionSerializer
             json.case_type kase.case_type
             json.has_case_concluded kase.has_case_concluded
             json.date_case_concluded kase.date_case_concluded
+            json.is_client_remanded kase.is_client_remanded
+            json.date_client_remanded kase.date_client_remanded
             json.appeal_maat_id kase.appeal_maat_id
             json.appeal_lodged_date kase.appeal_lodged_date
             json.appeal_with_changes_details kase.appeal_with_changes_details

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -6,6 +6,8 @@ module Decisions
       when :urn
         FeatureFlags.means_journey.enabled? ? edit(:has_case_concluded) : charges_summary_or_edit_new_charge
       when :has_case_concluded
+        edit(:is_client_remanded)
+      when :is_client_remanded
         charges_summary_or_edit_new_charge
       when :charges
         edit(:charges_summary)

--- a/app/views/steps/case/is_client_remanded/edit.html.erb
+++ b/app/views/steps/case/is_client_remanded/edit.html.erb
@@ -1,0 +1,26 @@
+<% title t('.page_title') %>
+<% step_header(path: crime_applications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:is_client_remanded, legend: { tag: 'h1', size: 'xl' }) do %>
+        <% @form_object.choices.each_with_index do |choice, index| %>
+          <% if choice == YesNoAnswer::YES %>
+            <%= f.govuk_radio_button :is_client_remanded, choice.value do %>
+              <%= f.govuk_date_field :date_client_remanded, maxlength_enabled: true,
+                                     legend: {
+                                       text: t('.date_client_remanded',),
+                                       size: 's'
+                                     } %>
+            <% end %>
+          <% else %>
+            <%= f.govuk_radio_button :is_client_remanded, choice.value, link_errors: index.zero? %>
+          <% end %>
+        <% end %>
+      <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -164,6 +164,24 @@ en:
               invalid_year: Enter a valid year
               year_too_early: Date is too far in the past
               future_not_allowed: Date case was concluded must be today or in the past
+        steps/case/is_client_remanded_form:
+          attributes:
+            is_client_remanded:
+              inclusion: Select yes if your client has the custody remanded
+            date_client_remanded:
+              blank: Date client custody was remanded cannot be blank
+              blank_day: Date client custody was remanded must include a day
+              blank_month: Date client custody was remanded must include a month
+              blank_year: Date client custody was remanded must include a year
+              blank_day_month: Date client custody was remanded must include a day and month
+              blank_day_year: Date client custody was remanded must include a day and year
+              blank_month_year: Date client custody was remanded must include a month and year
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date is too far in the past
+              future_not_allowed: Date client custody was remanded must be today or in the past
         steps/case/has_codefendants_form:
           attributes:
             has_codefendants:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -46,6 +46,8 @@ en:
         confirm_details: Are these details correct?
       steps_case_has_case_concluded_form:
         has_case_concluded: Has the case concluded?
+      steps_case_is_client_remanded_form:
+        is_client_remanded: Has a court remanded your client in custody?
       steps_case_charges_form:
         date_from: Start date %{index}
         date_to: End date %{index} (optional)
@@ -97,6 +99,8 @@ en:
         appeal_lodged_date: For example, 27 3 2007
       steps_case_has_case_concluded_form:
         date_case_concluded: For example, 27 3 2007
+      steps_case_is_client_remanded_form:
+        date_client_remanded: For example, 27 3 2007
       steps_case_charges_form:
         offence_name: Add one offence at a time, for example, robbery. You can add more later.
         offence_dates_attributes:
@@ -194,6 +198,8 @@ en:
         urn: Enter the unique reference number (URN) for your client’s case (optional)
       steps_case_has_case_concluded_form:
         has_case_concluded_options: *YESNO
+      steps_case_is_client_remanded_form:
+        is_client_remanded_options: *YESNO
       steps_case_charges_form:
         offence_name: Offence
       steps_case_charges_summary_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -151,6 +151,10 @@ en:
         edit:
           page_title: Has the case concluded?
           date_case_concluded: Enter when the case concluded
+      is_client_remanded:
+        edit:
+          page_title: Has a court remanded your client in custody?
+          date_client_remanded: Enter when they were remanded
       charges:
         edit:
           page_title: What has your client been charged with?

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -101,6 +101,12 @@ en:
           <<: *YESNO
       date_case_concluded:
         question: Enter when the case concluded
+      is_client_remanded:
+        question: Has a court remanded your client in custody?
+        answers:
+          <<: *YESNO
+      date_client_remanded:
+        question: Enter when they were remanded
       case_type:
         question: Case type
         answers:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -100,13 +100,13 @@ en:
         answers:
           <<: *YESNO
       date_case_concluded:
-        question: Enter when the case concluded
+        question: Date the case concluded
       is_client_remanded:
         question: Has a court remanded your client in custody?
         answers:
           <<: *YESNO
       date_client_remanded:
-        question: Enter when they were remanded
+        question: Date they were remanded
       case_type:
         question: Case type
         answers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
       namespace :case do
         edit_step :urn
         edit_step :has_case_concluded
+        edit_step :is_client_remanded
         crud_step :charges, param: :charge_id
         edit_step :charges_summary
         edit_step :has_codefendants

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,9 +136,11 @@ Rails.application.routes.draw do
       end
 
       namespace :case do
+        if FeatureFlags.means_journey.enabled?
+          edit_step :has_the_case_concluded, alias: :has_case_concluded
+          edit_step :has_court_remanded_client_in_custody,  alias: :is_client_remanded
+        end
         edit_step :urn
-        edit_step :has_case_concluded
-        edit_step :is_client_remanded
         crud_step :charges, param: :charge_id
         edit_step :charges_summary
         edit_step :has_codefendants

--- a/db/migrate/20240125141124_add_is_client_remanded_to_cases.rb
+++ b/db/migrate/20240125141124_add_is_client_remanded_to_cases.rb
@@ -1,0 +1,6 @@
+class AddIsClientRemandedToCases < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :is_client_remanded, :string
+    add_column :cases, :date_client_remanded, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_18_155035) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_25_141124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -50,6 +50,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_155035) do
     t.string "first_court_hearing_name"
     t.string "has_case_concluded"
     t.date "date_case_concluded"
+    t.string "is_client_remanded"
+    t.date "date_client_remanded"
     t.index ["crime_application_id"], name: "index_cases_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/case/is_client_remanded_controller_spec.rb
+++ b/spec/controllers/steps/case/is_client_remanded_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::IsClientRemandedController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Case::IsClientRemandedForm, Decisions::CaseDecisionTree
+end

--- a/spec/forms/steps/case/is_client_remanded_form_spec.rb
+++ b/spec/forms/steps/case/is_client_remanded_form_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Case::IsClientRemandedForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      is_client_remanded:,
+      date_client_remanded:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, case:) }
+  let(:case) { Case.new }
+
+  let(:is_client_remanded) { nil }
+  let(:date_client_remanded) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        form.choices
+      ).to eq([YesNoAnswer::YES, YesNoAnswer::NO])
+    end
+  end
+
+  describe '#save' do
+    context 'when `is_client_remanded` is not provided' do
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:is_client_remanded, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `is_client_remanded` is not valid' do
+      let(:is_client_remanded) { 'maybe' }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:is_client_remanded, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `is_client_remanded` is valid' do
+      let(:is_client_remanded) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:is_client_remanded, :invalid)).to be(false)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :case,
+                      expected_attributes: {
+                        'is_client_remanded' => YesNoAnswer::NO,
+                        'date_client_remanded' => nil
+                      }
+
+      context 'when `is_client_remanded` answer is no' do
+        context 'when a `date_client_remanded` was previously recorded' do
+          let(:date_client_remanded) { 1.month.ago.to_date }
+
+          it { is_expected.to be_valid }
+
+          it 'can make date_client_remanded field nil if no longer required' do
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['date_client_remanded']).to be_nil
+          end
+        end
+      end
+
+      context 'when `is_client_remanded` answer is yes' do
+        context 'when a `date_client_remanded` was previously recorded' do
+          let(:is_client_remanded) { YesNoAnswer::YES.to_s }
+          let(:date_client_remanded) { 1.month.ago.to_date }
+
+          it 'is valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :date_client_remanded,
+                :present
+              )
+            ).to be(false)
+          end
+
+          it 'cannot reset `date_client_remanded` as it is relevant' do
+            crime_application.case.update(is_client_remanded: YesNoAnswer::YES.to_s)
+
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['date_client_remanded']).to eq(date_client_remanded)
+          end
+        end
+
+        context 'when a `date_client_remanded` was not previously recorded' do
+          let(:is_client_remanded) { YesNoAnswer::YES.to_s }
+          let(:date_client_remanded) { 1.month.ago.to_date }
+
+          it 'is also valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :date_client_remanded,
+                :present
+              )
+            ).to be(false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 describe Summary::Sections::CaseDetails do
   subject { described_class.new(crime_application) }
 
@@ -62,7 +63,6 @@ describe Summary::Sections::CaseDetails do
     end
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#answers' do
     let(:answers) { subject.answers }
 

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -11,19 +11,23 @@ describe Summary::Sections::CaseDetails do
     )
   end
 
-  let(:has_case_concluded) { 'no' }
+  let(:has_case_concluded) { nil }
   let(:date_case_concluded) { nil }
+  let(:is_client_remanded) { nil }
+  let(:date_client_remanded) { nil }
 
   let(:kase) do
     instance_double(
       Case,
       urn:,
       case_type:,
+      has_case_concluded:,
+      date_case_concluded:,
+      is_client_remanded:,
+      date_client_remanded:,
       appeal_maat_id:,
       appeal_lodged_date:,
       appeal_with_changes_details:,
-      has_case_concluded:,
-      date_case_concluded:,
     )
   end
 
@@ -63,6 +67,8 @@ describe Summary::Sections::CaseDetails do
     let(:answers) { subject.answers }
 
     context "when has_case_concluded=='no'" do
+      let(:has_case_concluded) { 'no' }
+
       it 'has the correct rows' do
         expect(answers.count).to eq(3)
 
@@ -119,6 +125,82 @@ describe Summary::Sections::CaseDetails do
       end
     end
 
+    context "when is_client_remanded=='no'" do
+      let(:has_case_concluded) { 'no' }
+      let(:date_case_concluded) { nil }
+      let(:is_client_remanded) { 'no' }
+      let(:date_client_remanded) { nil }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(4)
+
+        answer = answers[0]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:case_type)
+        expect(answer.change_path).to match('applications/12345/steps/client/case_type')
+        expect(answer.value).to eq('foobar')
+
+        answer = answers[1]
+        expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answer.question).to eq(:case_urn)
+        expect(answer.change_path).to match('applications/12345/steps/case/urn')
+        expect(answer.value).to eq('xyz')
+
+        answer = answers[2]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:has_case_concluded)
+        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.value).to eq('no')
+
+        answer = answers[3]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:is_client_remanded)
+        expect(answer.change_path).to match('applications/12345/steps/case/is_client_remanded')
+        expect(answer.value).to eq('no')
+      end
+    end
+
+    context "when is_client_remanded=='yes'" do
+      let(:has_case_concluded) { 'no' }
+      let(:date_case_concluded) { nil }
+      let(:is_client_remanded) { 'yes' }
+      let(:date_client_remanded) { Time.zone.today }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+
+        answer = answers[0]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:case_type)
+        expect(answer.change_path).to match('applications/12345/steps/client/case_type')
+        expect(answer.value).to eq('foobar')
+
+        answer = answers[1]
+        expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answer.question).to eq(:case_urn)
+        expect(answer.change_path).to match('applications/12345/steps/case/urn')
+        expect(answer.value).to eq('xyz')
+
+        answer = answers[2]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:has_case_concluded)
+        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.value).to eq('no')
+
+        answer = answers[3]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:is_client_remanded)
+        expect(answer.change_path).to match('applications/12345/steps/case/is_client_remanded')
+        expect(answer.value).to eq('yes')
+
+        answer = answers[4]
+        expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
+        expect(answer.question).to eq(:date_client_remanded)
+        expect(answer.change_path).to match('applications/12345/steps/case/is_client_remanded')
+        expect(answer.value).to eq(date_client_remanded)
+      end
+    end
+
     context 'for appeal to crown court' do
       let(:appeal_lodged_date) { Date.new(2018, 11, 22) }
 
@@ -126,7 +208,7 @@ describe Summary::Sections::CaseDetails do
         let(:appeal_maat_id) { '123' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(4)
 
           answer = answers[1]
           expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
@@ -146,7 +228,7 @@ describe Summary::Sections::CaseDetails do
         let(:appeal_maat_id) { '' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(4)
 
           answer = answers[2]
           expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
@@ -166,7 +248,7 @@ describe Summary::Sections::CaseDetails do
         let(:appeal_maat_id) { '123' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(6)
+          expect(answers.count).to eq(5)
 
           answer = answers[1]
           expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
@@ -191,12 +273,6 @@ describe Summary::Sections::CaseDetails do
           expect(answer.question).to eq(:case_urn)
           expect(answer.change_path).to match('applications/12345/steps/case/urn')
           expect(answer.value).to eq('xyz')
-
-          answer = answers[5]
-          expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
-          expect(answer.question).to eq(:has_case_concluded)
-          expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
-          expect(answer.value).to eq('no')
         end
       end
 
@@ -204,7 +280,7 @@ describe Summary::Sections::CaseDetails do
         let(:appeal_maat_id) { '' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(6)
+          expect(answers.count).to eq(5)
 
           answer = answers[3]
           expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -87,7 +87,7 @@ describe Summary::Sections::CaseDetails do
         answer = answers[2]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:has_case_concluded)
-        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_the_case_concluded')
         expect(answer.value).to eq('no')
       end
     end
@@ -114,13 +114,13 @@ describe Summary::Sections::CaseDetails do
         answer = answers[2]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:has_case_concluded)
-        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_the_case_concluded')
         expect(answer.value).to eq('yes')
 
         answer = answers[3]
         expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
         expect(answer.question).to eq(:date_case_concluded)
-        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_the_case_concluded')
         expect(answer.value).to eq(date_case_concluded)
       end
     end
@@ -149,13 +149,13 @@ describe Summary::Sections::CaseDetails do
         answer = answers[2]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:has_case_concluded)
-        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_the_case_concluded')
         expect(answer.value).to eq('no')
 
         answer = answers[3]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:is_client_remanded)
-        expect(answer.change_path).to match('applications/12345/steps/case/is_client_remanded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_court_remanded_client_in_custody')
         expect(answer.value).to eq('no')
       end
     end
@@ -184,19 +184,19 @@ describe Summary::Sections::CaseDetails do
         answer = answers[2]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:has_case_concluded)
-        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_the_case_concluded')
         expect(answer.value).to eq('no')
 
         answer = answers[3]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:is_client_remanded)
-        expect(answer.change_path).to match('applications/12345/steps/case/is_client_remanded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_court_remanded_client_in_custody')
         expect(answer.value).to eq('yes')
 
         answer = answers[4]
         expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
         expect(answer.question).to eq(:date_client_remanded)
-        expect(answer.change_path).to match('applications/12345/steps/case/is_client_remanded')
+        expect(answer.change_path).to match('applications/12345/steps/case/has_court_remanded_client_in_custody')
         expect(answer.value).to eq(date_client_remanded)
       end
     end
@@ -297,19 +297,13 @@ describe Summary::Sections::CaseDetails do
       let(:case_type) { nil }
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(2)
+        expect(answers.count).to eq(1)
 
         answer = answers[0]
         expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answer.question).to eq(:case_urn)
         expect(answer.change_path).to match('applications/12345/steps/case/urn')
         expect(answer.value).to eq('xyz')
-
-        answer = answers[1]
-        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answer.question).to eq(:has_case_concluded)
-        expect(answer.change_path).to match('applications/12345/steps/case/has_case_concluded')
-        expect(answer.value).to eq('no')
       end
       # rubocop:enable RSpec/MultipleMemoizedHelpers
     end

--- a/spec/serializers/submission_serializer/sections/case_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/case_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
 
   let(:crime_application) { instance_double(CrimeApplication, case: kase) }
   let(:case_concluded_date) { DateTime.new(2023, 3, 2) }
+  let(:client_remand_date) { DateTime.new(2023, 3, 2) }
 
   let(:kase) do
     instance_double(
@@ -13,6 +14,8 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
       case_type: case_type,
       has_case_concluded: 'yes',
       date_case_concluded: case_concluded_date,
+      is_client_remanded: 'yes',
+      date_client_remanded: client_remand_date,
       appeal_maat_id: '123',
       appeal_lodged_date: appeal_lodged_date,
       appeal_with_changes_details: 'appeal changes',
@@ -36,6 +39,8 @@ RSpec.describe SubmissionSerializer::Sections::CaseDetails do
         case_type: case_type,
         has_case_concluded: 'yes',
         date_case_concluded: case_concluded_date,
+        is_client_remanded: 'yes',
+        date_client_remanded: client_remand_date,
         appeal_maat_id: '123',
         appeal_lodged_date: appeal_lodged_date,
         appeal_with_changes_details: 'appeal changes',

--- a/spec/services/adapters/structs/case_details_spec.rb
+++ b/spec/services/adapters/structs/case_details_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe Adapters::Structs::CaseDetails do
           appeal_with_changes_details
           has_case_concluded
           date_case_concluded
+          is_client_remanded
+          date_client_remanded
           charges
           codefendants
           has_codefendants

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Datastore::ApplicationSubmission do
       urn: '12345ABC',
       has_case_concluded: 'yes',
       date_case_concluded: 1.year.ago,
+      is_client_remanded: 'yes',
+      date_client_remanded: 1.year.ago,
       case_type: 'either_way',
       has_codefendants: 'yes',
       hearing_court_name: 'Manchester Crown Court',

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :has_case_concluded }
 
+    it 'redirects to the `has_case_concluded` page' do
+      expect(subject).to have_destination(:is_client_remanded, :edit, id: crime_application)
+    end
+  end
+
+  context 'when the step is `is_client_remanded`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :is_client_remanded }
+
     context 'and there are no charges yet' do
       let(:charges_double) { double(any?: false, create!: 'charge') }
 


### PR DESCRIPTION
## Description of change

Add "Has court remanded client in custody" page behind feature flag `means_journey`

**Add db columns**

cases.is_client_remanded(string)
cases.date_client_remanded(date)


## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-314

## Notes for reviewer
Currently "Has court remanded client in custody" page is behind a feature flag for local and staging

## Screenshots of changes (if applicable)

### Before changes:
<img width="1214" alt="Screenshot 2024-01-26 at 12 56 23" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/54a10e3a-b1b8-4020-a888-782fb99517b8">

### After changes:
<img width="1618" alt="Screenshot 2024-01-26 at 12 55 16" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/2ece87ef-d416-4377-98e3-811ce8446545">

## How to manually test the feature
