### PR TITLE
CRIMAPP-427 Add more information to submission

### DIFF
--- a/app/controllers/steps/submission/more_information_controller.rb
+++ b/app/controllers/steps/submission/more_information_controller.rb
@@ -1,0 +1,21 @@
+module Steps
+  module Submission
+    class MoreInformationController < Steps::SubmissionStepController
+      def edit
+        @form_object = MoreInformationForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(MoreInformationForm, as: :more_information)
+      end
+
+      private
+
+      def additional_permitted_params
+        [:need_more_information]
+      end
+    end
+  end
+end

--- a/app/forms/steps/submission/more_information_form.rb
+++ b/app/forms/steps/submission/more_information_form.rb
@@ -1,0 +1,36 @@
+module Steps
+  module Submission
+    class MoreInformationForm < Steps::BaseFormObject
+      attribute :additional_information, :string
+
+      validates :additional_information, presence: true,
+        unless: -> { more_information_not_needed? }
+
+      def persist!
+        self.additional_information = nil if more_information_not_needed?
+
+        crime_application.update(additional_information:)
+      end
+
+      def choices
+        YesNoAnswer.values
+      end
+
+      def need_more_information
+        return @need_more_information unless @need_more_information.nil?
+
+        YesNoAnswer::YES if crime_application.additional_information.present?
+      end
+
+      def need_more_information=(attr)
+        @need_more_information = YesNoAnswer.new(attr)
+      end
+
+      private
+
+      def more_information_not_needed?
+        need_more_information == YesNoAnswer::NO
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -22,12 +22,14 @@ module Summary
         housing_payments
         other_outgoings_details
         supporting_evidence
+        more_information
         legal_representative_details
       ],
       post_submission_evidence: %i[
         overview
         client_details
         supporting_evidence
+        more_information
         legal_representative_details
       ]
     }.freeze

--- a/app/presenters/summary/sections/more_information.rb
+++ b/app/presenters/summary/sections/more_information.rb
@@ -1,0 +1,19 @@
+module Summary
+  module Sections
+    class MoreInformation < Sections::BaseSection
+      def show?
+        FeatureFlags.more_information.enabled?
+      end
+
+      def answers
+        [
+          Components::FreeTextAnswer.new(
+            :additional_information,
+            crime_application.additional_information,
+            change_path: edit_steps_submission_more_information_path(crime_application)
+          )
+        ]
+      end
+    end
+  end
+end

--- a/app/presenters/task_list/collection.rb
+++ b/app/presenters/task_list/collection.rb
@@ -14,10 +14,12 @@ module TaskList
         [:case_details,     [:case_details, :ioj]],
         [:means_assessment, [:income_assessment, :capital_assessment, :check_your_answers, :check_assessment_result]],
         [:support_evidence, [:evidence_upload]],
+        [:more_information, [:more_information]],
         [:review_confirm,   [:review, :declaration]],
       ],
       post_submission_evidence: [
         [:support_evidence, [:evidence_upload]],
+        [:more_information, [:more_information]],
         [:review_confirm,   [:review, :declaration]],
       ]
     }.freeze

--- a/app/presenters/tasks/more_information.rb
+++ b/app/presenters/tasks/more_information.rb
@@ -1,0 +1,23 @@
+module Tasks
+  class MoreInformation < BaseTask
+    def path
+      edit_steps_submission_more_information_path
+    end
+
+    def not_applicable?
+      !FeatureFlags.more_information.enabled?
+    end
+
+    def can_start?
+      fulfilled?(EvidenceUpload) || fulfilled?(CaseDetails)
+    end
+
+    def in_progress?
+      crime_application.additional_information.present?
+    end
+
+    def completed?
+      in_progress?
+    end
+  end
+end

--- a/app/services/decisions/base_decision_tree.rb
+++ b/app/services/decisions/base_decision_tree.rb
@@ -27,6 +27,7 @@ module Decisions
     def url_options(controller, action, params = {})
       { controller: controller, action: action, id: current_crime_application }.merge(params)
     end
+
     # :nocov:
   end
 end

--- a/app/services/decisions/evidence_decision_tree.rb
+++ b/app/services/decisions/evidence_decision_tree.rb
@@ -5,9 +5,19 @@ module Decisions
       when :delete_document
         edit(:upload)
       when :upload_finished
-        edit('/steps/submission/review')
+        submission_root_step
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+
+    private
+
+    def submission_root_step
+      if FeatureFlags.more_information.enabled?
+        edit('/steps/submission/more_information')
+      else
+        edit('/steps/submission/review')
       end
     end
   end

--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -2,6 +2,8 @@ module Decisions
   class SubmissionDecisionTree < BaseDecisionTree
     def destination
       case step_name
+      when :more_information
+        edit(:review)
       when :review
         edit(:declaration)
       when :declaration, :submission_retry

--- a/app/views/steps/submission/more_information/edit.html.erb
+++ b/app/views/steps/submission/more_information/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:need_more_information, legend: { tag: 'h1', size: 'xl' }) do %>
+        <% @form_object.choices.each_with_index do |choice, index| %>
+          <% if choice.yes? %>
+            <%= f.govuk_radio_button :need_more_information, choice.value do %>
+              <%= f.govuk_text_area :additional_information %>
+            <% end %>
+          <% else %>
+            <%= f.govuk_radio_button :need_more_information, choice.value, link_errors: index.zero? %>
+          <% end %>
+        <% end %>
+      <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -385,6 +385,10 @@ en:
               inclusion: Select yes if your client’s outgoings are more than their income
             how_manage:
               blank: Enter how your client manages if their outgoings are more than their income
+        steps/submission/more_information_form:
+          attributes:
+            additional_information:
+              blank: Enter details you need to add to the application or select no
         steps/submission/declaration_form:
           attributes:
             legal_rep_first_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -74,8 +74,8 @@ en:
         housing_payment_type: Which of these payments does your client pay where they usually live?
       steps_outgoings_council_tax_form:
         council_tax: Does your client pay Council Tax where they usually live?
-      steps_evidence_additional_information_form:
-        add_additional_information: Do you need to add any more information to this application? 
+      steps_submission_more_information_form:
+        need_more_information: Do you need to add any more information to this application? 
         
 
     hint:
@@ -287,8 +287,8 @@ en:
         how_manage: How does your client manage if their outgoings are more than their income?
       steps_evidence_upload_form:
         upload_files: Upload files
-      steps_evidence_additional_information_form:
-        add_additional_information_options: *YESNO
+      steps_submission_more_information_form:
+        need_more_information_options: *YESNO
         additional_information: Enter details that will help us process this application 
       steps_submission_declaration_form:
         legal_rep_first_name: First name

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -311,11 +311,11 @@ en:
         unavailable: ClamAV Scan Service unavailable
         not_installed: "ClamAV Scan Error - clamdscan package must be installed and executable. Exception: %{message}"
         timeout: "ClamAV file scan breached %{timeout} second, scan abandoned"
-      additional_information:
-        edit:
-          page_title: Additional information 
 
     submission:
+      more_information:
+        edit:
+          page_title: More information 
       review:
         edit:
           page_title: Review the application

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -26,6 +26,7 @@ en:
       housing_payments: Housing Payments
       other_outgoings_details: Other outgoings
       supporting_evidence: Supporting evidence
+      more_information: More information
 
     questions:
       # BEGIN overview section
@@ -280,6 +281,6 @@ en:
       supporting_evidence:
         question: File name
       additional_information:
-        question: Additional information 
+        question: Details that will help us process this application
         absence_answer: *absence_none
       # END supporting evidence section

--- a/config/locales/en/tasklist.yml
+++ b/config/locales/en/tasklist.yml
@@ -9,9 +9,10 @@ en:
       case_details: About the case
       means_assessment: Means assessment
       support_evidence: Supporting evidence
+      more_information: More information
       review_confirm: Review and confirm
     task:
-      additional_information: Additional information
+      more_information: Add any more information
       client_details: Client details
       case_details: Case details
       ioj: Justification for legal aid
@@ -20,7 +21,6 @@ en:
       check_your_answers: Check your answers
       check_assessment_result: Check means assessment result
       evidence_upload: Upload evidence
-      pse_evidence_upload: Add supporting evidence
       review: Review the application
       declaration: Confirm declaration and submit application
       confirm_and_submit: Confirm and submit application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
       end
 
       namespace :submission do
+        edit_step :more_information
         edit_step :review
         edit_step :declaration
         edit_step :failure

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  more_information:
+    local: true
+    staging: true
+    production: false
 
 
 # NOTE: consider if the setting you are adding here

--- a/db/migrate/20240129124609_add_additional_information_to_crime_applications.rb
+++ b/db/migrate/20240129124609_add_additional_information_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddAdditionalInformationToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :additional_information, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_25_141124) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_29_124609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -89,6 +89,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_25_141124) do
     t.string "means_passport", default: [], array: true
     t.string "is_means_tested"
     t.string "application_type", default: "initial", null: false
+    t.text "additional_information"
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end

--- a/spec/controllers/steps/submission/more_information_controller_spec.rb
+++ b/spec/controllers/steps/submission/more_information_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::MoreInformationController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Submission::MoreInformationForm,
+                  Decisions::SubmissionDecisionTree
+end

--- a/spec/forms/steps/submission/more_information_form_spec.rb
+++ b/spec/forms/steps/submission/more_information_form_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::MoreInformationForm do
+  subject(:form) { described_class.new(additional_information:, crime_application:) }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:additional_information) { 'More information about this application.' }
+  let(:record_additional_information) { nil }
+
+  before do
+    allow(crime_application).to receive(:additional_information)
+      .and_return(record_additional_information)
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:additional_information) }
+
+    context 'when additional information is not needed' do
+      before { form.need_more_information = 'no' }
+
+      it { is_expected.not_to validate_presence_of(:additional_information) }
+    end
+  end
+
+  describe '#need_more_information' do
+    subject(:need_more_information) { form.need_more_information }
+
+    context 'when no additional information stored' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when additional information stored' do
+      let(:record_additional_information) { 'Old information' }
+
+      it { is_expected.to be YesNoAnswer::YES }
+    end
+
+    context 'when a new value is assigned' do
+      before { form.need_more_information = 'no' }
+
+      it { is_expected.to eq YesNoAnswer::NO }
+    end
+  end
+
+  describe '#save' do
+    it 'stores the `additional_information`' do
+      expect(crime_application).to receive(:update)
+        .with(additional_information:).and_return(true)
+
+      expect(form.save).to be true
+    end
+
+    context 'when additional information is not needed' do
+      before { form.need_more_information = 'no' }
+
+      it 'clears the `additional_information`' do
+        expect(crime_application).to receive(:update)
+          .with(additional_information: nil).and_return(true)
+
+        expect(form.save).to be true
+      end
+    end
+  end
+
+  describe '#choices' do
+    subject(:choices) { form.choices }
+
+    it { is_expected.to be YesNoAnswer.values }
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -49,6 +49,7 @@ describe Summary::HtmlPresenter do
             HousingPayments
             OtherOutgoingsDetails
             SupportingEvidence
+            MoreInformation
           ]
         end
 
@@ -76,6 +77,7 @@ describe Summary::HtmlPresenter do
             HousingPayments
             OtherOutgoingsDetails
             SupportingEvidence
+            MoreInformation
             LegalRepresentativeDetails
           ]
         end
@@ -95,6 +97,7 @@ describe Summary::HtmlPresenter do
             Overview
             ClientDetails
             SupportingEvidence
+            MoreInformation
           ]
         end
 
@@ -109,6 +112,7 @@ describe Summary::HtmlPresenter do
             Overview
             ClientDetails
             SupportingEvidence
+            MoreInformation
             LegalRepresentativeDetails
           ]
         end

--- a/spec/presenters/task_list/collection_spec.rb
+++ b/spec/presenters/task_list/collection_spec.rb
@@ -34,10 +34,16 @@ RSpec.describe TaskList::Collection do
       expect(subject[3].tasks).to eq([:evidence_upload])
     end
 
-    it 'has the `review_confirm` section' do
+    it 'has the `more_information` section' do
       expect(subject[4].index).to eq(5)
-      expect(subject[4].name).to eq(:review_confirm)
-      expect(subject[4].tasks).to eq([:review, :declaration])
+      expect(subject[4].name).to eq(:more_information)
+      expect(subject[4].tasks).to eq([:more_information])
+    end
+
+    it 'has the `review_confirm` section' do
+      expect(subject[5].index).to eq(6)
+      expect(subject[5].name).to eq(:review_confirm)
+      expect(subject[5].tasks).to eq([:review, :declaration])
     end
   end
 
@@ -63,7 +69,7 @@ RSpec.describe TaskList::Collection do
     it 'iterates through the sections defined, rendering each one' do
       expect(
         TaskList::Section
-      ).to receive(:new).exactly(5).times.and_return(double.as_null_object)
+      ).to receive(:new).exactly(6).times.and_return(double.as_null_object)
 
       expect(
         subject.render

--- a/spec/presenters/tasks/more_information_spec.rb
+++ b/spec/presenters/tasks/more_information_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::MoreInformation do
+  subject { described_class.new(crime_application:) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345'
+    )
+  end
+
+  describe '#path' do
+    it { expect(subject.path).to eq('/applications/12345/steps/submission/more_information') }
+  end
+
+  describe '#not_applicable?' do
+    it { expect(subject.not_applicable?).to be(false) }
+
+    context 'when feature flag disabled' do
+      before do
+        allow(FeatureFlags).to receive(:more_information) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+      end
+
+      it { expect(subject.not_applicable?).to be(true) }
+    end
+  end
+
+  describe '#can_start?' do
+    before do
+      allow(
+        subject
+      ).to receive(:fulfilled?).with(Tasks::EvidenceUpload).and_return(evidence_uploaded?)
+
+      allow(
+        subject
+      ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details?)
+    end
+
+    context 'when supporting evidence has been uploaded' do
+      let(:evidence_uploaded?) { true }
+      let(:case_details?) { false }
+
+      it { expect(subject.can_start?).to be(true) }
+    end
+
+    context 'when supporting evidence has not been uploaded and case details are not fulfilled' do
+      let(:evidence_uploaded?) { false }
+      let(:case_details?) { false }
+
+      it { expect(subject.can_start?).to be(false) }
+    end
+
+    context 'when case details are fulfilled' do
+      let(:evidence_uploaded?) { false }
+      let(:case_details?) { true }
+
+      it { expect(subject.can_start?).to be(true) }
+    end
+  end
+
+  describe '#in_progress?' do
+    before do
+      allow(
+        crime_application
+      ).to receive(:additional_information).and_return additional_information
+    end
+
+    context 'when additional information is given' do
+      let(:additional_information) { 'Some info' }
+
+      it { expect(subject.in_progress?).to be(true) }
+    end
+
+    context 'when additional information has not yet been given' do
+      let(:additional_information) { nil }
+
+      it { expect(subject.in_progress?).to be(false) }
+    end
+  end
+
+  describe '#completed?' do
+    before do
+      allow(
+        crime_application
+      ).to receive(:additional_information).and_return additional_information
+    end
+
+    context 'when additional information is given' do
+      let(:additional_information) { 'Some info' }
+
+      it { expect(subject.completed?).to be(true) }
+    end
+
+    context 'when additional information has not yet been given' do
+      let(:additional_information) { nil }
+
+      it { expect(subject.completed?).to be(false) }
+    end
+  end
+end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -279,7 +279,17 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:means_passported) { true }
       let(:evidence_required) { false }
 
-      it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
+      it { is_expected.to have_destination('/steps/submission/more_information', :edit, id: crime_application) }
+
+      context 'when more_information feature flag is not enabled' do
+        before do
+          allow(FeatureFlags).to receive(:more_information) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
+        end
+
+        it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
+      end
     end
 
     context 'and the application requires evidence upload' do
@@ -294,7 +304,17 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:means_passported) { false }
       let(:evidence_required) { false }
 
-      it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
+      it { is_expected.to have_destination('/steps/submission/more_information', :edit, id: crime_application) }
+
+      context 'when more_information feature flag is not enabled' do
+        before do
+          allow(FeatureFlags).to receive(:more_information) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
+        end
+
+        it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
+      end
     end
   end
 end

--- a/spec/services/decisions/evidence_decision_tree_spec.rb
+++ b/spec/services/decisions/evidence_decision_tree_spec.rb
@@ -22,7 +22,15 @@ RSpec.describe Decisions::EvidenceDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :upload_finished }
 
-    context 'has correct next step' do
+    it { is_expected.to have_destination('/steps/submission/more_information', :edit, id: crime_application) }
+
+    context 'when more_information feature flag is not enabled' do
+      before do
+        allow(FeatureFlags).to receive(:more_information) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+      end
+
       it { is_expected.to have_destination('/steps/submission/review', :edit, id: crime_application) }
     end
   end

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Decisions::SubmissionDecisionTree do
 
   it_behaves_like 'a decision tree'
 
+  context 'when the step is `more_information`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :more_information }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination(:review, :edit, id: crime_application) }
+    end
+  end
+
   context 'when the step is `review`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :review }


### PR DESCRIPTION
## Description of change
Add and optional more information step before submission/review for all application types.

## Link to relevant ticket
[CRIMAPP-427](https://dsdmoj.atlassian.net/browse/CRIMAPP-427)

## Notes for reviewer
This PR does not include submission to the datastore.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
### Task list
<img width="862" alt="Screenshot 2024-01-30 at 09 41 22" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/86e4b48e-b685-42f2-95c8-750a9762f7fd">
### Review page with no details added

<img width="793" alt="Screenshot 2024-01-30 at 09 40 51" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/2df182b3-e1d4-42a2-abad-2d471e8b5e4a">

### Review page with details added

<img width="805" alt="Screenshot 2024-01-30 at 09 40 37" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/dab7d5ce-928e-4814-9a09-0180142de1a6">

### More information page

<img width="892" alt="Screenshot 2024-01-30 at 09 44 57" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/e9d93b74-1692-4b4a-bb6d-f647c8e7f05f">
<img width="1013" alt="Screenshot 2024-01-30 at 09 44 52" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/fcd00077-cc16-4f44-bd5c-4de1ca209d88">
<img width="732" alt="Screenshot 2024-01-30 at 15 48 39" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/5c391efb-8b2c-4dc5-ab60-e077295e6ac6">

## How to manually test the feature


[CRIMAPP-427]: https://dsdmoj.atlassian.net/browse/CRIMAPP-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ