### PR TITLE
Fix routing for non means tested applications

### DIFF
--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -91,7 +91,8 @@ module Decisions
     end
 
     def means_test_required?
-      applicant.has_benefit_evidence == 'no' || applicant.benefit_type == 'none'
+      FeatureFlags.means_journey.enabled? && (applicant.has_benefit_evidence == 'no' ||
+        applicant.benefit_type == 'none')
     end
 
     def ioj_or_passported

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -25,8 +25,10 @@ module Decisions
         after_benefit_type
       when :retry_benefit_check
         determine_dwp_result_page
-      when :benefit_check_result, :has_benefit_evidence
+      when :benefit_check_result
         edit('/steps/case/urn')
+      when :has_benefit_evidence
+        after_has_benefit_evidence
       when :cannot_check_benefit_status
         after_cannot_check_benefit_status
       else
@@ -114,6 +116,14 @@ module Decisions
         edit(:cannot_check_benefit_status)
       else
         determine_dwp_result_page
+      end
+    end
+
+    def after_has_benefit_evidence
+      if form_object.has_benefit_evidence.yes? || FeatureFlags.means_journey.enabled?
+        edit('/steps/case/urn')
+      else
+        show(:evidence_exit)
       end
     end
 

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -171,7 +171,6 @@ en:
         has_benefit_evidence: This can be a letter from DWP or JobCentre Plus, or an image from a government app showing your client's name and their benefit details.
         has_benefit_evidence_options:
           'yes': You'll need to upload evidence at the end of this application.
-          'no': You'll need to tell us about your client's income if you do not have evidence.
       steps_client_contact_details_form:
         telephone_number: For example, 01632 960 001 or +44 808 157 0192
       steps_address_lookup_form:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ feature_flags:
     staging: true
     production: true
   means_journey:
-    local: false
+    local: true
     staging: true
     production: false
   post_submission_evidence:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ feature_flags:
     staging: true
     production: true
   means_journey:
-    local: true
+    local: false
     staging: true
     production: false
   post_submission_evidence:


### PR DESCRIPTION
## Description of change
Discovered a bug with routing when the means  journey feature flag is set to false
When a user enters a nino and selects a passporting benefit and then selects that they do not have evidence, they were not being shown the evidence exit screen 
This is due to previous changes to routing for means applications 

Scenarios 

<table>
<tr>
 <td>
Means journey ff 
 <td>
Nino
 <td>
benefit type
 <td>
Has benefit evidence
 <td>
Result
<tr>
 <td>
False
 <td>
Yes
 <td>
Yes
 <td>
No
 <td>
Evidence exit
</table>

<table>
<tr>
 <td>
Means journey ff 
 <td>
Nino
 <td>
benefit type
 <td>
Has benefit evidence
 <td>
Result
<tr>
 <td>
False
 <td>
Yes
 <td>
No
 <td>
-
 <td>
Evidence exit
</table>

<table>
<tr>
 <td>
Means journey ff 
 <td>
Nino
 <td>
benefit type
 <td>
Has benefit evidence
 <td>
Result
<tr>
 <td>
False
 <td>
Yes
 <td>
Yes
 <td>
Yes
 <td>
Can submit app if evidence provided or Applicant is not passported on means error is shown
</table>

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:


https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/c5c43001-0adb-47c9-8d50-9ae253f309d1

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/0e31027e-bcf7-4e6e-84d7-65f99cfdfd57


https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/f60bc588-ee67-49b7-a59d-b3f3a8ccd692



## How to manually test the feature
Turn means journey feature flag off and follow scenarios as above