### PR TITLE
Add overcommit to the repo

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,36 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+
+CommitMsg:
+  ALL:
+    requires_files: false
+    quiet: true
+
+  CapitalizedSubject:
+    enabled: false
+
+  SingleLineSubject:
+    enabled: false
+
+  TextWidth:
+    enabled: false
+
+  TrailingPeriod:
+    enabled: false
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    command: [ 'bundle', 'exec', 'rubocop' ] # Invoke within Bundler context
+    requires_files: true
+  ErbLint:
+    enabled: true
+    command: [ 'erblint' ]
+    requires_files: true

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Also, some functionality in the dashboard will make use of this datastore.
 For active development, and to debug or diagnose issues, running the datastore locally along the Apply application is
 the recommended way. Follow the instructions in the above repository to setup and run the datastore locally.
 
+### Overcommit
+
+Overcommit is a gem which adds git pre-commit hooks to your project. Pre-commit hooks run various
+lint checks before making a commit. Checks are configured on a project-wide basis in .overcommit.yml.
+
+To install the git hooks locally, run `overcommit --install`. If you don't want the git hooks installed, just don't run this command.
+
+Once the hooks are installed, if you need to you can skip them with the `-n` flag: `git commit -n`
+
 ## Running the tests
 
 You can run all the code linters and tests with:


### PR DESCRIPTION
## Description of change

Overcommit allows you to install a pre-commit hook to run linters and/or tests on files you have changed before making the commit/pushing. Personally I find this useful because it means you never push changes and then see the pipeline fail e.g. because you used the wrong kind of quotation marks or accidentally added a new line. But it's optional to install anyway so not everyone has to use it. 

https://github.com/sds/overcommit

This PR:
- Adds the config file overcommit.yml
- Updates the README

## Link to relevant ticket

N/A

## Notes for reviewer

N/A

## Screenshots of changes (if applicable)

N/A

### Before changes:

### After changes:

## How to manually test the feature

N/A
