### PR TITLE
CRIMAPP-486 Add residential property page

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -8,7 +8,7 @@ module ErrorHandling
         redirect_to invalid_token_errors_path
       when Errors::InvalidSession
         redirect_to invalid_session_errors_path
-      when Errors::SavingNotFound
+      when Errors::SavingNotFound || Errors::PropertyNotFound
         redirect_to not_found_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -2,16 +2,13 @@ module ErrorHandling
   extend ActiveSupport::Concern
 
   included do
-    # rubocop:disable Lint/DuplicateBranch
     rescue_from Exception do |exception|
       case exception
       when ActionController::InvalidAuthenticityToken
         redirect_to invalid_token_errors_path
       when Errors::InvalidSession
         redirect_to invalid_session_errors_path
-      when Errors::SavingNotFound
-        redirect_to not_found_errors_path
-      when Errors::PropertyNotFound
+      when Errors::SavingNotFound, Errors::PropertyNotFound
         redirect_to not_found_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path
@@ -26,7 +23,6 @@ module ErrorHandling
         redirect_to unhandled_errors_path
       end
     end
-    # rubocop:enable Lint/DuplicateBranch
   end
 
   private

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -8,7 +8,9 @@ module ErrorHandling
         redirect_to invalid_token_errors_path
       when Errors::InvalidSession
         redirect_to invalid_session_errors_path
-      when Errors::SavingNotFound || Errors::PropertyNotFound
+      when Errors::SavingNotFound
+        redirect_to not_found_errors_path
+      when Errors::PropertyNotFound
         redirect_to not_found_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -2,6 +2,7 @@ module ErrorHandling
   extend ActiveSupport::Concern
 
   included do
+    # rubocop:disable Lint/DuplicateBranch
     rescue_from Exception do |exception|
       case exception
       when ActionController::InvalidAuthenticityToken
@@ -25,6 +26,7 @@ module ErrorHandling
         redirect_to unhandled_errors_path
       end
     end
+    # rubocop:enable Lint/DuplicateBranch
   end
 
   private

--- a/app/controllers/steps/capital/properties_controller.rb
+++ b/app/controllers/steps/capital/properties_controller.rb
@@ -24,10 +24,6 @@ module Steps
       def properties
         @properties ||= current_crime_application.properties
       end
-
-      def additional_permitted_params
-        [:confirm_in_applicants_name]
-      end
     end
   end
 end

--- a/app/controllers/steps/capital/properties_controller.rb
+++ b/app/controllers/steps/capital/properties_controller.rb
@@ -22,7 +22,7 @@ module Steps
       end
 
       def properties
-        @properties ||= current_crime_application.applicant.properties
+        @properties ||= current_crime_application.properties
       end
 
       def additional_permitted_params

--- a/app/controllers/steps/capital/properties_controller.rb
+++ b/app/controllers/steps/capital/properties_controller.rb
@@ -1,0 +1,33 @@
+module Steps
+  module Capital
+    class PropertiesController < Steps::CapitalStepController
+      def edit
+        @form_object = PropertiesForm.build(
+          property_record, crime_application: current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          PropertiesForm, record: property_record, as: :properties
+        )
+      end
+
+      private
+
+      def property_record
+        @property_record ||= properties.find(params[:property_id])
+      rescue ActiveRecord::RecordNotFound
+        raise Errors::PropertyNotFound
+      end
+
+      def properties
+        @properties ||= current_crime_application.applicant.properties
+      end
+
+      def additional_permitted_params
+        [:confirm_in_applicants_name]
+      end
+    end
+  end
+end

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -19,8 +19,8 @@ module Steps
                 :outstanding_mortgage,
                 :percentage_applicant_owned,
                 :has_other_owners, presence: true
-      validates :is_home_address, presence: true, if: -> { crime_application.applicant.home_address? }
-      validates :is_home_address, inclusion: { in: YesNoAnswer.values }, if: -> { crime_application.applicant.home_address? }
+      validates :is_home_address, presence: true, if: -> { person_has_home_address? }
+      validates :is_home_address, inclusion: { in: YesNoAnswer.values }, if: -> { person_has_home_address? }
       validates :has_other_owners, inclusion: { in: YesNoAnswer.values }
       validates :percentage_partner_owned, presence: true, if: :include_partner?
       validates :custom_house_type, presence: true, unless: -> { house_type_is_listed? }
@@ -35,6 +35,10 @@ module Steps
 
       def before_save
         self.custom_house_type = nil if house_type_is_listed?
+      end
+
+      def person_has_home_address?
+        crime_application.applicant.home_address?
       end
 
       # TODO: use proper partner policy once we have one.

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -52,7 +52,7 @@ module Steps
       end
 
       def house_type_is_listed?
-        house_type != 'custom'
+        house_types.map(&:to_s).any? house_type
       end
     end
   end

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -29,17 +29,11 @@ module Steps
       end
 
       def persist!
-        record.update(
-          attributes.merge(attributes_to_reset)
-        )
+        record.update(attributes)
       end
 
-      def attributes_to_reset
-        if house_type_is_listed?
-          { 'custom_house_type' => nil }
-        else
-          {}
-        end
+      def before_save
+        self.custom_house_type = nil if house_type_is_listed?
       end
 
       # TODO: use proper partner policy once we have one.

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -1,0 +1,38 @@
+module Steps
+  module Capital
+    class PropertiesForm < Steps::BaseFormObject
+      delegate :property_type, to: :record
+
+      attribute :house_type, :string
+      attribute :bedrooms, :integer
+      attribute :value, :pence
+      attribute :outstanding_mortgage, :pence
+      attribute :percentage_applicant_owned, :integer
+      attribute :percentage_partner_owned, :integer
+      attribute :is_home_address, :value_object, source: YesNoAnswer
+      attribute :has_other_owners, :value_object, source: YesNoAnswer
+
+      validates :bedrooms,
+                :value,
+                :outstanding_mortgage,
+                :percentage_applicant_owned,
+                :is_home_address,
+                :has_other_owners, presence: true
+      validates :is_home_address, :has_other_owners, inclusion: { in: YesNoAnswer.values }
+      validates :percentage_partner_owned, presence: true, if: :include_partner?
+
+      def persist!
+        record.update(attributes)
+      end
+
+      # TODO: use proper partner policy once we have one.
+      def include_partner?
+        YesNoAnswer.new(crime_application.client_has_partner).yes?
+      end
+
+      def person_has_home_address?
+        crime_application.applicant.home_address?
+      end
+    end
+  end
+end

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -18,9 +18,10 @@ module Steps
                 :value,
                 :outstanding_mortgage,
                 :percentage_applicant_owned,
-                :is_home_address,
                 :has_other_owners, presence: true
-      validates :is_home_address, :has_other_owners, inclusion: { in: YesNoAnswer.values }
+      validates :is_home_address, presence: true, if: -> { crime_application.applicant.home_address? }
+      validates :is_home_address, inclusion: { in: YesNoAnswer.values }, if: -> { crime_application.applicant.home_address? }
+      validates :has_other_owners, inclusion: { in: YesNoAnswer.values }
       validates :percentage_partner_owned, presence: true, if: :include_partner?
       validates :custom_house_type, presence: true, unless: -> { house_type_is_listed? }
 

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -47,10 +47,6 @@ module Steps
         YesNoAnswer.new(crime_application.client_has_partner).yes?
       end
 
-      def person_has_home_address?
-        crime_application.applicant.home_address?
-      end
-
       def house_type_is_listed?
         house_types.map(&:to_s).any? house_type
       end

--- a/app/forms/steps/capital/property_type_form.rb
+++ b/app/forms/steps/capital/property_type_form.rb
@@ -5,6 +5,8 @@ module Steps
 
       validates :property_type, presence: true
 
+      attr_reader :property
+
       def choices
         PropertyType.values
       end
@@ -12,8 +14,15 @@ module Steps
       private
 
       def persist!
-        # TODO: If none, go to next step
-        # If type selected, build new properties form
+        return true if property_type == 'none'
+
+        @property = incomplete_property_for_type || crime_application.applicant.properties.create(property_type:)
+      end
+
+      def incomplete_property_for_type
+        return nil unless property_type
+
+        crime_application.applicant.properties.where(property_type:).reject(&:complete?).first
       end
     end
   end

--- a/app/forms/steps/capital/property_type_form.rb
+++ b/app/forms/steps/capital/property_type_form.rb
@@ -16,13 +16,13 @@ module Steps
       def persist!
         return true if property_type == 'none'
 
-        @property = incomplete_property_for_type || crime_application.applicant.properties.create(property_type:)
+        @property = incomplete_property_for_type || crime_application.properties.create(property_type:)
       end
 
       def incomplete_property_for_type
         return nil unless property_type
 
-        crime_application.applicant.properties.where(property_type:).reject(&:complete?).first
+        crime_application.properties.where(property_type:).reject(&:complete?).first
       end
     end
   end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -2,5 +2,6 @@ module Errors
   class InvalidSession < StandardError; end
   class ApplicationNotFound < StandardError; end
   class SavingNotFound < StandardError; end
+  class PropertyNotFound < StandardError; end
   class ApplicationCannotReceivePse < StandardError; end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -31,6 +31,7 @@ class CrimeApplication < ApplicationRecord
   has_one :ioj, through: :case
   has_many :addresses, through: :people
   has_many :codefendants, through: :case
+  has_many :properties, dependent: :destroy
 
   enum status: ApplicationStatus.enum_values
 

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -26,12 +26,12 @@ class CrimeApplication < ApplicationRecord
   accepts_nested_attributes_for :dependants, allow_destroy: true
 
   has_many :savings, dependent: :destroy
+  has_many :properties, dependent: :destroy
 
   # Shortcuts through intermediate tables
   has_one :ioj, through: :case
   has_many :addresses, through: :people
   has_many :codefendants, through: :case
-  has_many :properties, dependent: :destroy
 
   enum status: ApplicationStatus.enum_values
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,6 +4,7 @@ class Person < ApplicationRecord
 
   belongs_to :crime_application
   has_many :addresses, dependent: :destroy
+  has_many :properties, dependent: :destroy
 
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
   has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,7 +4,6 @@ class Person < ApplicationRecord
 
   belongs_to :crime_application
   has_many :addresses, dependent: :destroy
-  has_many :properties, dependent: :destroy
 
   has_one :home_address, dependent: :destroy, class_name: 'HomeAddress'
   has_one :correspondence_address, dependent: :destroy, class_name: 'CorrespondenceAddress'

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,6 +1,9 @@
 class Property < ApplicationRecord
   belongs_to :crime_application
 
+  attribute :value, :pence
+  attribute :outstanding_mortgage, :pence
+
   def complete?
     values_at(
       :property_type,

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -12,7 +12,6 @@ class Property < ApplicationRecord
       :value,
       :outstanding_mortgage,
       :percentage_applicant_owned,
-      :is_home_address,
       :has_other_owners
     ).all?(&:present?)
   end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,5 +1,5 @@
 class Property < ApplicationRecord
-  belongs_to :person
+  belongs_to :crime_application
 
   def complete?
     values_at(

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,0 +1,16 @@
+class Property < ApplicationRecord
+  belongs_to :person
+
+  def complete?
+    values_at(
+      :property_type,
+      :house_type,
+      :bedrooms,
+      :value,
+      :outstanding_mortgage,
+      :percentage_applicant_owned,
+      :is_home_address,
+      :has_other_owners
+    ).all?(&:present?)
+  end
+end

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -7,6 +7,8 @@ module Decisions
       when :savings
         # TODO: Add next step
       when :property_type
+        after_property_type(form_object.property)
+      when :properties
         # TODO: Add next step
       when :premium_bonds
         # TODO: Add next step
@@ -21,6 +23,12 @@ module Decisions
       return edit(:premium_bonds) unless saving
 
       edit(:savings, saving_id: saving)
+    end
+
+    def after_property_type(property)
+      return edit(:saving_type) unless property
+
+      edit(:properties, property_id: property)
     end
   end
 end

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -9,7 +9,8 @@ module Decisions
       when :property_type
         after_property_type(form_object.property)
       when :properties
-        # TODO: Add next step
+        # TODO: Update next step
+        edit(:saving_type)
       when :premium_bonds
         # TODO: Add next step
       else

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -10,6 +10,7 @@ module Decisions
         after_property_type(form_object.property)
       when :properties
         # TODO: Add next step
+        after_properties
       when :premium_bonds
         # TODO: Add next step
       else
@@ -29,6 +30,11 @@ module Decisions
       return edit(:saving_type) unless property
 
       edit(:properties, property_id: property)
+    end
+
+    def after_properties
+      # TODO: Update next step
+      edit(:saving_type)
     end
   end
 end

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -10,7 +10,6 @@ module Decisions
         after_property_type(form_object.property)
       when :properties
         # TODO: Add next step
-        after_properties
       when :premium_bonds
         # TODO: Add next step
       else
@@ -30,11 +29,6 @@ module Decisions
       return edit(:saving_type) unless property
 
       edit(:properties, property_id: property)
-    end
-
-    def after_properties
-      # TODO: Update next step
-      edit(:saving_type)
     end
   end
 end

--- a/app/value_objects/house_type.rb
+++ b/app/value_objects/house_type.rb
@@ -1,0 +1,9 @@
+class HouseType < ValueObject
+  VALUES = [
+    BUNGALOW = new(:bungalow),
+    DETACHED = new(:detached),
+    FLAT = new(:flat),
+    SEMIDETACHED = new(:semidetached),
+    TERRACED = new(:terraced),
+  ].freeze
+end

--- a/app/value_objects/house_type.rb
+++ b/app/value_objects/house_type.rb
@@ -2,7 +2,7 @@ class HouseType < ValueObject
   VALUES = [
     BUNGALOW = new(:bungalow),
     DETACHED = new(:detached),
-    FLAT = new(:flat),
+    FLAT_OR_MAISONETTE = new(:flat_or_maisonette),
     SEMIDETACHED = new(:semidetached),
     TERRACED = new(:terraced),
   ].freeze

--- a/app/views/steps/capital/properties/edit.html.erb
+++ b/app/views/steps/capital/properties/edit.html.erb
@@ -12,7 +12,16 @@
     </h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_collection_radio_buttons :house_type, HouseType.values, :value, inline: false, legend: { size: 's' } %>
+      <%= f.govuk_radio_buttons_fieldset :house_type, legend: { size: 's' } do %>
+        <% @form_object.house_types.each_with_index do |option, index| %>
+          <%= f.govuk_radio_button :house_type, option, link_errors: index.zero? %>
+        <% end %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :house_type, 'custom' do %>
+          <%= f.govuk_text_field :custom_house_type, autocomplete: 'off', width: 'one-third' %>
+        <%end%>
+      <% end %>
+
       <%= f.govuk_number_field :bedrooms, inputmode: 'numeric', width: 'one-third' %>
       <%= f.govuk_number_field :value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
       <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>

--- a/app/views/steps/capital/properties/edit.html.erb
+++ b/app/views/steps/capital/properties/edit.html.erb
@@ -27,7 +27,7 @@
       <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' if f.object.include_partner? %>
-      <% if f.object.crime_application.applicant.home_address? %>
+      <% if f.object.person_has_home_address? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>

--- a/app/views/steps/capital/properties/edit.html.erb
+++ b/app/views/steps/capital/properties/edit.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl">
+      <%= t(".heading.#{@form_object.property_type}") %>
+    </h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :house_type, HouseType.values, :value, inline: false, legend: { size: 's' } %>
+      <%= f.govuk_number_field :bedrooms, inputmode: 'numeric', width: 'one-third' %>
+      <%= f.govuk_number_field :value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+      <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+      <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
+      <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' if f.object.include_partner? %>
+      <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } if f.object.person_has_home_address? %>
+      <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/capital/properties/edit.html.erb
+++ b/app/views/steps/capital/properties/edit.html.erb
@@ -27,7 +27,9 @@
       <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' if f.object.include_partner? %>
-      <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } if f.object.person_has_home_address? %>
+      <% if f.object.crime_application.applicant.home_address? %>
+        <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
+      <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
 
       <%= f.continue_button %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -475,6 +475,10 @@ en:
               blank: Select yes if your client has any Premium Bonds
         steps/capital/properties_form:
           attributes:
+            house_type:
+              blank: Enter the type of property
+            custom_house_type:
+              blank: Enter the type of property
             bedrooms:
               blank: Enter how many bedrooms are there
             value:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -473,7 +473,22 @@ en:
               blank: Enter the holder number
             has_premium_bonds: 
               blank: Select yes if your client has any Premium Bonds
-
+        steps/capital/properties_form:
+          attributes:
+            bedrooms:
+              blank: Enter how many bedrooms are there
+            value:
+              blank: Enter how much the property is worth
+            outstanding_mortgage:
+              blank: Enter how much is left to pay on the mortgage
+            percentage_applicant_owned:
+              blank: Enter the percentage of the property your client owns
+            percentage_partner_owned:
+              blank: Enter the percentage of the property your client's partner owns
+            is_home_address:
+              inclusion: Select yes if the address of the property is the same as your client's home address
+            has_other_owners:
+              inclusion: Select yes if anyone else owns part of the land
         steps/submission/more_information_form:
           attributes:
             additional_information:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -441,3 +441,21 @@ en:
         premium_bonds_holder_number: Enter the holder number
         premium_bonds_total_value: Enter the total value of their bonds
         has_premium_bonds_options: *YESNO
+      steps_capital_properties_form:
+        house_type: Which type of property is it?
+        house_type_options:
+          bungalow: Bungalow,
+          detached: Detached,
+          flat: Flat or maisonette,
+          semidetached: Semi-detached,
+          terraced: Terraced,
+        bedrooms: How many bedrooms are there?
+        value: How much is the property worth?
+        outstanding_mortgage: How much is left to pay on the mortgage?
+        percentage_applicant_owned: What percentage of the property does your client own?
+        percentage_partner_owned: What percentage of the property does your client’s partner own?
+        is_home_address: Is the address of the property the same as your client’s home address?
+        is_home_address_options: *YESNO
+        has_other_owners: Does anyone else own part of the property?
+        has_other_owners_options: *YESNO
+

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -180,6 +180,9 @@ en:
         property_type: Add one asset at a time. You can add more later.
       steps_capital_saving_type_form:
         saving_type: Add one savings account at a time. You can add more later.
+      steps_capital_properties_form:
+        bedrooms: Enter ‘0’ if the property is a studio.
+        value: You can use property websites to find the estimated value.
 
     label:
       cookies_settings_form:
@@ -447,11 +450,13 @@ en:
         has_premium_bonds_options: *YESNO
       steps_capital_properties_form:
         house_type_options:
-          bungalow: Bungalow,
-          detached: Detached,
-          flat: Flat or maisonette,
-          semidetached: Semi-detached,
-          terraced: Terraced,
+          bungalow: Bungalow
+          detached: Detached
+          flat_or_maisonette: Flat or maisonette
+          semidetached: Semi-detached
+          terraced: Terraced
+          custom: The type of property is not listed
+        custom_house_type: Enter the type of property
         bedrooms: How many bedrooms are there?
         value: How much is the property worth?
         outstanding_mortgage: How much is left to pay on the mortgage?

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -102,6 +102,10 @@ en:
         are_wages_paid_into_account: Are your client’s wages or benefits paid into this account?
         confirm_in_applicants_name: Confirm the following 
         account_holder: Whose name is the account in?
+      steps_capital_properties_form:
+        house_type: Which type of property is it?
+        is_home_address: Is the address of the property the same as your client’s home address?
+        has_other_owners: Does anyone else own part of the property?
 
     hint:
       steps_client_details_form:
@@ -442,7 +446,6 @@ en:
         premium_bonds_total_value: Enter the total value of their bonds
         has_premium_bonds_options: *YESNO
       steps_capital_properties_form:
-        house_type: Which type of property is it?
         house_type_options:
           bungalow: Bungalow,
           detached: Detached,
@@ -454,8 +457,6 @@ en:
         outstanding_mortgage: How much is left to pay on the mortgage?
         percentage_applicant_owned: What percentage of the property does your client own?
         percentage_partner_owned: What percentage of the property does your client’s partner own?
-        is_home_address: Is the address of the property the same as your client’s home address?
         is_home_address_options: *YESNO
-        has_other_owners: Does anyone else own part of the property?
         has_other_owners_options: *YESNO
 

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -314,6 +314,14 @@ en:
           page_title: Does your client have any Premium Bonds?
           heading:  Does your client have any Premium Bonds?
 
+      properties:
+        edit:
+          page_title: Your client’s residential property
+          heading:
+            residential: Your client’s residential property
+            commercial: Your client’s commercial property
+            land: Your client’s land
+
     evidence:
       upload:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
         edit_step :which_savings_does_client_have, alias: :saving_type
         crud_step :savings, param: :saving_id
         edit_step :does_client_have_premium_bonds, alias: :premium_bonds
+        crud_step :properties, param: :property_id
       end
 
       namespace :evidence do

--- a/db/migrate/20240221121558_create_properties.rb
+++ b/db/migrate/20240221121558_create_properties.rb
@@ -1,0 +1,22 @@
+class CreateProperties < ActiveRecord::Migration[7.0]
+  def change
+    create_table :properties, id: :uuid do |t|
+      t.references :person, type: :uuid, foreign_key: true, null: false
+
+      t.string :property_type, null: false
+      t.string :house_type
+      t.integer :size_in_acres
+      t.string :usage
+      t.integer :bedrooms
+      t.integer :value
+      t.integer :outstanding_mortgage
+      t.integer :percentage_applicant_owned
+      t.integer :percentage_partner_owned
+      t.string :is_home_address
+      t.string :has_other_owners
+      t.json :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240221121558_create_properties.rb
+++ b/db/migrate/20240221121558_create_properties.rb
@@ -1,10 +1,11 @@
 class CreateProperties < ActiveRecord::Migration[7.0]
   def change
     create_table :properties, id: :uuid do |t|
-      t.references :person, type: :uuid, foreign_key: true, null: false
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false
 
       t.string :property_type, null: false
       t.string :house_type
+      t.string :custom_house_type
       t.integer :size_in_acres
       t.string :usage
       t.integer :bedrooms

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -173,6 +173,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
     t.string "ended_employment_within_three_months"
     t.string "client_has_dependants"
     t.string "has_savings"
+    t.string "payments", default: [], array: true
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 
@@ -248,6 +249,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 
+  create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "person_id", null: false
+    t.string "property_type", null: false
+    t.string "house_type"
+    t.integer "size_in_acres"
+    t.string "usage"
+    t.integer "bedrooms"
+    t.integer "value"
+    t.integer "outstanding_mortgage"
+    t.integer "percentage_applicant_owned"
+    t.integer "percentage_partner_owned"
+    t.string "is_home_address"
+    t.string "has_other_owners"
+    t.json "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id"], name: "index_properties_on_person_id"
+  end
+
   create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -298,4 +318,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
   add_foreign_key "outgoings", "crime_applications"
   add_foreign_key "people", "crime_applications"
   add_foreign_key "savings", "crime_applications"
+  add_foreign_key "properties", "people"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_21_121558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -205,18 +205,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
     t.index ["charge_id"], name: "index_offence_dates_on_charge_id"
   end
 
-  create_table "outgoing_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "crime_application_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "payment_type", null: false
-    t.integer "amount", null: false
-    t.string "frequency", null: false
-    t.jsonb "metadata", default: {}, null: false
-    t.index ["crime_application_id", "payment_type"], name: "index_crime_application_outgoings_payment_type", unique: true
-    t.index ["crime_application_id"], name: "index_outgoings_payments_on_crime_application_id"
-  end
-
   create_table "outgoings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "outgoings_more_than_income"
@@ -228,6 +216,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
     t.string "pays_council_tax"
     t.integer "council_tax_amount"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
+  end
+
+  create_table "outgoings_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "payment_type", null: false
+    t.integer "amount"
+    t.string "frequency"
+    t.jsonb "metadata", default: {}
+    t.index ["crime_application_id", "payment_type"], name: "index_crime_application_outgoings_payment_type", unique: true
+    t.index ["crime_application_id"], name: "index_outgoings_payments_on_crime_application_id"
   end
 
   create_table "people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -305,6 +305,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
   end
 
   add_foreign_key "addresses", "people"
+  add_foreign_key "capitals", "crime_applications"
   add_foreign_key "cases", "crime_applications"
   add_foreign_key "charges", "cases"
   add_foreign_key "codefendants", "cases"
@@ -315,9 +316,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
   add_foreign_key "incomes", "crime_applications"
   add_foreign_key "iojs", "cases"
   add_foreign_key "offence_dates", "charges"
-  add_foreign_key "outgoings_payments", "crime_applications"
   add_foreign_key "outgoings", "crime_applications"
+  add_foreign_key "outgoings_payments", "crime_applications"
   add_foreign_key "people", "crime_applications"
-  add_foreign_key "savings", "crime_applications"
   add_foreign_key "properties", "crime_applications"
+  add_foreign_key "savings", "crime_applications"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -173,7 +173,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_121558) do
     t.string "ended_employment_within_three_months"
     t.string "client_has_dependants"
     t.string "has_savings"
-    t.string "payments", default: [], array: true
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -250,9 +250,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
   end
 
   create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "person_id", null: false
+    t.uuid "crime_application_id", null: false
     t.string "property_type", null: false
     t.string "house_type"
+    t.string "custom_house_type"
     t.integer "size_in_acres"
     t.string "usage"
     t.integer "bedrooms"
@@ -265,7 +266,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
     t.json "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["person_id"], name: "index_properties_on_person_id"
+    t.index ["crime_application_id"], name: "index_properties_on_crime_application_id"
   end
 
   create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -318,5 +319,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_120639) do
   add_foreign_key "outgoings", "crime_applications"
   add_foreign_key "people", "crime_applications"
   add_foreign_key "savings", "crime_applications"
-  add_foreign_key "properties", "people"
+  add_foreign_key "properties", "crime_applications"
 end

--- a/spec/controllers/steps/capital/properties_controller_spec.rb
+++ b/spec/controllers/steps/capital/properties_controller_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PropertiesController, type: :controller do
+  let(:form_class) { Steps::Capital::PropertiesForm }
+  let(:decision_tree_class) { Decisions::CapitalDecisionTree }
+
+  let(:crime_application) { CrimeApplication.create }
+
+  describe '#edit' do
+    context 'when application is not found' do
+      it 'redirects to the application not found error page' do
+        get :edit, params: { id: '12345', property_id: '123' }
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when application is found' do
+      let(:property) do
+        Property.create!(property_type: PropertyType::RESIDENTIAL, crime_application: crime_application)
+      end
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: crime_application, property_id: property }
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when property is for another application' do
+      let(:property) do
+        Property.create!(property_type: PropertyType::RESIDENTIAL, crime_application: CrimeApplication.create!)
+      end
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: crime_application, property_id: property }
+
+        expect(response).to redirect_to(not_found_errors_path)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+
+    let(:expected_params) do
+      {
+        :id => crime_application,
+        :property_id => property,
+        form_class_params_name => { foo: 'bar' }
+      }
+    end
+
+    context 'when application is not found' do
+      let(:crime_application) { '12345' }
+      let(:property) { '123' }
+
+      it 'redirects to the application not found error page' do
+        put :update, params: expected_params
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when property is for another application' do
+      let(:property) do
+        Property.create!(property_type: PropertyType::RESIDENTIAL, crime_application: CrimeApplication.create!)
+      end
+
+      it 'responds with HTTP success' do
+        put :update, params: expected_params
+
+        expect(response).to redirect_to(not_found_errors_path)
+      end
+    end
+
+    context 'when an in progress application and property is found' do
+      let(:property) do
+        Property.create!(property_type: PropertyType::RESIDENTIAL, crime_application: crime_application)
+      end
+
+      before do
+        property
+        allow(form_class).to receive(:new).and_return(form_object)
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          expect(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) { instance_double(decision_tree_class, destination: '/expected_destination') }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(decision_tree_class).to receive(:new).and_return(decision_tree)
+
+          put :update, params: expected_params
+
+          expect(response).to have_http_status(:redirect)
+          expect(subject).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          expect(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the property page again' do
+          put :update, params: expected_params, session: { crime_application_id: crime_application.id }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/capital/properties_form_spec.rb
+++ b/spec/forms/steps/capital/properties_form_spec.rb
@@ -41,24 +41,6 @@ RSpec.describe Steps::Capital::PropertiesForm do
     end
   end
 
-  describe '#person_has_home_address?' do
-    before do
-      allow(applicant).to receive(:home_address?).and_return(has_home_address)
-    end
-
-    context 'applicant has home address' do
-      let(:has_home_address) { true }
-
-      it { expect(subject.person_has_home_address?).to be(true) }
-    end
-
-    context 'applicant has no home address' do
-      let(:has_home_address) { false }
-
-      it { expect(subject.person_has_home_address?).to be(false) }
-    end
-  end
-
   describe '#save' do
     let(:required_attributes) do
       {

--- a/spec/forms/steps/capital/properties_form_spec.rb
+++ b/spec/forms/steps/capital/properties_form_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Steps::Capital::PropertiesForm do
   let(:attributes) { {} }
 
   let(:crime_application) do
-    instance_double(CrimeApplication, client_has_partner:)
+    instance_double(CrimeApplication, client_has_partner:, applicant:)
   end
-
+  let(:applicant) { instance_double(Applicant) }
   let(:record) { Property.new }
   let(:client_has_partner) { 'no' }
 
@@ -38,6 +38,24 @@ RSpec.describe Steps::Capital::PropertiesForm do
       before { allow(subject).to receive(:house_type_is_listed?).and_return(false) }
 
       it { is_expected.to validate_presence_of(:custom_house_type) }
+    end
+  end
+
+  describe '#person_has_home_address?' do
+    before do
+      allow(applicant).to receive(:home_address?).and_return(has_home_address)
+    end
+
+    context 'applicant has home addresss' do
+      let(:has_home_address) { true }
+
+      it { expect(subject.person_has_home_address?).to be(true) }
+    end
+
+    context 'applicant has no home addresss' do
+      let(:has_home_address) { false }
+
+      it { expect(subject.person_has_home_address?).to be(false) }
     end
   end
 

--- a/spec/forms/steps/capital/properties_form_spec.rb
+++ b/spec/forms/steps/capital/properties_form_spec.rb
@@ -15,9 +15,10 @@ RSpec.describe Steps::Capital::PropertiesForm do
   let(:crime_application) do
     instance_double(CrimeApplication, client_has_partner:, applicant:)
   end
-  let(:applicant) { instance_double(Applicant) }
+  let(:applicant) { instance_double(Applicant, home_address?: home_address?) }
   let(:record) { Property.new }
   let(:client_has_partner) { 'no' }
+  let(:home_address?) { true }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:house_type) }
@@ -25,19 +26,32 @@ RSpec.describe Steps::Capital::PropertiesForm do
     it { is_expected.to validate_presence_of(:value) }
     it { is_expected.to validate_presence_of(:outstanding_mortgage) }
     it { is_expected.to validate_presence_of(:percentage_applicant_owned) }
-    it { is_expected.to validate_is_a(:is_home_address, YesNoAnswer) }
     it { is_expected.to validate_is_a(:has_other_owners, YesNoAnswer) }
 
-    context 'percentage_partner_owned' do
+    describe '#percentage_partner_owned' do
       before { allow(subject).to receive(:include_partner?).and_return(true) }
 
       it { is_expected.to validate_presence_of(:percentage_partner_owned) }
     end
 
-    context 'custom_house_type' do
+    describe '#custom_house_type' do
       before { allow(subject).to receive(:house_type_is_listed?).and_return(false) }
 
       it { is_expected.to validate_presence_of(:custom_house_type) }
+    end
+
+    describe '#is_home_address' do
+      context 'when applicant home address is present' do
+        let(:home_address?) { true }
+
+        it { is_expected.to validate_is_a(:is_home_address, YesNoAnswer) }
+      end
+
+      context 'when applicant home address is not present' do
+        let(:home_address?) { false }
+
+        it { is_expected.not_to validate_is_a(:is_home_address, YesNoAnswer) }
+      end
     end
   end
 

--- a/spec/forms/steps/capital/properties_form_spec.rb
+++ b/spec/forms/steps/capital/properties_form_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PropertiesForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      record:,
+    }.merge(attributes)
+  end
+
+  let(:attributes) { {} }
+
+  let(:crime_application) do
+    instance_double(CrimeApplication, client_has_partner:)
+  end
+
+  let(:record) { Property.new }
+  let(:client_has_partner) { 'no' }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:house_type) }
+    it { is_expected.to validate_presence_of(:bedrooms) }
+    it { is_expected.to validate_presence_of(:value) }
+    it { is_expected.to validate_presence_of(:outstanding_mortgage) }
+    it { is_expected.to validate_presence_of(:percentage_applicant_owned) }
+    it { is_expected.to validate_is_a(:is_home_address, YesNoAnswer) }
+    it { is_expected.to validate_is_a(:has_other_owners, YesNoAnswer) }
+
+    context 'percentage_partner_owned' do
+      before { allow(subject).to receive(:include_partner?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:percentage_partner_owned) }
+    end
+
+    context 'custom_house_type' do
+      before { allow(subject).to receive(:house_type_is_listed?).and_return(false) }
+
+      it { is_expected.to validate_presence_of(:custom_house_type) }
+    end
+  end
+
+  describe '#save' do
+    let(:required_attributes) do
+      {
+        house_type: 'bungalow',
+        custom_house_type: nil,
+        bedrooms: 2,
+        value: 170_000,
+        outstanding_mortgage: 100_000,
+        percentage_applicant_owned: 10,
+        is_home_address: 'yes',
+        has_other_owners: 'yes',
+      }
+    end
+
+    context 'when client has no partner' do
+      let(:client_has_partner) { 'no' }
+
+      context 'for valid details' do
+        let(:attributes) { required_attributes }
+
+        it 'updates the record' do
+          expect(record).to receive(:update).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+
+    context 'when client has a partner' do
+      let(:client_has_partner) { 'yes' }
+
+      context 'for invalid details' do
+        let(:attributes) { required_attributes }
+
+        it 'updates the record' do
+          expect(record).not_to receive(:update)
+
+          expect(subject.save).to be(false)
+        end
+      end
+
+      context 'for valid details' do
+        let(:attributes) { required_attributes.merge(percentage_partner_owned: 10) }
+
+        it 'updates the record' do
+          expect(record).to receive(:update).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/capital/properties_form_spec.rb
+++ b/spec/forms/steps/capital/properties_form_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Steps::Capital::PropertiesForm do
       allow(applicant).to receive(:home_address?).and_return(has_home_address)
     end
 
-    context 'applicant has home addresss' do
+    context 'applicant has home address' do
       let(:has_home_address) { true }
 
       it { expect(subject.person_has_home_address?).to be(true) }
     end
 
-    context 'applicant has no home addresss' do
+    context 'applicant has no home address' do
       let(:has_home_address) { false }
 
       it { expect(subject.person_has_home_address?).to be(false) }
@@ -71,6 +71,26 @@ RSpec.describe Steps::Capital::PropertiesForm do
         is_home_address: 'yes',
         has_other_owners: 'yes',
       }
+    end
+
+    context 'when house type is not listed' do
+      context 'with valid attributes' do
+        let(:attributes) { required_attributes.merge(house_type: 'custom', custom_house_type: 'custom house type') }
+
+        it 'updates the record' do
+          expect(record).to receive(:update).and_return(true)
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'with invalid attributes' do
+        let(:attributes) { required_attributes.merge(house_type: 'custom') }
+
+        it 'updates the record' do
+          expect(record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+      end
     end
 
     context 'when client has no partner' do

--- a/spec/forms/steps/capital/property_type_form_spec.rb
+++ b/spec/forms/steps/capital/property_type_form_spec.rb
@@ -1,13 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Capital::PropertyTypeForm do
-  subject(:form) { described_class.new }
+  subject(:form) { described_class.new(crime_application:) }
+
+  let(:crime_application) { instance_double(CrimeApplication, properties:) }
+  let(:properties) { class_double(Property, where: existing_properties) }
+  let(:existing_properties) { [] }
 
   describe '#choices' do
     it 'returns the possible choices' do
       expect(
         form.choices
       ).to eq([PropertyType::RESIDENTIAL, PropertyType::COMMERCIAL, PropertyType::LAND])
+    end
+  end
+
+  describe '#save' do
+    let(:property_type) { PropertyType.values.sample }
+    let(:new_property) { instance_double(Property) }
+    let(:existing_property) { instance_double(Property, complete?: complete?) }
+    let(:complete?) { false }
+
+    before do
+      allow(properties).to receive(:create).with(property_type:).and_return new_property
+
+      form.property_type = property_type
+      form.save
+    end
+
+    context 'when client has no properties' do
+      let(:property_type) { 'none' }
+
+      it 'returns true but does not set or create a property' do
+        expect(form.property).to be_nil
+        expect(properties).not_to have_received(:create)
+      end
+    end
+
+    context 'when there are no properties of the property type' do
+      it 'a new property of the property type is created' do
+        expect(form.property).to be new_property
+        expect(properties).to have_received(:create).with(property_type:)
+      end
+    end
+
+    context 'when a property of the type exists' do
+      let(:existing_properties) { [existing_property] }
+
+      it 'is set as the property' do
+        expect(form.property).to be existing_property
+        expect(properties).not_to have_received(:create)
+      end
+
+      context 'when the existing property is complete' do
+        let(:complete?) { true }
+
+        it 'a new property of the property type is created' do
+          expect(form.property).to be new_property
+          expect(properties).to have_received(:create).with(property_type:)
+        end
+      end
     end
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Property, type: :model do
+  subject(:instance) { described_class.new(attributes) }
+
+  let(:attributes) { { id: nil } }
+
+  describe '#complete?' do
+    subject(:complete) { instance.complete? }
+
+    context 'when initialized' do
+      it { is_expected.to be false }
+    end
+
+    context 'when property_type is residential' do
+      let(:required_attributes) do
+        {
+          id: SecureRandom.uuid,
+          person_id: SecureRandom.uuid,
+          property_type: PropertyType.values.sample,
+          house_type: HouseType.values.sample,
+          bedrooms: 2,
+          value: 300_000,
+          outstanding_mortgage: 100_000,
+          percentage_applicant_owned: 20,
+          percentage_partner_owned: nil,
+          is_home_address: 'yes',
+          has_other_owners: 'no',
+        }
+      end
+
+      context 'when all provided attributes are present' do
+        let(:attributes) { required_attributes }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when any required attributes are missing' do
+        let(:attributes) { required_attributes.merge(outstanding_mortgage: nil) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Property, type: :model do
       let(:required_attributes) do
         {
           id: SecureRandom.uuid,
-          person_id: SecureRandom.uuid,
+          crime_application_id: SecureRandom.uuid,
           property_type: PropertyType.values.sample,
           house_type: HouseType.values.sample,
           bedrooms: 2,

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -30,4 +30,30 @@ RSpec.describe Decisions::CapitalDecisionTree do
       end
     end
   end
+
+  context 'when the step is `property_type`' do
+    let(:crime_application) { instance_double(CrimeApplication, id: '10') }
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :property_type }
+
+    before do
+      allow(form_object).to receive_messages(crime_application:, property:)
+    end
+
+    context 'the client has no properties' do
+      let(:property) { nil }
+
+      it 'redirects to select saving type' do
+        expect(subject).to have_destination(:saving_type, :edit, id: crime_application)
+      end
+    end
+
+    context 'the client has selected a property type' do
+      let(:property) { instance_double(Property) }
+
+      it 'redirects the edit `properties` page' do
+        expect(subject).to have_destination(:properties, :edit, id: crime_application, property_id: property)
+      end
+    end
+  end
 end

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe Decisions::CapitalDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
+  let(:form_object) { double('FormObject') }
+  let(:crime_application) { instance_double(CrimeApplication, id: '10') }
+
   it_behaves_like 'a decision tree'
 
   context 'when the step is `saving_type`' do
-    let(:crime_application) { instance_double(CrimeApplication, id: '10') }
-    let(:form_object) { double('FormObject') }
     let(:step_name) { :saving_type }
 
     before do
@@ -32,8 +33,6 @@ RSpec.describe Decisions::CapitalDecisionTree do
   end
 
   context 'when the step is `property_type`' do
-    let(:crime_application) { instance_double(CrimeApplication, id: '10') }
-    let(:form_object) { double('FormObject') }
     let(:step_name) { :property_type }
 
     before do
@@ -53,6 +52,23 @@ RSpec.describe Decisions::CapitalDecisionTree do
 
       it 'redirects the edit `properties` page' do
         expect(subject).to have_destination(:properties, :edit, id: crime_application, property_id: property)
+      end
+    end
+  end
+
+  context 'when the step is `properties`' do
+    let(:step_name) { :properties }
+    let(:property) { instance_double(Property) }
+
+    before do
+      allow(form_object).to receive_messages(crime_application:, property:)
+    end
+
+    context 'the client has selected a property type' do
+      let(:property) { instance_double(Property) }
+
+      it 'redirects the edit `saving_type` page' do
+        expect(subject).to have_destination(:saving_type, :edit, id: crime_application)
       end
     end
   end

--- a/spec/value_objects/house_type_spec.rb
+++ b/spec/value_objects/house_type_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HouseType do
 
   describe '.values' do
     it 'returns all possible values' do
-      expect(described_class.values.map(&:to_s)).to eq(%w[bungalow detached flat semidetached terraced])
+      expect(described_class.values.map(&:to_s)).to eq(%w[bungalow detached flat_or_maisonette semidetached terraced])
     end
   end
 end

--- a/spec/value_objects/house_type_spec.rb
+++ b/spec/value_objects/house_type_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe HouseType do
+  subject { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w[bungalow detached flat semidetached terraced])
+    end
+  end
+end

--- a/spec/value_objects/property_type_spec.rb
+++ b/spec/value_objects/property_type_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe PropertyType do
+  subject { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w[residential commercial land])
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add 'Your client’s residential property' page
Creates a new property from the property_type page.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-486

## Notes for reviewer

- This is the 2nd screen in the assets loop/journey.
- Currently, after saving properties, page gets redirected to "Which savings does your client have inside or outside the UK?" page. 
- Next page should be "What is the address of your client’s land?" (yet to implement)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="343" alt="Screenshot 2024-02-26 at 13 31 03" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/a3ef6748-0a19-4d21-a617-d5c7f822a848">

<img width="362" alt="Screenshot 2024-02-26 at 13 31 58" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/e6eb0164-f74b-4b17-afa4-f2713975333a">

<img width="462" alt="Screenshot 2024-02-26 at 13 34 37" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/b410357a-7d13-4ea0-9173-103f42f7c1f3">

## How to manually test the feature
http://localhost:3000/applications/:id/capital/which_assets_does_client_own
