### PR TITLE
CRIMAPP-458 add outgoing payments table and model

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -15,6 +15,8 @@ class CrimeApplication < ApplicationRecord
   has_many :documents, dependent: :destroy
   has_many :income_payments, dependent: :destroy
   accepts_nested_attributes_for :income_payments, allow_destroy: true
+  has_many :outgoings_payments, dependent: :destroy
+  accepts_nested_attributes_for :outgoings_payments, allow_destroy: true
 
   has_many :income_benefits, dependent: :destroy
   accepts_nested_attributes_for :income_benefits, allow_destroy: true

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -1,0 +1,6 @@
+class OutgoingsPayment < ApplicationRecord
+  belongs_to :crime_application
+  attribute :amount, :pence
+
+  store_accessor :metadata, :details
+end

--- a/app/value_objects/outgoings_payment_type.rb
+++ b/app/value_objects/outgoings_payment_type.rb
@@ -1,0 +1,11 @@
+class OutgoingsPaymentType < ValueObject
+  VALUES = [
+    RENT = new(:rent),
+    MORTGAGE = new(:mortgage),
+    BOARD_AND_LODGING = new(:board_and_lodging),
+    COUNCIL_TAX = new(:council_tax),
+    CHILDCARE = new(:childcare),
+    MAINTENANCE = new(:maintenance),
+    LEGAL_AID_CONTRIBUTION = new(:legal_aid_contribution)
+  ].freeze
+end

--- a/db/migrate/20240208114218_create_outgoings_payments.rb
+++ b/db/migrate/20240208114218_create_outgoings_payments.rb
@@ -1,0 +1,15 @@
+class CreateOutgoingsPayments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :outgoings_payments, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false
+
+      t.timestamps
+
+      t.string :payment_type, null: false
+      t.integer :amount
+      t.string :frequency
+      t.jsonb :metadata, default: {}
+      t.index [:crime_application_id, :payment_type], unique: true, name: "index_crime_application_outgoings_payment_type"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -194,6 +194,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_104823) do
     t.index ["charge_id"], name: "index_offence_dates_on_charge_id"
   end
 
+  create_table "outgoing_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "payment_type", null: false
+    t.integer "amount", null: false
+    t.string "frequency", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.index ["crime_application_id", "payment_type"], name: "index_crime_application_outgoings_payment_type", unique: true
+    t.index ["crime_application_id"], name: "index_outgoings_payments_on_crime_application_id"
+  end
+
   create_table "outgoings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "outgoings_more_than_income"
@@ -272,6 +284,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_104823) do
   add_foreign_key "incomes", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
+  add_foreign_key "outgoings_payments", "crime_applications"
   add_foreign_key "outgoings", "crime_applications"
   add_foreign_key "people", "crime_applications"
   add_foreign_key "savings", "crime_applications"


### PR DESCRIPTION
## Description of change

- Add migration to create outgoing payments table,
- Add uniqueness index on crime_application_id with payment_type columns so each application can have only one of each payment type
- Add model which belongs_to CrimeApplication

## Link to relevant ticket

[CRIMAPP-458](https://dsdmoj.atlassian.net/browse/CRIMAPP-458)

## Notes for reviewer

## Screenshots of changes (if applicable)

N/A

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-458]: https://dsdmoj.atlassian.net/browse/CRIMAPP-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ