### PR TITLE
[CRIMAPP-281] Limit dependants to 50

### DIFF
--- a/app/forms/steps/income/dependants_form.rb
+++ b/app/forms/steps/income/dependants_form.rb
@@ -7,7 +7,7 @@ module Steps
 
       delegate :dependants_attributes=, to: :crime_application
 
-      validates :dependants, length: { in: 0...Dependant::MAX_TOTAL_DEPENDANTS },
+      validates :dependants, length: { maximum: Dependant::MAX_TOTAL_DEPENDANTS },
                 unless: :any_marked_for_destruction?
 
       validates_with DependantsValidator, unless: :any_marked_for_destruction?

--- a/app/forms/steps/income/dependants_form.rb
+++ b/app/forms/steps/income/dependants_form.rb
@@ -7,6 +7,9 @@ module Steps
 
       delegate :dependants_attributes=, to: :crime_application
 
+      validates :dependants, length: { in: 0...Dependant::MAX_TOTAL_DEPENDANTS },
+                unless: :any_marked_for_destruction?
+
       validates_with DependantsValidator, unless: :any_marked_for_destruction?
 
       def dependants

--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -1,5 +1,6 @@
 class Dependant < ApplicationRecord
   MAX_AGE = 18
+  MAX_TOTAL_DEPENDANTS = 50
 
   belongs_to :crime_application
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -377,7 +377,7 @@ en:
         steps/income/dependants_form:
           attributes:
             dependants:
-              too_long: Must have fewer than 50 dependants
+              too_long: Must have 50 or fewer dependants
         steps/income/dependant_fieldset_form:
           summary:
             age:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -374,6 +374,10 @@ en:
           attributes:
             client_has_dependants:
               inclusion: Select yes if your client has any dependants
+        steps/income/dependants_form:
+          attributes:
+            dependants:
+              too_long: Must have fewer than 50 dependants
         steps/income/dependant_fieldset_form:
           summary:
             age:

--- a/config/locales/en/integer.yml
+++ b/config/locales/en/integer.yml
@@ -52,3 +52,4 @@ en:
       48: forty eighth
       49: forty ninth
       50: fiftieth
+      51: fifty first

--- a/spec/forms/steps/income/dependants_form_spec.rb
+++ b/spec/forms/steps/income/dependants_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Steps::Income::DependantsForm do
   end
 
   describe '#dependants' do
-    context 'there are no dependants' do
+    context 'when there are no dependants' do
       let(:dependants_attributes) { {} }
 
       it 'returns an empty collection' do
@@ -31,13 +31,25 @@ RSpec.describe Steps::Income::DependantsForm do
       end
     end
 
-    context 'there are existing dependants' do
+    context 'when there are existing dependants' do
       it 'builds a collection of `DependantFieldsetForm` instances' do
         expect(subject.dependants[0]).to be_an_instance_of(Steps::Income::DependantFieldsetForm)
         expect(subject.dependants[1]).to be_an_instance_of(Steps::Income::DependantFieldsetForm)
 
         expect(subject.dependants[0].age).to eq(17)
         expect(subject.dependants[1].age).to eq(0)
+      end
+    end
+
+    context 'when there are more than 50 dependants' do
+      before do
+        (1..50).each do
+          crime_application.dependants.create!(age: 1)
+        end
+      end
+
+      it 'will not allow more dependants to be added' do
+
       end
     end
   end

--- a/spec/forms/steps/income/dependants_form_spec.rb
+++ b/spec/forms/steps/income/dependants_form_spec.rb
@@ -41,15 +41,25 @@ RSpec.describe Steps::Income::DependantsForm do
       end
     end
 
-    context 'when there are more than 50 dependants' do
-      before do
-        (1..50).each do
-          crime_application.dependants.create!(age: 1)
-        end
+    context 'when there are 50 dependants' do
+      let(:dependants_attributes) do
+        Array.new(50) { |i| [i.to_s, { 'age' => 5 }] }.to_h
       end
 
-      it 'will not allow more dependants to be added' do
+      it 'is valid' do
+        expect(subject.crime_application.dependants.size).to eq 50
+        expect(subject).to be_valid
+      end
+    end
 
+    context 'when there are 51 or more dependants' do
+      let(:dependants_attributes) do
+        Array.new(51) { |i| [i.to_s, { 'age' => 5 }] }.to_h
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?('dependants', :too_long)).to be(true)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Limits number of dependants a user can add to 50. Arbitrary number, seems sensible.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-281

## Notes for reviewer
- Added the 'fifty first' translation string because of a quirk in the way this 50 limit works:
- When the user presses 'Add new dependant' that creates a new row in the `dependants` database table, but wit a `NULL` age value.
- If the user then presses 'Add new dependant' to save the age for entry number 50 (which updates the database correctly), yet another row is generated in the database for entry number 51, with a `NULL` age, however a validation error is also shown
- Therefore the simplest solution is to allow Dependant entry number 51 to show on screen, show the error message and hope the user does not ever have 50 dependants.

## Screenshots of changes (if applicable)

<img width="710" alt="Screenshot 2024-02-16 at 10 04 58" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/2dc444c7-ac51-49df-80aa-225eaa6dbafa">



## How to manually test the feature
Create an application and then navigate to the dependants form e.g.:

https://https://staging.review-criminal-legal-aid.service.justice.gov.uk/applications/<CRIME APP ID>/steps/income/dependants