### PR TITLE
Fix/validation for missing case type

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -29,8 +29,10 @@ module DeveloperTools
       find_or_create_applicant
 
       crime_application.update(
+        is_means_tested: YesNoAnswer::YES,
         client_has_partner: YesNoAnswer::NO,
         navigation_stack: [
+          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_has_nino_path(crime_application),
@@ -57,8 +59,10 @@ module DeveloperTools
       find_or_create_case
 
       crime_application.update(
+        is_means_tested: YesNoAnswer::YES,
         client_has_partner: YesNoAnswer::NO,
         navigation_stack: [
+          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
           edit_steps_client_contact_details_path(crime_application),

--- a/app/services/passporting/ioj_passporter.rb
+++ b/app/services/passporting/ioj_passporter.rb
@@ -50,7 +50,7 @@ module Passporting
     end
 
     def appeal_case_type?
-      return false if crime_application.not_means_tested?
+      return false if kase.case_type.nil?
 
       CaseType.new(kase.case_type).appeal?
     end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -12,7 +12,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
       ]
     end
 
-    if record.case.case_type.nil? && record.is_means_tested == 'yes'
+    if record.is_means_tested == 'yes' && record.case.case_type.nil?
       errors << [
         :base, :case_type_missing, { change_path: edit_steps_client_case_type_path }
       ]

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -1,12 +1,20 @@
 class ApplicationFulfilmentValidator < BaseFulfilmentValidator
   private
 
-  def perform_validations
+  # More validations can be added here
+  # Errors, when more than one, will maintain the order
+  def perform_validations # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     errors = []
 
     unless Passporting::MeansPassporter.new(record).call || evidence_present?
       errors << [
         :means_passport, :blank, { change_path: edit_steps_client_details_path }
+      ]
+    end
+
+    if record.case.case_type.nil? && record.is_means_tested == 'yes'
+      errors << [
+        :base, :case_type_missing, { change_path: edit_steps_client_case_type_path }
       ]
     end
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -13,6 +13,8 @@ en:
         # fulfillment validation errors
         crime_application:
           attributes:
+            base:
+              case_type_missing: A case type needs to be selected
             means_passport:
               blank: Applicant is not passported on means
             ioj_passport:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -35,7 +35,7 @@ en:
       steps_provider_select_office_form:
         office_code: Select your office account number
       steps_client_is_means_tested_form:
-        is_means_tested: Is this application means tested?
+        is_means_tested:  Is this application subject to the usual means or passported test?
       steps_client_has_partner_form:
         client_has_partner: Does your client have a partner?
       steps_client_details_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -35,7 +35,7 @@ en:
       steps_provider_select_office_form:
         office_code: Select your office account number
       steps_client_is_means_tested_form:
-        is_means_tested:  Is this application subject to the usual means or passported test?
+        is_means_tested: Is this application subject to the usual means or passported test?
       steps_client_has_partner_form:
         client_has_partner: Does your client have a partner?
       steps_client_details_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -19,7 +19,7 @@ en:
     client:
       is_means_tested:
         edit:
-          page_title: Is this application means tested?
+          page_title:  Is this application subject to the usual means or passported test?
       has_partner:
         edit:
           page_title: Does your client have a partner?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -19,7 +19,7 @@ en:
     client:
       is_means_tested:
         edit:
-          page_title:  Is this application subject to the usual means or passported test?
+          page_title: Is this application subject to the usual means or passported test?
       has_partner:
         edit:
           page_title: Does your client have a partner?


### PR DESCRIPTION
## Description of change
In applications where provider initially sets non-means tested to true, then returns and changes to false, there will be no case type recorded. We need to add to the validator to catch this scenario.

### Screenshot after changes:
<img width="720" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/cc28d5f2-54c0-422c-a0cd-ad1da3f5fd2f">

## How to manually test the feature
Create an application that is not means tested
When reaching the CYA page, click the change link for the means tested No answer - change it to Yes. 
Click save and continue
Select No for partner
Click save and continue
Click Confirm declaration and submit application
Click Save and submit to see errors