### PR TITLE
[CRIMAPP-678] Display correct percentage ownership question text

### DIFF
--- a/app/views/steps/capital/property_owners/edit.html.erb
+++ b/app/views/steps/capital/property_owners/edit.html.erb
@@ -24,7 +24,8 @@
               <%= po_field.govuk_text_field :other_relationship, autocomplete: 'off', width: 'one-third' %>
             <%end%>
           <% end %>
-          <%= po_field.govuk_number_field :percentage_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
+          <%= po_field.govuk_number_field :percentage_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third',
+                                          label: { text: t("helpers.label.steps_capital_property_owners_form.property_owners_attributes.percentage_owned_#{@form_object.record.property_type}") } %>
 
           <%= po_field.button t('.remove_button', index:), type: :submit, value: '1', name: po_field.field_name(:_destroy, index: po_field.id),
                         class: %w[govuk-button govuk-button--warning],

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -662,7 +662,8 @@ en:
             other: Their relationship is not listed
           other_relationship: Enter their relationship
           percentage_owned_land: What percentage of the land do they own?
-          percentage_owned_residential: What percentage of the property do they own?
+          percentage_owned_residential: &percentage_owned_text What percentage of the property do they own?
+          percentage_owned_commercial: *percentage_owned_text
       steps_capital_frozen_income_savings_assets_form:
         has_frozen_income_or_assets_options: *YESNO
       steps_capital_answers_form: # TODO :: NOT WORKING

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -661,7 +661,8 @@ en:
             property_company: Property company
             other: Their relationship is not listed
           other_relationship: Enter their relationship
-          percentage_owned: What percentage of the land do they own?
+          percentage_owned_land: What percentage of the land do they own?
+          percentage_owned_residential: What percentage of the property do they own?
       steps_capital_frozen_income_savings_assets_form:
         has_frozen_income_or_assets_options: *YESNO
       steps_capital_answers_form: # TODO :: NOT WORKING

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -187,6 +187,17 @@ RSpec.describe Summary::Components::Property, type: :component do
         )
       end
 
+      context 'when land' do
+        let(:property_type) { 'land' }
+
+        it 'renders correct percentage ownership text' do
+          expect(page).to have_summary_row(
+            'What percentage of the land do they own?',
+            '10.57%',
+          )
+        end
+      end
+
       context 'when other relationship' do
         let(:relationship) { 'other' }
 


### PR DESCRIPTION
## Description of change
Percentage ownership text for the residential property property owners form page was not matching design. This has been updated

## Link to relevant ticket
[CRIMAPP-678](https://dsdmoj.atlassian.net/browse/CRIMAPP-678)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="971" alt="Screenshot 2024-04-11 at 14 30 49" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/06980b98-10bc-4df9-868d-40603329b0ad">
<img width="971" alt="Screenshot 2024-04-11 at 14 31 08" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/0d523c4b-147c-440f-a6bf-8cf1186a6cf7">
<img width="971" alt="Screenshot 2024-04-11 at 14 38 29" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/c69f4bd6-5b6e-4fa0-a84e-de2200d25750">

## How to manually test the feature

1. Navigate to the 'Which assets does your client own or part-own inside or outside the UK?' page
2. Select Residential Property' Radio button'
3. Save and continue
4. Enter the required data selecting YES to the ‘Does anyone else own part of the property?’ question.
5. Save and continue
6. On the 'Other people who own your client’s residential property' page, verify the question text reads 'What percentage of the property do they own?'

Repeat the steps for the commercial property property owner screen. The question text should be 'What percentage of the property do they own?. 

Repeat the steps for the land property property owner screen. The question text should be 'What percentage of the **land** do they own?. 

[CRIMAPP-678]: https://dsdmoj.atlassian.net/browse/CRIMAPP-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ