### PR TITLE
[CRIMAPP-717] Update width of cya screens

### DIFF
--- a/app/views/steps/capital/answers/edit.html.erb
+++ b/app/views/steps/capital/answers/edit.html.erb
@@ -2,23 +2,21 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'shared/flash_banner' %>
-    <%= govuk_error_summary(@form_object) %>
+  <%= render partial: 'shared/flash_banner' %>
+  <%= govuk_error_summary(@form_object) %>
 
-    <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
+  <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
 
-    <h1 class="govuk-heading-xl">
-      <%=t '.heading' %>
-    </h1>
+  <h1 class="govuk-heading-xl">
+    <%=t '.heading' %>
+  </h1>
 
-    <%= render @presenter.capital_sections %>
+  <%= render @presenter.capital_sections %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.govuk_check_boxes_fieldset :has_no_other_assets, legend: { size: 'm' } do %>
-        <%= f.govuk_check_box :has_no_other_assets, YesNoAnswer::YES.to_s, multiple: false, label: { text: t('helpers.label.steps_capital_answers_form.has_no_other_assets') } %>
-      <% end %>
-      <%= f.continue_button %>
+  <%= step_form @form_object do |f| %>
+    <%= f.govuk_check_boxes_fieldset :has_no_other_assets, legend: { size: 'm' } do %>
+      <%= f.govuk_check_box :has_no_other_assets, YesNoAnswer::YES.to_s, multiple: false, label: { text: t('helpers.label.steps_capital_answers_form.has_no_other_assets') } %>
     <% end %>
-  </div>
+    <%= f.continue_button %>
+  <% end %>
 </div>

--- a/app/views/steps/income/answers/edit.html.erb
+++ b/app/views/steps/income/answers/edit.html.erb
@@ -2,21 +2,19 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'shared/flash_banner' %>
-    <%= govuk_error_summary(@form_object) %>
+  <%= render partial: 'shared/flash_banner' %>
+  <%= govuk_error_summary(@form_object) %>
 
-    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+  <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
 
-    <h1 class="govuk-heading-xl">
-      <%=t '.heading' %>
-    </h1>
+  <h1 class="govuk-heading-xl">
+    <%=t '.heading' %>
+  </h1>
 
-    <h1 class="govuk-heading-l"><%= t('.subheading') %></h1>
+  <h1 class="govuk-heading-l"><%= t('.subheading') %></h1>
 
-    <%= render @presenter.income_sections %>
-    <%= step_form @form_object do |f| %>
-      <%= f.continue_button %>
-    <% end %>
-  </div>
+  <%= render @presenter.income_sections %>
+  <%= step_form @form_object do |f| %>
+    <%= f.continue_button %>
+  <% end %>
 </div>

--- a/app/views/steps/outgoings/answers/edit.html.erb
+++ b/app/views/steps/outgoings/answers/edit.html.erb
@@ -2,22 +2,20 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'shared/flash_banner' %>
-    <%= govuk_error_summary(@form_object) %>
+  <%= render partial: 'shared/flash_banner' %>
+  <%= govuk_error_summary(@form_object) %>
 
-    <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
+  <span class="govuk-caption-xl"><%= t('steps.outgoings.caption') %></span>
 
-    <h1 class="govuk-heading-xl">
-      <%=t '.heading' %>
-    </h1>
+  <h1 class="govuk-heading-xl">
+    <%=t '.heading' %>
+  </h1>
 
-    <h1 class="govuk-heading-l"><%= t('.subheading') %></h1>
+  <h1 class="govuk-heading-l"><%= t('.subheading') %></h1>
 
-    <%= render @presenter.outgoings_sections %>
+  <%= render @presenter.outgoings_sections %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.continue_button %>
-    <% end %>
-  </div>
+  <%= step_form @form_object do |f| %>
+    <%= f.continue_button %>
+  <% end %>
 </div>


### PR DESCRIPTION
## Description of change
Update width of cya screens to be full screen like the review the application screen

## Link to relevant ticket
[CRIMAPP-717](https://dsdmoj.atlassian.net/browse/CRIMAPP-717)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1280" alt="Screenshot 2024-04-15 at 17 52 26" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/44006c92-d432-4e36-b349-ff2be1f0e676">
<img width="1280" alt="Screenshot 2024-04-15 at 17 52 33" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/6e707c3a-1774-460d-996c-8952744e021f">

## How to manually test the feature


[CRIMAPP-717]: https://dsdmoj.atlassian.net/browse/CRIMAPP-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ