### PR TITLE
CRIMAPP 502 premium bonds

### DIFF
--- a/app/controllers/steps/capital/premium_bonds_controller.rb
+++ b/app/controllers/steps/capital/premium_bonds_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Capital
+    class PremiumBondsController < Steps::CapitalStepController
+      def edit
+        @form_object = PremiumBondsForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(PremiumBondsForm, as: :premium_bonds)
+      end
+    end
+  end
+end

--- a/app/forms/steps/base_form_object.rb
+++ b/app/forms/steps/base_form_object.rb
@@ -28,11 +28,13 @@ module Steps
     delegate :application_type, to: :crime_application
 
     def save
+      before_save
       valid? && persist!
     end
 
     # This is a `save if you can, but it's fine if not` method, bypassing validations
     def save!
+      before_save
       persist!
     rescue StandardError
       false
@@ -83,5 +85,9 @@ module Steps
       raise 'Subclasses of BaseFormObject need to implement #persist!'
     end
     # :nocov:
+    #
+
+    # Override in subclass where needed. For example, to reset attributes.
+    def before_save; end
   end
 end

--- a/app/forms/steps/capital/premium_bonds_form.rb
+++ b/app/forms/steps/capital/premium_bonds_form.rb
@@ -1,0 +1,34 @@
+module Steps
+  module Capital
+    class PremiumBondsForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :capital
+
+      attribute :has_premium_bonds, :value_object, source: YesNoAnswer
+      attribute :premium_bonds_total_value, :pence
+      attribute :premium_bonds_holder_number, :string
+
+      validates :has_premium_bonds, inclusion: { in: YesNoAnswer.values }
+
+      validates(
+        :premium_bonds_total_value,
+        :premium_bonds_holder_number,
+        presence: true,
+        if: -> { has_premium_bonds&.yes? }
+      )
+
+      private
+
+      def persist!
+        capital.update(attributes)
+      end
+
+      def before_save
+        return if has_premium_bonds.yes?
+
+        self.premium_bonds_total_value = nil
+        self.premium_bonds_holder_number = nil
+      end
+    end
+  end
+end

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -1,0 +1,4 @@
+class Capital < ApplicationRecord
+  belongs_to :crime_application
+  attribute :premium_bonds_total_value, :pence
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -10,6 +10,7 @@ class CrimeApplication < ApplicationRecord
   has_one :partner, dependent: :destroy
   has_one :income, dependent: :destroy
   has_one :outgoings, dependent: :destroy
+  has_one :capital, dependent: :destroy
 
   has_many :people, dependent: :destroy
   has_many :documents, dependent: :destroy

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -8,6 +8,8 @@ module Decisions
         # TODO: Add next step
       when :property_type
         # TODO: Add next step
+      when :premium_bonds
+        # TODO: Add next step
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end

--- a/app/views/steps/capital/premium_bonds/edit.html.erb
+++ b/app/views/steps/capital/premium_bonds/edit.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:has_premium_bonds, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
+        <%= f.govuk_radio_button :has_premium_bonds, YesNoAnswer::YES do %>
+          <%= f.govuk_number_field :premium_bonds_total_value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_text_field :premium_bonds_holder_number, autocomplete: 'off', extra_letter_spacing: true, width: 'one-third' %>
+        <% end %>
+
+        <%= f.govuk_radio_button :has_premium_bonds, YesNoAnswer::NO %>
+      <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -465,6 +465,15 @@ en:
               inclusion: Select whose name the account is in
             confirm_in_applicants_name:
               confirm: Confirm the account is in your client’s name
+        steps/capital/premium_bonds_form:
+          attributes:
+            premium_bonds_total_value: 
+              blank: Enter the total value of their bonds
+            premium_bonds_holder_number: 
+              blank: Enter the holder number
+            has_premium_bonds: 
+              blank: Select yes if your client has any Premium Bonds
+
         steps/submission/more_information_form:
           attributes:
             additional_information:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -437,3 +437,7 @@ en:
         account_holder_options: *OWNERSHIP_OPTIONS 
         confirm_in_applicants_name_options: 
           'true': I confirm that the account is in my client's name 
+      steps_capital_premium_bonds_form:
+        premium_bonds_holder_number: Enter the holder number
+        premium_bonds_total_value: Enter the total value of their bonds
+        has_premium_bonds_options: *YESNO

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -309,6 +309,10 @@ en:
             cash_isa: Your client’s cash ISA
             national_savings_or_post_office: Your client’s National Savings or Post Office account
             other: Your client’s other cash investment
+      premium_bonds:
+        edit:
+          page_title: Does your client have any Premium Bonds?
+          heading:  Does your client have any Premium Bonds?
 
     evidence:
       upload:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
         edit_step :which_assets_does_client_own, alias: :property_type
         edit_step :which_savings_does_client_have, alias: :saving_type
         crud_step :savings, param: :saving_id
+        edit_step :does_client_have_premium_bonds, alias: :premium_bonds
       end
 
       namespace :evidence do

--- a/db/migrate/20240221120639_create_capital.rb
+++ b/db/migrate/20240221120639_create_capital.rb
@@ -1,0 +1,13 @@
+class CreateCapital < ActiveRecord::Migration[7.0]
+  def change
+    create_table :capitals, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false, index: { unique: true }
+
+      t.string :has_premium_bonds
+      t.integer :premium_bonds_total_value
+      t.string :premium_bonds_holder_number
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_20_104823) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -32,6 +32,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_104823) do
     t.string "lookup_id"
     t.index ["person_id"], name: "index_addresses_on_person_id"
     t.index ["type", "person_id"], name: "index_addresses_on_type_and_person_id", unique: true
+  end
+
+  create_table "capitals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.string "has_premium_bonds"
+    t.integer "premium_bonds_total_value"
+    t.string "premium_bonds_holder_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crime_application_id"], name: "index_capitals_on_crime_application_id", unique: true
   end
 
   create_table "cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/steps/capital/premium_bonds_controller_spec.rb
+++ b/spec/controllers/steps/capital/premium_bonds_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PremiumBondsController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Capital::PremiumBondsForm,
+                  Decisions::CapitalDecisionTree
+end

--- a/spec/forms/steps/capital/premium_bonds_form_spec.rb
+++ b/spec/forms/steps/capital/premium_bonds_form_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PremiumBondsForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
+      record: capital,
+    }.merge(attributes)
+  end
+
+  let(:attributes) { {} }
+
+  let(:capital) { instance_double(Capital) }
+
+  let(:crime_application) do
+    instance_double(CrimeApplication, capital:)
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_is_a(:has_premium_bonds, YesNoAnswer) }
+
+    context 'when has premium bonds answered yes' do
+      before { form.has_premium_bonds = 'yes' }
+
+      it { is_expected.to validate_presence_of(:premium_bonds_total_value) }
+      it { is_expected.to validate_presence_of(:premium_bonds_holder_number) }
+    end
+
+    context 'when has premium bonds answered no' do
+      before { form.has_premium_bonds = 'no' }
+
+      it { is_expected.not_to validate_presence_of(:premium_bonds_total_value) }
+      it { is_expected.not_to validate_presence_of(:premium_bonds_holder_number) }
+    end
+  end
+
+  describe '#save' do
+    context 'for valid details' do
+      before do
+        allow(capital).to receive(:update).and_return(true)
+
+        form.has_premium_bonds = has_premium_bonds
+        form.premium_bonds_total_value = '100023.00'
+        form.premium_bonds_holder_number = '123568A'
+
+        subject.save
+      end
+
+      context 'when has premium bonds answered yes' do
+        let(:has_premium_bonds) { 'yes' }
+
+        let(:expected_args) do
+          {
+            has_premium_bonds: YesNoAnswer::YES,
+            premium_bonds_total_value: '100023.00',
+            premium_bonds_holder_number: '123568A'
+          }
+        end
+
+        it 'updates capital with premium bond details' do
+          expect(capital).to have_received(:update).with(expected_args.stringify_keys)
+        end
+      end
+
+      context 'when has premium bonds answered no' do
+        let(:has_premium_bonds) { 'no' }
+
+        let(:expected_args) do
+          {
+            has_premium_bonds: YesNoAnswer::NO,
+            premium_bonds_total_value: nil,
+            premium_bonds_holder_number: nil
+          }.stringify_keys
+        end
+
+        it 'updates the record and sets the detail attributes to nil' do
+          expect(capital).to have_received(:update).with(expected_args)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

## Link to relevant ticket
[CRIMAPP-560](https://dsdmoj.atlassian.net/browse/CRIMAPP-560)

## Notes for reviewer
This PR also adds "before_save" to the save methods on the base steps controller to clean up how we currently reset attributes. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="788" alt="Screenshot 2024-02-23 at 17 36 54" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/6b2edc16-907f-4a2a-a43e-3e70662cfb1f">
<img width="846" alt="Screenshot 2024-02-23 at 17 36 45" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/9d70daee-5d22-46cc-983e-8f89cd5a6bb1">
<img width="847" alt="Screenshot 2024-02-23 at 17 36 03" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/3fa531db-6d7d-4937-b967-d577e18b4031">

## How to manually test the feature


[CRIMAPP-560]: https://dsdmoj.atlassian.net/browse/CRIMAPP-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ