### PR TITLE
CRIMAPP-357 - Fix charges page flow

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -17,6 +17,10 @@ class Charge < ApplicationRecord
     offence_name.present? && valid_dates?
   end
 
+  def incomplete?
+    !complete?
+  end
+
   def valid_dates?
     offence_dates.any? && offence_dates.all?(&:date_from)
   end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -17,10 +17,6 @@ class Charge < ApplicationRecord
     offence_name.present? && valid_dates?
   end
 
-  def incomplete?
-    !complete?
-  end
-
   def valid_dates?
     offence_dates.any? && offence_dates.all?(&:date_from)
   end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -40,7 +40,7 @@ module Decisions
     private
 
     def charges_summary_or_edit_new_charge
-      return edit(:charges_summary) if case_charges.any?
+      return edit(:charges_summary) if case_charges.any?(&:complete?)
 
       edit_new_charge
     end
@@ -99,8 +99,13 @@ module Decisions
     end
 
     def edit_new_charge
-      charge = case_charges.create!
+      charge = incomplete_charges.present? ? incomplete_charges.first : case_charges.create!
+
       edit(:charges, charge_id: charge)
+    end
+
+    def incomplete_charges
+      case_charges.select(&:incomplete?)
     end
 
     def case_charges

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -105,7 +105,7 @@ module Decisions
     end
 
     def incomplete_charges
-      case_charges.select(&:incomplete?)
+      case_charges.reject(&:complete?)
     end
 
     def case_charges

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'feature flag `means_journey` is disabled' do
       let(:feature_flag_means_journey_enabled) { false }
-      let(:charges_double) { double(any?: false, create!: 'charge', select: nil) }
+      let(:charges_double) { double(any?: false, create!: 'charge', reject: nil) }
 
       it 'redirects to the edit `charges` page' do
         expect(subject).to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge')
@@ -71,7 +71,7 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:step_name) { :is_client_remanded }
 
     context 'and there are no charges yet' do
-      let(:charges_double) { double(any?: false, create!: 'charge', select: nil) }
+      let(:charges_double) { double(any?: false, create!: 'charge', reject: nil) }
 
       it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
     end
@@ -180,7 +180,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and answer is `yes`' do
       let(:add_offence) { YesNoAnswer::YES }
-      let(:charges_double) { double(create!: 'charge', select: nil) }
+      let(:charges_double) { double(create!: 'charge', reject: nil) }
 
       # No need to repeat this test, just once is enough as sanity check
       it 'creates a blank new `charge` record' do

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'feature flag `means_journey` is disabled' do
       let(:feature_flag_means_journey_enabled) { false }
-      let(:charges_double) { double(any?: false, create!: 'charge') }
+      let(:charges_double) { double(any?: false, create!: 'charge', select: nil) }
 
       it 'redirects to the edit `charges` page' do
         expect(subject).to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge')
@@ -71,7 +71,7 @@ RSpec.describe Decisions::CaseDecisionTree do
     let(:step_name) { :is_client_remanded }
 
     context 'and there are no charges yet' do
-      let(:charges_double) { double(any?: false, create!: 'charge') }
+      let(:charges_double) { double(any?: false, create!: 'charge', select: nil) }
 
       it { is_expected.to have_destination(:charges, :edit, id: crime_application, charge_id: 'charge') }
     end
@@ -180,7 +180,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'and answer is `yes`' do
       let(:add_offence) { YesNoAnswer::YES }
-      let(:charges_double) { double(create!: 'charge') }
+      let(:charges_double) { double(create!: 'charge', select: nil) }
 
       # No need to repeat this test, just once is enough as sanity check
       it 'creates a blank new `charge` record' do


### PR DESCRIPTION
## Description of change
Empty charges getting created while navigating from `remand` to `offence` page 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-357

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="681" alt="Screenshot 2024-02-05 at 18 07 31" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/3374450a-a438-4854-a6db-11ba6911b520">

### After changes:
<img width="656" alt="Screenshot 2024-02-05 at 18 08 10" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/6cfa1d84-9a4d-4b1e-a63d-3a1682b1e6bb">

## How to manually test the feature

1. Save form "Has a court remanded your client in custody?"
2. Next page should be "What has your client been charged with?"
3. Click "back" button
4. Save form "Has a court remanded your client in custody?"
5. Next page should be "What has your client been charged with?"  (earlier it was "You have added 1 offence" page with 1 incomplete offence)


