### PR TITLE
CRIMAPP-559 add premium bonds to submission/review

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -22,6 +22,7 @@ module Summary
         housing_payments
         other_outgoings_details
         savings
+        premium_bonds
         supporting_evidence
         more_information
         legal_representative_details

--- a/app/presenters/summary/sections/premium_bonds.rb
+++ b/app/presenters/summary/sections/premium_bonds.rb
@@ -1,0 +1,48 @@
+module Summary
+  module Sections
+    # rubocop:disable Naming/PredicateName, Metrics/MethodLength, Metrics/AbcSize
+    class PremiumBonds < Sections::BaseSection
+      def show?
+        capital.present? && super
+      end
+
+      def answers
+        [
+          Components::ValueAnswer.new(
+            :has_premium_bonds,
+            crime_application.capital.has_premium_bonds,
+            change_path: change_path,
+            show: true
+          ),
+          Components::FreeTextAnswer.new(
+            :premium_bonds_holder_number,
+            crime_application.capital.premium_bonds_holder_number,
+            change_path: change_path,
+            show: have_premium_bonds?
+          ),
+          Components::MoneyAnswer.new(
+            :premium_bonds_total_value,
+            crime_application.capital.premium_bonds_total_value,
+            change_path: change_path,
+            show: have_premium_bonds?
+          )
+        ].select(&:show?)
+      end
+
+      private
+
+      def have_premium_bonds?
+        YesNoAnswer.new(capital.has_premium_bonds).yes?
+      end
+
+      def change_path
+        edit_steps_capital_premium_bonds_path(crime_application)
+      end
+
+      def capital
+        @capital ||= crime_application.capital
+      end
+    end
+    # rubocop:enable Naming/PredicateName, Metrics/MethodLength, Metrics/AbcSize
+  end
+end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -38,6 +38,7 @@ en:
         cash_isa: Cash ISA
         national_savings_or_post_office: National Savings or Post Office account
         other: Other cash investment
+      premium_bonds: Premium Bonds
 
     questions:
       # BEGIN overview section
@@ -329,4 +330,15 @@ en:
       sort_code: 
         question: What is the sort code or branch name?
         absence_answer: *absence_none
-    # END saving
+      # END saving
+      #
+      # START premium_bonds
+      has_premium_bonds: 
+        question: Does your client have any Premium Bonds?
+        answers: *YESNO 
+      premium_bonds_total_value: 
+        question: Enter the total value of their bonds
+      premium_bonds_holder_number: 
+        question: Enter the holder number
+        absence_answer: ''
+      # END premium_bonds

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -10,7 +10,8 @@ describe Summary::HtmlPresenter do
   let(:database_application) do
     instance_double(CrimeApplication, applicant: double, case: double, ioj: double,
                     status: :in_progress, income: double, outgoings: double,
-                    documents: double, application_type: application_type, savings: [double])
+                    documents: double, application_type: application_type, savings: [double],
+                    capital: double)
   end
 
   let(:datastore_application) do
@@ -69,6 +70,7 @@ describe Summary::HtmlPresenter do
             HousingPayments
             OtherOutgoingsDetails
             Savings
+            PremiumBonds
             SupportingEvidence
             MoreInformation
           ]
@@ -98,6 +100,7 @@ describe Summary::HtmlPresenter do
             HousingPayments
             OtherOutgoingsDetails
             Savings
+            PremiumBonds
             SupportingEvidence
             MoreInformation
             LegalRepresentativeDetails

--- a/spec/presenters/summary/sections/premium_bonds_spec.rb
+++ b/spec/presenters/summary/sections/premium_bonds_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe Summary::Sections::PremiumBonds do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { instance_double(CrimeApplication, capital: capital, in_progress?: true, to_param: 12_345) }
+
+  let(:capital) do
+    instance_double(
+      Capital,
+      has_premium_bonds: 'yes',
+      premium_bonds_holder_number: 'A123',
+      premium_bonds_total_value: '10.01'
+    )
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:premium_bonds) }
+  end
+
+  describe '#show?' do
+    context 'when there is capital' do
+      it 'shows this section' do
+        expect(subject.show?).to be(true)
+      end
+    end
+
+    context 'when there is no capital' do
+      let(:capital) { nil }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    context 'when client has premium bonds' do
+      let(:expected_change_path) do
+        'applications/12345/steps/capital/does_client_have_premium_bonds'
+      end
+
+      it 'shows all answers' do
+        expect(answers.count).to eq(3)
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:has_premium_bonds)
+        expect(answers[0].change_path).to match(expected_change_path)
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answers[1].question).to eq(:premium_bonds_holder_number)
+        expect(answers[1].change_path).to match(expected_change_path)
+        expect(answers[1].value).to eq('A123')
+
+        expect(answers[2]).to be_an_instance_of(Summary::Components::MoneyAnswer)
+        expect(answers[2].question).to eq(:premium_bonds_total_value)
+        expect(answers[1].change_path).to match(expected_change_path)
+        expect(answers[2].value).to eq('10.01')
+      end
+    end
+
+    context 'when client has no premium bonds' do
+      before do
+        allow(capital).to receive(:has_premium_bonds).and_return('no')
+      end
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Add premium bonds to submission/review

## Link to relevant ticket
[CRIMAPP-559](https://dsdmoj.atlassian.net/browse/CRIMAPP-559)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## With premium bonds
<img width="985" alt="Screenshot 2024-03-08 at 16 30 10" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/c3742d81-d85b-4e19-9522-d7780ade3a85">

## With no premium bonds
<img width="1016" alt="Screenshot 2024-03-08 at 16 30 43" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/1bd0c027-a5ee-46f7-848a-dd67129f93c3">

## A datastore record
<img width="906" alt="Screenshot 2024-03-08 at 16 36 46" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/c0963eb5-1d31-4c89-81fb-4c400d8ec9b6">
<img width="955" alt="Screenshot 2024-03-08 at 16 33 47" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/7cbd81a6-4eb7-4e9e-b67b-e62249c42445">


## How to manually test the feature


[CRIMAPP-559]: https://dsdmoj.atlassian.net/browse/CRIMAPP-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ