### PR TITLE
CRIMAPP-511 Confirm account holder on edit

### DIFF
--- a/app/forms/steps/capital/savings_form.rb
+++ b/app/forms/steps/capital/savings_form.rb
@@ -20,15 +20,7 @@ module Steps
         record.update(attributes)
       end
 
-      def confirm_in_applicants_name=(confirm)
-        return unless confirm && !include_partner?
-
-        self.account_holder = OwnershipType::APPLICANT
-      end
-
-      def confirm_in_applicants_name
-        account_holder == OwnershipType::APPLICANT
-      end
+      attr_accessor :confirm_in_applicants_name
 
       # TODO: use proper partner policy once we have one.
       def include_partner?
@@ -39,6 +31,18 @@ module Steps
         return unless account_holder.blank? || !account_holder.applicant?
 
         errors.add(:confirm_in_applicants_name, :confirm)
+      end
+
+      private
+
+      def before_save
+        return if include_partner?
+
+        self.account_holder = if confirm_in_applicants_name.blank?
+                                nil
+                              else
+                                OwnershipType::APPLICANT
+                              end
       end
     end
   end

--- a/spec/forms/steps/capital/savings_form_spec.rb
+++ b/spec/forms/steps/capital/savings_form_spec.rb
@@ -72,13 +72,20 @@ RSpec.describe Steps::Capital::SavingsForm do
   end
 
   describe '#confirm_in_applicants_name=(confirm)' do
-    subject(:confirm) { form.confirm_in_applicants_name = value }
+    subject(:confirm) do
+      form.confirm_in_applicants_name = value
+      form.save
+    end
 
     context 'when value is true' do
       let(:value) { true }
 
       it 'sets `#account_holder` to `applicant`' do
         expect { confirm }.to change(form, :account_holder).from(nil).to(OwnershipType::APPLICANT)
+      end
+
+      it 'is not persisted (i.e. needs re-confirming)' do
+        expect(form.confirm_in_applicants_name).to be_nil
       end
 
       context 'when client has parter' do
@@ -118,6 +125,7 @@ RSpec.describe Steps::Capital::SavingsForm do
           account_balance: '100.01',
           is_overdrawn: YesNoAnswer.values.sample,
           are_wages_paid_into_account: YesNoAnswer.values.sample,
+          confirm_in_applicants_name: YesNoAnswer::YES
         }
       end
 


### PR DESCRIPTION
## Description of change

The provider is now required to confirm account ownership when saving an existing and valid application. Prior to this, the confirm box was checked if the provider has previously confirmed ownership was with the applicant. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-511

## Notes for reviewer
This change also updates the form to use the recently introduced `Form#before_save`.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
