### PR TITLE
CRIMAPP-258 income add check your answers page to income section

### DIFF
--- a/app/controllers/steps/income/answers_controller.rb
+++ b/app/controllers/steps/income/answers_controller.rb
@@ -1,0 +1,20 @@
+module Steps
+  module Income
+    class AnswersController < Steps::IncomeStepController
+      include Steps::NoOpAdvanceStep
+      before_action :set_presenter
+
+      private
+
+      def advance_as
+        :answers
+      end
+
+      def set_presenter
+        @presenter = Summary::HtmlPresenter.new(
+          crime_application: current_crime_application
+        )
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -54,6 +54,12 @@ module Summary
       outgoings: %i[
         housing_payments
         other_outgoings_details
+      ],
+      income: %i[
+        employment_details
+        income_details
+        other_income_details
+        dependants
       ]
     }.freeze
 
@@ -75,6 +81,12 @@ module Summary
 
     def outgoings_sections
       SECTIONS.fetch(:outgoings).map do |section|
+        Sections.const_get(section.to_s.camelize).new(crime_application)
+      end.select(&:show?)
+    end
+
+    def income_sections
+      SECTIONS.fetch(:income).map do |section|
         Sections.const_get(section.to_s.camelize).new(crime_application)
       end.select(&:show?)
     end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -58,8 +58,10 @@ module Summary
       income: %i[
         employment_details
         income_details
-        other_income_details
+        income_payments_details
+        income_benefits_details
         dependants
+        other_income_details
       ]
     }.freeze
 

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -31,12 +31,17 @@ module Decisions
       when :manage_without_income
         edit(:answers)
       when :answers
-        routes = Rails.application.routes.url_helpers
+        step_path = Rails.application.routes.url_helpers
         if previous_step_path.in? [
-          routes.edit_steps_income_employment_status_path(crime_application),
-          routes.edit_steps_income_lost_job_in_custody_path(crime_application)
+          step_path.edit_steps_income_employment_status_path(crime_application),
+          step_path.edit_steps_income_lost_job_in_custody_path(crime_application)
         ]
           continuing_evidence_upload
+        elsif previous_step_path.in? [
+          step_path.edit_steps_income_income_benefits_path(crime_application),
+          step_path.edit_steps_income_client_has_dependants_path(crime_application)
+        ]
+          determine_showing_no_income_page
         else
           determine_continuing_means_journey
         end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -29,6 +29,8 @@ module Decisions
       when :dependants_finished
         determine_showing_no_income_page
       when :manage_without_income
+        edit(:answers)
+      when :answers
         determine_continuing_means_journey
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
@@ -43,7 +45,7 @@ module Decisions
         if ended_employment_within_three_months?
           edit(:lost_job_in_custody)
         elsif appeal_no_changes?
-          edit('/steps/evidence/upload')
+          edit(:answers)
         else
           edit(:income_before_tax)
         end
@@ -55,7 +57,7 @@ module Decisions
 
     def after_lost_job_in_custody
       if appeal_no_changes?
-        edit('/steps/evidence/upload')
+        edit(:answers)
       else
         edit(:income_before_tax)
       end
@@ -89,7 +91,7 @@ module Decisions
       if requires_full_means_assessment?
         edit(:client_has_dependants)
       else
-        determine_showing_no_income_page
+        edit(:answers)
       end
     end
 
@@ -97,7 +99,7 @@ module Decisions
       if form_object.client_has_dependants.yes?
         edit_dependants(add_blank: true)
       else
-        determine_showing_no_income_page
+        edit(:answers)
       end
     end
 
@@ -112,7 +114,7 @@ module Decisions
       if payments.empty?
         edit(:manage_without_income)
       else
-        determine_continuing_means_journey
+        edit(:answers)
       end
     end
 

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -33,9 +33,9 @@ module Decisions
       when :answers
         routes = Rails.application.routes.url_helpers
         if previous_step_path.in? [
-                                    routes.edit_steps_income_employment_status_path(crime_application),
-                                    routes.edit_steps_income_lost_job_in_custody_path(crime_application)
-                                  ]
+          routes.edit_steps_income_employment_status_path(crime_application),
+          routes.edit_steps_income_lost_job_in_custody_path(crime_application)
+        ]
           continuing_evidence_upload
         else
           determine_continuing_means_journey

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -33,15 +33,10 @@ module Decisions
       when :answers
         step_path = Rails.application.routes.url_helpers
         if previous_step_path.in? [
-          step_path.edit_steps_income_employment_status_path(crime_application),
-          step_path.edit_steps_income_lost_job_in_custody_path(crime_application)
+          step_path.edit_steps_income_employment_status_path(id: crime_application.id),
+          step_path.edit_steps_income_lost_job_in_custody_path(id: crime_application.id)
         ]
           continuing_evidence_upload
-        elsif previous_step_path.in? [
-          step_path.edit_steps_income_income_benefits_path(crime_application),
-          step_path.edit_steps_income_client_has_dependants_path(crime_application)
-        ]
-          determine_showing_no_income_page
         else
           determine_continuing_means_journey
         end
@@ -63,7 +58,6 @@ module Decisions
         if ended_employment_within_three_months?
           edit(:lost_job_in_custody)
         elsif appeal_no_changes?
-          # edit('/steps/evidence/upload')
           edit(:answers)
         else
           edit(:income_before_tax)
@@ -76,7 +70,6 @@ module Decisions
 
     def after_lost_job_in_custody
       if appeal_no_changes?
-        # edit('/steps/evidence/upload')
         edit(:answers)
       else
         edit(:income_before_tax)

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -111,7 +111,7 @@ module Decisions
       if requires_full_means_assessment?
         edit(:client_has_dependants)
       else
-        edit(:answers)
+        determine_showing_no_income_page
       end
     end
 
@@ -119,7 +119,7 @@ module Decisions
       if form_object.client_has_dependants.yes?
         edit_dependants(add_blank: true)
       else
-        edit(:answers)
+        determine_showing_no_income_page
       end
     end
 

--- a/app/views/steps/income/answers/edit.html.erb
+++ b/app/views/steps/income/answers/edit.html.erb
@@ -1,8 +1,6 @@
 <% title t('.page_title') %>
 <% step_header %>
 
-<%= previous_step_path %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'shared/flash_banner' %>

--- a/app/views/steps/income/answers/edit.html.erb
+++ b/app/views/steps/income/answers/edit.html.erb
@@ -1,0 +1,22 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+    <%= govuk_error_summary(@form_object) %>
+
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+
+    <h1 class="govuk-heading-xl">
+      <%=t '.heading' %>
+    </h1>
+
+    <h1 class="govuk-heading-l"><%= t('.subheading') %></h1>
+
+    <%= render @presenter.income_sections %>
+    <%= step_form @form_object do |f| %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/income/answers/edit.html.erb
+++ b/app/views/steps/income/answers/edit.html.erb
@@ -1,6 +1,8 @@
 <% title t('.page_title') %>
 <% step_header %>
 
+<%= previous_step_path %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'shared/flash_banner' %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -282,6 +282,11 @@ en:
       manage_without_income:
         edit:
           page_title: How does client manage with no income?
+      answers:
+        edit:
+          page_title: Check your answers - Your client's income
+          heading: Check your answers
+          subheading: Your client’s income
 
     outgoings:
       caption: Outgoings assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
         edit_step :how_does_client_manage_with_no_income, alias: :manage_without_income
         edit_step :which_payments_does_client_get, alias: :income_payments
         edit_step :which_benefits_does_client_get, alias: :income_benefits
+        edit_step :check_your_answers_income, alias: :answers
       end
 
       namespace :outgoings, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do

--- a/spec/controllers/steps/income/answers_controller_spec.rb
+++ b/spec/controllers/steps/income/answers_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::AnswersController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Shared::NoOpForm,
+                  Decisions::IncomeDecisionTree
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -258,4 +258,29 @@ describe Summary::HtmlPresenter do
       it { is_expected.to match_array(expected_sections) }
     end
   end
+
+  describe '#income_sections' do
+    subject(:income_sections) { presenter.income_sections.map { |s| s.class.name.demodulize } }
+
+    before do
+      allow_any_instance_of(
+        Summary::Sections::BaseSection
+      ).to receive(:show?).and_return(true)
+    end
+
+    let(:crime_application) { database_application }
+
+    expected_sections = %w[
+      EmploymentDetails
+      IncomeDetails
+      Dependants
+      OtherIncomeDetails
+    ]
+
+    context 'when an initial application' do
+      let(:application_type) { 'initial' }
+
+      it { is_expected.to match_array(expected_sections) }
+    end
+  end
 end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -273,6 +273,8 @@ describe Summary::HtmlPresenter do
     expected_sections = %w[
       EmploymentDetails
       IncomeDetails
+      IncomePaymentsDetails
+      IncomeBenefitsDetails
       Dependants
       OtherIncomeDetails
     ]

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
         context 'when case_type is appeal no changes' do
           let(:case_type) { 'appeal_to_crown_court' }
 
-          it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+          it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
         end
       end
     end
@@ -87,7 +87,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
     context 'when case_type is appeal no changes' do
       let(:case_type) { 'appeal_to_crown_court' }
 
-      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+      it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
     end
   end
 
@@ -225,7 +225,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       context 'when there are payments' do
         let(:income_payments) { [{ amount: 1234 }] }
 
-        it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+        it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
       end
     end
   end
@@ -264,7 +264,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
         let(:client_owns_property) { YesNoAnswer::NO.to_s }
         let(:has_savings) { YesNoAnswer::NO.to_s }
 
-        it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+        it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
       end
     end
 
@@ -347,7 +347,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       let(:client_owns_property) { YesNoAnswer::NO.to_s }
       let(:has_savings) { YesNoAnswer::NO.to_s }
 
-      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+      it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
     end
   end
 
@@ -379,7 +379,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       let(:client_owns_property) { YesNoAnswer::NO.to_s }
       let(:has_savings) { YesNoAnswer::NO.to_s }
 
-      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+      it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
     end
   end
 end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       let(:client_owns_property) { YesNoAnswer::NO.to_s }
       let(:has_savings) { YesNoAnswer::NO.to_s }
 
-      it { is_expected.to have_destination('/steps/outgoings/housing_payment_type', :edit, id: crime_application) }
+      it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
     end
 
     context 'when full means assessment does not need completing' do
@@ -380,6 +380,62 @@ RSpec.describe Decisions::IncomeDecisionTree do
       let(:has_savings) { YesNoAnswer::NO.to_s }
 
       it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
+    end
+  end
+
+  context 'when the step is `answers`' do
+    before do
+      allow(crime_application).to receive(:navigation_stack).and_return(navigation_stack)
+    end
+
+    let(:form_object) { double('FormObject') }
+    let(:destination_url) {
+      Rails.application.routes.url_helpers.edit_steps_income_answers_path(id: crime_application.id)
+    }
+    let(:step_name) { :answers }
+    let(:navigation_stack) {
+      [
+        source_url,
+        destination_url
+      ]
+    }
+
+    context "when source is 'employment_status' path" do
+      let(:source_url) {
+        Rails.application.routes.url_helpers.edit_steps_income_employment_status_path(id: crime_application.id)
+      }
+
+      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+    end
+
+    context "when source is 'lost_job_in_custody' path" do
+      let(:source_url) {
+        Rails.application.routes.url_helpers.edit_steps_income_lost_job_in_custody_path(id: crime_application.id)
+      }
+
+      it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+    end
+
+    context "when source is 'manage_without_income'" do
+      before do
+        allow(subject).to receive(:requires_full_means_assessment?).and_return(requires_full_means_assessment)
+      end
+
+      let(:source_url) {
+        Rails.application.routes.url_helpers.edit_steps_income_manage_without_income_path(crime_application)
+      }
+
+      context 'when full means assessment needs completing' do
+        let(:requires_full_means_assessment) { true }
+
+        it { is_expected.to have_destination('/steps/outgoings/housing_payment_type', :edit, id: crime_application) }
+      end
+
+      context 'when full means assessment does not needs completing' do
+        let(:requires_full_means_assessment) { false }
+
+        it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
+      end
     end
   end
 end

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -166,28 +166,6 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       let(:case_type) { 'summary_only' }
 
       context 'has correct next step' do
-        # it { is_expected.to have_destination('/steps/capital/trust_fund', :edit, id: crime_application) }
-        it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
-      end
-    end
-  end
-
-  context 'when the step is `answers`' do
-    let(:form_object) { double('FormObject') }
-    let(:step_name) { :answers }
-
-    context 'when case_type requires full capital assessment' do
-      let(:case_type) { 'indictable' }
-
-      context 'has correct next step' do
-        it { is_expected.to have_destination('/steps/capital/property_type', :edit, id: crime_application) }
-      end
-    end
-
-    context 'when case_type does not require full capital assessment' do
-      let(:case_type) { 'summary_only' }
-
-      context 'has correct next step' do
         it { is_expected.to have_destination('/steps/capital/trust_fund', :edit, id: crime_application) }
       end
     end

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -166,7 +166,8 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       let(:case_type) { 'summary_only' }
 
       context 'has correct next step' do
-        it { is_expected.to have_destination('/steps/capital/trust_fund', :edit, id: crime_application) }
+        # it { is_expected.to have_destination('/steps/capital/trust_fund', :edit, id: crime_application) }
+        it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
       end
     end
   end

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -171,4 +171,25 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       end
     end
   end
+
+  context 'when the step is `answers`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :answers }
+
+    context 'when case_type requires full capital assessment' do
+      let(:case_type) { 'indictable' }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination('/steps/capital/property_type', :edit, id: crime_application) }
+      end
+    end
+
+    context 'when case_type does not require full capital assessment' do
+      let(:case_type) { 'summary_only' }
+
+      context 'has correct next step' do
+        it { is_expected.to have_destination('/steps/capital/trust_fund', :edit, id: crime_application) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Add "Check your answers" page to income section

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-258

## Notes for reviewer
> [!IMPORTANT]  
> -Special attention required for **income_decision_tree.rb**


## Screenshots of changes (if applicable)

### Before changes:

### After changes:
### **New income decision tree**
<img width="1716" alt="Screenshot 2024-04-09 at 01 09 46" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/1983238f-bbf6-4273-9423-cdbf978491eb">


## How to manually test the feature
http://localhost:3000/applications/:id/steps/income/what_is_clients_employment_status
