### PR TITLE
CRIMAPP-516 Make pre-order work page conditional

### DIFF
--- a/app/forms/steps/case/has_case_concluded_form.rb
+++ b/app/forms/steps/case/has_case_concluded_form.rb
@@ -27,9 +27,18 @@ module Steps
       end
 
       def attributes_to_reset
-        {
-          'date_case_concluded' => (date_case_concluded if case_concluded?)
-        }
+        if case_concluded?
+          {
+            'date_case_concluded' => date_case_concluded
+          }
+        else
+          {
+            'date_case_concluded' => nil,
+            'is_preorder_work_claimed' => nil,
+            'preorder_work_date' => nil,
+            'preorder_work_details' => nil
+          }
+        end
       end
 
       def case_concluded?

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -1,11 +1,12 @@
 module Decisions
+  # rubocop:disable Metrics/ClassLength
   class CaseDecisionTree < BaseDecisionTree
     def destination # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
       case step_name
       when :urn
         FeatureFlags.means_journey.enabled? ? edit(:has_case_concluded) : charges_summary_or_edit_new_charge
       when :has_case_concluded
-        edit(:is_preorder_work_claimed)
+        after_has_case_concluded
       when :is_preorder_work_claimed
         edit(:is_client_remanded)
       when :is_client_remanded
@@ -38,6 +39,12 @@ module Decisions
     end
 
     private
+
+    def after_has_case_concluded
+      return edit(:is_client_remanded) if form_object.has_case_concluded.no?
+
+      edit(:is_preorder_work_claimed)
+    end
 
     def charges_summary_or_edit_new_charge
       return edit(:charges_summary) if case_charges.any?(&:complete?)
@@ -126,4 +133,5 @@ module Decisions
       edit('/steps/submission/more_information')
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/spec/forms/steps/case/has_case_concluded_form_spec.rb
+++ b/spec/forms/steps/case/has_case_concluded_form_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe Steps::Case::HasCaseConcludedForm do
                       association_name: :case,
                       expected_attributes: {
                         'has_case_concluded' => YesNoAnswer::NO,
-                        'date_case_concluded' => nil
+                        'date_case_concluded' => nil,
+                        'is_preorder_work_claimed' => nil,
+                        'preorder_work_date' => nil,
+                        'preorder_work_details' => nil
                       }
 
       context 'when `has_case_concluded` answer is no' do

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -49,11 +49,23 @@ RSpec.describe Decisions::CaseDecisionTree do
   end
 
   context 'when the step is `has_case_concluded`' do
-    let(:form_object) { double('FormObject') }
+    let(:form_object) { double('FormObject', case: kase, has_case_concluded: has_case_concluded) }
     let(:step_name) { :has_case_concluded }
 
-    it 'redirects to the `is_preorder_work_claimed` page' do
-      expect(subject).to have_destination(:is_preorder_work_claimed, :edit, id: crime_application)
+    context 'and answer is `yes`' do
+      let(:has_case_concluded) { YesNoAnswer::YES }
+
+      it 'redirects to the `is_preorder_work_claimed` page' do
+        expect(subject).to have_destination(:is_preorder_work_claimed, :edit, id: crime_application)
+      end
+    end
+
+    context 'and answer is `no`' do
+      let(:has_case_concluded) { YesNoAnswer::NO }
+
+      it 'redirects to the `is_client_remanded` page' do
+        expect(subject).to have_destination(:is_client_remanded, :edit, id: crime_application)
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change

Add conditional logic for "Has the Case concluded" question

Has the case concluded?
- yes

> -  Redirects to **"Do you intend to claim pre-order work?"** page

- no

>-  Redirects to **"Has a court remanded your client in custody?"** page
>- Reset 'Pre-order work' attributes to nil

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-516

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="2450" alt="Screenshot 2024-02-16 at 13 58 27" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/c8834b07-4920-46f2-b175-56ab4a369740">




## How to manually test the feature
