### PR TITLE
CRIMAPP-677 Delete existing assets on selecting 'My client does not own any of these assets' option

### DIFF
--- a/app/forms/steps/capital/property_type_form.rb
+++ b/app/forms/steps/capital/property_type_form.rb
@@ -14,7 +14,10 @@ module Steps
       private
 
       def persist!
-        return true if property_type == 'none'
+        if property_type == 'none'
+          crime_application.properties.destroy_all
+          return true
+        end
 
         @property = incomplete_property_for_type || crime_application.properties.create!(property_type:)
       end

--- a/spec/forms/steps/capital/property_type_form_spec.rb
+++ b/spec/forms/steps/capital/property_type_form_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Steps::Capital::PropertyTypeForm do
 
     before do
       allow(properties).to receive(:create!).with(property_type:).and_return new_property
+      allow(properties).to receive(:destroy_all)
 
       form.property_type = property_type
       form.save
@@ -58,6 +59,15 @@ RSpec.describe Steps::Capital::PropertyTypeForm do
         it 'a new property of the property type is created' do
           expect(form.property).to be new_property
           expect(properties).to have_received(:create!).with(property_type:)
+        end
+      end
+
+      context 'when client selects `no assets` option after adding assets' do
+        let(:property_type) { 'none' }
+
+        it 'deletes existing properties' do
+          expect(properties).to have_received(:destroy_all)
+          expect(properties).not_to have_received(:create!)
         end
       end
     end


### PR DESCRIPTION
## Description of change
Delete existing assets if user select "My client does not own any of these assets" option

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-677

## Notes for reviewer
Please follow ticket [comments](https://dsdmoj.atlassian.net/browse/CRIMAPP-677?focusedCommentId=441715)

## Screenshots of changes (if applicable)

<img width="706" alt="Screenshot 2024-04-03 at 15 02 02" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/ac5531fe-2fe5-4342-8ef9-aa16c5ac0b0d">

### Before changes:

### After changes:

## How to manually test the feature
http://localhost:3000/applications/:id/steps/capital/which_assets_does_client_own
