### PR TITLE
[CRIMAPP-490] Add outgoings mortgage payment form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.40'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.41'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 4a1688c86f55dd2cc295831096f29134638efcdc
-  tag: v1.0.40
+  revision: b119af1db6bf6f11d32dbb3cd28ed2d11856ad6a
+  tag: v1.0.41
   specs:
-    laa-criminal-legal-aid-schemas (1.0.40)
+    laa-criminal-legal-aid-schemas (1.0.41)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/controllers/steps/outgoings/mortgage_controller.rb
+++ b/app/controllers/steps/outgoings/mortgage_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Outgoings
+    class MortgageController < Steps::OutgoingsStepController
+      def edit
+        @form_object = MortgageForm.build(current_crime_application)
+      end
+
+      def update
+        update_and_advance(MortgageForm, as: :mortgage)
+      end
+    end
+  end
+end

--- a/app/forms/steps/outgoings/mortgage_form.rb
+++ b/app/forms/steps/outgoings/mortgage_form.rb
@@ -1,0 +1,37 @@
+module Steps
+  module Outgoings
+    class MortgageForm < Steps::BaseFormObject
+      attribute :amount, :pence
+      attribute :frequency, :value_object, source: PaymentFrequencyType
+
+      validates :amount, presence: true, numericality: { greater_than: 0 }
+      validates :frequency, presence: true, inclusion: { in: PaymentFrequencyType.values }
+
+      def self.build(crime_application)
+        payment = crime_application.outgoings_payments.mortgage
+
+        new.tap do |form|
+          form.attributes = payment.slice(:amount, :frequency) if payment
+        end
+      end
+
+      private
+
+      def persist!
+        ::OutgoingsPayment.transaction do
+          reset!
+
+          crime_application.outgoings_payments.create!(
+            payment_type: OutgoingsPaymentType::MORTGAGE.value,
+            amount: amount,
+            frequency: frequency,
+          )
+        end
+      end
+
+      def reset!
+        crime_application.outgoings_payments.where(payment_type: OutgoingsPaymentType::MORTGAGE.value).destroy_all
+      end
+    end
+  end
+end

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -2,5 +2,12 @@ class OutgoingsPayment < ApplicationRecord
   belongs_to :crime_application
 
   attribute :amount, :pence
+  attribute :payment_type, :value_object, source: HousingPaymentType
+
   store_accessor :metadata, :details, :case_reference
+
+  # TODO: Not sure why scope does not work instead
+  def self.mortgage
+    where(payment_type: OutgoingsPaymentType::MORTGAGE).order(created_at: :desc).first
+  end
 end

--- a/app/serializers/submission_serializer/definitions/payment.rb
+++ b/app/serializers/submission_serializer/definitions/payment.rb
@@ -3,7 +3,7 @@ module SubmissionSerializer
     class Payment < Definitions::BaseDefinition
       def to_builder
         Jbuilder.new do |json|
-          json.payment_type payment_type
+          json.payment_type payment_type.respond_to?(:value) ? payment_type.to_s : payment_type
           json.amount amount_before_type_cast
           json.frequency frequency
           json.metadata metadata

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -3,7 +3,8 @@ module Decisions
     def destination # rubocop:disable Metrics/MethodLength
       case step_name
       when :housing_payment_type
-        # TODO: determine and link to next step when we have it
+        after_housing_payment_type
+      when :board_and_lodgings, :mortgage
         edit(:council_tax)
       when :council_tax
         edit(:outgoings_payments)
@@ -15,6 +16,19 @@ module Decisions
         edit('/steps/capital/property_type')
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+
+    private
+
+    def after_housing_payment_type
+      if form_object.housing_payment_type.nil?
+        # TODO: Consider appropriate action for empty housing_payment_type
+        edit(:council_tax)
+      elsif form_object.housing_payment_type.value == :board_lodgings
+        edit(:board_and_lodgings)
+      elsif form_object.housing_payment_type.value == :mortgage
+        edit(:mortgage)
       end
     end
   end

--- a/app/views/steps/outgoings/mortgage/edit.html.erb
+++ b/app/views/steps/outgoings/mortgage/edit.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_fieldset(legend: { text: t('.mortgage_legend'), tag: 'h1', size: 'xl' }) do %>
+        <%= f.govuk_text_field(:amount,
+                               width: 'one-half',
+                               prefix_text: '£',
+                               hint: { text: t('.amount_hint') },
+                               autocomplete: 'off') %>
+
+        <%= f.govuk_collection_radio_buttons(:frequency,
+                                             PaymentFrequencyType.values,
+                                             :value,
+                                             legend: { size: 's', class: 'govuk-!-font-weight-regular' }) %>
+        <% end %>
+      <%= f.continue_button %>
+    <% end %>
+
+  </div>
+</div>

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -2,6 +2,7 @@ Dir[File.expand_path('app/attributes/type') + '/*.rb'].each { |f| require f }
 
 ActiveModel::Type.register(:string, Type::StrippedString)
 ActiveModel::Type.register(:value_object, Type::ValueObject)
+ActiveRecord::Type.register(:value_object, Type::ValueObject)
 ActiveModel::Type.register(:multiparam_date, Type::MultiparamDate)
 ActiveModel::Type.register(:pence, Type::Pence)
 ActiveRecord::Type.register(:pence, Type::Pence)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -421,6 +421,15 @@ en:
           attributes:
             housing_payment_type:
               inclusion: Select which payment your client pays where they usually live
+        steps/outgoings/mortgage_form:
+          attributes:
+            amount:
+              blank: Enter how much your client's mortgage payments are, after taking away Housing Benefit
+              greater_than: Your client's mortgage payments must be more than 0
+              not_a_number: Your client's mortgage payments, after taking away Housing Benefit, must be a number, like 50
+            frequency:
+              blank: Select how often they pay mortgage payments
+              inclusion: Select how often they pay mortgage payments
         steps/outgoings/council_tax_form:
           attributes:
             pays_council_tax:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -89,6 +89,8 @@ en:
         manage_without_income: How does your client manage with no income?
       steps_outgoings_housing_payment_type_form:
         housing_payment_type: Which of these payments does your client pay where they usually live?
+      steps_outgoings_mortgage_form:
+        frequency: Select how often they pay mortgage payments
       steps_outgoings_council_tax_form:
         council_tax: Does your client pay Council Tax where they usually live?
       steps_outgoings_outgoings_payments_form:
@@ -416,6 +418,9 @@ en:
           mortgage: Mortgage
           board_lodgings: Board and lodgings
           none: My client does not pay any of these payments
+      steps_outgoings_mortgage_form:
+        amount: How much are your client's mortgage payments?
+        frequency_options: *frequency_options
       steps_outgoings_council_tax_form:
         pays_council_tax_options: *YESNO
         council_tax_amount: How much do they pay yearly?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -282,6 +282,11 @@ en:
       housing_payment_type:
         edit:
           page_title: Which of these payments does your client pay where they usually live?
+      mortgage:
+        edit:
+          page_title: Mortgage payments
+          mortgage_legend: Mortgage payments
+          amount_hint: Only include mortgage payments where they usually live.
       council_tax:
         edit:
           page_title: Does your client pay Council Tax where they usually live?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
         edit_step :has_client_paid_income_tax_rate, alias: :income_tax_rate
         edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
         edit_step :which_payments_does_client_pay, alias: :outgoings_payments
+        edit_step :mortgage_payments, alias: :mortgage
       end
 
       namespace :capital, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do

--- a/spec/controllers/steps/outgoings/mortgage_controller_spec.rb
+++ b/spec/controllers/steps/outgoings/mortgage_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::MortgageController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Outgoings::MortgageForm, Decisions::OutgoingsDecisionTree do
+    describe 'CRUD actions' do
+      let(:crime_application) { CrimeApplication.create }
+
+      context 'finishing mortgage' do
+        it 'has the expected step name' do
+          expect(subject).to receive(:update_and_advance).with(
+            Steps::Outgoings::MortgageForm, as: :mortgage
+          )
+
+          put :update, params: { id: crime_application }
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/outgoings/mortgage_form_spec.rb
+++ b/spec/forms/steps/outgoings/mortgage_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::MortgageForm do
+  let(:crime_application) { CrimeApplication.new }
+
+  describe '#build' do
+    subject(:form) { described_class.build(crime_application) }
+
+    context 'when no mortgage payment exists' do
+      it 'creates empty form if model does not exist' do
+        expect(subject.amount).to be_nil
+        expect(subject.frequency).to be_nil
+      end
+    end
+
+    context 'when mortgage payment exists' do
+      let(:existing_mortgage_payment) {
+        OutgoingsPayment.new(
+          crime_application: crime_application,
+          payment_type: OutgoingsPaymentType::MORTGAGE.to_s,
+          amount: 8999,
+          frequency: 'four_weeks',
+        )
+      }
+
+      before do
+        allow(crime_application.outgoings_payments).to receive(:mortgage).and_return(existing_mortgage_payment)
+      end
+
+      it 'loads model if it exists' do
+        expect(subject.amount).to eq(8999)
+        expect(subject.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
+      end
+    end
+  end
+
+  describe '#save' do
+    subject(:form) { described_class.new(arguments) }
+
+    let(:payments) do
+      subject.crime_application.outgoings_payments
+    end
+
+    context 'with valid data' do
+      before do
+        allow(crime_application.outgoings_payments).to receive(:create!).and_return(true)
+
+        form.save
+      end
+
+      let(:arguments) do
+        { 'amount' => '91891', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is valid' do
+        expect(subject).to be_valid
+        expect(subject.amount).to eq '91891'
+        expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
+      end
+    end
+
+    it_behaves_like 'a basic amount with frequency', described_class
+  end
+end

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
           amount_before_type_cast: 14_744,
           frequency: 'month',
           metadata: {},
+        ),
+        instance_double(
+          OutgoingsPayment,
+          payment_type: HousingPaymentType::MORTGAGE,
+          amount_before_type_cast: 3_292_900,
+          frequency: 'annual',
+          metadata: {},
         )
       ]
     end
@@ -111,12 +118,20 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
             ],
           },
           outgoings_details: {
-            outgoings: [{
-              payment_type: 'council_tax',
-              amount: 14_744,
-              frequency: 'month',
-              metadata: {},
-            }],
+            outgoings: [
+              {
+                payment_type: 'council_tax',
+                amount: 14_744,
+                frequency: 'month',
+                metadata: {},
+              },
+              {
+                payment_type: 'mortgage',
+                amount: 3_292_900,
+                frequency: 'annual',
+                metadata: {},
+              }
+            ],
             housing_payment_type: 'mortgage',
             income_tax_rate_above_threshold: 'no',
             outgoings_more_than_income: 'yes',

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -25,8 +25,56 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :housing_payment_type }
 
-    context 'has correct next step' do
+    context 'with nothing somehow selected' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(nil)
+      end
+
       it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+    end
+
+    context 'when the option selected is mortgage' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(HousingPaymentType::MORTGAGE)
+      end
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:mortgage, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the mortgage form is completed' do
+      let(:form_object) { double('FormObject') }
+      let(:step_name) { :mortgage }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the option selected is board_and_lodgings' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(HousingPaymentType::BOARD_LODGINGS)
+      end
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:board_and_lodgings, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the board_and_lodging form is completed' do
+      let(:form_object) { double('FormObject') }
+      let(:step_name) { :board_and_lodgings }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+      end
     end
   end
 

--- a/spec/support/shared_examples/payment_shared_examples.rb
+++ b/spec/support/shared_examples/payment_shared_examples.rb
@@ -248,3 +248,65 @@ RSpec.shared_examples 'a payment form' do |payment_class|
     end
   end
 end
+
+RSpec.shared_examples 'a basic amount with frequency' do |payment_class|
+  describe 'amount with frequency' do
+    subject(:form) { payment_class.new(arguments) }
+
+    # Ensure thorough validity test in host spec
+    context 'when amount and frequency are valid' do
+      let(:arguments) do
+        { 'amount' => '12239', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'has amount and frquency' do
+        expect(subject.amount).to eq '12239'
+        expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
+      end
+    end
+
+    context 'when amount is less than 0' do
+      let(:arguments) do
+        { 'amount' => '-122', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:amount, :greater_than)).to be(true)
+      end
+    end
+
+    context 'when amount is not a number' do
+      let(:arguments) do
+        { 'amount' => 'nine quid', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:amount, :not_a_number)).to be(true)
+      end
+    end
+
+    context 'when amount is blank' do
+      let(:arguments) do
+        { 'amount' => '', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:amount, :blank)).to be(true)
+      end
+    end
+
+    context 'when frequency is not valid' do
+      let(:arguments) do
+        { 'amount' => '1221', 'frequency' => 'every 2 months' }.merge(crime_application:)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:frequency, :inclusion)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION


## Description of change
Adds mortgage payment form. Submission/Rehydration were already implemented in previous Outgoings work (with minor update)

## Link to relevant ticket
Apply part of https://dsdmoj.atlassian.net/browse/CRIMAPP-490

Page: https://dsdmoj.atlassian.net/browse/CRIMAPP-268
Submit: https://dsdmoj.atlassian.net/browse/CRIMAPP-269
Rehydrate: https://dsdmoj.atlassian.net/browse/CRIMAPP-270

## Notes for reviewer
- depends on #650  so awaiting merge of that branch first
- payment.rb Includes submission/rehydration fix caused by making ValueObjects registered with ActiveRecord therefore requires explicit deserialization, deliberately chose `.to_s` rather than `.value` as it is JSON but feedback welcome
## Screenshots of changes (if applicable)

### Before changes:
N/A
### After changes:
<img width="754" alt="Screenshot 2024-03-05 at 01 41 56" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/ceb3fbe8-3737-4d1f-8f6a-f111caf33050">

## How to manually test the feature
Create an application and manually go to /steps/outgoings/mortgage_payments