### PR TITLE
[CRIMAPP-457] Prevent pse apps from being submitted without evidence

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -37,4 +37,5 @@ class CrimeApplication < ApplicationRecord
   # Before submitting the application we run a final
   # validation to ensure some key details are fulfilled
   validates_with ApplicationFulfilmentValidator, on: :submission, unless: :post_submission_evidence?
+  validates_with PseFulfilmentValidator, on: :submission, if: :post_submission_evidence?
 end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -1,24 +1,6 @@
-class ApplicationFulfilmentValidator < ActiveModel::Validator
-  include Routing
-
-  attr_reader :record
-
-  def validate(record)
-    @record = record
-
-    errors = perform_validations
-    add_errors(errors)
-  end
-
-  # Used by the `Routing` module to build the urls
-  def default_url_options
-    { id: record }
-  end
-
+class ApplicationFulfilmentValidator < BaseFulfilmentValidator
   private
 
-  # More validations can be added here
-  # Errors, when more than one, will maintain the order
   def perform_validations
     errors = []
 
@@ -39,15 +21,5 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
 
   def ioj_present?
     record.ioj.present? && record.ioj.types.any?
-  end
-
-  def evidence_present?
-    record.documents.stored.any?
-  end
-
-  def add_errors(errors)
-    errors.each do |(attr, type, opts)|
-      record.errors.add(attr, type, **opts)
-    end
   end
 end

--- a/app/validators/base_fulfilment_validator.rb
+++ b/app/validators/base_fulfilment_validator.rb
@@ -1,0 +1,37 @@
+class BaseFulfilmentValidator < ActiveModel::Validator
+  include Routing
+
+  attr_reader :record
+
+  def validate(record)
+    @record = record
+
+    errors = perform_validations
+    add_errors(errors)
+  end
+
+  # Used by the `Routing` module to build the urls
+  def default_url_options
+    { id: record }
+  end
+
+  private
+
+  # More validations can be added here
+  # Errors, when more than one, will maintain the order
+  # :nocov:
+  def perform_validations
+    raise 'implement in subclasses'
+  end
+  # :nocov:
+
+  def evidence_present?
+    record.documents.stored.any?
+  end
+
+  def add_errors(errors)
+    errors.each do |(attr, type, opts)|
+      record.errors.add(attr, type, **opts)
+    end
+  end
+end

--- a/app/validators/pse_fulfilment_validator.rb
+++ b/app/validators/pse_fulfilment_validator.rb
@@ -1,0 +1,15 @@
+class PseFulfilmentValidator < BaseFulfilmentValidator
+  private
+
+  def perform_validations
+    errors = []
+
+    unless evidence_present?
+      errors << [
+        :documents, :blank, { change_path: edit_steps_evidence_upload_path }
+      ]
+    end
+
+    errors
+  end
+end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -17,6 +17,8 @@ en:
               blank: Applicant is not passported on means
             ioj_passport:
               blank: Justification for legal aid needs to be completed
+            documents:
+              blank: Upload supporting evidence
         # evidence upload data model
         document:
           attributes:

--- a/spec/validators/pse_fulfilment_validator_spec.rb
+++ b/spec/validators/pse_fulfilment_validator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+module Test
+  CrimeApplicationValidatable = Struct.new(:documents, keyword_init: true) do
+    include ActiveModel::Validations
+    validates_with PseFulfilmentValidator
+
+    def to_param
+      '12345'
+    end
+  end
+end
+
+RSpec.describe PseFulfilmentValidator, type: :model do
+  subject { Test::CrimeApplicationValidatable.new(arguments) }
+
+  let(:arguments) do
+    { documents: }
+  end
+
+  let(:documents) { double(stored: stored_documents) }
+  let(:stored_documents) { [] }
+
+  context 'Pse validation' do
+    context 'when the pse application does not have uploaded evidence' do
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:documents, :blank)).to be(true)
+        expect(subject.errors.first.details[:change_path]).to eq('/applications/12345/steps/evidence/upload')
+      end
+    end
+
+    context 'when the pse application has uploaded evidence' do
+      let(:stored_documents) { [Document.new] }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+        expect(subject.errors.of_kind?(:documents, :blank)).not_to be(true)
+      end
+    end
+  end
+end

--- a/spec/validators/pse_fulfilment_validator_spec.rb
+++ b/spec/validators/pse_fulfilment_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Test
-  CrimeApplicationValidatable = Struct.new(:documents, keyword_init: true) do
+  PseApplicationValidatable = Struct.new(:documents, keyword_init: true) do
     include ActiveModel::Validations
     validates_with PseFulfilmentValidator
 
@@ -12,7 +12,7 @@ module Test
 end
 
 RSpec.describe PseFulfilmentValidator, type: :model do
-  subject { Test::CrimeApplicationValidatable.new(arguments) }
+  subject { Test::PseApplicationValidatable.new(arguments) }
 
   let(:arguments) do
     { documents: }


### PR DESCRIPTION
## Description of change
Adds validation to the review/submit page to prevent users from submitting a pse application without uploading evidence 

## Link to relevant ticket
[CRIMAPP-457](https://dsdmoj.atlassian.net/browse/CRIMAPP-457)

## Notes for reviewer
I attempted to add a validation message to the upload screen itself but the error was shown when evidence was deleted meaning when an application only has one piece of evidence and that is deleted, the validation checking there is at least one piece of supporting evidence fails and then the error is shown. This is not simple to change so this approach was implemented instead as it is technically simpler

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="939" alt="Screenshot 2024-02-09 at 15 32 43" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/8a73d9f1-ca59-4a66-9b1e-23b175c9103d">

## How to manually test the feature

1. Start a pse application
2. Click save and continue on the add supporting evidence screen 
3. Click whatever option on the adding more information and save and continue 
4. Review the application and save and continue 
5. Attempt to submit the application and you should see a validation error like the one in the screenshot 
6. Click the change link and ensure it takes you back to the evidence upload screen 

Play around with uploading and deleting files
Also ensure regular applications do not show this validation as users are not required to submit evidence (for now)

[CRIMAPP-457]: https://dsdmoj.atlassian.net/browse/CRIMAPP-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ