### PR TITLE
Fix app flow when passporting benefit is not selected

### DIFF
--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -91,10 +91,10 @@ module Decisions
     end
 
     def means_test_or_ioj
-      if current_crime_application.benefit_check_passported?
-        edit('/steps/income/employment_status')
-      else
+      if current_crime_application.not_means_tested?
         ioj_or_passported
+      else
+        edit('/steps/income/employment_status')
       end
     end
 

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -83,19 +83,15 @@ module Decisions
     def after_hearing_details
       return edit(:first_court_hearing) if form_object.is_first_court_hearing.no?
 
-      means_test_or_ioj
+      ioj_or_passported
     end
 
     def after_first_court_hearing
-      means_test_or_ioj
+      ioj_or_passported
     end
 
-    def means_test_or_ioj
-      if current_crime_application.not_means_tested?
-        ioj_or_passported
-      else
-        edit('/steps/income/employment_status')
-      end
+    def means_test_required?
+      applicant.has_benefit_evidence == 'no' || applicant.benefit_type == 'none'
     end
 
     def ioj_or_passported
@@ -107,6 +103,8 @@ module Decisions
     end
 
     def after_ioj
+      return edit('/steps/income/employment_status') if means_test_required?
+
       return edit('/steps/evidence/upload') if evidence_upload_required?
 
       edit('/steps/submission/more_information')
@@ -137,6 +135,10 @@ module Decisions
 
     def blank_date_required?
       current_charge.offence_dates.map(&:date_from).exclude?(nil)
+    end
+
+    def applicant
+      @applicant ||= current_crime_application.applicant
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -25,10 +25,8 @@ module Decisions
         after_benefit_type
       when :retry_benefit_check
         determine_dwp_result_page
-      when :benefit_check_result
-        after_dwp_check
-      when :has_benefit_evidence
-        after_has_benefit_evidence
+      when :benefit_check_result, :has_benefit_evidence
+        edit('/steps/case/urn')
       when :cannot_check_benefit_status
         after_cannot_check_benefit_status
       else
@@ -130,18 +128,6 @@ module Decisions
         edit(:benefit_check_result)
       else
         edit('steps/dwp/confirm_result')
-      end
-    end
-
-    def after_dwp_check
-      edit('/steps/case/urn')
-    end
-
-    def after_has_benefit_evidence
-      if form_object.has_benefit_evidence.yes?
-        edit('/steps/case/urn')
-      else
-        show(:evidence_exit)
       end
     end
 

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -171,6 +171,7 @@ en:
         has_benefit_evidence: This can be a letter from DWP or JobCentre Plus, or an image from a government app showing your client's name and their benefit details.
         has_benefit_evidence_options:
           'yes': You'll need to upload evidence at the end of this application.
+          'no': You'll need to tell us about your client's income if you do not have evidence.
       steps_client_contact_details_form:
         telephone_number: For example, 01632 960 001 or +44 808 157 0192
       steps_address_lookup_form:

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Decisions::CaseDecisionTree do
   let(:codefendants_double) { double('codefendants_collection') }
   let(:charges_double) { double('charges_collection') }
   let(:applicant_double) { double('applicant') }
-  let(:benefit_check_passported) { nil }
+  let(:not_means_tested) { nil }
 
   before do
     allow(
@@ -17,7 +17,7 @@ RSpec.describe Decisions::CaseDecisionTree do
     ).to receive(:crime_application).and_return(crime_application)
 
     allow(crime_application).to receive_messages(update: true, date_stamp: nil,
-                                                 benefit_check_passported?: benefit_check_passported)
+                                                 not_means_tested?: not_means_tested)
   end
 
   it_behaves_like 'a decision tree'
@@ -245,7 +245,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'when court did hear first hearing' do
       let(:is_first_court_hearing) { FirstHearingAnswer::YES }
-      let(:benefit_check_passported) { false }
+      let(:not_means_tested) { true }
 
       before do
         allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(ioj_passported)
@@ -266,7 +266,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'when the application is means tested' do
       let(:is_first_court_hearing) { FirstHearingAnswer::YES }
-      let(:benefit_check_passported) { true }
+      let(:not_means_tested) { false }
 
       it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
     end
@@ -275,7 +275,7 @@ RSpec.describe Decisions::CaseDecisionTree do
   context 'when the step is `first_court_hearing`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :first_court_hearing }
-    let(:benefit_check_passported) { false }
+    let(:not_means_tested) { true }
 
     it 'runs the `means_test_or_ioj` logic' do
       expect(subject).to receive(:means_test_or_ioj)
@@ -288,7 +288,7 @@ RSpec.describe Decisions::CaseDecisionTree do
     end
 
     context 'and application is means tested' do
-      let(:benefit_check_passported) { true }
+      let(:not_means_tested) { false }
 
       it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
     end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -245,7 +245,6 @@ RSpec.describe Decisions::CaseDecisionTree do
 
     context 'when court did hear first hearing' do
       let(:is_first_court_hearing) { FirstHearingAnswer::YES }
-      let(:not_means_tested) { true }
 
       before do
         allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(ioj_passported)
@@ -263,34 +262,15 @@ RSpec.describe Decisions::CaseDecisionTree do
         it { is_expected.to have_destination(:ioj_passport, :edit, id: crime_application) }
       end
     end
-
-    context 'when the application is means tested' do
-      let(:is_first_court_hearing) { FirstHearingAnswer::YES }
-      let(:not_means_tested) { false }
-
-      it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
-    end
   end
 
   context 'when the step is `first_court_hearing`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :first_court_hearing }
-    let(:not_means_tested) { true }
-
-    it 'runs the `means_test_or_ioj` logic' do
-      expect(subject).to receive(:means_test_or_ioj)
-      subject.destination
-    end
 
     it 'runs the `ioj_or_passported` logic' do
       expect(subject).to receive(:ioj_or_passported)
       subject.destination
-    end
-
-    context 'and application is means tested' do
-      let(:not_means_tested) { false }
-
-      it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
     end
   end
 
@@ -304,8 +284,11 @@ RSpec.describe Decisions::CaseDecisionTree do
     end
   end
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   context 'when the step is `ioj`' do
     let(:form_object) { double('FormObject') }
+    let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+    let(:has_benefit_evidence) { nil }
     let(:step_name) { :ioj }
 
     before do
@@ -316,6 +299,34 @@ RSpec.describe Decisions::CaseDecisionTree do
       allow_any_instance_of(
         Evidence::Requirements
       ).to receive(:any?).and_return(evidence_required)
+
+      allow(applicant_double).to receive_messages(has_benefit_evidence:, benefit_type:)
+    end
+
+    context 'and means test required' do
+      let(:means_passported) { false }
+      let(:evidence_required) { nil }
+
+      context 'when has benefit evidence is no' do
+        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+        let(:has_benefit_evidence) { 'no' }
+
+        it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
+      end
+
+      context 'when benefit type is none' do
+        let(:benefit_type) { 'none' }
+
+        it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
+      end
+    end
+
+    context 'and the application requires evidence upload' do
+      let(:means_passported) { false }
+      let(:evidence_required) { true }
+      let(:has_benefit_evidence) { true }
+
+      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
     end
 
     context 'and the application is means-passported' do
@@ -324,20 +335,6 @@ RSpec.describe Decisions::CaseDecisionTree do
 
       it { is_expected.to have_destination('/steps/submission/more_information', :edit, id: crime_application) }
     end
-
-    context 'and the application requires evidence upload' do
-      let(:means_passported) { false }
-      let(:evidence_required) { true }
-
-      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
-    end
-
-    # TODO: means test journey to be implemented
-    context 'and the application is not means-passported' do
-      let(:means_passported) { false }
-      let(:evidence_required) { false }
-
-      it { is_expected.to have_destination('/steps/submission/more_information', :edit, id: crime_application) }
-    end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -9,15 +9,13 @@ RSpec.describe Decisions::CaseDecisionTree do
   let(:codefendants_double) { double('codefendants_collection') }
   let(:charges_double) { double('charges_collection') }
   let(:applicant_double) { double('applicant') }
-  let(:not_means_tested) { nil }
 
   before do
     allow(
       form_object
     ).to receive(:crime_application).and_return(crime_application)
 
-    allow(crime_application).to receive_messages(update: true, date_stamp: nil,
-                                                 not_means_tested?: not_means_tested)
+    allow(crime_application).to receive_messages(update: true, date_stamp: nil)
   end
 
   it_behaves_like 'a decision tree'

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -365,20 +365,10 @@ RSpec.describe Decisions::ClientDecisionTree do
   # rubocop:enable RSpec/MultipleMemoizedHelpers
 
   context 'when the step is `has_benefit_evidence`' do
-    let(:form_object) { double('FormObject', applicant:, has_benefit_evidence:) }
+    let(:form_object) { double('FormObject', applicant:) }
     let(:step_name) { :has_benefit_evidence }
 
-    context 'and the answer is `yes`' do
-      let(:has_benefit_evidence) { YesNoAnswer::YES }
-
-      it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
-    end
-
-    context 'and the answer is `no`' do
-      let(:has_benefit_evidence) { YesNoAnswer::NO }
-
-      it { is_expected.to have_destination(:evidence_exit, :show, id: crime_application) }
-    end
+    it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
   end
 
   context 'when the step is `retry_benefit_check`' do


### PR DESCRIPTION
## Description of change
Discovered during qa testing, when no passporting benefit is selected then applicant is not being routed to means assessment and they are not being correctly routed to the ioj screens 

Makes the following fixes: 
- Reverts to routing to the ioj screens following the court hearing details 
- Routes to means assessment following ioj screens if the applicant does not have a passporting benefit or does not have benefit evidence 
- Following an undetermined dwp check, routes to case details if instead of the benefit exit screen if user does not have benefit evidence

## Link to relevant ticket
[CRIMAPP-693](https://dsdmoj.atlassian.net/browse/CRIMAPP-693)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Test the scenarios above and in the ticket 


[CRIMAPP-693]: https://dsdmoj.atlassian.net/browse/CRIMAPP-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ