### PR TITLE
Add summary cards to staging and local

### DIFF
--- a/app/views/steps/submission/shared/_section.html.erb
+++ b/app/views/steps/submission/shared/_section.html.erb
@@ -1,9 +1,24 @@
-<% unless section.headless? %>
-  <h2 class="govuk-heading-m">
-    <%= t(section.name, scope: 'summary.sections') %>
-  </h2>
-<% end %>
+<% if FeatureFlags.summary_cards.enabled? && !section.headless?%>
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">
+        <%= t(section.name, scope: 'summary.sections') %>
+      </h2>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <%= render section.answers, editable: section.editable? %>
+      </dl>
+    </div>
+  </div>
+<% else %>
+  <% unless section.headless? %>
+    <h2 class="govuk-heading-m">
+      <%= t(section.name, scope: 'summary.sections') %>
+    </h2>
+  <% end %>
 
-<dl class="govuk-summary-list">
-  <%= render section.answers, editable: section.editable? %>
-</dl>
+  <dl class="govuk-summary-list">
+    <%= render section.answers, editable: section.editable? %>
+  </dl>
+<% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  summary_cards:
+    local: true
+    staging: true
+    production: false
 
 
 # NOTE: consider if the setting you are adding here

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Dashboard', :authorized do
       # client details section, no change links
       assert_select 'h2', 'Client details'
 
-      assert_select 'dl.govuk-summary-list:nth-of-type(2)' do
+      assert_select 'dl.govuk-summary-list' do
         assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(1)' do
           assert_select 'dt:nth-of-type(1)', 'First name'
           assert_select 'dd:nth-of-type(1)', 'Kit'


### PR DESCRIPTION
## Description of change
Uses summary cards for the Review screen.
Feature flagged to staging and local only.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2024-02-29 at 16 17 15](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/2d79fdad-22f5-4fa4-ad32-88f053f31c3d)

### After changes:

![Screenshot 2024-02-29 at 15 51 37](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/4db62d1f-57f4-4ba4-9d7d-2abeadc95f1d)



## How to manually test the feature
