### PR TITLE
Fix/add guard clause for case concluded remanded

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -29,10 +29,8 @@ module DeveloperTools
       find_or_create_applicant
 
       crime_application.update(
-        is_means_tested: YesNoAnswer::YES,
         client_has_partner: YesNoAnswer::NO,
         navigation_stack: [
-          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_has_nino_path(crime_application),
@@ -59,10 +57,8 @@ module DeveloperTools
       find_or_create_case
 
       crime_application.update(
-        is_means_tested: YesNoAnswer::YES,
         client_has_partner: YesNoAnswer::NO,
         navigation_stack: [
-          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_contact_details_path(crime_application),

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -29,8 +29,10 @@ module DeveloperTools
       find_or_create_applicant
 
       crime_application.update(
+        is_means_tested: YesNoAnswer::YES,
         client_has_partner: YesNoAnswer::NO,
         navigation_stack: [
+          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_has_nino_path(crime_application),
@@ -57,8 +59,10 @@ module DeveloperTools
       find_or_create_case
 
       crime_application.update(
+        is_means_tested: YesNoAnswer::YES,
         client_has_partner: YesNoAnswer::NO,
         navigation_stack: [
+          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_contact_details_path(crime_application),

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -33,29 +33,30 @@ module Summary
 
           Components::FreeTextAnswer.new(
             :case_urn, kase.urn,
-            change_path: edit_steps_case_urn_path, show: true
+            show: true,
+            change_path: edit_steps_case_urn_path
           ),
 
           Components::ValueAnswer.new(
             :has_case_concluded, kase.has_case_concluded,
-            change_path: edit_steps_case_has_case_concluded_path
+            change_path: case_concluded_change_path
           ),
 
           Components::DateAnswer.new(
             :date_case_concluded, kase.date_case_concluded,
             show: case_concluded?,
-            change_path: edit_steps_case_has_case_concluded_path,
+            change_path: case_concluded_change_path
           ),
 
           Components::ValueAnswer.new(
             :is_client_remanded, kase.is_client_remanded,
-            change_path: edit_steps_case_is_client_remanded_path
+            change_path: client_remanded_change_path
           ),
 
           Components::DateAnswer.new(
             :date_client_remanded, kase.date_client_remanded,
             show: client_remanded?,
-            change_path: edit_steps_case_is_client_remanded_path
+            change_path: client_remanded_change_path
           ),
         ].select(&:show?)
       end
@@ -73,6 +74,18 @@ module Summary
 
       def client_remanded?
         kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
+      end
+
+      def case_concluded_change_path
+        return nil unless FeatureFlags.means_journey.enabled?
+
+        edit_steps_case_has_case_concluded_path
+      end
+
+      def client_remanded_change_path
+        return nil unless FeatureFlags.means_journey.enabled?
+
+        edit_steps_case_is_client_remanded_path
       end
     end
   end


### PR DESCRIPTION
## Description of change
With means_journey FeatureFlag off in local, the CYA page was breaking as the app does not have the case concluded and remanded in custody routes defined. Put these behind guard clauses to make sure they don't get called whilst means_journey FeatureFlag is off, so that this change can be deployed to prod. 

To test:

1. You can see that in main, if you switch the means_journey feature flag to false for local (and restart your local server), that the CYA page blows up as the case concluded and client remanded routes aren't defined.
2. Checkout this branch
3. Complete a means tested application, Selecting Yes and providing dates for Case concluded and Client remanded pages
4. Ensure on the CYA page, those 4 rows show in the Case section, and the change links go to the correct pages
5. Ensure that the application submits
6. Switch the means_journey feature flag to false for local and restart your local server
7. Complete an application - you should not see the means tested q, or Case concluded and Client remanded pages
8. Ensure the CYA page renders, Ensure those 4 rows are not there
9. Ensure that the application submits