### PR TITLE
Update routing of means journey

### DIFF
--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -1,18 +1,20 @@
 module Decisions
   class CapitalDecisionTree < BaseDecisionTree
-    def destination
+    def destination # rubocop:disable Metrics/MethodLength
       case step_name
-      when :saving_type
-        after_saving_type(form_object.saving)
-      when :savings
-        # TODO: Add next step
       when :property_type
         after_property_type(form_object.property)
       when :properties
-        # TODO: Update next step
-        edit(:saving_type)
+        # TODO: Route to approprite property page loop once built
+        edit(:saving_type) # Placeholder to join up flow
+      when :saving_type
+        after_saving_type(form_object.saving)
+      when :savings
+        # TODO: Route to approprite savings page loop once built
+        edit(:premium_bonds) # Placeholder to join up flow
       when :premium_bonds
-        # TODO: Add next step
+        # TODO: Route to national savings certificates once built
+        edit('/steps/case/urn') # Placeholder to join up flow
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -103,7 +103,7 @@ module Decisions
     end
 
     def edit_dependants(add_blank: false)
-      dependants = crime_app.dependants
+      dependants = crime_application.dependants
       dependants.create! if add_blank || dependants.empty?
 
       edit(:dependants)
@@ -126,34 +126,34 @@ module Decisions
     end
 
     def appeal_no_changes?
-      crime_app.case.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s
+      crime_application.case.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s
     end
 
     def summary_only?
-      crime_app.case.case_type == CaseType::SUMMARY_ONLY.to_s
+      crime_application.case.case_type == CaseType::SUMMARY_ONLY.to_s
     end
 
     def income_below_threshold?
-      crime_app.income.income_above_threshold == 'no'
+      crime_application.income.income_above_threshold == 'no'
     end
 
     def no_frozen_assets?
-      crime_app.income.has_frozen_income_or_assets == 'no'
+      crime_application.income.has_frozen_income_or_assets == 'no'
     end
 
     def no_property?
-      crime_app.income.client_owns_property == 'no'
+      crime_application.income.client_owns_property == 'no'
     end
 
     def no_savings?
-      crime_app.income.has_savings == 'no'
+      crime_application.income.has_savings == 'no'
     end
 
     def payments
-      crime_app.income_payments + crime_app.income_benefits
+      crime_application.income_payments + crime_application.income_benefits
     end
 
-    def crime_app
+    def crime_application
       form_object.crime_application
     end
 

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -1,5 +1,5 @@
 module Decisions
-  class IncomeDecisionTree < BaseDecisionTree
+  class IncomeDecisionTree < BaseDecisionTree # rubocop:disable Metrics/ClassLength
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
 
     def destination
@@ -7,8 +7,7 @@ module Decisions
       when :employment_status
         after_employment_status
       when :lost_job_in_custody
-        # TODO: link to next step when we have it
-        edit(:income_before_tax)
+        after_lost_job_in_custody
       when :income_before_tax
         after_income_before_tax
       when :frozen_income_savings_assets
@@ -20,8 +19,7 @@ module Decisions
       when :income_payments
         edit(:income_benefits)
       when :income_benefits
-        # TODO: link to next step when we have it
-        edit(:client_has_dependants)
+        after_income_benefits
       when :client_has_dependants
         after_client_has_dependants
       when :add_dependant
@@ -29,8 +27,7 @@ module Decisions
       when :delete_dependant
         edit_dependants
       when :dependants_finished
-        # TODO: link to next step when we have it
-        edit(:manage_without_income)
+        determine_showing_no_income_page
       when :manage_without_income
         # TODO: link to next step when we have it
         edit('/steps/outgoings/housing_payment_type')
@@ -46,6 +43,8 @@ module Decisions
       if not_working?
         if ended_employment_within_three_months?
           edit(:lost_job_in_custody)
+        elsif appeal_no_changes?
+          edit('/steps/evidence/upload')
         else
           edit(:income_before_tax)
         end
@@ -55,12 +54,19 @@ module Decisions
       end
     end
 
+    def after_lost_job_in_custody
+      if appeal_no_changes?
+        edit('/steps/evidence/upload')
+      else
+        edit(:income_before_tax)
+      end
+    end
+
     def after_income_before_tax
       if income_below_threshold?
         edit(:frozen_income_savings_assets)
       else
-        # TODO: once we have the next step
-        edit(:client_has_dependants)
+        edit(:income_payments)
       end
     end
 
@@ -68,8 +74,7 @@ module Decisions
       if no_frozen_assets?
         edit(:client_owns_property)
       else
-        # TODO: once we have the next step
-        edit(:client_has_dependants)
+        edit(:income_payments)
       end
     end
 
@@ -77,8 +82,15 @@ module Decisions
       if no_property?
         edit(:has_savings)
       else
-        # TODO: once we have the next step
+        edit(:income_payments)
+      end
+    end
+
+    def after_income_benefits
+      if dependants_relevant?
         edit(:client_has_dependants)
+      else
+        determine_showing_no_income_page
       end
     end
 
@@ -86,15 +98,23 @@ module Decisions
       if form_object.client_has_dependants.yes?
         edit_dependants(add_blank: true)
       else
-        edit(:manage_without_income)
+        determine_showing_no_income_page
       end
     end
 
     def edit_dependants(add_blank: false)
-      dependants = form_object.crime_application.dependants
+      dependants = crime_app.dependants
       dependants.create! if add_blank || dependants.empty?
 
       edit(:dependants)
+    end
+
+    def determine_showing_no_income_page
+      if payments.empty?
+        edit(:manage_without_income)
+      else
+        edit('/steps/outgoings/housing_payment_type')
+      end
     end
 
     def not_working?
@@ -105,16 +125,44 @@ module Decisions
       form_object.ended_employment_within_three_months&.yes?
     end
 
+    def appeal_no_changes?
+      crime_app.case.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s
+    end
+
+    def summary_only?
+      crime_app.case.case_type == CaseType::SUMMARY_ONLY.to_s
+    end
+
     def income_below_threshold?
-      form_object.income_above_threshold.no?
+      crime_app.income.income_above_threshold == 'no'
     end
 
     def no_frozen_assets?
-      form_object.has_frozen_income_or_assets.no?
+      crime_app.income.has_frozen_income_or_assets == 'no'
     end
 
     def no_property?
-      form_object.client_owns_property.no?
+      crime_app.income.client_owns_property == 'no'
+    end
+
+    def no_savings?
+      crime_app.income.has_savings == 'no'
+    end
+
+    def payments
+      crime_app.income_payments + crime_app.income_benefits
+    end
+
+    def crime_app
+      form_object.crime_application
+    end
+
+    def dependants_relevant?
+      if income_below_threshold? && no_frozen_assets?
+        !(summary_only? || (no_property? && no_savings?))
+      else
+        true
+      end
     end
   end
 end

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -3,6 +3,7 @@ module Decisions
     def destination
       case step_name
       when :housing_payment_type
+        # TODO: determine and link to next step when we have it
         edit(:council_tax)
       when :council_tax
         # TODO: link to next step when we have it
@@ -10,7 +11,7 @@ module Decisions
       when :income_tax_rate
         edit(:outgoings_more_than_income)
       when :outgoings_more_than_income
-        edit('/steps/case/urn')
+        edit('/steps/capital/property_type')
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
     let(:step_name) { :outgoings_more_than_income }
 
     context 'has correct next step' do
-      it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
+      it { is_expected.to have_destination('/steps/capital/property_type', :edit, id: crime_application) }
     end
   end
 end

--- a/spec/value_objects/outgoings_payment_type_spec.rb
+++ b/spec/value_objects/outgoings_payment_type_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe OutgoingsPaymentType do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(
+        %w[
+          rent
+          mortgage
+          board_and_lodging
+          council_tax
+          childcare
+          maintenance
+          legal_aid_contribution
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Update routing of means journey

Stitch together capital pages as placeholder route
Connect outgoings to capital
Add routing logic to Income as per https://miro.com/app/board/uXjVO75Jwao=/?moveToWidget=3458764570607376929&cot=14

## How to manually test the feature
Check means journey skips to evidence upload if case type is appeal to CC (no changes) aka appeal_to_crown_court after the employment page (or job lost in custody page if triggered)

Check dependants skipped based on: https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk?node-id=7035:54438&mode=design#651514930

Check manage_no_income page is not shown if any payments/benefits are declared 
(I did consider adding a check if income < £12,475 == 'yes' too but it would take us to a cul-de-sac where income > £12,475 && no payments declared  and we wouldn't show the manage_no_income page and the user hasn't been contested on the lack of payments inconsistency) 