### PR TITLE
Submit additional information with PSE application

### DIFF
--- a/app/serializers/submission_serializer/sections/pse_application_details.rb
+++ b/app/serializers/submission_serializer/sections/pse_application_details.rb
@@ -10,6 +10,7 @@ module SubmissionSerializer
           json.application_type crime_application.application_type
           json.created_at crime_application.created_at
           json.submitted_at crime_application.submitted_at
+          json.additional_information crime_application.additional_information if FeatureFlags.more_information.enabled?
         end
       end
     end

--- a/spec/serializers/submission_serializer/sections/pse_application_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/pse_application_details_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe SubmissionSerializer::Sections::PseApplicationDetails do
           application_type: 'post_submission_evidence',
           ioj_passport: ['on_age_under18'],
           means_passport: ['on_age_under18'],
+          additional_information: 'PSE additional information',
         )
       end
 
@@ -30,7 +31,8 @@ RSpec.describe SubmissionSerializer::Sections::PseApplicationDetails do
           reference: 10_000_001,
           application_type: 'post_submission_evidence',
           created_at: created_at,
-          submitted_at: submitted_at
+          submitted_at: submitted_at,
+          additional_information: 'PSE additional information'
         }.as_json
       end
 


### PR DESCRIPTION
## Description of change

Fixes an issue where the additional information is not submitted along with the rest of the application details for a PSE application. Noted when testing locally.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
