### PR TITLE
[CHORE] Typo Child Benfit in Outgoings

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -370,7 +370,7 @@ en:
           details: Enter the other sources of income they get
       steps_income_income_benefits_form:
         types_options:
-          child: Child Benfit
+          child: Child Benefit
           working_or_child_tax_credit: Working Tax Credit or Child Tax Credit
           incapacity: Incapacity Benefit
           industrial_injuries_disablement: Industrial Injuries Disablement Benefit
@@ -466,8 +466,8 @@ en:
         account_balance: What is the account balance?
         is_overdrawn_options: *YESNO
         are_wages_paid_into_account_options: *YESNO
-        account_holder_options: *OWNERSHIP_OPTIONS 
-        confirm_in_applicants_name_options: 
+        account_holder_options: *OWNERSHIP_OPTIONS
+        confirm_in_applicants_name_options:
           'true': I confirm that the account is in my client's name
       steps_capital_savings_summary_form:
         add_saving_options: *YESNO
@@ -491,4 +491,3 @@ en:
         percentage_partner_owned: What percentage of the property does your client’s partner own?
         is_home_address_options: *YESNO
         has_other_owners_options: *YESNO
-


### PR DESCRIPTION
## Description of change
Typo, missing vowel

## Link to relevant ticket
N/A

## Notes for reviewer
N/A

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2024-02-28 at 16 00 40](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/57d4561a-0ee3-4224-a9ed-024c301376d8)

### After changes:
![Screenshot 2024-02-28 at 16 00 54](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/eae1cadd-0fb0-49de-8abe-3de9dff8e28a)

## How to manually test the feature
`<staging url>/applications/<crime application id>/steps/income/which_benefits_does_client_get`