### PR TITLE
CRIMAPP-606 Truncate 10ths of a penny

### DIFF
--- a/app/attributes/type/pence.rb
+++ b/app/attributes/type/pence.rb
@@ -18,7 +18,7 @@ module Type
       return if value.is_a?(::String) && non_numeric_string?(value)
       return super if value.is_a?(Integer)
 
-      super((value.to_f * 100).round)
+      super((value.to_f * 100).to_i)
     end
 
     def cast(value)

--- a/spec/attributes/type/pence_spec.rb
+++ b/spec/attributes/type/pence_spec.rb
@@ -57,9 +57,17 @@ RSpec.describe Type::Pence do
     context 'when value is a float string' do
       let(:value) { '321.019' }
 
-      it { is_expected.to eq(32_102) }
+      it 'is expected to truncate tenths of pennies' do
+        expect(serialized_value).to eq(32_101)
+      end
 
       it { is_expected.to be_a(Integer) }
+    end
+
+    context 'when value is a negative float string' do
+      let(:value) { '-1.019' }
+
+      it { is_expected.to eq(-101) }
     end
 
     context 'when value is an integer string' do


### PR DESCRIPTION
## Description of change
Truncate rather than rounding 10ths of a penny. 

## Link to relevant ticket
[CRIMAPP-606](https://dsdmoj.atlassian.net/browse/CRIMAPP-606)

## Notes for reviewer

Previously the Pence type would round tenths of a penny which meant that a form input of 0.999 would be saved and displayed as £1.00. This PR changes that behaviour so that £0.999 is saved and displayed as £0.99.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-606]: https://dsdmoj.atlassian.net/browse/CRIMAPP-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ