### PR TITLE
Pence type can handle nil and negative values

### DIFF
--- a/app/attributes/type/pence.rb
+++ b/app/attributes/type/pence.rb
@@ -10,11 +10,13 @@ module Type
     def deserialize(value)
       return if value.blank?
 
-      super.to_f / 100
+      cast(value * 0.01)
     end
 
     def serialize(value)
-      return value if value.is_a? Integer
+      return if value.nil?
+      return if value.is_a?(::String) && non_numeric_string?(value)
+      return super if value.is_a?(Integer)
 
       super((value.to_f * 100).round)
     end

--- a/spec/attributes/type/pence_spec.rb
+++ b/spec/attributes/type/pence_spec.rb
@@ -18,19 +18,43 @@ RSpec.describe Type::Pence do
   describe '#serialize' do
     subject(:serialized_value) { pence.serialize(value) }
 
-    describe 'when value is `nil`' do
-      let(:value) { 0 }
+    context 'when value is `nil`' do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when value is a blank string' do
+      let(:value) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when value is zero' do
+      let(:value) { '0' }
 
       it { is_expected.to eq(0) }
     end
 
-    describe 'when value is a float' do
+    context 'when value is non-numeric string' do
+      let(:value) { 'wibble' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when value is a float' do
       let(:value) { 1.23109923 }
 
       it { is_expected.to eq(123) }
     end
 
-    describe 'when value is a string' do
+    context 'when value is -ve numeric string' do
+      let(:value) { '-0.02' }
+
+      it { is_expected.to eq(-2) }
+    end
+
+    context 'when value is a float string' do
       let(:value) { '321.019' }
 
       it { is_expected.to eq(32_102) }
@@ -38,62 +62,68 @@ RSpec.describe Type::Pence do
       it { is_expected.to be_a(Integer) }
     end
 
+    context 'when value is an integer string' do
+      let(:value) { '321' }
+
+      it { is_expected.to eq(32_100) }
+    end
+
+    context 'when value is a numeric string with spaces' do
+      let(:value) { ' 321 ' }
+
+      it { is_expected.to eq(32_100) }
+    end
+
     describe 'when value is an integer' do
       let(:value) { 123 }
 
-      it { is_expected.to eq(123) }
+      it 'assumes the value is already in pennies' do
+        expect(subject).to eq(123)
+      end
     end
   end
 
-  describe '#deserialize(value)' do
+  describe '#deserialize' do
     subject(:deserialized_value) { pence.deserialize(value) }
 
-    describe 'when value is `nil`' do
+    context 'when value is `nil`' do
       let(:value) { nil }
 
       it { is_expected.to be_nil }
     end
 
-    describe 'when value is `empty`' do
-      let(:value) { '' }
+    context 'when value is zero' do
+      let(:value) { 0 }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to eq '0.00' }
     end
 
-    describe 'when value is a float' do
-      let(:value) { 1100.09 }
+    context 'when value positive Integer' do
+      let(:value) { 123_120 }
 
-      it { is_expected.to eq(11.00) }
+      it { is_expected.to eq '1231.20' }
+    end
 
-      it { is_expected.to be_a(Float) }
+    context 'when value is a negative Integer' do
+      let(:value) { -1 }
+
+      it { is_expected.to eq '-0.01' }
     end
   end
 
-  describe '#cast(value)' do
-    subject(:coerced_value) { pence.cast(value) }
+  describe '#cast' do
+    subject(:cast_value) { pence.cast(value) }
 
-    describe 'when value is `nil`' do
-      let(:value) { nil }
+    context 'when value is string' do
+      let(:value) { '0.09' }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to eq '0.09' }
     end
 
-    describe 'when value is a float' do
-      let(:value) { 1.23 }
-
-      it { is_expected.to eq('1.23') }
-    end
-
-    describe 'when value is a string' do
-      let(:value) { '321.01' }
-
-      it { is_expected.to eq('321.01') }
-    end
-
-    describe 'when value is an integer' do
+    context 'when value is an integer' do
       let(:value) { 123 }
 
-      it { is_expected.to eq(123) }
+      it { is_expected.to eq 123 }
     end
   end
 end

--- a/spec/support/shared_examples/payment_shared_examples.rb
+++ b/spec/support/shared_examples/payment_shared_examples.rb
@@ -144,7 +144,7 @@ RSpec.shared_examples 'a payment form' do |payment_class|
         }
         record = payments.find_by(payment_type: 'other')
         expect(payments.size).to eq 1
-        expect(record.amount).to eq 103.26
+        expect(record.amount).to eq '103.26'
         expect(record.frequency).to eq 'month'
         expect(record.details).to eq 'Earned some cash selling furniture'
 
@@ -154,7 +154,7 @@ RSpec.shared_examples 'a payment form' do |payment_class|
         }
         record = payments.find_by(payment_type: 'other')
         expect(payments.size).to eq 1
-        expect(record.amount).to eq 8982.10
+        expect(record.amount).to eq '8982.10'
         expect(record.frequency).to eq 'annual'
         expect(record.details).to be_nil
       end


### PR DESCRIPTION
## Description of change
Prior to this change, `nil` amounts were being serialised as `0`. This change fixes that.
It also specs Pence to make sure that it can handle negative numbers.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="476" alt="Screenshot 2024-02-23 at 15 29 19" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/894e7719-0389-482b-8924-b1ee89a9dd5a">

### After changes:
<img width="523" alt="Screenshot 2024-02-23 at 15 29 36" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/7044aa65-14f6-41c0-9606-914642d7bebb">

## How to manually test the feature
Load a form with a pence attribute. Do not fill it in and save the page. Confirm that the pence attribute is not set to 0.00. 
