### PR TITLE
[CRIMAPP-492] Add outgoings council tax form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.40'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.41'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 4a1688c86f55dd2cc295831096f29134638efcdc
-  tag: v1.0.40
+  revision: b119af1db6bf6f11d32dbb3cd28ed2d11856ad6a
+  tag: v1.0.41
   specs:
-    laa-criminal-legal-aid-schemas (1.0.40)
+    laa-criminal-legal-aid-schemas (1.0.41)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/controllers/steps/outgoings/council_tax_controller.rb
+++ b/app/controllers/steps/outgoings/council_tax_controller.rb
@@ -2,9 +2,7 @@ module Steps
   module Outgoings
     class CouncilTaxController < Steps::OutgoingsStepController
       def edit
-        @form_object = CouncilTaxForm.build(
-          current_crime_application
-        )
+        @form_object = CouncilTaxForm.build(current_crime_application)
       end
 
       def update

--- a/app/controllers/steps/outgoings/mortgage_controller.rb
+++ b/app/controllers/steps/outgoings/mortgage_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Outgoings
+    class MortgageController < Steps::OutgoingsStepController
+      def edit
+        @form_object = MortgageForm.build(current_crime_application)
+      end
+
+      def update
+        update_and_advance(MortgageForm, as: :mortgage)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/outgoings/rent_controller.rb
+++ b/app/controllers/steps/outgoings/rent_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Outgoings
+    class RentController < Steps::OutgoingsStepController
+      def edit
+        @form_object = RentForm.build(current_crime_application)
+      end
+
+      def update
+        update_and_advance(RentForm, as: :rent)
+      end
+    end
+  end
+end

--- a/app/forms/steps/outgoings/council_tax_form.rb
+++ b/app/forms/steps/outgoings/council_tax_form.rb
@@ -5,16 +5,19 @@ module Steps
       has_one_association :outgoings
 
       attribute :pays_council_tax, :value_object, source: YesNoAnswer
-      attribute :council_tax_amount, :pence
+      attribute :amount, :pence
 
+      validates :amount, presence: true, numericality: { greater_than: 0 }, if: -> { pays_council_tax? }
       validates_inclusion_of :pays_council_tax, in: :choices
 
-      validates :council_tax_amount,
-                presence: true,
-                numericality: {
-                  greater_than: 0,
-                },
-                if: -> { pays_council_tax? }
+      def self.build(crime_application)
+        payment = crime_application.outgoings_payments.council_tax
+
+        new.tap do |form|
+          form.attributes = payment.slice(:amount) if payment
+          form.pays_council_tax = crime_application.outgoings&.pays_council_tax
+        end
+      end
 
       def choices
         YesNoAnswer.values
@@ -23,19 +26,26 @@ module Steps
       private
 
       def persist!
-        outgoings.update(
-          attributes.merge(attributes_to_reset)
-        )
-      end
+        ::OutgoingsPayment.transaction do
+          reset!
+          outgoings.update(pays_council_tax:)
 
-      def attributes_to_reset
-        {
-          'council_tax_amount' => (council_tax_amount if pays_council_tax?)
-        }
+          if pays_council_tax?
+            crime_application.outgoings_payments.create!(
+              payment_type: OutgoingsPaymentType::COUNCIL_TAX.value,
+              amount: amount,
+              frequency: PaymentFrequencyType::ANNUALLY.value,
+            )
+          end
+        end
       end
 
       def pays_council_tax?
         pays_council_tax&.yes?
+      end
+
+      def reset!
+        crime_application.outgoings_payments.where(payment_type: OutgoingsPaymentType::COUNCIL_TAX.value).destroy_all
       end
     end
   end

--- a/app/forms/steps/outgoings/mortgage_form.rb
+++ b/app/forms/steps/outgoings/mortgage_form.rb
@@ -1,0 +1,37 @@
+module Steps
+  module Outgoings
+    class MortgageForm < Steps::BaseFormObject
+      attribute :amount, :pence
+      attribute :frequency, :value_object, source: PaymentFrequencyType
+
+      validates :amount, presence: true, numericality: { greater_than: 0 }
+      validates :frequency, presence: true, inclusion: { in: PaymentFrequencyType.values }
+
+      def self.build(crime_application)
+        payment = crime_application.outgoings_payments.mortgage
+
+        new.tap do |form|
+          form.attributes = payment.slice(:amount, :frequency) if payment
+        end
+      end
+
+      private
+
+      def persist!
+        ::OutgoingsPayment.transaction do
+          reset!
+
+          crime_application.outgoings_payments.create!(
+            payment_type: OutgoingsPaymentType::MORTGAGE.value,
+            amount: amount,
+            frequency: frequency,
+          )
+        end
+      end
+
+      def reset!
+        crime_application.outgoings_payments.where(payment_type: OutgoingsPaymentType::MORTGAGE.value).destroy_all
+      end
+    end
+  end
+end

--- a/app/forms/steps/outgoings/rent_form.rb
+++ b/app/forms/steps/outgoings/rent_form.rb
@@ -1,0 +1,37 @@
+module Steps
+  module Outgoings
+    class RentForm < Steps::BaseFormObject
+      attribute :amount, :pence
+      attribute :frequency, :value_object, source: PaymentFrequencyType
+
+      validates :amount, presence: true, numericality: { greater_than: 0 }
+      validates :frequency, presence: true, inclusion: { in: PaymentFrequencyType.values }
+
+      def self.build(crime_application)
+        payment = crime_application.outgoings_payments.rent
+
+        new.tap do |form|
+          form.attributes = payment.slice(:amount, :frequency) if payment
+        end
+      end
+
+      private
+
+      def persist!
+        ::OutgoingsPayment.transaction do
+          reset!
+
+          crime_application.outgoings_payments.create!(
+            payment_type: OutgoingsPaymentType::RENT.value,
+            amount: amount,
+            frequency: frequency,
+          )
+        end
+      end
+
+      def reset!
+        crime_application.outgoings_payments.where(payment_type: OutgoingsPaymentType::RENT.value).destroy_all
+      end
+    end
+  end
+end

--- a/app/models/outgoings.rb
+++ b/app/models/outgoings.rb
@@ -1,4 +1,3 @@
 class Outgoings < ApplicationRecord
   belongs_to :crime_application
-  attribute :council_tax_amount, :pence
 end

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -10,4 +10,8 @@ class OutgoingsPayment < ApplicationRecord
   def self.mortgage
     where(payment_type: OutgoingsPaymentType::MORTGAGE).order(created_at: :desc).first
   end
+
+  def self.rent
+    where(payment_type: OutgoingsPaymentType::RENT).order(created_at: :desc).first
+  end
 end

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -14,4 +14,8 @@ class OutgoingsPayment < ApplicationRecord
   def self.rent
     where(payment_type: OutgoingsPaymentType::RENT).order(created_at: :desc).first
   end
+
+  def self.council_tax
+    where(payment_type: OutgoingsPaymentType::COUNCIL_TAX).order(created_at: :desc).first
+  end
 end

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -2,5 +2,12 @@ class OutgoingsPayment < ApplicationRecord
   belongs_to :crime_application
 
   attribute :amount, :pence
+  attribute :payment_type, :value_object, source: HousingPaymentType
+
   store_accessor :metadata, :details, :case_reference
+
+  # TODO: Not sure why scope does not work instead
+  def self.mortgage
+    where(payment_type: OutgoingsPaymentType::MORTGAGE).order(created_at: :desc).first
+  end
 end

--- a/app/presenters/summary/components/money_answer.rb
+++ b/app/presenters/summary/components/money_answer.rb
@@ -1,0 +1,9 @@
+module Summary
+  module Components
+    class PaymentAnswer < BaseAnswer
+      def to_partial_path
+        'steps/submission/shared/money_answer'
+      end
+    end
+  end
+end

--- a/app/presenters/summary/components/payment_answer.rb
+++ b/app/presenters/summary/components/payment_answer.rb
@@ -1,0 +1,9 @@
+module Summary
+  module Components
+    class PaymentAnswer < BaseAnswer
+      def to_partial_path
+        'steps/submission/shared/payment_answer'
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/housing_payments.rb
+++ b/app/presenters/summary/sections/housing_payments.rb
@@ -11,6 +11,10 @@ module Summary
             :housing_payment_type, outgoings.housing_payment_type,
             change_path: edit_steps_outgoings_housing_payment_type_path
           ),
+          Components::PaymentAnswer.new(
+            :mortgage, mortgage,
+            change_path: edit_steps_outgoings_mortgage_path
+          ),
         ].select(&:show?)
       end
 
@@ -18,6 +22,14 @@ module Summary
 
       def outgoings
         @outgoings ||= crime_application.outgoings
+      end
+
+      # TODO: Attempted to get an appropriate Struct to return this value
+      # however doing so caused headache with specs
+      def mortgage
+        crime_application.outgoings_payments.first do |p|
+          p.payment_type == HousingPaymentType::MORTGAGE.to_s
+        end
       end
     end
   end

--- a/app/presenters/summary/sections/housing_payments.rb
+++ b/app/presenters/summary/sections/housing_payments.rb
@@ -6,20 +6,22 @@ module Summary
       end
 
       def answers # rubocop:disable Metrics/MethodLength
-        [
-          Components::ValueAnswer.new(
-            :housing_payment_type, outgoings.housing_payment_type,
-            change_path: edit_steps_outgoings_housing_payment_type_path
-          ),
-          Components::PaymentAnswer.new(
-            :mortgage, mortgage,
-            change_path: edit_steps_outgoings_mortgage_path
-          ),
-          Components::PaymentAnswer.new(
-            :rent, rent,
-            change_path: edit_steps_outgoings_rent_path
-          ),
-        ].select(&:show?)
+        (
+          [
+            Components::ValueAnswer.new(
+              :housing_payment_type, outgoings.housing_payment_type,
+              change_path: edit_steps_outgoings_housing_payment_type_path
+            ),
+            Components::PaymentAnswer.new(
+              :mortgage, mortgage,
+              change_path: edit_steps_outgoings_mortgage_path
+            ),
+            Components::PaymentAnswer.new(
+              :rent, rent,
+              change_path: edit_steps_outgoings_rent_path
+            ),
+          ] + council_tax_info
+        ).select(&:show?)
       end
 
       private
@@ -28,18 +30,33 @@ module Summary
         @outgoings ||= crime_application.outgoings
       end
 
+      def show_council_tax?
+        false
+      end
+
+      def council_tax_info
+        return [] if board_lodgings
+
+        [
+          Components::ValueAnswer.new(
+            :pays_council_tax, outgoings.pays_council_tax,
+            change_path: edit_steps_outgoings_council_tax_path
+          ),
+          Components::PaymentAnswer.new(
+            :council_tax, council_tax,
+            change_path: edit_steps_outgoings_council_tax_path
+          ),
+        ]
+      end
+
       # TODO: Attempted to get an appropriate Struct to return this value
       # however doing so caused headache with specs. Ensure match is using
       # .to_s to ensure both ActiveRecord and Struct models work as expected
-      def mortgage
-        crime_application.outgoings_payments.find do |p|
-          p.payment_type.to_s == HousingPaymentType::MORTGAGE.to_s
-        end
-      end
-
-      def rent
-        crime_application.outgoings_payments.find do |p|
-          p.payment_type.to_s == HousingPaymentType::RENT.to_s
+      (HousingPaymentType::VALUES + [OutgoingsPaymentType::COUNCIL_TAX]).each do |type|
+        define_method(type.to_s) do
+          crime_application.outgoings_payments.find do |p|
+            p.payment_type.to_s == type.to_s
+          end
         end
       end
     end

--- a/app/presenters/summary/sections/housing_payments.rb
+++ b/app/presenters/summary/sections/housing_payments.rb
@@ -5,7 +5,7 @@ module Summary
         outgoings.present? && super
       end
 
-      def answers
+      def answers # rubocop:disable Metrics/MethodLength
         [
           Components::ValueAnswer.new(
             :housing_payment_type, outgoings.housing_payment_type,
@@ -14,6 +14,10 @@ module Summary
           Components::PaymentAnswer.new(
             :mortgage, mortgage,
             change_path: edit_steps_outgoings_mortgage_path
+          ),
+          Components::PaymentAnswer.new(
+            :rent, rent,
+            change_path: edit_steps_outgoings_rent_path
           ),
         ].select(&:show?)
       end
@@ -25,10 +29,17 @@ module Summary
       end
 
       # TODO: Attempted to get an appropriate Struct to return this value
-      # however doing so caused headache with specs
+      # however doing so caused headache with specs. Ensure match is using
+      # .to_s to ensure both ActiveRecord and Struct models work as expected
       def mortgage
-        crime_application.outgoings_payments.first do |p|
-          p.payment_type == HousingPaymentType::MORTGAGE.to_s
+        crime_application.outgoings_payments.find do |p|
+          p.payment_type.to_s == HousingPaymentType::MORTGAGE.to_s
+        end
+      end
+
+      def rent
+        crime_application.outgoings_payments.find do |p|
+          p.payment_type.to_s == HousingPaymentType::RENT.to_s
         end
       end
     end

--- a/app/serializers/submission_serializer/definitions/payment.rb
+++ b/app/serializers/submission_serializer/definitions/payment.rb
@@ -3,7 +3,7 @@ module SubmissionSerializer
     class Payment < Definitions::BaseDefinition
       def to_builder
         Jbuilder.new do |json|
-          json.payment_type payment_type
+          json.payment_type payment_type.respond_to?(:value) ? payment_type.to_s : payment_type
           json.amount amount_before_type_cast
           json.frequency frequency
           json.metadata metadata

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -31,6 +31,14 @@ module Adapters
         Structs::OutgoingsDetails.new(means_details.outgoings_details)
       end
 
+      def outgoings_payments
+        return [] unless means_details.outgoings_details.outgoings
+
+        means_details.outgoings_details.outgoings.map do |struct|
+          OutgoingsPayment.new(struct.attributes)
+        end
+      end
+
       def documents
         supporting_evidence.map do |struct|
           Document.new(

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -3,7 +3,8 @@ module Decisions
     def destination # rubocop:disable Metrics/MethodLength
       case step_name
       when :housing_payment_type
-        # TODO: determine and link to next step when we have it
+        after_housing_payment_type
+      when :board_and_lodgings, :mortgage
         edit(:council_tax)
       when :council_tax
         edit(:outgoings_payments)
@@ -15,6 +16,19 @@ module Decisions
         edit('/steps/capital/property_type')
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
+      end
+    end
+
+    private
+
+    def after_housing_payment_type
+      if form_object.housing_payment_type.nil?
+        # TODO: Consider appropriate action for empty housing_payment_type
+        edit(:council_tax)
+      elsif form_object.housing_payment_type.value == :board_lodgings
+        edit(:board_and_lodgings)
+      elsif form_object.housing_payment_type.value == :mortgage
+        edit(:mortgage)
       end
     end
   end

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -4,7 +4,7 @@ module Decisions
       case step_name
       when :housing_payment_type
         after_housing_payment_type
-      when :board_and_lodgings, :mortgage
+      when :board_and_lodgings, :mortgage, :rent
         edit(:council_tax)
       when :council_tax
         edit(:outgoings_payments)
@@ -29,6 +29,8 @@ module Decisions
         edit(:board_and_lodgings)
       elsif form_object.housing_payment_type.value == :mortgage
         edit(:mortgage)
+      elsif form_object.housing_payment_type.value == :rent
+        edit(:rent)
       end
     end
   end

--- a/app/value_objects/payment_frequency_type.rb
+++ b/app/value_objects/payment_frequency_type.rb
@@ -6,4 +6,12 @@ class PaymentFrequencyType < ValueObject
     MONTHLY = new(:month),
     ANNUALLY = new(:annual),
   ].freeze
+
+  def self.to_phrase(value)
+    I18n.t("helpers/dictionary.frequency_phrases.#{value}")
+  end
+
+  def to_phrase
+    I18n.t("helpers/dictionary.frequency_phrases.#{self}")
+  end
 end

--- a/app/views/steps/outgoings/council_tax/edit.html.erb
+++ b/app/views/steps/outgoings/council_tax/edit.html.erb
@@ -12,8 +12,10 @@
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice.yes? %>
             <%= f.govuk_radio_button :pays_council_tax, choice.value do %>
-              <%= f.govuk_number_field :council_tax_amount,
-                                       prefix_text: '£' %>
+              <%= f.govuk_text_field(:amount,
+                                     width: 'one-half',
+                                     prefix_text: '£',
+                                     autocomplete: 'off') %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :pays_council_tax, choice.value, link_errors: index.zero? %>

--- a/app/views/steps/outgoings/mortgage/edit.html.erb
+++ b/app/views/steps/outgoings/mortgage/edit.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_fieldset(legend: { text: t('.mortgage_legend'), tag: 'h1', size: 'xl' }) do %>
+        <%= f.govuk_text_field(:amount,
+                               width: 'one-half',
+                               prefix_text: '£',
+                               hint: { text: t('.amount_hint') },
+                               autocomplete: 'off') %>
+
+        <%= f.govuk_collection_radio_buttons(:frequency,
+                                             PaymentFrequencyType.values,
+                                             :value,
+                                             legend: { size: 's', class: 'govuk-!-font-weight-regular' }) %>
+        <% end %>
+      <%= f.continue_button %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/steps/outgoings/rent/edit.html.erb
+++ b/app/views/steps/outgoings/rent/edit.html.erb
@@ -1,0 +1,25 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+
+    <%= govuk_error_summary(@form_object) %>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_fieldset(legend: { text: t('.rent_legend'), tag: 'h1', size: 'xl' }) do %>
+        <%= f.govuk_text_field(:amount,
+                               width: 'one-half',
+                               prefix_text: '£',
+                               hint: { text: t('.amount_hint') },
+                               autocomplete: 'off') %>
+        <%= f.govuk_collection_radio_buttons(:frequency,
+                                             PaymentFrequencyType.values,
+                                             :value,
+                                             legend: { size: 's', class: 'govuk-!-font-weight-regular' }) %>
+        <% end %>
+      <%= f.continue_button %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/steps/submission/shared/_payment_answer.html.erb
+++ b/app/views/steps/submission/shared/_payment_answer.html.erb
@@ -1,0 +1,19 @@
+<%
+  content_for(:row_question, flush: true) do
+    t("summary.questions.#{payment_answer.question}.question", **payment_answer.i18n_opts)
+  end
+
+  content_for(:row_answer, flush: true) do
+    simple_format(
+      t(
+        "summary.questions.#{payment_answer.question}.answers.description",
+        amount: payment_answer.value.amount,
+        frequency: PaymentFrequencyType.to_phrase(payment_answer.value.frequency)
+      ),
+      { class: 'govuk-body' }
+    )
+  end
+%>
+
+<%= render partial: 'steps/submission/shared/summary_row',
+           locals: { row: payment_answer, editable: editable } %>

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -2,6 +2,7 @@ Dir[File.expand_path('app/attributes/type') + '/*.rb'].each { |f| require f }
 
 ActiveModel::Type.register(:string, Type::StrippedString)
 ActiveModel::Type.register(:value_object, Type::ValueObject)
+ActiveRecord::Type.register(:value_object, Type::ValueObject)
 ActiveModel::Type.register(:multiparam_date, Type::MultiparamDate)
 ActiveModel::Type.register(:pence, Type::Pence)
 ActiveRecord::Type.register(:pence, Type::Pence)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -443,7 +443,7 @@ en:
           attributes:
             pays_council_tax:
               inclusion: Select yes if your client pays Council Tax where they usually live
-            council_tax_amount:
+            amount:
               blank: Enter how much your client pays yearly
               greater_than: How much they pay yearly must be more than 0
               invalid: How much they pay yearly must be a number, like 50

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -421,6 +421,15 @@ en:
           attributes:
             housing_payment_type:
               inclusion: Select which payment your client pays where they usually live
+        steps/outgoings/mortgage_form:
+          attributes:
+            amount:
+              blank: Enter how much your client's mortgage payments are, after taking away Housing Benefit
+              greater_than: Your client's mortgage payments must be more than 0
+              not_a_number: Your client's mortgage payments, after taking away Housing Benefit, must be a number, like 50
+            frequency:
+              blank: Select how often they pay mortgage payments
+              inclusion: Select how often they pay mortgage payments
         steps/outgoings/council_tax_form:
           attributes:
             pays_council_tax:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -430,6 +430,15 @@ en:
             frequency:
               blank: Select how often they pay mortgage payments
               inclusion: Select how often they pay mortgage payments
+        steps/outgoings/rent_form:
+          attributes:
+            amount:
+              blank: Enter how much rent your client pays, after taking away Housing Benefit
+              greater_than: Your client's rent payments must be more than 0
+              not_a_number: Your client's rent payments, after taking away Housing Benefit, must be a number, like 50
+            frequency:
+              blank: Select how often they pay rent payments
+              inclusion: Select how often they pay rent payments
         steps/outgoings/council_tax_form:
           attributes:
             pays_council_tax:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -89,6 +89,8 @@ en:
         manage_without_income: How does your client manage with no income?
       steps_outgoings_housing_payment_type_form:
         housing_payment_type: Which of these payments does your client pay where they usually live?
+      steps_outgoings_mortgage_form:
+        frequency: Select how often they pay mortgage payments
       steps_outgoings_council_tax_form:
         council_tax: Does your client pay Council Tax where they usually live?
       steps_outgoings_outgoings_payments_form:
@@ -416,6 +418,9 @@ en:
           mortgage: Mortgage
           board_lodgings: Board and lodgings
           none: My client does not pay any of these payments
+      steps_outgoings_mortgage_form:
+        amount: How much are your client's mortgage payments?
+        frequency_options: *frequency_options
       steps_outgoings_council_tax_form:
         pays_council_tax_options: *YESNO
         council_tax_amount: How much do they pay yearly?

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -11,6 +11,12 @@ en:
     YESNO: &YESNO
       'yes': 'Yes'
       'no': 'No'
+    frequency_phrases: &frequency_phrases
+      'week': 'week'
+      'fortnight': '2 weeks'
+      'four_weeks': '4 weeks'
+      'month': 'month'
+      'annual': 'year'
     frequency_options: &frequency_options
       'week': 'Every week'
       'fortnight': 'Every 2 weeks'

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -97,6 +97,8 @@ en:
         housing_payment_type: Which of these payments does your client pay where they usually live?
       steps_outgoings_mortgage_form:
         frequency: Select how often they pay mortgage payments
+      steps_outgoings_rent_form:
+        frequency: Select how often they pay rent payments
       steps_outgoings_council_tax_form:
         council_tax: Does your client pay Council Tax where they usually live?
       steps_outgoings_outgoings_payments_form:
@@ -426,6 +428,9 @@ en:
           none: My client does not pay any of these payments
       steps_outgoings_mortgage_form:
         amount: How much are your client's mortgage payments?
+        frequency_options: *frequency_options
+      steps_outgoings_rent_form:
+        amount: How much rent does your client pay, after taking away Housing Benefit?
         frequency_options: *frequency_options
       steps_outgoings_council_tax_form:
         pays_council_tax_options: *YESNO

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -434,7 +434,7 @@ en:
         frequency_options: *frequency_options
       steps_outgoings_council_tax_form:
         pays_council_tax_options: *YESNO
-        council_tax_amount: How much do they pay yearly?
+        amount: How much do they pay yearly?
       steps_outgoings_income_tax_rate_form:
         income_tax_rate_above_threshold_options: *YESNO
       steps_outgoings_outgoings_payments_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -287,6 +287,11 @@ en:
           page_title: Mortgage payments
           mortgage_legend: Mortgage payments
           amount_hint: Only include mortgage payments where they usually live.
+      rent:
+        edit:
+          page_title: Rent payments
+          rent_legend: Rent payments
+          amount_hint: Only include rent payments where they usually live.
       council_tax:
         edit:
           page_title: Does your client pay Council Tax where they usually live?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -282,6 +282,11 @@ en:
       housing_payment_type:
         edit:
           page_title: Which of these payments does your client pay where they usually live?
+      mortgage:
+        edit:
+          page_title: Mortgage payments
+          mortgage_legend: Mortgage payments
+          amount_hint: Only include mortgage payments where they usually live.
       council_tax:
         edit:
           page_title: Does your client pay Council Tax where they usually live?

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -261,6 +261,10 @@ en:
           mortgage: Mortgage
           board_lodgings: Board and lodgings
           none: None
+      mortgage:
+        question: How much are your client's mortgage payments?
+        answers:
+          description: "£%{amount} every %{frequency}"
       # END housing payments section
 
       # BEGIN other outgoings details section

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -265,6 +265,10 @@ en:
         question: How much are your client's mortgage payments?
         answers:
           description: "£%{amount} every %{frequency}"
+      rent:
+        question: How much rent does your client pay, after taking away Housing Benefit?
+        answers:
+          description: "£%{amount} every %{frequency}"
       # END housing payments section
 
       # BEGIN other outgoings details section

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -269,6 +269,14 @@ en:
         question: How much rent does your client pay, after taking away Housing Benefit?
         answers:
           description: "£%{amount} every %{frequency}"
+      pays_council_tax:
+        question: Does your client pay Council Tax where they usually live?
+        answers:
+          <<: *YESNO
+      council_tax:
+        question: How much do they pay yearly?
+        answers:
+          description: "£%{amount}"
       # END housing payments section
 
       # BEGIN other outgoings details section

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
         edit_step :has_client_paid_income_tax_rate, alias: :income_tax_rate
         edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
         edit_step :which_payments_does_client_pay, alias: :outgoings_payments
+        edit_step :mortgage_payments, alias: :mortgage
       end
 
       namespace :capital, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
         edit_step :are_clients_outgoings_more_than_income, alias: :outgoings_more_than_income
         edit_step :which_payments_does_client_pay, alias: :outgoings_payments
         edit_step :mortgage_payments, alias: :mortgage
+        edit_step :rent_payments, alias: :rent
       end
 
       namespace :capital, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do

--- a/db/migrate/20240307011302_remove_council_tax_amount_field_from_outgoings.rb
+++ b/db/migrate/20240307011302_remove_council_tax_amount_field_from_outgoings.rb
@@ -1,0 +1,37 @@
+class RemoveCouncilTaxAmountFieldFromOutgoings < ActiveRecord::Migration[7.0]
+  def up
+    Outgoings.transaction do
+      Outgoings
+        .where("pays_council_tax = 'yes' AND council_tax_amount IS NOT NULL")
+        .in_batches(of: 100)
+        .each_record do |outgoing|
+          OutgoingsPayment.create!(
+            crime_application_id: outgoing.crime_application_id,
+            payment_type: OutgoingsPaymentType::COUNCIL_TAX.value,
+            amount: outgoing.council_tax_amount,
+            frequency: PaymentFrequencyType::ANNUALLY,
+          )
+      end
+    end
+
+    remove_column :outgoings, :council_tax_amount
+  end
+
+  def down
+    add_column :outgoings, :council_tax_amount, :bigint, default: nil
+
+    Outgoings.transaction do
+      outgoing_payments = OutgoingsPayment
+        .where(payment_type: OutgoingsPaymentType::COUNCIL_TAX)
+        .joins("INNER JOIN outgoings ON outgoings.crime_application_id = outgoings_payments.crime_application_id AND outgoings.pays_council_tax = 'yes'")
+        .in_batches(of: 100)
+
+      outgoing_payments.each_record do |payment|
+        outgoing = Outgoings.find_by(crime_application_id: payment.crime_application_id)
+        outgoing.update!(council_tax_amount: payment.amount_before_type_cast)
+      end
+
+      outgoing_payments.destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_29_125141) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_07_011302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -213,7 +213,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_125141) do
     t.string "income_tax_rate_above_threshold"
     t.string "housing_payment_type"
     t.string "pays_council_tax"
-    t.integer "council_tax_amount"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/outgoings/mortgage_controller_spec.rb
+++ b/spec/controllers/steps/outgoings/mortgage_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::MortgageController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Outgoings::MortgageForm, Decisions::OutgoingsDecisionTree do
+    describe 'CRUD actions' do
+      let(:crime_application) { CrimeApplication.create }
+
+      context 'finishing mortgage' do
+        it 'has the expected step name' do
+          expect(subject).to receive(:update_and_advance).with(
+            Steps::Outgoings::MortgageForm, as: :mortgage
+          )
+
+          put :update, params: { id: crime_application }
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/steps/outgoings/rent_controller_spec.rb
+++ b/spec/controllers/steps/outgoings/rent_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::RentController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Outgoings::RentForm, Decisions::OutgoingsDecisionTree do
+    describe 'CRUD actions' do
+      let(:crime_application) { CrimeApplication.create }
+
+      context 'finishing rent' do
+        it 'has the expected step name' do
+          expect(subject).to receive(:update_and_advance).with(
+            Steps::Outgoings::RentForm, as: :rent
+          )
+
+          put :update, params: { id: crime_application }
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/outgoings/mortgage_form_spec.rb
+++ b/spec/forms/steps/outgoings/mortgage_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::MortgageForm do
+  let(:crime_application) { CrimeApplication.new }
+
+  describe '#build' do
+    subject(:form) { described_class.build(crime_application) }
+
+    context 'when no mortgage payment exists' do
+      it 'creates empty form if model does not exist' do
+        expect(subject.amount).to be_nil
+        expect(subject.frequency).to be_nil
+      end
+    end
+
+    context 'when mortgage payment exists' do
+      let(:existing_mortgage_payment) {
+        OutgoingsPayment.new(
+          crime_application: crime_application,
+          payment_type: OutgoingsPaymentType::MORTGAGE.to_s,
+          amount: 8999,
+          frequency: 'four_weeks',
+        )
+      }
+
+      before do
+        allow(crime_application.outgoings_payments).to receive(:mortgage).and_return(existing_mortgage_payment)
+      end
+
+      it 'loads model if it exists' do
+        expect(subject.amount).to eq(8999)
+        expect(subject.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
+      end
+    end
+  end
+
+  describe '#save' do
+    subject(:form) { described_class.new(arguments) }
+
+    let(:payments) do
+      subject.crime_application.outgoings_payments
+    end
+
+    context 'with valid data' do
+      before do
+        allow(crime_application.outgoings_payments).to receive(:create!).and_return(true)
+
+        form.save
+      end
+
+      let(:arguments) do
+        { 'amount' => '91891', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is valid' do
+        expect(subject).to be_valid
+        expect(subject.amount).to eq '91891'
+        expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
+      end
+    end
+
+    it_behaves_like 'a basic amount with frequency', described_class
+  end
+end

--- a/spec/forms/steps/outgoings/rent_form_spec.rb
+++ b/spec/forms/steps/outgoings/rent_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Outgoings::RentForm do
+  let(:crime_application) { CrimeApplication.new }
+
+  describe '#build' do
+    subject(:form) { described_class.build(crime_application) }
+
+    context 'when no rent payment exists' do
+      it 'creates empty form if model does not exist' do
+        expect(subject.amount).to be_nil
+        expect(subject.frequency).to be_nil
+      end
+    end
+
+    context 'when rent payment exists' do
+      let(:existing_rent_payment) {
+        OutgoingsPayment.new(
+          crime_application: crime_application,
+          payment_type: OutgoingsPaymentType::RENT.to_s,
+          amount: 8999,
+          frequency: 'four_weeks',
+        )
+      }
+
+      before do
+        allow(crime_application.outgoings_payments).to receive(:rent).and_return(existing_rent_payment)
+      end
+
+      it 'loads model if it exists' do
+        expect(subject.amount).to eq(8999)
+        expect(subject.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
+      end
+    end
+  end
+
+  describe '#save' do
+    subject(:form) { described_class.new(arguments) }
+
+    let(:payments) do
+      subject.crime_application.outgoings_payments
+    end
+
+    context 'with valid data' do
+      before do
+        allow(crime_application.outgoings_payments).to receive(:create!).and_return(true)
+
+        form.save
+      end
+
+      let(:arguments) do
+        { 'amount' => '91891', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is valid' do
+        expect(subject).to be_valid
+        expect(subject.amount).to eq '91891'
+        expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
+      end
+    end
+
+    it_behaves_like 'a basic amount with frequency', described_class
+  end
+end

--- a/spec/presenters/summary/sections/housing_payments_spec.rb
+++ b/spec/presenters/summary/sections/housing_payments_spec.rb
@@ -32,6 +32,15 @@ describe Summary::Sections::HousingPayments do
     )
   end
 
+  let(:rent_payment) do
+    instance_double(
+      OutgoingsPayment,
+      payment_type: 'rent',
+      amount: 5555,
+      frequency: 'month'
+    )
+  end
+
   # A legitimate outgoing but should not be shown in this section
   let(:maintenance_payment) do
     instance_double(
@@ -92,6 +101,25 @@ describe Summary::Sections::HousingPayments do
           .to match('applications/12345/steps/outgoings/mortgage_payments')
         expect(answers[1].value.amount).to eq(333)
         expect(answers[1].value.frequency).to eq('year')
+      end
+    end
+
+    context 'with rent' do
+      let(:outgoings_payments) do
+        [
+          rent_payment,
+          maintenance_payment,
+        ]
+      end
+
+      it 'shows this section' do
+        expect(answers.count).to eq(2)
+        expect(answers[1]).to be_an_instance_of(Summary::Components::PaymentAnswer)
+        expect(answers[1].question).to eq(:rent)
+        expect(answers[1].change_path)
+          .to match('applications/12345/steps/outgoings/rent_payments')
+        expect(answers[1].value.amount).to eq(5555)
+        expect(answers[1].value.frequency).to eq('month')
       end
     end
   end

--- a/spec/serializers/submission_serializer/sections/means_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/means_details_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
           amount_before_type_cast: 14_744,
           frequency: 'month',
           metadata: {},
+        ),
+        instance_double(
+          OutgoingsPayment,
+          payment_type: HousingPaymentType::MORTGAGE,
+          amount_before_type_cast: 3_292_900,
+          frequency: 'annual',
+          metadata: {},
         )
       ]
     end
@@ -111,12 +118,20 @@ RSpec.describe SubmissionSerializer::Sections::MeansDetails do
             ],
           },
           outgoings_details: {
-            outgoings: [{
-              payment_type: 'council_tax',
-              amount: 14_744,
-              frequency: 'month',
-              metadata: {},
-            }],
+            outgoings: [
+              {
+                payment_type: 'council_tax',
+                amount: 14_744,
+                frequency: 'month',
+                metadata: {},
+              },
+              {
+                payment_type: 'mortgage',
+                amount: 3_292_900,
+                frequency: 'annual',
+                metadata: {},
+              }
+            ],
             housing_payment_type: 'mortgage',
             income_tax_rate_above_threshold: 'no',
             outgoings_more_than_income: 'yes',

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -25,8 +25,56 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :housing_payment_type }
 
-    context 'has correct next step' do
+    context 'with nothing somehow selected' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(nil)
+      end
+
       it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+    end
+
+    context 'when the option selected is mortgage' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(HousingPaymentType::MORTGAGE)
+      end
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:mortgage, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the mortgage form is completed' do
+      let(:form_object) { double('FormObject') }
+      let(:step_name) { :mortgage }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the option selected is board_and_lodgings' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(HousingPaymentType::BOARD_LODGINGS)
+      end
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:board_and_lodgings, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the board_and_lodging form is completed' do
+      let(:form_object) { double('FormObject') }
+      let(:step_name) { :board_and_lodgings }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+      end
     end
   end
 

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -76,6 +76,27 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
         it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
       end
     end
+
+    context 'when the option selected is rent' do
+      before do
+        allow(
+          form_object
+        ).to receive(:housing_payment_type).and_return(HousingPaymentType::RENT)
+      end
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:rent, :edit, id: crime_application) }
+      end
+    end
+
+    context 'when the rent form is completed' do
+      let(:form_object) { double('FormObject') }
+      let(:step_name) { :rent }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination(:council_tax, :edit, id: crime_application) }
+      end
+    end
   end
 
   context 'when the step is `council_tax`' do

--- a/spec/support/shared_examples/payment_shared_examples.rb
+++ b/spec/support/shared_examples/payment_shared_examples.rb
@@ -248,3 +248,65 @@ RSpec.shared_examples 'a payment form' do |payment_class|
     end
   end
 end
+
+RSpec.shared_examples 'a basic amount with frequency' do |payment_class|
+  describe 'amount with frequency' do
+    subject(:form) { payment_class.new(arguments) }
+
+    # Ensure thorough validity test in host spec
+    context 'when amount and frequency are valid' do
+      let(:arguments) do
+        { 'amount' => '12239', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'has amount and frquency' do
+        expect(subject.amount).to eq '12239'
+        expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
+      end
+    end
+
+    context 'when amount is less than 0' do
+      let(:arguments) do
+        { 'amount' => '-122', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:amount, :greater_than)).to be(true)
+      end
+    end
+
+    context 'when amount is not a number' do
+      let(:arguments) do
+        { 'amount' => 'nine quid', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:amount, :not_a_number)).to be(true)
+      end
+    end
+
+    context 'when amount is blank' do
+      let(:arguments) do
+        { 'amount' => '', 'frequency' => 'month' }.merge(crime_application:)
+      end
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:amount, :blank)).to be(true)
+      end
+    end
+
+    context 'when frequency is not valid' do
+      let(:arguments) do
+        { 'amount' => '1221', 'frequency' => 'every 2 months' }.merge(crime_application:)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:frequency, :inclusion)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/value_objects/payment_frequency_type_spec.rb
+++ b/spec/value_objects/payment_frequency_type_spec.rb
@@ -18,4 +18,24 @@ RSpec.describe PaymentFrequencyType do
       )
     end
   end
+
+  describe '.to_phrase' do
+    it 'returns the human name of the frequency' do
+      expect(described_class::WEEKLY.to_phrase).to eq 'week'
+      expect(described_class::FORTNIGHTLY.to_phrase).to eq '2 weeks'
+      expect(described_class::FOUR_WEEKLY.to_phrase).to eq '4 weeks'
+      expect(described_class::MONTHLY.to_phrase).to eq 'month'
+      expect(described_class::ANNUALLY.to_phrase).to eq 'year'
+    end
+  end
+
+  describe '#to_phrase' do
+    it 'returns the human name of the frequency' do
+      expect(described_class.to_phrase(:week)).to eq 'week'
+      expect(described_class.to_phrase(:fortnight)).to eq '2 weeks'
+      expect(described_class.to_phrase(:four_weeks)).to eq '4 weeks'
+      expect(described_class.to_phrase(:month)).to eq 'month'
+      expect(described_class.to_phrase(:annual)).to eq 'year'
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Updates Council Tax outgoings page to save payment data in `outgoings_payments`, shows council tax information on the review summary pages but only if housing type is rent/mortgage. Submission/rehydration.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-492

Form: https://dsdmoj.atlassian.net/browse/CRIMAPP-265 (updated)
Summary: https://dsdmoj.atlassian.net/browse/CRIMAPP-495
Submission: https://dsdmoj.atlassian.net/browse/CRIMAPP-266
Rehydration: https://dsdmoj.atlassian.net/browse/CRIMAPP-267
DB Migration: https://dsdmoj.atlassian.net/browse/CRIMAPP-613

## Notes for reviewer
N/A

## Screenshots of changes (if applicable)
### Summary
<img width="559" alt="Screenshot 2024-03-07 at 03 27 43" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/1513d12c-b9d9-4de3-b24e-1413f4a99b1f">

<img width="536" alt="Screenshot 2024-03-07 at 03 26 31" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/72fe2874-1cdf-4289-bbf6-593fc5876f62">


## How to manually test the feature
Go to /steps/outgoings/does_client_pay_council_tax

Then go to /steps/outgoings/housing_payments_where_client_lives to complete housing outgoings

Then go to /steps/submission/review to see the summary

Submit an application, then as a Caseworker in Review, return the application to see the rehydration in Apply