### PR TITLE
CRIMAPP-511 add savings

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -8,6 +8,8 @@ module ErrorHandling
         redirect_to invalid_token_errors_path
       when Errors::InvalidSession
         redirect_to invalid_session_errors_path
+      when Errors::SavingNotFound
+        redirect_to not_found_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path
       # NOTE: Add more custom errors as they are needed, for instance:

--- a/app/controllers/steps/capital/saving_type_controller.rb
+++ b/app/controllers/steps/capital/saving_type_controller.rb
@@ -8,7 +8,7 @@ module Steps
       end
 
       def update
-        update_and_advance(SavingTypeForm, as: :savings)
+        update_and_advance(SavingTypeForm, as: :saving_type)
       end
 
       def additional_permitted_params

--- a/app/controllers/steps/capital/savings_controller.rb
+++ b/app/controllers/steps/capital/savings_controller.rb
@@ -1,0 +1,33 @@
+module Steps
+  module Capital
+    class SavingsController < Steps::CapitalStepController
+      def edit
+        @form_object = SavingsForm.build(
+          saving_record, crime_application: current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          SavingsForm, record: saving_record, as: :savings
+        )
+      end
+
+      private
+
+      def saving_record
+        @saving_record ||= savings.find(params[:saving_id])
+      rescue ActiveRecord::RecordNotFound
+        raise Errors::SavingNotFound
+      end
+
+      def savings
+        @savings ||= current_crime_application.savings
+      end
+
+      def additional_permitted_params
+        [:confirm_in_applicants_name]
+      end
+    end
+  end
+end

--- a/app/forms/steps/capital/saving_type_form.rb
+++ b/app/forms/steps/capital/saving_type_form.rb
@@ -5,6 +5,8 @@ module Steps
 
       validates :saving_type, presence: true
 
+      attr_reader :saving
+
       def choices
         SavingType.values
       end
@@ -12,8 +14,15 @@ module Steps
       private
 
       def persist!
-        # TODO: If none, go to next step
-        # If type selected, build new savings form
+        return true if saving_type == 'none'
+
+        @saving = incomplete_saving_for_type || crime_application.savings.create(saving_type:)
+      end
+
+      def incomplete_saving_for_type
+        return nil unless saving_type
+
+        crime_application.savings.where(saving_type:).reject(&:complete?).first
       end
     end
   end

--- a/app/forms/steps/capital/savings_form.rb
+++ b/app/forms/steps/capital/savings_form.rb
@@ -1,0 +1,45 @@
+module Steps
+  module Capital
+    class SavingsForm < Steps::BaseFormObject
+      delegate :saving_type, to: :record
+
+      attribute :provider_name, :string
+      attribute :account_balance, :pence
+      attribute :sort_code, :string
+      attribute :account_number, :string
+      attribute :is_overdrawn, :value_object, source: YesNoAnswer
+      attribute :are_wages_paid_into_account, :value_object, source: YesNoAnswer
+      attribute :account_holder, :value_object, source: OwnershipType
+
+      validates :provider_name, :sort_code, :account_number, :account_balance, presence: true
+      validates :is_overdrawn, :are_wages_paid_into_account, inclusion: { in: YesNoAnswer.values }
+      validates :account_holder, inclusion: { in: OwnershipType.values, if: :include_partner? }
+      validate :owned_by_applicant, unless: :include_partner?
+
+      def persist!
+        record.update(attributes)
+      end
+
+      def confirm_in_applicants_name=(confirm)
+        return unless confirm && !include_partner?
+
+        self.account_holder = OwnershipType::APPLICANT
+      end
+
+      def confirm_in_applicants_name
+        account_holder == OwnershipType::APPLICANT
+      end
+
+      # TODO: use proper partner policy once we have one.
+      def include_partner?
+        YesNoAnswer.new(crime_application.client_has_partner).yes?
+      end
+
+      def owned_by_applicant
+        return unless account_holder.blank? || !account_holder.applicant?
+
+        errors.add(:confirm_in_applicants_name, :confirm)
+      end
+    end
+  end
+end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,5 +1,6 @@
 module Errors
   class InvalidSession < StandardError; end
   class ApplicationNotFound < StandardError; end
+  class SavingNotFound < StandardError; end
   class ApplicationCannotReceivePse < StandardError; end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -22,6 +22,8 @@ class CrimeApplication < ApplicationRecord
   has_many :dependants, dependent: :destroy
   accepts_nested_attributes_for :dependants, allow_destroy: true
 
+  has_many :savings, dependent: :destroy
+
   # Shortcuts through intermediate tables
   has_one :ioj, through: :case
   has_many :addresses, through: :people

--- a/app/models/saving.rb
+++ b/app/models/saving.rb
@@ -1,0 +1,9 @@
+class Saving < ApplicationRecord
+  belongs_to :crime_application
+
+  attribute :account_balance, :pence
+
+  def complete?
+    attributes.values.none?(&:blank?)
+  end
+end

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -3,12 +3,22 @@ module Decisions
     def destination
       case step_name
       when :saving_type
+        after_saving_type(form_object.saving)
+      when :savings
         # TODO: Add next step
       when :property_type
         # TODO: Add next step
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
+    end
+
+    private
+
+    def after_saving_type(saving)
+      return edit(:premium_bonds) unless saving
+
+      edit(:savings, saving_id: saving)
     end
   end
 end

--- a/app/value_objects/ownership_type.rb
+++ b/app/value_objects/ownership_type.rb
@@ -1,0 +1,7 @@
+class OwnershipType < ValueObject
+  VALUES = [
+    APPLICANT = new(:applicant),
+    APPLICANT_AND_PARTNER = new(:applicant_and_partner),
+    PARTNER = new(:partner),
+  ].freeze
+end

--- a/app/views/steps/capital/savings/edit.html.erb
+++ b/app/views/steps/capital/savings/edit.html.erb
@@ -1,0 +1,33 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl">
+      <%= t(".heading.#{@form_object.saving_type}") %>
+    </h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_text_field :provider_name, autocomplete: 'off' %>
+      <%= f.govuk_text_field :sort_code, autocomplete: 'off', inputmode: 'numeric', extra_letter_spacing: true, width: 'one-half' %>
+      <%= f.govuk_text_field :account_number, autocomplete: 'off', inputmode: 'numeric', extra_letter_spacing: true, width: 'one-half' %>
+      <%= f.govuk_number_field :account_balance, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+      <%= f.govuk_collection_radio_buttons :is_overdrawn, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
+      <%= f.govuk_collection_radio_buttons :are_wages_paid_into_account, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
+
+      <% if f.object.include_partner? %>
+        <%= f.govuk_collection_radio_buttons :account_holder, OwnershipType.values, :value, legend: { size: 's' } %>
+      <% else %>
+
+        <%= f.govuk_check_boxes_fieldset :confirm_in_applicants_name, legend: { size: 'm' } do %>
+        <%= f.govuk_check_box :confirm_in_applicants_name, true, multiple: false %>
+        <% end %>
+      <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -447,6 +447,24 @@ en:
           attributes:
             saving_type:
               blank: Select which savings your client has inside or outside the UK, or select 'My client does not have any of these savings'
+        steps/capital/savings_form:
+          attributes:
+            provider_name: 
+              blank: Enter the name of the bank, building society or other holder of the savings
+            sort_code: 
+              blank: Enter the sort code or branch name
+            account_number: 
+              blank: Enter the account number
+            account_balance: 
+              blank: Enter the account balance
+            is_overdrawn: 
+              inclusion: Select yes if the account is overdrawn
+            are_wages_paid_into_account: 
+              inclusion: Select yes if your client's wages or benefits are paid into this account
+            account_holder: 
+              inclusion: Select whose name the account is in
+            confirm_in_applicants_name:
+              confirm: Confirm the account is in your client’s name
         steps/submission/more_information_form:
           attributes:
             additional_information:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -4,6 +4,10 @@ en:
     ioj_justification_hint: &ioj_justification_hint 'Enter justification'
     frequency_legend: &frequency_legend 'Select how often they get this payment'
     amount_label: &amount_label 'Enter amount'
+    OWNERSHIP_OPTIONS: &OWNERSHIP_OPTIONS
+      applicant: 'Client'
+      applicant_and_partner: 'Client and partner'
+      partner: 'Partner'
     YESNO: &YESNO
       'yes': 'Yes'
       'no': 'No'
@@ -93,6 +97,11 @@ en:
         property_type: Which assets does your client own or part-own inside or outside the UK?
       steps_capital_saving_type_form:
         saving_type: Which savings does your client have inside or outside the UK?
+      steps_capital_savings_form:
+        is_overdrawn: Is the account overdrawn?
+        are_wages_paid_into_account: Are your client’s wages or benefits paid into this account?
+        confirm_in_applicants_name: Confirm the following 
+        account_holder: Whose name is the account in?
 
     hint:
       steps_client_details_form:
@@ -418,3 +427,13 @@ en:
           national_savings_or_post_office: National Savings or Post Office accounts
           other: Any other cash investment
           none: My client does not have any of these savings
+      steps_capital_savings_form:
+        provider_name: What is the name of the bank, building society or other holder of the savings?
+        sort_code: What is the sort code or branch name?
+        account_number: What is the account number?
+        account_balance: What is the account balance?
+        is_overdrawn_options: *YESNO
+        are_wages_paid_into_account_options: *YESNO
+        account_holder_options: *OWNERSHIP_OPTIONS 
+        confirm_in_applicants_name_options: 
+          'true': I confirm that the account is in my client's name 

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -300,6 +300,15 @@ en:
       property_type:
         edit:
           page_title: Which assets does your client own or part-own inside or outside the UK?
+      savings:
+        edit:
+          page_title: Add savings account details 
+          heading: 
+            bank: Your client’s bank account
+            building_society: Your client’s building society account
+            cash_isa: Your client’s cash ISA
+            national_savings_or_post_office: Your client’s National Savings or Post Office account
+            other: Your client’s other cash investment
 
     evidence:
       upload:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
       namespace :capital, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
         edit_step :which_assets_does_client_own, alias: :property_type
         edit_step :which_savings_does_client_have, alias: :saving_type
+        crud_step :savings, param: :saving_id
       end
 
       namespace :evidence do

--- a/db/migrate/20240216142643_create_savings.rb
+++ b/db/migrate/20240216142643_create_savings.rb
@@ -1,0 +1,18 @@
+class CreateSavings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :savings, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false
+
+      t.string :saving_type, null: false
+      t.string :provider_name
+      t.string :sort_code
+      t.string :account_number
+      t.integer :account_balance
+      t.string :is_overdrawn
+      t.string :are_wages_paid_into_account
+      t.string :account_holder
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,6 +246,21 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_104823) do
     t.index ["auth_provider", "uid"], name: "index_providers_on_auth_provider_and_uid", unique: true
   end
 
+  create_table "savings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.string "saving_type", null: false
+    t.string "provider_name"
+    t.string "sort_code"
+    t.string "account_number"
+    t.integer "account_balance"
+    t.string "is_overdrawn"
+    t.string "are_wages_paid_into_account"
+    t.string "account_holder"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crime_application_id"], name: "index_savings_on_crime_application_id"
+  end
+
   add_foreign_key "addresses", "people"
   add_foreign_key "cases", "crime_applications"
   add_foreign_key "charges", "cases"
@@ -259,4 +274,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_104823) do
   add_foreign_key "offence_dates", "charges"
   add_foreign_key "outgoings", "crime_applications"
   add_foreign_key "people", "crime_applications"
+  add_foreign_key "savings", "crime_applications"
 end

--- a/spec/controllers/steps/capital/savings_controller_spec.rb
+++ b/spec/controllers/steps/capital/savings_controller_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::SavingsController, type: :controller do
+  let(:form_class) { Steps::Capital::SavingsForm }
+  let(:decision_tree_class) { Decisions::CapitalDecisionTree }
+
+  let(:crime_application) { CrimeApplication.create }
+
+  describe '#edit' do
+    context 'when application is not found' do
+      it 'redirects to the application not found error page' do
+        get :edit, params: { id: '12345', saving_id: '123' }
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when application is found' do
+      let(:saving) do
+        Saving.create!(saving_type: SavingType::BANK, crime_application: crime_application)
+      end
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: crime_application, saving_id: saving }
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when saving is for another application' do
+      let(:saving) do
+        Saving.create!(saving_type: SavingType::BANK, crime_application: CrimeApplication.create!)
+      end
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: crime_application, saving_id: saving }
+
+        expect(response).to redirect_to(not_found_errors_path)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+
+    let(:expected_params) do
+      {
+        :id => crime_application,
+        :saving_id => saving,
+        form_class_params_name => { foo: 'bar' }
+      }
+    end
+
+    context 'when application is not found' do
+      let(:crime_application) { '12345' }
+      let(:saving) { '123' }
+
+      it 'redirects to the application not found error page' do
+        put :update, params: expected_params
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when saving is for another application' do
+      let(:saving) do
+        Saving.create!(saving_type: SavingType::BANK, crime_application: CrimeApplication.create!)
+      end
+
+      it 'responds with HTTP success' do
+        put :update, params: expected_params
+
+        expect(response).to redirect_to(not_found_errors_path)
+      end
+    end
+
+    context 'when an in progress application and saving is found' do
+      let(:saving) do
+        Saving.create!(saving_type: SavingType::BANK, crime_application: crime_application)
+      end
+
+      before do
+        saving
+        allow(form_class).to receive(:new).and_return(form_object)
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          expect(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) { instance_double(decision_tree_class, destination: '/expected_destination') }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(decision_tree_class).to receive(:new).and_return(decision_tree)
+
+          put :update, params: expected_params
+
+          expect(response).to have_http_status(:redirect)
+          expect(subject).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          expect(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the question page again' do
+          put :update, params: expected_params, session: { crime_application_id: crime_application.id }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/capital/saving_type_form_spec.rb
+++ b/spec/forms/steps/capital/saving_type_form_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Capital::SavingTypeForm do
-  subject(:form) { described_class.new }
+  subject(:form) { described_class.new(crime_application:) }
+
+  let(:crime_application) { instance_double(CrimeApplication, savings:) }
+  let(:savings) { class_double(Saving, where: existing_savings) }
+  let(:existing_savings) { [] }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -9,6 +13,54 @@ RSpec.describe Steps::Capital::SavingTypeForm do
         form.choices
       ).to eq([SavingType::BANK, SavingType::BUILDING_SOCIETY, SavingType::CASH_ISA,
                SavingType::NATIONAL_SAVINGS_OR_POST_OFFICE, SavingType::OTHER])
+    end
+  end
+
+  describe '#save' do
+    let(:saving_type) { SavingType.values.sample }
+    let(:new_saving) { instance_double(Saving) }
+    let(:existing_saving) { instance_double(Saving, complete?: complete?) }
+    let(:complete?) { false }
+
+    before do
+      allow(savings).to receive(:create).with(saving_type:).and_return new_saving
+
+      form.saving_type = saving_type
+      form.save
+    end
+
+    context 'when client has no savings' do
+      let(:saving_type) { 'none' }
+
+      it 'returns true but does not set or create a saving' do
+        expect(form.saving).to be_nil
+        expect(savings).not_to have_received(:create)
+      end
+    end
+
+    context 'when there are no savings of the saving type' do
+      it 'a new saving of the saving type is created' do
+        expect(form.saving).to be new_saving
+        expect(savings).to have_received(:create).with(saving_type:)
+      end
+    end
+
+    context 'when a saving of the type exists' do
+      let(:existing_savings) { [existing_saving] }
+
+      it 'is set as the saving' do
+        expect(form.saving).to be existing_saving
+        expect(savings).not_to have_received(:create)
+      end
+
+      context 'when the existing saving is complete' do
+        let(:complete?) { true }
+
+        it 'a new saving of the saving type is created' do
+          expect(form.saving).to be new_saving
+          expect(savings).to have_received(:create).with(saving_type:)
+        end
+      end
     end
   end
 end

--- a/spec/forms/steps/capital/savings_form_spec.rb
+++ b/spec/forms/steps/capital/savings_form_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::SavingsForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      record:,
+    }.merge(attributes)
+  end
+
+  let(:attributes) { {} }
+
+  let(:crime_application) do
+    instance_double(CrimeApplication, client_has_partner:)
+  end
+
+  let(:record) { Saving.new }
+  let(:client_has_partner) { 'no' }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:provider_name) }
+    it { is_expected.to validate_presence_of(:sort_code) }
+    it { is_expected.to validate_presence_of(:account_number) }
+    it { is_expected.to validate_presence_of(:account_balance) }
+    it { is_expected.to validate_is_a(:is_overdrawn, YesNoAnswer) }
+    it { is_expected.to validate_is_a(:are_wages_paid_into_account, YesNoAnswer) }
+
+    context 'when client has no partner' do
+      describe 'errors on `confirm_in_applicants_name`' do
+        subject(:error_message) do
+          form.errors.full_messages_for(:confirm_in_applicants_name).first
+        end
+
+        before do
+          form.account_holder = ownership
+          form.valid?
+        end
+
+        context 'when ownership type is `OwnershipType::Applicant`' do
+          let(:ownership) { OwnershipType::APPLICANT }
+
+          it { is_expected.to be_nil }
+        end
+
+        context 'when ownership type is `nil`' do
+          let(:ownership) { nil }
+
+          it { is_expected.to eq 'Confirm the account is in your client’s name' }
+        end
+
+        context 'when ownership type is Partner' do
+          let(:ownership) { OwnershipType::PARTNER }
+
+          it { is_expected.to eq 'Confirm the account is in your client’s name' }
+        end
+
+        context 'when ownership type is Applicant and Partner' do
+          let(:ownership) { OwnershipType::APPLICANT_AND_PARTNER }
+
+          it { is_expected.to eq 'Confirm the account is in your client’s name' }
+        end
+      end
+    end
+
+    context 'when client has a partner' do
+      let(:client_has_partner) { 'yes' }
+
+      it { is_expected.to validate_is_a(:account_holder, OwnershipType) }
+    end
+  end
+
+  describe '#confirm_in_applicants_name=(confirm)' do
+    subject(:confirm) { form.confirm_in_applicants_name = value }
+
+    context 'when value is true' do
+      let(:value) { true }
+
+      it 'sets `#account_holder` to `applicant`' do
+        expect { confirm }.to change(form, :account_holder).from(nil).to(OwnershipType::APPLICANT)
+      end
+
+      context 'when client has parter' do
+        let(:client_has_partner) { 'yes' }
+
+        it 'does not set the account holder' do
+          expect { confirm }.not_to(change(form, :account_holder))
+        end
+      end
+    end
+
+    context 'when value is false' do
+      let(:value) { false }
+
+      it 'does not set the account holder' do
+        expect { confirm }.not_to(change(form, :account_holder))
+      end
+    end
+
+    context 'when value is nil' do
+      let(:value) { nil }
+
+      it 'does not set the account holder' do
+        expect { confirm }.not_to(change(form, :account_holder))
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'for valid details' do
+      let(:attributes) do
+        {
+          provider_name: 'Bank of Test',
+          account_holder: OwnershipType::APPLICANT,
+          sort_code: '01-01-01',
+          account_number: '01234500',
+          account_balance: '100.01',
+          is_overdrawn: YesNoAnswer.values.sample,
+          are_wages_paid_into_account: YesNoAnswer.values.sample,
+        }
+      end
+
+      it 'updates the record' do
+        expect(record).to receive(:update).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/saving_spec.rb
+++ b/spec/models/saving_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Saving, type: :model do
+  subject(:instance) { described_class.new(attributes) }
+
+  let(:attributes) { { id: nil } }
+
+  describe '#complete?' do
+    subject(:complete) { instance.complete? }
+
+    context 'when initialized' do
+      it { is_expected.to be false }
+    end
+
+    context 'when all provided attributes are present' do
+      let(:attributes) do
+        {
+          id: SecureRandom.uuid,
+          crime_application_id: SecureRandom.uuid,
+          saving_type: SavingType.values.sample,
+          provider_name: 'Bank of Test',
+          account_holder: OwnershipType.values.sample,
+          sort_code: '01-01-01',
+          account_number: '01234500',
+          account_balance: '100.01',
+          is_overdrawn: YesNoAnswer.values.sample,
+          are_wages_paid_into_account: YesNoAnswer.values.sample,
+          created_at: Time.zone.now,
+          updated_at: Time.zone.now
+        }
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -4,4 +4,30 @@ RSpec.describe Decisions::CapitalDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
   it_behaves_like 'a decision tree'
+
+  context 'when the step is `saving_type`' do
+    let(:crime_application) { instance_double(CrimeApplication, id: '10') }
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :saving_type }
+
+    before do
+      allow(form_object).to receive_messages(crime_application:, saving:)
+    end
+
+    context 'the client has no savings' do
+      let(:saving) { nil }
+
+      it 'redirects premium bonds' do
+        expect(subject).to have_destination(:premium_bonds, :edit, id: crime_application)
+      end
+    end
+
+    context 'the client has selected a saving type' do
+      let(:saving) { 'new_saving' }
+
+      it 'redirects the edit `savings` page' do
+        expect(subject).to have_destination(:savings, :edit, id: crime_application, saving_id: saving)
+      end
+    end
+  end
 end

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -43,3 +43,33 @@ RSpec::Matchers.define :validate_absence_of do |attribute, error = :present|
     "expected `#{attribute}` not to have error `#{error}` but got `#{errors_for(attribute, object)}`"
   end
 end
+
+RSpec::Matchers.define :validate_is_a do |attribute, klass|
+  include ValidationHelpers
+
+  match do |object|
+    value = klass.values.sample.to_s
+    object.send("#{attribute}=", value)
+    return false if check_errors(object, attribute, :inclusion)
+
+    object.send("#{attribute}=", nil)
+    return false unless check_errors(object, attribute, :inclusion)
+
+    object.send("#{attribute}=", 'not_a_type')
+    check_errors(object, attribute, :inclusion)
+  end
+
+  chain :on_context, :validation_context
+
+  description do
+    "validate #{attribute} is a #{klass}"
+  end
+
+  failure_message do |_object|
+    "expected `#{attribute}` to have an error unless #{klass}"
+  end
+
+  failure_message_when_negated do |_object|
+    "expected `#{attribute}` not to have an error unless #{klass}"
+  end
+end

--- a/spec/value_objects/ownership_type_spec.rb
+++ b/spec/value_objects/ownership_type_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe OwnershipType do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(
+        %w[
+          applicant
+          applicant_and_partner
+          partner
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds the ‘Your Client’s savings?’ page. 
Creates a new saving from the saving_type page.
 

## Link to relevant ticket
[CRIMAPP-511](https://dsdmoj.atlassian.net/browse/CRIMAPP-511)

## Notes for reviewer
This is the 2nd screen in the savings loop/journey.
The savings summary page and premium bond destinations are part of a separate ticket.

This PR also introduces a new validation helper to check that an attribute is validated as a ValueObject. For example: 
```ruby
it { is_expected.to validate_is_a(:account_holder, OwnershipType) }
```

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

### Savings form without partner
![Screenshot 2024-02-20 at 13 09 02](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/6cabe91d-eec3-406b-aa8f-208a552dd2b7)


### Savings form with partner
![Screenshot 2024-02-20 at 13 05 05](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/dfda61ff-6d5a-452c-b0b0-219b72700017)

### Errors without partner

![Screenshot 2024-02-20 at 17 04 58](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/1f1fe0a6-b545-43d6-8447-8a9b7e7d5dac)

### Errors with partner

![Screenshot 2024-02-20 at 17 06 01](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/ba531077-4986-465e-aaee-7878ecfecc84)

## How to manually test the feature


[CRIMAPP-511]: https://dsdmoj.atlassian.net/browse/CRIMAPP-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ