### PR TITLE
[CRIMAPP-284] Income benefits and payment minor refactor 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.55'
+    tag: 'v1.0.56'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 604914c53ce855d1cd752361561ba804fbc25eba
-  tag: v1.0.55
+  revision: 47b673ce0947e87dfdf44841bddf0e371290d828
+  tag: v1.0.56
   specs:
-    laa-criminal-legal-aid-schemas (1.0.54)
+    laa-criminal-legal-aid-schemas (1.0.56)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/forms/steps/income/income_benefits_form.rb
+++ b/app/forms/steps/income/income_benefits_form.rb
@@ -1,15 +1,7 @@
 module Steps
   module Income
     class IncomeBenefitsForm < Steps::BaseFormObject
-      # NOTE: Remember to add any new types to this list otherwise it will not show on page edit
-      PAYMENT_TYPES_ORDER = %w[
-        child
-        working_or_child_tax_credit
-        incapacity
-        industrial_injuries_disablement
-        jsa
-        other
-      ].freeze
+      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomeBenefitType.values
 
       attribute :income_benefits, array: true, default: [] # Used by BaseFormObject
       attribute :types, array: true, default: [] # Used by edit.html.erb to represent selected checkbox value

--- a/app/forms/steps/income/income_benefits_form.rb
+++ b/app/forms/steps/income/income_benefits_form.rb
@@ -1,7 +1,9 @@
+require 'laa_crime_schemas'
+
 module Steps
   module Income
     class IncomeBenefitsForm < Steps::BaseFormObject
-      PAYMENT_TYPES_ORDER = ::LaaCrimeSchemas::Types::IncomeBenefitType.values
+      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomeBenefitType.values
 
       attribute :income_benefits, array: true, default: [] # Used by BaseFormObject
       attribute :types, array: true, default: [] # Used by edit.html.erb to represent selected checkbox value

--- a/app/forms/steps/income/income_benefits_form.rb
+++ b/app/forms/steps/income/income_benefits_form.rb
@@ -1,7 +1,7 @@
 module Steps
   module Income
     class IncomeBenefitsForm < Steps::BaseFormObject
-      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomeBenefitType.values
+      PAYMENT_TYPES_ORDER = ::LaaCrimeSchemas::Types::IncomeBenefitType.values
 
       attribute :income_benefits, array: true, default: [] # Used by BaseFormObject
       attribute :types, array: true, default: [] # Used by edit.html.erb to represent selected checkbox value

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -1,7 +1,9 @@
+require 'laa_crime_schemas'
+
 module Steps
   module Income
     class IncomePaymentsForm < Steps::BaseFormObject
-      PAYMENT_TYPES_ORDER = ::LaaCrimeSchemas::Types::IncomePaymentType.values
+      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomePaymentType.values
 
       attribute :income_payments, array: true, default: [] # Used by BaseFormObject
       attribute :types, array: true, default: [] # Used by edit.html.erb to represent selected checkbox value

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -1,7 +1,7 @@
 module Steps
   module Income
     class IncomePaymentsForm < Steps::BaseFormObject
-      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomePaymentType.values
+      PAYMENT_TYPES_ORDER = ::LaaCrimeSchemas::Types::IncomePaymentType.values
 
       attribute :income_payments, array: true, default: [] # Used by BaseFormObject
       attribute :types, array: true, default: [] # Used by edit.html.erb to represent selected checkbox value

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -1,19 +1,7 @@
 module Steps
   module Income
     class IncomePaymentsForm < Steps::BaseFormObject
-      # NOTE: Remember to add any new types to this list otherwise it will not show on page edit
-      PAYMENT_TYPES_ORDER = %w[
-        maintenance
-        private_pension
-        state_pension
-        interest_investment
-        student_loan_grant
-        board_from_family
-        rent
-        financial_support_with_access
-        from_friends_relatives
-        other
-      ].freeze
+      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomePaymentType.values
 
       attribute :income_payments, array: true, default: [] # Used by BaseFormObject
       attribute :types, array: true, default: [] # Used by edit.html.erb to represent selected checkbox value

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,8 +2,8 @@ class Address < ApplicationRecord
   ADDRESS_ATTRIBUTES = %i[
     address_line_one
     address_line_two
-    postcode
     city
+    postcode
     country
   ].freeze
 

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Summary::Components::Property, type: :component do
         )
         expect(page).to have_summary_row(
           'Address',
-          'TW7 london United Kingdom',
+          'london TW7 United Kingdom',
         )
       end
     end

--- a/spec/presenters/summary/sections/contact_details_spec.rb
+++ b/spec/presenters/summary/sections/contact_details_spec.rb
@@ -76,7 +76,7 @@ describe Summary::Sections::ContactDetails do
       expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[0].question).to eq(:home_address)
       expect(answers[0].change_path).to match('applications/12345/steps/address/details/ff53a8dd')
-      expect(answers[0].value).to eq("Test\r\nHome\r\nPostcode\r\nCity\r\nCountry")
+      expect(answers[0].value).to eq("Test\r\nHome\r\nCity\r\nPostcode\r\nCountry")
 
       expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
       expect(answers[1].question).to eq(:correspondence_address_type)
@@ -86,7 +86,7 @@ describe Summary::Sections::ContactDetails do
       expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[2].question).to eq(:correspondence_address)
       expect(answers[2].change_path).to match('applications/12345/steps/address/results/e77e4fa3')
-      expect(answers[2].value).to eq("Test\r\nCorrespondence\r\nPostcode\r\nCity\r\nCountry")
+      expect(answers[2].value).to eq("Test\r\nCorrespondence\r\nCity\r\nPostcode\r\nCountry")
 
       expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[3].question).to eq(:telephone_number)


### PR DESCRIPTION
## Description of change
Small refactor to income benefits and payments forms to use shared type in schema
Also amends the presentation of address to Address line 1 -> Address line 2 -> City -> Postcode -> Country

## Link to relevant ticket
[CRIMAPP-284](https://dsdmoj.atlassian.net/browse/CRIMAPP-284)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="506" alt="Screenshot 2024-03-21 at 13 18 32" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/36f220d5-0933-4160-91db-53a299cc1fed">

### After changes:
<img width="755" alt="Screenshot 2024-03-21 at 16 03 27" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/e429b511-7fac-4a43-bece-5fd154873764">


## How to manually test the feature


[CRIMAPP-284]: https://dsdmoj.atlassian.net/browse/CRIMAPP-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ