### PR TITLE
[CRIAMPP-411] Add last_jsa_appointment_date field

### DIFF
--- a/app/forms/steps/client/benefit_type_form.rb
+++ b/app/forms/steps/client/benefit_type_form.rb
@@ -5,8 +5,15 @@ module Steps
       has_one_association :applicant
 
       attribute :benefit_type, :value_object, source: BenefitType
+      attribute :last_jsa_appointment_date, :multiparam_date
 
-      validates_inclusion_of :benefit_type, in: :choices
+      validates :benefit_type,
+                inclusion: { in: :choices }
+
+      validates :last_jsa_appointment_date,
+                multiparam_date: true,
+                presence: true,
+                if: -> { jsa? }
 
       def choices
         BenefitType.values
@@ -16,15 +23,26 @@ module Steps
 
       def changed?
         # The attribute is a `value_object`, overriding generic `#changed?`
-        !applicant.benefit_type.eql?(benefit_type.to_s)
+        !applicant.benefit_type.eql?(benefit_type.to_s) ||
+          !applicant.last_jsa_appointment_date.eql?(last_jsa_appointment_date)
       end
 
       def persist!
         return true unless changed?
 
         applicant.update(
-          attributes
+          attributes.merge(attributes_to_reset)
         )
+      end
+
+      def attributes_to_reset
+        {
+          'last_jsa_appointment_date' => (last_jsa_appointment_date if jsa?)
+        }
+      end
+
+      def jsa?
+        benefit_type&.jsa?
       end
     end
   end

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -43,6 +43,13 @@ module Summary
                        ))
         end
 
+        if jsa?
+          answers.push(Components::DateAnswer.new(
+                         :last_jsa_appointment_date, applicant.last_jsa_appointment_date,
+                         change_path: edit_steps_client_benefit_type_path
+                       ))
+        end
+
         answers.select(&:show?)
         answers
       end
@@ -64,6 +71,10 @@ module Summary
 
       def no_benefit?
         crime_application.applicant.benefit_type.nil?
+      end
+
+      def jsa?
+        crime_application.applicant.benefit_type == 'jsa'
       end
     end
   end

--- a/app/views/steps/client/benefit_type/edit.html.erb
+++ b/app/views/steps/client/benefit_type/edit.html.erb
@@ -8,8 +8,21 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset :benefit_type, legend: { tag: 'h1', size: 'xl' } do %>
         <% @form_object.choices.each_with_index do |option, index| %>
-          <%= f.govuk_radio_divider if option.none? %>
-          <%= f.govuk_radio_button :benefit_type, option, link_errors: index.zero? %>
+
+        <% if option.jsa? %>
+            <%= f.govuk_radio_button :benefit_type, option.value do %>
+              <%= f.govuk_date_field :last_jsa_appointment_date, maxlength_enabled: true,
+                                      legend: {
+                                        text: t('.last_jsa_appointment_date'),
+                                        size: 's', class: 'govuk-!-font-weight-regular'
+                                      } %>
+            <% end %>
+          <% elsif option.none? %>
+            <%= f.govuk_radio_divider %>
+            <%= f.govuk_radio_button :benefit_type, option, link_errors: index.zero? %>
+          <% else %>
+            <%= f.govuk_radio_button :benefit_type, option, link_errors: index.zero? %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -111,6 +111,20 @@ en:
           attributes:
             benefit_type:
               inclusion: Select a benefit type
+            last_jsa_appointment_date:
+              blank: Enter the date your client last attended an appointment with their JSA work coach
+              blank_day: Date your client last attended an appointment with their JSA work coach must include a day
+              blank_month: Date your client last attended an appointment with their JSA work coach must include a month
+              blank_year: Date your client last attended an appointment with their JSA work coach must include a year
+              blank_day_month: Date your client last attended an appointment with their JSA work coach must include a day and month
+              blank_day_year: Date your client last attended an appointment with their JSA work coach must include a day and year
+              blank_month_year: Date your client last attended an appointment with their JSA work coach must include a month and year
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date your client last attended an appointment with their JSA work coach is too far in the past
+              future_not_allowed: Date your client last attended an appointment with their JSA work coach must be today or in the past
         steps/client/has_benefit_evidence_form:
           attributes:
             has_benefit_evidence:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -164,6 +164,7 @@ en:
         nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       steps_client_benefit_type_form:
         benefit_type: This will help us review your application. It will not affect the DWP check.
+        last_jsa_appointment_date: This is sometimes known as ‘signing on’.
       steps_client_cannot_check_benefit_status_form:
         will_enter_nino_options:
           'no': You may not be able to submit your application without the National Insurance number

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -63,6 +63,7 @@ en:
       benefit_type:
         edit:
           page_title: Does your client get one of these passporting benefits?
+          last_jsa_appointment_date: Enter when your client last attended an appointment with their JSA work coach
       benefit_exit:
         show:
           page_title: Use eForms for this application

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -140,6 +140,8 @@ en:
           esa: Income-related Employment and Support Allowance (ESA)
           income_support: Income Support
           none: None
+      last_jsa_appointment_date:
+        question: Date of latest JSA appointment
       # END client details section
 
       # BEGIN contact details section

--- a/db/migrate/20240415145143_add_last_jsa_appointment_date_to_people.rb
+++ b/db/migrate/20240415145143_add_last_jsa_appointment_date_to_people.rb
@@ -1,0 +1,5 @@
+class AddLastJsaAppointmentDateToPeople < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :last_jsa_appointment_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_26_165829) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_15_145143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -250,6 +250,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_26_165829) do
     t.string "benefit_type"
     t.string "has_benefit_evidence"
     t.string "will_enter_nino"
+    t.date "last_jsa_appointment_date"
     t.index ["crime_application_id"], name: "index_people_on_crime_application_id", unique: true
   end
 

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -22,11 +22,12 @@ describe Summary::Sections::ClientDetails do
       date_of_birth: Date.new(1999, 1, 20),
       nino: nino,
       benefit_type: benefit_type,
+      last_jsa_appointment_date: Date.new(2024, 2, 21)
     )
   end
 
   let(:nino) { '123456' }
-  let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+  let(:benefit_type) { BenefitType::JSA.to_s }
   let(:application_type) { ApplicationType::INITIAL }
   let(:pse?) { false }
 
@@ -58,7 +59,7 @@ describe Summary::Sections::ClientDetails do
     let(:answers) { subject.answers }
 
     it 'has the correct rows' do
-      expect(answers.count).to eq(6)
+      expect(answers.count).to eq(7)
 
       expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
       expect(answers[0].question).to eq(:first_name)
@@ -77,7 +78,7 @@ describe Summary::Sections::ClientDetails do
 
       expect(answers[3]).to be_an_instance_of(Summary::Components::DateAnswer)
       expect(answers[3].question).to eq(:date_of_birth)
-      expect(answers[2].change_path).to match('applications/12345/steps/client/details')
+      expect(answers[3].change_path).to match('applications/12345/steps/client/details')
       expect(answers[3].value).to eq(Date.new(1999, 1, 20))
 
       expect(answers[4]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
@@ -88,7 +89,12 @@ describe Summary::Sections::ClientDetails do
       expect(answers[5]).to be_an_instance_of(Summary::Components::ValueAnswer)
       expect(answers[5].question).to eq(:passporting_benefit)
       expect(answers[5].change_path).to match('applications/12345/steps/client/benefit_type')
-      expect(answers[5].value).to eq('universal_credit')
+      expect(answers[5].value).to eq('jsa')
+
+      expect(answers[6]).to be_an_instance_of(Summary::Components::DateAnswer)
+      expect(answers[6].question).to eq(:last_jsa_appointment_date)
+      expect(answers[6].change_path).to match('applications/12345/steps/client/benefit_type')
+      expect(answers[6].value).to eq(Date.new(2024, 2, 21))
     end
 
     context 'when there is no `benefit_type` value' do
@@ -104,7 +110,7 @@ describe Summary::Sections::ClientDetails do
       let(:pse?) { true }
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(6)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Add last_jsa_appointment_date field

Modifies Benefit Type page to add a date field when JSA is selected. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-441
## Notes for reviewer
This is the modification to Apply only. No submission.
For some reason Benefit type is not persisting, but this is also not persisting on staging at the moment, so a bug ticket is being raised to look into that separately 

## Screenshots of changes (if applicable)

### Before changes:
<img width="777" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/6b063270-d09f-4462-9344-ef8b9b9ca682">
<img width="944" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/759ad759-0315-4f51-9e4b-30dda1f16957">

### After changes:
<img width="688" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/7ed51302-9554-4363-8b2e-479f51e085ac">
<img width="952" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/8f58d212-8736-4566-8e91-8b426c2febc1">


## How to manually test the feature
Run migration
Create an application with JSA benefit type
Do not enter date, attempt form submit, check error message shows
Check any other date validations you want (no day, no month, year in future, year in 1800, day = 34 etc)
Put in valid date and click save and continue
Navigate to /submission/review, check Date is in the Client details section after benefit type - check copy against designs. 
Hit change link on date - check navigates to client/benefit_type
Change benefit type, make sure form submits, 
Navigate to /submission/review, check Date row is NOT in the Client details section after benefit type
(Can check data to make sure last_jsa_apt_date is nil)
