### PR TITLE
CRIMAPP-487 - Add residential property address page

### DIFF
--- a/app/controllers/steps/capital/properties_controller.rb
+++ b/app/controllers/steps/capital/properties_controller.rb
@@ -16,13 +16,9 @@ module Steps
       private
 
       def property_record
-        @property_record ||= properties.find(params[:property_id])
+        @property_record ||= current_crime_application.properties.find(params[:property_id])
       rescue ActiveRecord::RecordNotFound
         raise Errors::PropertyNotFound
-      end
-
-      def properties
-        @properties ||= current_crime_application.properties
       end
     end
   end

--- a/app/controllers/steps/capital/property_address_controller.rb
+++ b/app/controllers/steps/capital/property_address_controller.rb
@@ -1,0 +1,31 @@
+module Steps
+  module Capital
+    class PropertyAddressController < Steps::CapitalStepController
+      def edit
+        @form_object = PropertyAddressForm.build(
+          property_record, crime_application: current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(PropertyAddressForm, record: property_record, as: :property_address)
+      end
+
+      private
+
+      def property_record
+        @property_record ||= properties.find(params[:property_id])
+      rescue ActiveRecord::RecordNotFound
+        raise Errors::PropertyNotFound
+      end
+
+      def properties
+        @properties ||= current_crime_application.properties
+      end
+
+      def additional_permitted_params
+        [address: [:address_line_one, :address_line_two, :city, :country, :postcode]]
+      end
+    end
+  end
+end

--- a/app/controllers/steps/capital/property_address_controller.rb
+++ b/app/controllers/steps/capital/property_address_controller.rb
@@ -14,13 +14,9 @@ module Steps
       private
 
       def property_record
-        @property_record ||= properties.find(params[:property_id])
+        @property_record ||= current_crime_application.properties.find(params[:property_id])
       rescue ActiveRecord::RecordNotFound
         raise Errors::PropertyNotFound
-      end
-
-      def properties
-        @properties ||= current_crime_application.properties
       end
 
       def additional_permitted_params

--- a/app/forms/steps/capital/properties_form.rb
+++ b/app/forms/steps/capital/properties_form.rb
@@ -19,11 +19,11 @@ module Steps
                 :outstanding_mortgage,
                 :percentage_applicant_owned,
                 :has_other_owners, presence: true
-      validates :is_home_address, presence: true, if: -> { person_has_home_address? }
-      validates :is_home_address, inclusion: { in: YesNoAnswer.values }, if: -> { person_has_home_address? }
+      validates :is_home_address, presence: true, if: :person_has_home_address?
+      validates :is_home_address, inclusion: { in: YesNoAnswer.values }, if: :person_has_home_address?
       validates :has_other_owners, inclusion: { in: YesNoAnswer.values }
       validates :percentage_partner_owned, presence: true, if: :include_partner?
-      validates :custom_house_type, presence: true, unless: -> { house_type_is_listed? }
+      validates :custom_house_type, presence: true, unless: :house_type_is_listed?
 
       def house_types
         HouseType.values
@@ -43,7 +43,7 @@ module Steps
 
       # TODO: use proper partner policy once we have one.
       def include_partner?
-        YesNoAnswer.new(crime_application.client_has_partner).yes?
+        YesNoAnswer.new(crime_application.client_has_partner.to_s).yes?
       end
 
       def house_type_is_listed?

--- a/app/forms/steps/capital/property_address_form.rb
+++ b/app/forms/steps/capital/property_address_form.rb
@@ -4,30 +4,15 @@ module Steps
       delegate :property_type, to: :record
 
       attribute :address
+      attribute :address_line_one
+      attribute :address_line_two
+      attribute :city
+      attribute :country
+      attribute :postcode
 
       validates :address, presence: true
 
       validates_with AddressValidator
-
-      def address_line_one
-        address[:address_line_one]
-      end
-
-      def address_line_two
-        address[:address_line_two]
-      end
-
-      def city
-        address[:city]
-      end
-
-      def country
-        address[:country]
-      end
-
-      def postcode
-        address[:postcode]
-      end
 
       private
 

--- a/app/forms/steps/capital/property_address_form.rb
+++ b/app/forms/steps/capital/property_address_form.rb
@@ -5,6 +5,8 @@ module Steps
 
       attribute :address
 
+      validates :address, presence: true
+
       validates_with AddressValidator
 
       def address_line_one

--- a/app/forms/steps/capital/property_address_form.rb
+++ b/app/forms/steps/capital/property_address_form.rb
@@ -1,0 +1,39 @@
+module Steps
+  module Capital
+    class PropertyAddressForm < Steps::BaseFormObject
+      delegate :property_type, to: :record
+
+      attribute :address
+
+      validates_with AddressValidator
+
+      def address_line_one
+        address[:address_line_one]
+      end
+
+      def address_line_two
+        address[:address_line_two]
+      end
+
+      def city
+        address[:city]
+      end
+
+      def country
+        address[:country]
+      end
+
+      def postcode
+        address[:postcode]
+      end
+
+      private
+
+      def persist!
+        record.update(
+          attributes
+        )
+      end
+    end
+  end
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -4,6 +4,10 @@ class Property < ApplicationRecord
   attribute :value, :pence
   attribute :outstanding_mortgage, :pence
 
+  store_accessor :address, :address_line_one, :address_line_two, :city, :country, :postcode
+
+  OPTIONAL_ADDRESS_ATTRIBUTES = %w[address_line_two].freeze
+
   def complete?
     values_at(
       :property_type,

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -1,6 +1,6 @@
 module Decisions
   class CapitalDecisionTree < BaseDecisionTree
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     def destination
       case step_name
       when :saving_type
@@ -23,7 +23,7 @@ module Decisions
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     private
 

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -46,7 +46,7 @@ module Decisions
     end
 
     def after_properties
-      return edit(:property_address) if form_object.is_home_address.no?
+      return edit(:property_address) if form_object.is_home_address.nil? || form_object.is_home_address.no?
 
       # TODO: Route to approprite property page loop once built
       edit(:saving_type) # Placeholder to join up flow

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -12,8 +12,10 @@ module Decisions
       when :property_type
         after_property_type(form_object.property)
       when :properties
-        # TODO: Route to approprite property page loop once built
-        edit(:saving_type) # Placeholder to join up flow
+        after_properties
+      when :property_address
+        # TODO: Route to property owner page once built
+        edit(:saving_type)
       when :premium_bonds
         # TODO: Route to national savings certificates once built
         edit('/steps/case/urn') # Placeholder to join up flow
@@ -41,6 +43,13 @@ module Decisions
       return edit(:saving_type) unless property
 
       edit(:properties, property_id: property)
+    end
+
+    def after_properties
+      return edit(:property_address) if form_object.is_home_address.no?
+
+      # TODO: Route to approprite property page loop once built
+      edit(:saving_type) # Placeholder to join up flow
     end
   end
 end

--- a/app/validators/address_validator.rb
+++ b/app/validators/address_validator.rb
@@ -1,0 +1,11 @@
+class AddressValidator < ActiveModel::Validator
+  attr_reader :record
+
+  def validate(record)
+    record.address.each_with_index do |(key, value), index|
+      next if Property::OPTIONAL_ADDRESS_ATTRIBUTES.any? key
+
+      record.errors.add(key, :blank, index: index + 1) if value.blank?
+    end
+  end
+end

--- a/app/validators/address_validator.rb
+++ b/app/validators/address_validator.rb
@@ -2,9 +2,8 @@ class AddressValidator < ActiveModel::Validator
   attr_reader :record
 
   def validate(record)
-    (record.address || {}).each_with_index do |(key, value), index|
-      next if Property::OPTIONAL_ADDRESS_ATTRIBUTES.any? key
-
+    required_attributes = (record.address || {}).reject { |k, _v| Property::OPTIONAL_ADDRESS_ATTRIBUTES.any? k }
+    required_attributes.each_with_index do |(key, value), index|
       record.errors.add(key, :blank, index: index + 1) if value.blank?
     end
   end

--- a/app/validators/address_validator.rb
+++ b/app/validators/address_validator.rb
@@ -2,7 +2,7 @@ class AddressValidator < ActiveModel::Validator
   attr_reader :record
 
   def validate(record)
-    record.address.each_with_index do |(key, value), index|
+    (record.address || {}).each_with_index do |(key, value), index|
       next if Property::OPTIONAL_ADDRESS_ATTRIBUTES.any? key
 
       record.errors.add(key, :blank, index: index + 1) if value.blank?

--- a/app/views/steps/capital/property_address/edit.html.erb
+++ b/app/views/steps/capital/property_address/edit.html.erb
@@ -7,9 +7,9 @@
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl"><%=t ".heading.#{@form_object.property_type}" %></h1>
-
     <%= step_form @form_object do |f| %>
-      <%= f.fields_for :address, OpenStruct.new(@form_object.address) do |address_field| %>
+      <%# NOTE: Address is just a replacement of OpenStruct rubocop was complaining about %>
+      <%= f.fields_for :address, Address.new(@form_object.address) do |address_field| %>
         <%= address_field.govuk_text_field :address_line_one, autocomplete: 'off' %>
         <%= address_field.govuk_text_field :address_line_two, autocomplete: 'off' %>
         <%= address_field.govuk_text_field :city, autocomplete: 'off' %>

--- a/app/views/steps/capital/property_address/edit.html.erb
+++ b/app/views/steps/capital/property_address/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t ".heading.#{@form_object.property_type}" %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.fields_for :address, OpenStruct.new(@form_object.address) do |address_field| %>
+        <%= address_field.govuk_text_field :address_line_one, autocomplete: 'off' %>
+        <%= address_field.govuk_text_field :address_line_two, autocomplete: 'off' %>
+        <%= address_field.govuk_text_field :city, autocomplete: 'off' %>
+        <%= address_field.govuk_text_field :country, autocomplete: 'off' %>
+        <%= address_field.govuk_text_field :postcode, autocomplete: 'off', width: 'one-third' %>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -514,7 +514,6 @@ en:
           attributes:
             address_line_one:
               blank: Enter address line 1, typically the building and street
-            address_line_two: # optional
             city:
               blank: Enter town or city
             country:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -510,6 +510,17 @@ en:
               inclusion: Select yes if the address of the property is the same as your client's home address
             has_other_owners:
               inclusion: Select yes if anyone else owns part of the land
+        steps/capital/property_address_form:
+          attributes:
+            address_line_one:
+              blank: Enter address line 1, typically the building and street
+            address_line_two: # optional
+            city:
+              blank: Enter town or city
+            country:
+              blank:  Enter country
+            postcode:
+              blank: Enter postcode
         steps/submission/more_information_form:
           attributes:
             additional_information:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -491,3 +491,10 @@ en:
         percentage_partner_owned: What percentage of the property does your client’s partner own?
         is_home_address_options: *YESNO
         has_other_owners_options: *YESNO
+      steps_capital_property_address_form:
+        address:
+          address_line_one: Address line 1
+          address_line_two: Address line 2 (optional)
+          city: Town or city
+          country: Country
+          postcode: Postcode

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -346,6 +346,14 @@ en:
             commercial: Your client’s commercial property
             land: Your client’s land
 
+      property_address:
+        edit:
+          page_title: What is the address of your client’s land?
+          heading:
+            residential: What is the address of your client’s residential property?
+            commercial: What is the address of your client’s commercial property?
+            land: What is the address of your client’s land?
+
     evidence:
       upload:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,8 @@ Rails.application.routes.draw do
         crud_step :savings, param: :saving_id
         edit_step :clients_savings, alias: :savings_summary
         edit_step :does_client_have_premium_bonds, alias: :premium_bonds
-        crud_step :properties, param: :property_id
+        crud_step :properties, alias: :properties, param: :property_id, except: [:destroy]
+        crud_step :property_address, alias: :property_address, param: :property_id, except: [:destroy]
       end
 
       namespace :evidence do

--- a/db/migrate/20240229125141_change_column_address_in_properties.rb
+++ b/db/migrate/20240229125141_change_column_address_in_properties.rb
@@ -1,0 +1,9 @@
+class ChangeColumnAddressInProperties < ActiveRecord::Migration[7.0]
+  def up
+    change_column(:properties, :address, :jsonb)
+  end
+
+  def down
+    change_column(:properties, :address, :json)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_25_175632) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_29_125141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -262,7 +262,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_25_175632) do
     t.integer "percentage_partner_owned"
     t.string "is_home_address"
     t.string "has_other_owners"
-    t.json "address"
+    t.jsonb "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["crime_application_id"], name: "index_properties_on_crime_application_id"

--- a/spec/controllers/steps/capital/property_address_controller_spec.rb
+++ b/spec/controllers/steps/capital/property_address_controller_spec.rb
@@ -1,7 +1,82 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Capital::PropertyAddressController, type: :controller do
+  let(:form_class) { Steps::Capital::PropertyAddresForm }
+  let(:decision_tree_class) { Decisions::CapitalDecisionTree }
   let(:crime_application) { CrimeApplication.create }
+  let(:property) do
+    Property.create!(property_type: PropertyType::RESIDENTIAL, crime_application: crime_application)
+  end
 
-  pending 'add specs'
+  describe '#edit' do
+    context 'when property is not found' do
+      it 'redirects to the property not found error page' do
+        get :edit, params: { id: '12345', property_id: '123' }
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when property is found' do
+      it 'responds with HTTP success' do
+        get :edit, params: { id: crime_application, property_id: property }
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when property is for another application' do
+      let(:property) do
+        Property.create!(property_type: PropertyType::RESIDENTIAL, crime_application: CrimeApplication.create!)
+      end
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: crime_application, property_id: property }
+
+        expect(response).to redirect_to(not_found_errors_path)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:expected_params) do
+      {
+        id: crime_application,
+        property_id: property,
+        steps_capital_property_address_form: {address: address_attributes}
+      }
+    end
+
+    context 'when valid address attributes' do
+      let(:address_attributes) do
+        {
+          address_line_one: 'address_line_one',
+          address_line_two: 'address_line_two',
+          city: 'city',
+          country: 'country',
+          postcode: 'postcode'
+        }
+      end
+
+      it 'redirects to the which_savings path' do
+        put :update, params: expected_params, session: { crime_application_id: crime_application.id }
+        expect(response).to redirect_to(/which_savings_does_client_have/)
+      end
+    end
+
+    context 'when invalid address attributes' do
+      let(:address_attributes) do
+        {
+          address_line_one: nil,
+          address_line_two: 'address_line_two',
+          city: nil,
+          country: 'country',
+          postcode: 'postcode'
+        }
+      end
+
+      it 'redirects to the edit property address path' do
+        put :update, params: expected_params, session: { crime_application_id: crime_application.id }
+        expect(response).not_to redirect_to(/which_savings_does_client_have/)
+      end
+    end
+  end
 end

--- a/spec/controllers/steps/capital/property_address_controller_spec.rb
+++ b/spec/controllers/steps/capital/property_address_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Steps::Capital::PropertyAddressController, type: :controller do
       {
         id: crime_application,
         property_id: property,
-        steps_capital_property_address_form: {address: address_attributes}
+        steps_capital_property_address_form: { address: address_attributes }
       }
     end
 

--- a/spec/controllers/steps/capital/property_address_controller_spec.rb
+++ b/spec/controllers/steps/capital/property_address_controller_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PropertyAddressController, type: :controller do
+  let(:crime_application) { CrimeApplication.create }
+
+  pending 'add specs'
+end

--- a/spec/forms/steps/capital/property_address_form_spec.rb
+++ b/spec/forms/steps/capital/property_address_form_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PropertyAddressForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      record:,
+    }.merge(attributes)
+  end
+
+  let(:attributes) { { address: valid_attributes } }
+
+  let(:crime_application) do
+    instance_double(CrimeApplication)
+  end
+  let(:applicant) { instance_double(Applicant, home_address?: home_address?) }
+  let(:record) { Property.new }
+
+  describe '#save' do
+    let(:valid_attributes) do
+      {
+        address_line_one: 'address_line_one',
+        address_line_two: 'address_line_two',
+        city: 'city',
+        country: 'country',
+        postcode: 'postcode'
+      }
+    end
+
+    context 'with valid attributes' do
+      let(:attributes) { { address: valid_attributes } }
+
+      it 'updates the record' do
+        expect(record).to receive(:update).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'with invalid attributes' do
+      context 'when address is not present' do
+        let(:attributes) { { address: nil } }
+
+        it 'does not updates the record' do
+          expect(record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+      end
+
+      context 'when address is incomplete' do
+        let(:attributes) { { address: valid_attributes.merge(address_line_one: nil, city: nil) } }
+
+        it 'does not updates the record' do
+          expect(record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -59,16 +59,33 @@ RSpec.describe Decisions::CapitalDecisionTree do
   end
 
   context 'when the step is `properties`' do
-    let(:form_object) { double('FormObject', property:) }
+    let(:form_object) { double('FormObject', property:, is_home_address:) }
     let(:step_name) { :properties }
     let(:property) { instance_double(Property) }
 
-    context 'the client has selected a property type' do
-      let(:property) { instance_double(Property) }
+    context 'when property address same as home address' do
+      let(:is_home_address) { YesNoAnswer::YES }
 
       it 'redirects the edit `saving_type` page' do
         expect(subject).to have_destination(:saving_type, :edit, id: crime_application)
       end
+    end
+
+    context 'when property address different from home address' do
+      let(:is_home_address) { YesNoAnswer::NO }
+
+      it 'redirects the edit `property_address` page' do
+        expect(subject).to have_destination(:property_address, :edit, id: crime_application)
+      end
+    end
+  end
+
+  context 'when the step is `property_address`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :property_address }
+
+    context 'has correct next step' do
+      it { is_expected.to have_destination(:saving_type, :edit, id: crime_application) }
     end
   end
 


### PR DESCRIPTION
## Description of change
Add "What is the address of your client’s residential property?" page if client selects 'no' for the question "Is the address of the property the same as your client’s home address?" in the "Your client’s residential property" page

## Link to relevant ticket
[CRIMAPP-487](https://dsdmoj.atlassian.net/browse/CRIMAPP-487)

## Notes for reviewer
Currently we are routing to "which_savings_does_client_have" for all paths of capital assets. It will change as we introduce more pages to the journey

## Screenshots of changes (if applicable)

### Before changes:
<img width="1538" alt="Screenshot 2024-02-29 at 14 16 59" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/79844a6b-2eca-4243-800d-221f916553e1">


### After changes:
<img width="2084" alt="Screenshot 2024-02-29 at 14 14 24" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/35cf4d1a-53aa-44b1-9b1d-511c140abf27">

## How to manually test the feature




[CRIMAPP-487]: https://dsdmoj.atlassian.net/browse/CRIMAPP-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ