### PR TITLE
CRIMAPP-606 handle larger amounts of money

### DIFF
--- a/app/attributes/type/pence.rb
+++ b/app/attributes/type/pence.rb
@@ -2,29 +2,46 @@ module Type
   # Assumes if set with an Integer value it must already be pence
   # Consider situations where form input fields auto-convert string values
   # to Integer rather than Float which could cause invalid values to be persisted
-  class Pence < ActiveRecord::Type::Integer
+  class Pence < ActiveRecord::Type::BigInteger
     def type
       :pence
     end
 
     def deserialize(value)
-      return if value.blank?
+      return if value.nil?
 
       cast(value * 0.01)
     end
 
     def serialize(value)
-      return if value.nil?
-      return if value.is_a?(::String) && non_numeric_string?(value)
-      return super if value.is_a?(Integer)
+      serialize_cast_value(cast(value))
+    end
 
-      super((value.to_f * 100).to_i)
+    def serialize_cast_value(value)
+      ensure_in_range(convert_to_pennies(cast(value)))
     end
 
     def cast(value)
-      return format('%0.02f', value) if value.is_a? Float
+      return if value.nil?
+      return if value.is_a?(::String) && non_numeric_string?(value)
 
-      value
+      format('%0.02f', convert_from_pennies(value))
+    end
+
+    private
+
+    def convert_to_pennies(value)
+      return if value.nil?
+      return value if value.is_a? ::Integer
+
+      (value.to_f * 100).to_i
+    end
+
+    def convert_from_pennies(value)
+      return nil unless value
+      return value unless value.is_a? ::Integer
+
+      value * 0.01
     end
   end
 end

--- a/db/migrate/20240326165829_change_pence_to_big_integer.rb
+++ b/db/migrate/20240326165829_change_pence_to_big_integer.rb
@@ -1,0 +1,13 @@
+class ChangePenceToBigInteger < ActiveRecord::Migration[7.0]
+  def change
+    change_column :capitals, :premium_bonds_total_value, :bigint
+    change_column :capitals, :trust_fund_amount_held, :bigint
+    change_column :capitals, :trust_fund_yearly_dividend, :bigint
+    change_column :payments, :amount, :bigint
+    change_column :investments, :value, :bigint
+    change_column :national_savings_certificates, :value, :bigint
+    change_column :properties, :outstanding_mortgage, :bigint
+    change_column :properties, :value, :bigint
+    change_column :savings, :account_balance, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_26_165829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -37,14 +37,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
   create_table "capitals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "has_premium_bonds"
-    t.integer "premium_bonds_total_value"
+    t.bigint "premium_bonds_total_value"
     t.string "premium_bonds_holder_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "has_national_savings_certificates"
     t.string "will_benefit_from_trust_fund"
-    t.integer "trust_fund_amount_held"
-    t.integer "trust_fund_yearly_dividend"
+    t.bigint "trust_fund_amount_held"
+    t.bigint "trust_fund_yearly_dividend"
     t.string "has_frozen_income_or_assets"
     t.index ["crime_application_id"], name: "index_capitals_on_crime_application_id", unique: true
   end
@@ -160,7 +160,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
   create_table "investments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "investment_type", null: false
-    t.integer "value"
+    t.bigint "value"
     t.text "description"
     t.string "ownership_type"
     t.datetime "created_at", null: false
@@ -190,7 +190,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
   create_table "national_savings_certificates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id", null: false
     t.string "certificate_number"
-    t.integer "value"
+    t.bigint "value"
     t.string "holder_number"
     t.string "ownership_type"
     t.datetime "created_at", null: false
@@ -223,7 +223,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
     t.uuid "crime_application_id", null: false
     t.string "type", null: false
     t.string "payment_type", null: false
-    t.integer "amount", null: false
+    t.bigint "amount", null: false
     t.string "frequency", null: false
     t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", null: false
@@ -259,8 +259,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
     t.integer "size_in_acres"
     t.string "usage"
     t.integer "bedrooms"
-    t.integer "value"
-    t.integer "outstanding_mortgage"
+    t.bigint "value"
+    t.bigint "outstanding_mortgage"
     t.decimal "percentage_applicant_owned"
     t.decimal "percentage_partner_owned"
     t.string "is_home_address"
@@ -308,7 +308,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_194424) do
     t.string "provider_name"
     t.string "sort_code"
     t.string "account_number"
-    t.integer "account_balance"
+    t.bigint "account_balance"
     t.string "is_overdrawn"
     t.string "are_wages_paid_into_account"
     t.string "ownership_type"

--- a/spec/attributes/type/pence_spec.rb
+++ b/spec/attributes/type/pence_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
+# forces size
+
 RSpec.describe Type::Pence do
-  subject(:pence) { described_class.new }
+  subject(:pence) { described_class.new(**args) }
+
+  let(:args) { {} }
 
   describe 'registry' do
     it 'is registered with ActiveModel type `:pence`' do
@@ -89,6 +93,14 @@ RSpec.describe Type::Pence do
         expect(subject).to eq(123)
       end
     end
+
+    describe 'when value in pence exceeds 4bytes' do
+      let(:value) { (2**31) * 0.01 }
+
+      it 'is within range' do
+        expect(subject).to eq(2_147_483_648)
+      end
+    end
   end
 
   describe '#deserialize' do
@@ -131,7 +143,7 @@ RSpec.describe Type::Pence do
     context 'when value is an integer' do
       let(:value) { 123 }
 
-      it { is_expected.to eq 123 }
+      it { is_expected.to eq '1.23' }
     end
   end
 end

--- a/spec/forms/steps/income/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/income_benefits_form_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Steps::Income::IncomeBenefitsForm do
           expect(subject.errors.of_kind?('jsa-details', :invalid)).to be(true)
 
           # Error attributes should respond
-          expect(subject.send(:'child-amount')).to eq ''
+          expect(subject.send(:'child-amount')).to be_nil
         end
       end
     end

--- a/spec/forms/steps/income/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/income_payments_form_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Steps::Income::IncomePaymentsForm do
           expect(subject.errors.of_kind?('student-loan-grant-details', :invalid)).to be(true)
 
           # Error attributes should respond
-          expect(subject.send(:'maintenance-amount')).to eq ''
+          expect(subject.send(:'maintenance-amount')).to be_nil
         end
       end
     end

--- a/spec/forms/steps/outgoings/board_and_lodging_form_spec.rb
+++ b/spec/forms/steps/outgoings/board_and_lodging_form_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Steps::Outgoings::BoardAndLodgingForm do
                            payment_type: OutgoingsPaymentType::BOARD_AND_LODGING.to_s,
                            frequency: 'four_weeks',
                            amount: 600,
-                           metadata: { 'board_amount' => 700, 'food_amount' => 100, 'payee_name' => 'Joan',
+                           metadata: { 'board_amount' => 700.0, 'food_amount' => 100.0, 'payee_name' => 'Joan',
                                       'payee_relationship_to_client' => 'Landlady' })
     }
 
@@ -51,8 +51,8 @@ RSpec.describe Steps::Outgoings::BoardAndLodgingForm do
     end
 
     it 'sets the form attributes from the model metadata' do
-      expect(form.board_amount).to eq('7.00')
-      expect(form.food_amount).to eq('1.00')
+      expect(form.board_amount).to eq('700.00')
+      expect(form.food_amount).to eq('100.00')
       expect(form.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
       expect(form.payee_name).to eq('Joan')
       expect(form.payee_relationship_to_client).to eq('Landlady')

--- a/spec/forms/steps/outgoings/council_tax_form_spec.rb
+++ b/spec/forms/steps/outgoings/council_tax_form_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
       end
 
       it 'loads model if it exists' do
-        expect(subject.amount).to eq(8999)
+        expect(subject.amount).to eq('89.99')
       end
     end
   end
@@ -96,7 +96,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
       before do
         allow(crime_application.outgoings_payments).to receive(:create!).with(
           payment_type: OutgoingsPaymentType::COUNCIL_TAX,
-          amount: 91_891,
+          amount: '918.91',
           frequency: PaymentFrequencyType::ANNUALLY,
         ).and_return(true)
       end
@@ -116,7 +116,7 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
       it 'creates an outgoings_payment record' do
         expect(crime_application.outgoings_payments).to receive(:create!).with(
           payment_type: OutgoingsPaymentType::COUNCIL_TAX,
-          amount: 91_891,
+          amount: '918.91',
           frequency: PaymentFrequencyType::ANNUALLY,
         ).once
 

--- a/spec/forms/steps/outgoings/mortgage_form_spec.rb
+++ b/spec/forms/steps/outgoings/mortgage_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Steps::Outgoings::MortgageForm do
       end
 
       it 'loads model if it exists' do
-        expect(subject.amount).to eq(8999)
+        expect(subject.amount).to eq('89.99')
         expect(subject.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe Steps::Outgoings::MortgageForm do
 
       it 'is valid' do
         expect(subject).to be_valid
-        expect(subject.amount).to eq '91891'
+        expect(subject.amount).to eq '91891.00'
         expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
       end
     end

--- a/spec/forms/steps/outgoings/outgoings_payments_form_spec.rb
+++ b/spec/forms/steps/outgoings/outgoings_payments_form_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Steps::Outgoings::OutgoingsPaymentsForm do
               'types' => %w[childcare legal_aid_contribution], # Selected payment checkboxes
 
               'childcare' =>  { 'amount' => '56.12', 'frequency' => 'week' }, # Data for selected payment
-              'maintenance' => { 'amount' => '', 'frequency' => '' },
+              'maintenance' => { 'amount' => nil, 'frequency' => nil },
               'legal_aid_contribution' => { 'amount' => '44', 'frequency' => 'week', 'case_reference' => 'CASE1234' },
             }
           }
@@ -88,7 +88,7 @@ RSpec.describe Steps::Outgoings::OutgoingsPaymentsForm do
           expect(subject.errors.of_kind?('childcare-frequency', :inclusion)).to be(true)
 
           # Error attributes should respond
-          expect(subject.send(:'childcare-amount')).to eq ''
+          expect(subject.send(:'childcare-amount')).to be_nil
         end
       end
     end

--- a/spec/forms/steps/outgoings/rent_form_spec.rb
+++ b/spec/forms/steps/outgoings/rent_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Steps::Outgoings::RentForm do
         OutgoingsPayment.new(
           crime_application: crime_application,
           payment_type: OutgoingsPaymentType::RENT.to_s,
-          amount: 8999,
+          amount: 8999.0,
           frequency: 'four_weeks',
         )
       }
@@ -28,7 +28,7 @@ RSpec.describe Steps::Outgoings::RentForm do
       end
 
       it 'loads model if it exists' do
-        expect(subject.amount).to eq(8999)
+        expect(subject.amount).to eq('8999.00')
         expect(subject.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe Steps::Outgoings::RentForm do
 
       it 'is valid' do
         expect(subject).to be_valid
-        expect(subject.amount).to eq '91891'
+        expect(subject.amount).to eq '91891.00'
         expect(subject.frequency).to eq PaymentFrequencyType::MONTHLY
       end
     end

--- a/spec/presenters/summary/sections/housing_payments_spec.rb
+++ b/spec/presenters/summary/sections/housing_payments_spec.rb
@@ -28,7 +28,7 @@ describe Summary::Sections::HousingPayments do
     instance_double(
       OutgoingsPayment,
       payment_type: 'mortgage',
-      amount: 333,
+      amount: 333.0,
       frequency: 'year'
     )
   end
@@ -37,7 +37,7 @@ describe Summary::Sections::HousingPayments do
     instance_double(
       OutgoingsPayment,
       payment_type: 'rent',
-      amount: 5555,
+      amount: 5555.0,
       frequency: 'month'
     )
   end
@@ -46,7 +46,7 @@ describe Summary::Sections::HousingPayments do
     instance_double(
       OutgoingsPayment,
       payment_type: 'council_tax',
-      amount: 6666,
+      amount: 6666.0,
       frequency: 'annual'
     )
   end
@@ -55,10 +55,10 @@ describe Summary::Sections::HousingPayments do
     instance_double(
       OutgoingsPayment,
       payment_type: 'board_and_lodging',
-      amount: 750,
+      amount: 750.0,
       frequency: 'month',
-      board_amount: 800,
-      food_amount: 50,
+      board_amount: 800.0,
+      food_amount: 50.0,
       payee_name: 'George',
       payee_relationship_to_client: 'Friend'
     )
@@ -69,7 +69,7 @@ describe Summary::Sections::HousingPayments do
     instance_double(
       OutgoingsPayment,
       payment_type: 'maintenance',
-      amount: 101,
+      amount: 101.0,
       frequency: 'week'
     )
   end
@@ -240,13 +240,13 @@ describe Summary::Sections::HousingPayments do
         expect(answers[1].question).to eq(:board_amount)
         expect(answers[1].change_path)
           .to match('applications/12345/steps/outgoings/board_and_lodging_payments')
-        expect(answers[1].value.amount).to eq(800)
+        expect(answers[1].value.amount).to eq('800.00')
 
         expect(answers[2]).to be_an_instance_of(Summary::Components::PaymentAnswer)
         expect(answers[2].question).to eq(:food_amount)
         expect(answers[2].change_path)
           .to match('applications/12345/steps/outgoings/board_and_lodging_payments')
-        expect(answers[2].value.amount).to eq(50)
+        expect(answers[2].value.amount).to eq('50.00')
 
         expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answers[3].question).to eq(:payee_name)

--- a/spec/support/shared_examples/payment_shared_examples.rb
+++ b/spec/support/shared_examples/payment_shared_examples.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples 'a payment fieldset form' do |fieldset_class|
       let(:amount) { '' }
 
       it { is_expected.not_to be_valid }
-      it { expect(subject.amount).to eq '' }
+      it { expect(subject.amount).to be_nil }
       it { expect(subject.errors.of_kind?(:amount, :not_a_number)).to be(true) }
     end
 
@@ -306,7 +306,7 @@ RSpec.shared_examples 'a basic amount with frequency' do |payment_class|
       end
 
       it 'has amount and frquency' do
-        expect(subject.amount).to eq '12239'
+        expect(subject.amount).to eq '12239.00'
         expect(subject.frequency.to_s).to eq 'month'
       end
     end


### PR DESCRIPTION
## Description of change
Support amounts greater than 4bytes when expressed in pennies.
Do not convert integers to pennies.

## Link to relevant ticket
[CRIMAPP-606](https://dsdmoj.atlassian.net/browse/CRIMAPP-606)

## Notes for reviewer

I spiked an alternative implementation that uses a Money value object (which I prefer), but have opted against that for now to reduce size of this change https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/tree/money-type

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-606]: https://dsdmoj.atlassian.net/browse/CRIMAPP-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ