### PR TITLE
CRIMAPP-721 warn about incomplete records on CYA and submission review

### DIFF
--- a/app/controllers/steps/submission/review_controller.rb
+++ b/app/controllers/steps/submission/review_controller.rb
@@ -1,15 +1,19 @@
 module Steps
   module Submission
     class ReviewController < Steps::SubmissionStepController
-      include Steps::NoOpAdvanceStep
-
       before_action :set_presenter
 
-      private
-
-      def advance_as
-        :review
+      def edit
+        @form_object = ReviewForm.build(
+          current_crime_application
+        )
       end
+
+      def update
+        update_and_advance(ReviewForm, as: :review)
+      end
+
+      private
 
       def set_presenter
         @presenter = Summary::HtmlPresenter.new(

--- a/app/forms/steps/capital/answers_form.rb
+++ b/app/forms/steps/capital/answers_form.rb
@@ -3,7 +3,9 @@ module Steps
     class AnswersForm < Steps::BaseFormObject
       attribute :has_no_other_assets
 
-      validates_with CapitalAssessment::ConfirmationValidator
+      validate do
+        CapitalAssessment::ConfirmationValidator.new(self).validate
+      end
 
       delegate :capital, to: :crime_application
 

--- a/app/forms/steps/capital/answers_form.rb
+++ b/app/forms/steps/capital/answers_form.rb
@@ -3,11 +3,12 @@ module Steps
     class AnswersForm < Steps::BaseFormObject
       attribute :has_no_other_assets
 
-      validates :has_no_other_assets, presence: true
-      validates :has_no_other_assets, inclusion: { in: [YesNoAnswer::YES.to_s] }
+      validates_with CapitalAssessment::ConfirmationValidator
+
+      delegate :capital, to: :crime_application
 
       def persist!
-        record.update(attributes)
+        record.valid?(:check_answers) && record.update(attributes)
       end
     end
   end

--- a/app/forms/steps/case/charges_summary_form.rb
+++ b/app/forms/steps/case/charges_summary_form.rb
@@ -18,7 +18,7 @@ module Steps
       private
 
       def all_charges_have_details
-        errors.add(:add_offence, :missing_details) unless charges.all?(&:complete?)
+        errors.add(:base, :missing_details) unless charges.all?(&:complete?)
       end
 
       # NOTE: this step is not persisting anything to DB.

--- a/app/forms/steps/submission/review_form.rb
+++ b/app/forms/steps/submission/review_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Submission
+    class ReviewForm < Steps::BaseFormObject
+      def persist!
+        crime_application.valid?(:submission)
+      end
+    end
+  end
+end

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -8,6 +8,24 @@ class Capital < ApplicationRecord
   has_many :national_savings_certificates, through: :crime_application
   has_many :properties, through: :crime_application
 
-  validates_with CapitalAssessment::AnswersValidator, on: [:submission, :check_answers]
-  validates_with CapitalAssessment::ConfirmationValidator, on: :submission
+  validate on: :submission do
+    answers_validator.validate
+    confirmation_validator.validate
+  end
+
+  validate on: :check_answers do
+    answers_validator.validate
+  end
+
+  def complete?
+    confirmation_validator.confirmed? && answers_validator.all_complete?
+  end
+
+  def confirmation_validator
+    @confirmation_validator ||= CapitalAssessment::ConfirmationValidator.new(self)
+  end
+
+  def answers_validator
+    @answers_validator ||= CapitalAssessment::AnswersValidator.new(self)
+  end
 end

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -7,4 +7,7 @@ class Capital < ApplicationRecord
   has_many :investments, through: :crime_application
   has_many :national_savings_certificates, through: :crime_application
   has_many :properties, through: :crime_application
+
+  validates_with CapitalAssessment::AnswersValidator, on: [:submission, :check_answers]
+  validates_with CapitalAssessment::ConfirmationValidator, on: :submission
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -16,17 +16,29 @@ class Case < ApplicationRecord
               mapping: %i[hearing_court_name name],
               constructor: :find_by_name, allow_nil: true
 
+  validates_with CaseDetails::AnswersValidator, on: [:check_answers, :submission]
+
   def complete?
     case_hearing_attributes_present? &&
       case_concluded_attributes_present? &&
       client_remanded_attributes_present? &&
-      preorder_work_attributes_present?
+      preorder_work_attributes_present? &&
+      all_codefendants_complete? &&
+      all_charges_complete?
   end
 
   private
 
   def case_hearing_attributes_present?
     values_at(:hearing_court_name, :hearing_date).all?(&:present?)
+  end
+
+  def all_codefendants_complete?
+    codefendants.all?(&:complete?)
+  end
+
+  def all_charges_complete?
+    charges.all?(&:complete?)
   end
 
   def case_concluded_attributes_present?

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -1,0 +1,39 @@
+module TypeOfMeansAssessment
+  extend ActiveSupport::Concern
+
+  delegate :kase, :income, :income_payments, :income_benefits, :capital, to: :crime_application
+
+  def requires_full_means_assessment?
+    if income_below_threshold? && no_frozen_assets?
+      !(summary_only? || (no_property? && no_savings?))
+    else
+      true
+    end
+  end
+
+  def requires_full_capital?
+    [
+      CaseType::EITHER_WAY,
+      CaseType::INDICTABLE,
+      CaseType::ALREADY_IN_CROWN_COURT
+    ].include?(CaseType.new(kase.case_type))
+  end
+
+  private
+
+  def no_property?
+    income.client_owns_property == 'no'
+  end
+
+  def no_savings?
+    income.has_savings == 'no'
+  end
+
+  def no_frozen_assets?
+    income.has_frozen_income_or_assets == 'no'
+  end
+
+  def income_below_threshold?
+    income.income_above_threshold == 'no'
+  end
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -5,6 +5,7 @@ class CrimeApplication < ApplicationRecord
   attr_readonly :application_type
 
   has_one :case, dependent: :destroy
+  alias kase case
 
   has_one :applicant, dependent: :destroy
   has_one :partner, dependent: :destroy

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -55,6 +55,8 @@ class Property < ApplicationRecord
   end
 
   def complete?
+    return false unless property_type
+
     values_at(*REQUIRED_ATTRIBUTES[property_type.to_sym]).all?(&:present?) &&
       address_complete? && property_owners_complete?
   end

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -52,6 +52,8 @@ module Summary
 
       private
 
+      delegate :kase, to: :crime_application
+
       # :nocov:
       def answers
         raise 'must be implemented in subclasses'

--- a/app/presenters/summary/sections/capital_loop_base.rb
+++ b/app/presenters/summary/sections/capital_loop_base.rb
@@ -1,8 +1,10 @@
 module Summary
   module Sections
     class CapitalLoopBase < Sections::BaseSection
+      include TypeOfMeansAssessment
+
       def show?
-        capital && requires_full_capital
+        capital && requires_full_capital?
       end
 
       def answers
@@ -34,14 +36,6 @@ module Summary
 
       def capital
         @capital ||= crime_application.capital
-      end
-
-      def requires_full_capital
-        [
-          CaseType::EITHER_WAY.to_s,
-          CaseType::INDICTABLE.to_s,
-          CaseType::ALREADY_IN_CROWN_COURT.to_s
-        ].include?(crime_application.case.case_type)
       end
 
       def absence_answer

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -98,9 +98,7 @@ module Summary
 
       private
 
-      def kase
-        @kase ||= crime_application.case
-      end
+      delegate :kase, to: :crime_application
 
       def appeal_case_type?
         return false unless kase&.case_type

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -98,8 +98,6 @@ module Summary
 
       private
 
-      delegate :kase, to: :crime_application
-
       def appeal_case_type?
         return false unless kase&.case_type
 

--- a/app/presenters/summary/sections/codefendants.rb
+++ b/app/presenters/summary/sections/codefendants.rb
@@ -17,10 +17,6 @@ module Summary
 
       private
 
-      def kase
-        @kase ||= crime_application.case
-      end
-
       def codefendants
         @codefendants ||= kase.codefendants
       end

--- a/app/presenters/summary/sections/first_court_hearing.rb
+++ b/app/presenters/summary/sections/first_court_hearing.rb
@@ -13,12 +13,6 @@ module Summary
           ),
         ].select(&:show?)
       end
-
-      private
-
-      def kase
-        @kase ||= crime_application.case
-      end
     end
   end
 end

--- a/app/presenters/summary/sections/next_court_hearing.rb
+++ b/app/presenters/summary/sections/next_court_hearing.rb
@@ -25,12 +25,6 @@ module Summary
         ].select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength
-
-      private
-
-      def kase
-        @kase ||= crime_application.case
-      end
     end
   end
 end

--- a/app/presenters/summary/sections/offences.rb
+++ b/app/presenters/summary/sections/offences.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class Offences < Sections::BaseSection
       def show?
-        crime_application.case.present? && super
+        crime_application.kase.present? && super
       end
 
       def answers
@@ -18,7 +18,7 @@ module Summary
       private
 
       def offences
-        @offences ||= crime_application.case.charges
+        @offences ||= crime_application.kase.charges
       end
     end
   end

--- a/app/presenters/summary/sections/overview.rb
+++ b/app/presenters/summary/sections/overview.rb
@@ -56,7 +56,7 @@ module Summary
       end
 
       def show_overview_details?
-        crime_application.case.present?
+        crime_application.kase.present?
       end
     end
   end

--- a/app/presenters/tasks/case_details.rb
+++ b/app/presenters/tasks/case_details.rb
@@ -12,13 +12,15 @@ module Tasks
       fulfilled?(ClientDetails)
     end
 
+    delegate :kase, to: :crime_application
+
     # If we have a `case` record we consider this in progress
     def in_progress?
-      crime_application.case.present?
+      kase.present?
     end
 
     def completed?
-      crime_application.case.complete?
+      kase.complete?
     end
   end
 end

--- a/app/serializers/submission_serializer/sections/base_section.rb
+++ b/app/serializers/submission_serializer/sections/base_section.rb
@@ -34,6 +34,8 @@ module SubmissionSerializer
         raise 'must be implemented in subclasses'
       end
       # :nocov:
+
+      delegate :kase, to: :crime_application
     end
   end
 end

--- a/app/serializers/submission_serializer/sections/case_details.rb
+++ b/app/serializers/submission_serializer/sections/case_details.rb
@@ -36,10 +36,6 @@ module SubmissionSerializer
 
       private
 
-      def kase
-        @kase ||= crime_application.case
-      end
-
       def case_type
         if appeal_to_crown_court_case? && financial_circumstances_changed?
           return CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES.to_s

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -19,6 +19,8 @@ module Adapters
         Structs::CaseDetails.new(case_details)
       end
 
+      alias kase case
+
       def ioj
         Structs::InterestsOfJustice.new(interests_of_justice)
       end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -1,6 +1,8 @@
 module Decisions
   class IncomeDecisionTree < BaseDecisionTree # rubocop:disable Metrics/ClassLength
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
+    #
+    include TypeOfMeansAssessment
 
     def destination
       case step_name
@@ -124,7 +126,7 @@ module Decisions
     end
 
     def determine_showing_no_income_page
-      if payments.empty?
+      if income_payments.empty? && income_benefits.empty?
         edit(:manage_without_income)
       else
         edit(:answers)
@@ -139,45 +141,19 @@ module Decisions
       form_object.ended_employment_within_three_months&.yes?
     end
 
+    delegate :kase, :income, :income_payments, :income_benefits, to: :crime_application
+
     def appeal_no_changes?
-      crime_application.case.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s &&
-        crime_application.case.appeal_financial_circumstances_changed == 'no'
+      kase.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s &&
+        kase.appeal_financial_circumstances_changed == 'no'
     end
 
     def summary_only?
-      crime_application.case.case_type == CaseType::SUMMARY_ONLY.to_s
-    end
-
-    def income_below_threshold?
-      crime_application.income.income_above_threshold == 'no'
-    end
-
-    def no_frozen_assets?
-      crime_application.income.has_frozen_income_or_assets == 'no'
-    end
-
-    def no_property?
-      crime_application.income.client_owns_property == 'no'
-    end
-
-    def no_savings?
-      crime_application.income.has_savings == 'no'
-    end
-
-    def payments
-      crime_application.income_payments + crime_application.income_benefits
+      kase.case_type == CaseType::SUMMARY_ONLY.to_s
     end
 
     def crime_application
       form_object.crime_application
-    end
-
-    def requires_full_means_assessment?
-      if income_below_threshold? && no_frozen_assets?
-        !(summary_only? || (no_property? && no_savings?))
-      else
-        true
-      end
     end
 
     def determine_continuing_means_journey

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -141,8 +141,6 @@ module Decisions
       form_object.ended_employment_within_three_months&.yes?
     end
 
-    delegate :kase, :income, :income_payments, :income_benefits, to: :crime_application
-
     def appeal_no_changes?
       kase.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s &&
         kase.appeal_financial_circumstances_changed == 'no'

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -49,9 +49,9 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
   end
 
   def all_sections_complete?
-    return false if requires_full_means_assessment? && !capital&.valid?(:submission)
+    return false if requires_full_means_assessment? && !capital&.complete?
 
-    kase.valid?(:submission)
+    kase.complete?
   end
 
   alias crime_application record

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -1,4 +1,6 @@
 class ApplicationFulfilmentValidator < BaseFulfilmentValidator
+  include TypeOfMeansAssessment
+
   private
 
   # More validations can be added here
@@ -13,7 +15,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
       ]
     end
 
-    if record.is_means_tested == 'yes' && record.case.case_type.nil?
+    if record.is_means_tested == 'yes' && kase.case_type.nil?
       errors << [
         :base, :case_type_missing, { change_path: edit_steps_client_case_type_path }
       ]
@@ -25,6 +27,12 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
       ]
     end
 
+    unless all_sections_complete?
+      errors << [
+        :base, :incomplete_records, { change_path: edit_steps_submission_review_path }
+      ]
+    end
+
     errors
   end
 
@@ -33,10 +41,18 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
   end
 
   def means_record_present?
-    record.income.present? && record.income&.employment_status&.include?('not_working')
+    income.present? && income&.employment_status&.include?('not_working')
   end
 
   def client_remanded_in_custody?
-    (record.case.is_client_remanded == 'yes') && record.case.date_client_remanded.present?
+    kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
   end
+
+  def all_sections_complete?
+    return false if requires_full_means_assessment? && !capital&.valid?(:submission)
+
+    kase.valid?(:submission)
+  end
+
+  alias crime_application record
 end

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -1,21 +1,20 @@
 module CapitalAssessment
-  class AnswersValidator < ActiveModel::Validator
-    def validate(record)
-      record.errors.add :base, :incomplete_records if any_incomplete_records?(record)
+  class AnswersValidator
+    def initialize(record)
+      @record = record
     end
 
-    private
+    attr_reader :record
 
-    def any_incomplete_records?(capital)
-      incomplete?(capital.properties) ||
-        incomplete?(capital.savings) ||
-        incomplete?(capital.investments) ||
-        incomplete?(capital.national_savings_certificates) ||
-        incomplete?(capital.national_savings_certificates)
+    def validate
+      record.errors.add :base, :incomplete_records unless all_complete?
     end
 
-    def incomplete?(records)
-      records.any? { |p| !p.complete? }
+    def all_complete? # rubocop:disable Metrics/CyclomaticComplexity
+      record.properties.all?(&:complete?) &&
+        record.savings.all?(&:complete?) &&
+        record.investments.all?(&:complete?) &&
+        record.national_savings_certificates.all?(&:complete?)
     end
   end
 end

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -1,0 +1,21 @@
+module CapitalAssessment
+  class AnswersValidator < ActiveModel::Validator
+    def validate(record)
+      record.errors.add :base, :incomplete_records if any_incomplete_records?(record)
+    end
+
+    private
+
+    def any_incomplete_records?(capital)
+      incomplete?(capital.properties) ||
+        incomplete?(capital.savings) ||
+        incomplete?(capital.investments) ||
+        incomplete?(capital.national_savings_certificates) ||
+        incomplete?(capital.national_savings_certificates)
+    end
+
+    def incomplete?(records)
+      records.any? { |p| !p.complete? }
+    end
+  end
+end

--- a/app/validators/capital_assessment/confirmation_validator.rb
+++ b/app/validators/capital_assessment/confirmation_validator.rb
@@ -1,12 +1,16 @@
 module CapitalAssessment
-  class ConfirmationValidator < ActiveModel::Validator
-    def validate(record)
-      record.errors.add :has_no_other_assets, :blank unless confirmed?(record)
+  class ConfirmationValidator
+    def initialize(record)
+      @record = record
     end
 
-    private
+    attr_reader :record
 
-    def confirmed?(record)
+    def validate
+      record.errors.add :has_no_other_assets, :blank unless confirmed?
+    end
+
+    def confirmed?
       record.has_no_other_assets == YesNoAnswer::YES.to_s
     end
   end

--- a/app/validators/capital_assessment/confirmation_validator.rb
+++ b/app/validators/capital_assessment/confirmation_validator.rb
@@ -1,0 +1,13 @@
+module CapitalAssessment
+  class ConfirmationValidator < ActiveModel::Validator
+    def validate(record)
+      record.errors.add :has_no_other_assets, :blank unless confirmed?(record)
+    end
+
+    private
+
+    def confirmed?(record)
+      record.has_no_other_assets == YesNoAnswer::YES.to_s
+    end
+  end
+end

--- a/app/validators/case_details/answers_validator.rb
+++ b/app/validators/case_details/answers_validator.rb
@@ -1,0 +1,7 @@
+module CaseDetails
+  class AnswersValidator < ActiveModel::Validator
+    def validate(record)
+      record.errors.add :base, :incomplete_records unless record.complete?
+    end
+  end
+end

--- a/app/views/shared/_submission_error_warning.html.erb
+++ b/app/views/shared/_submission_error_warning.html.erb
@@ -1,9 +1,0 @@
-<% unless record.valid?(:check_answers) %>
-  <div class="govuk-error-summary">
-    <% record.errors.each do |e| %>
-      <h2 class="govuk-error-summary__title govuk-!-margin-bottom-0">
-        <%= e.message %>
-      </h2>
-    <% end %>
-  </div>
-<% end %>

--- a/app/views/shared/_submission_error_warning.html.erb
+++ b/app/views/shared/_submission_error_warning.html.erb
@@ -1,0 +1,9 @@
+<% unless record.valid?(:check_answers) %>
+  <div class="govuk-error-summary">
+    <% record.errors.each do |e| %>
+      <h2 class="govuk-error-summary__title govuk-!-margin-bottom-0">
+        <%= e.message %>
+      </h2>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/steps/capital/answers/edit.html.erb
+++ b/app/views/steps/capital/answers/edit.html.erb
@@ -5,7 +5,15 @@
   <div class="govuk-grid-column">
     <%= render partial: 'shared/flash_banner' %>
 
-    <%= render partial: 'shared/submission_error_warning', locals: { record: @form_object.capital } %>
+    <% unless @form_object.capital.valid?(:check_answers) %>
+      <div class="govuk-error-summary">
+        <% @form_object.capital.errors.each do |e| %>
+          <h2 class="govuk-error-summary__title govuk-!-margin-bottom-0">
+            <%= e.message %>
+          </h2>
+        <% end %>
+      </div>
+    <% end %>
 
     <%= govuk_error_summary(@form_object) %>
 

--- a/app/views/steps/capital/answers/edit.html.erb
+++ b/app/views/steps/capital/answers/edit.html.erb
@@ -2,8 +2,11 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column">
     <%= render partial: 'shared/flash_banner' %>
+
+    <%= render partial: 'shared/submission_error_warning', locals: { record: @form_object.capital } %>
+
     <%= govuk_error_summary(@form_object) %>
 
     <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
@@ -15,8 +18,8 @@
     <%= render @presenter.capital_sections %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_check_boxes_fieldset :has_no_other_assets, legend: { size: 'm' } do %>
-        <%= f.govuk_check_box :has_no_other_assets, YesNoAnswer::YES.to_s, multiple: false, label: { text: t('helpers.label.steps_capital_answers_form.has_no_other_assets') } %>
+      <%= f.govuk_check_boxes_fieldset :has_no_other_assets, multiple: false do %>
+        <%= f.govuk_check_box :has_no_other_assets, YesNoAnswer::YES, multiple: false, link_errors: true %>
       <% end %>
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/capital/savings/confirm_destroy.html.erb
+++ b/app/views/steps/capital/savings/confirm_destroy.html.erb
@@ -2,7 +2,7 @@
 <% step_header(path: edit_steps_capital_savings_summary_path) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column">
     <h1 class="govuk-heading-xl">
       <%=t '.heading' %>
     </h1>

--- a/app/views/steps/income/answers/edit.html.erb
+++ b/app/views/steps/income/answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column">
     <%= render partial: 'shared/flash_banner' %>
     <%= govuk_error_summary(@form_object) %>
 

--- a/app/views/steps/outgoings/answers/edit.html.erb
+++ b/app/views/steps/outgoings/answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column">
     <%= render partial: 'shared/flash_banner' %>
     <%= govuk_error_summary(@form_object) %>
 

--- a/app/views/steps/shared/_ownership_form_fields.html.erb
+++ b/app/views/steps/shared/_ownership_form_fields.html.erb
@@ -1,7 +1,7 @@
 <% if f.object.include_partner? %>
   <%= f.govuk_collection_radio_buttons :ownership_type, OwnershipType.values, :value, legend: { size: 's' } %>
 <% else %>
-  <%= f.govuk_check_boxes_fieldset :confirm_in_applicants_name, legend: { size: 'm' } do %>
-  <%= f.govuk_check_box :confirm_in_applicants_name, true, multiple: false %>
+  <%= f.govuk_check_boxes_fieldset :confirm_in_applicants_name, multiple: false do %>
+    <%= f.govuk_check_box :confirm_in_applicants_name, true, multiple: false, link_errors: true %>
   <% end %>
 <% end %>

--- a/app/views/steps/submission/review/edit.html.erb
+++ b/app/views/steps/submission/review/edit.html.erb
@@ -3,7 +3,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column">
-    <%= govuk_error_summary(@form_object) %>
+    <% unless current_crime_application.valid?(:submission) %>
+      <div class="govuk-error-summary">
+        <% current_crime_application.errors.each do |e| %>
+          <h2 class="govuk-error-summary__title govuk-!-margin-bottom-0">
+            <%= e.message %>
+          </h2>
+        <% end %>
+      </div>
+    <% end %>
 
     <h1 class="govuk-heading-xl"><%= t('.heading')%></h1>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -12,6 +12,7 @@ en:
       models:
         # fulfillment validation errors
         crime_application:
+          incomplete_records: You need to complete all questions before you can submit the application
           attributes:
             base:
               case_type_missing: A case type needs to be selected
@@ -21,6 +22,8 @@ en:
               blank: Justification for legal aid needs to be completed
             documents:
               blank: Upload supporting evidence
+        capital:
+          incomplete_records: You need to complete all questions before you can submit the application
         # evidence upload data model
         document:
           attributes:
@@ -264,9 +267,10 @@ en:
               blank: Enter or select an offence
         steps/case/charges_summary_form:
           attributes:
+            base:
+              missing_details: You must complete all offence details in order to proceed
             add_offence:
               inclusion: Select yes if you want to add another offence
-              missing_details: You must complete all offence details in order to proceed
         steps/case/offence_date_fieldset_form:
           shared_date_errors: &shared_date_errors
             blank: Date cannot be blank
@@ -735,6 +739,8 @@ en:
         steps/capital/frozen_income_savings_assets_form: *FROZEN_INCOME_ASSETS_VALIDATION
         steps/capital/answers_form:
           attributes:
+            base:
+              incomplete_records: You need to complete all questions before you can submit the application
             has_no_other_assets:
               blank: Confirm your client has no other assets or capital
         steps/submission/more_information_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -683,5 +683,6 @@ en:
           percentage_owned_commercial: *percentage_owned_text
       steps_capital_frozen_income_savings_assets_form:
         has_frozen_income_or_assets_options: *YESNO
-      steps_capital_answers_form: # TODO :: NOT WORKING
-        has_no_other_assets: My client confirms they have no other assets or capital
+      steps_capital_answers_form:
+        has_no_other_assets_options: 
+          'yes': My client confirms they have no other assets or capital

--- a/spec/controllers/steps/submission/review_controller_spec.rb
+++ b/spec/controllers/steps/submission/review_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Submission::ReviewController, type: :controller do
-  it_behaves_like 'a no-op advance step controller', :review, Decisions::SubmissionDecisionTree
+  it_behaves_like 'a generic step controller', Steps::Submission::ReviewForm, Decisions::SubmissionDecisionTree
 end

--- a/spec/forms/steps/capital/answers_form_spec.rb
+++ b/spec/forms/steps/capital/answers_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Steps::Capital::AnswersForm do
 
       it 'updates capital record' do
         expect(capital).to receive(:update).and_return(true)
-        expect(subject.save).to be(true)
+        expect(subject.save!).to be(true)
       end
     end
   end
@@ -45,12 +45,10 @@ RSpec.describe Steps::Capital::AnswersForm do
       end
     end
 
-    context 'when `has_no_other_assets` is `yes` but capital is not valid for submission' do
+    context 'when `has_no_other_assets` is `yes` but answers are incomplete' do
       let(:attributes) { { has_no_other_assets: YesNoAnswer::YES.to_s } }
 
-      before do
-        allow(capital).to receive(:valid?).with(:check_answers).and_return(false)
-      end
+      before { capital.properties.build }
 
       it 'updates capital record' do
         expect(capital).not_to receive(:update)

--- a/spec/forms/steps/capital/answers_form_spec.rb
+++ b/spec/forms/steps/capital/answers_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Steps::Capital::AnswersForm do
 
   let(:attributes) { {} }
 
-  let(:crime_application) { instance_double(CrimeApplication, capital:) }
+  let(:crime_application) { CrimeApplication.new(capital:) }
   let(:capital) { Capital.new }
 
   context 'with valid attributes' do
@@ -40,6 +40,19 @@ RSpec.describe Steps::Capital::AnswersForm do
       let(:attributes) { { has_no_other_assets: nil } }
 
       it 'does not update capital record' do
+        expect(capital).not_to receive(:update)
+        expect(subject.save).to be(false)
+      end
+    end
+
+    context 'when `has_no_other_assets` is `yes` but capital is not valid for submission' do
+      let(:attributes) { { has_no_other_assets: YesNoAnswer::YES.to_s } }
+
+      before do
+        allow(capital).to receive(:valid?).with(:check_answers).and_return(false)
+      end
+
+      it 'updates capital record' do
         expect(capital).not_to receive(:update)
         expect(subject.save).to be(false)
       end

--- a/spec/forms/steps/case/charges_summary_form_spec.rb
+++ b/spec/forms/steps/case/charges_summary_form_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Steps::Case::ChargesSummaryForm do
 
         it 'has a validation error' do
           expect(subject).not_to be_valid
-          expect(subject.errors.of_kind?(:add_offence, :missing_details)).to be(true)
+          expect(subject.errors.of_kind?(:base, :missing_details)).to be(true)
         end
 
         it 'returns false' do

--- a/spec/forms/steps/submission/review_form_spec.rb
+++ b/spec/forms/steps/submission/review_form_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Submission::ReviewForm do
+  subject { described_class.new(arguments) }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:arguments) { { crime_application: } }
+
+  describe '#save' do
+    context 'when no submission validation issues' do
+      before do
+        allow(crime_application).to receive(:valid?).with(:submission).and_return(true)
+      end
+
+      it 'succeeds' do
+        expect(subject.save).to be true
+      end
+    end
+
+    context 'when submission validation issues' do
+      before do
+        allow(crime_application).to receive(:valid?).with(:submission).and_return(false)
+      end
+
+      it 'fails to save' do
+        expect(subject.save).to be false
+      end
+    end
+  end
+end

--- a/spec/models/capital_spec.rb
+++ b/spec/models/capital_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.describe Capital, type: :model do
+  subject(:instance) { described_class.new(attributes) }
+
+  let(:attributes) do
+    { crime_application: CrimeApplication.new, has_no_other_assets: has_no_other_assets }
+  end
+
+  let(:has_no_other_assets) { nil }
+
+  describe '#confirmed?' do
+    subject(:confirmed?) { instance.confirmation_validator.confirmed? }
+
+    context 'when has_no_other_assets nil' do
+      it { is_expected.to be false }
+    end
+
+    context 'when has_no_other_assets no' do
+      let(:has_no_other_assets) { 'onotherstring' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when has_no_other_assets true' do
+      let(:has_no_other_assets) { 'yes' }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#complete?' do
+    subject(:complete?) { instance.complete? }
+
+    context 'when #confirmed?' do
+      let(:has_no_other_assets) { 'yes' }
+
+      it { is_expected.to be true }
+
+      context 'when has incomplete answers' do
+        before { instance.national_savings_certificates.build }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#all_answers_complete?' do
+    subject(:all_answers_complete?) { instance.answers_validator.all_complete? }
+
+    context 'when empty records' do
+      it { is_expected.to be true }
+    end
+
+    context 'with in incomplete property' do
+      before { instance.properties.build }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with an incomplete saving' do
+      before { instance.savings.build }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with an incomplete investment' do
+      before { instance.investments.build }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with an incomplete national_savings_certificates' do
+      before { instance.national_savings_certificates.build }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with a complete national_savings_certificates' do
+      before do
+        allow(instance).to receive(:national_savings_certificates) {
+          [double(NationalSavingsCertificate, complete?: true)]
+        }
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe 'valid?(:check_answers)' do
+    subject(:valid?) { instance.valid?(:check_answers) }
+
+    context 'when not confirmed' do
+      it { is_expected.to be true }
+    end
+
+    context 'when some answers are incomplete' do
+      before { instance.properties.build }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe 'valid?(:submission)' do
+    subject(:valid?) { instance.valid?(:submission) }
+
+    context 'when not confirmed' do
+      it { is_expected.to be false }
+    end
+
+    context 'when confirmed' do
+      let(:has_no_other_assets) { 'yes' }
+
+      context 'and without incomplete answers' do
+        it { is_expected.to be true }
+      end
+
+      context 'when some answers are incomplete' do
+        before { instance.properties.build }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -1,9 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Case, type: :model do
-  subject { described_class.new(attributes) }
+  subject(:instance) { described_class.new(attributes) }
 
   let(:attributes) { {} }
+
+  let(:case_attributes) do
+    {
+      crime_application: CrimeApplication.new,
+      hearing_court_name: 'court name',
+      hearing_date: Time.zone.today,
+      is_first_court_hearing: nil,
+      first_court_hearing_name: nil,
+      has_case_concluded: nil,
+      date_case_concluded: nil,
+      is_client_remanded: nil,
+      date_client_remanded: nil,
+      is_preorder_work_claimed: nil,
+      preorder_work_date: nil,
+      preorder_work_details: nil
+    }
+  end
 
   describe '#hearing_court' do
     let(:attributes) { { hearing_court_name: court_name } }
@@ -63,22 +80,6 @@ RSpec.describe Case, type: :model do
 
   # rubocop:disable RSpec/PredicateMatcher
   describe 'complete?' do
-    let(:case_attributes) do
-      {
-        hearing_court_name: 'court name',
-        hearing_date: Time.zone.today,
-        is_first_court_hearing: nil,
-        first_court_hearing_name: nil,
-        has_case_concluded: nil,
-        date_case_concluded: nil,
-        is_client_remanded: nil,
-        date_client_remanded: nil,
-        is_preorder_work_claimed: nil,
-        preorder_work_date: nil,
-        preorder_work_details: nil
-      }
-    end
-
     context 'case hearing attributes' do
       let(:attributes) { case_attributes }
 
@@ -173,4 +174,23 @@ RSpec.describe Case, type: :model do
     end
   end
   # rubocop:enable RSpec/PredicateMatcher
+
+  describe 'valid?(:submission)' do
+    subject(:valid?) { instance.valid?(:submission) }
+
+    context 'when not complete?' do
+      it { is_expected.to be false }
+
+      it 'has errors on base' do
+        valid?
+        expect(instance.errors.of_kind?(:base, :incomplete_records)).to be(true)
+      end
+    end
+
+    context 'when complete?' do
+      let(:attributes) { case_attributes }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -9,7 +9,7 @@ describe Summary::HtmlPresenter do
 
   let(:database_application) do
     instance_double(
-      CrimeApplication, applicant: double, case: (double case_type: 'either_way'), ioj: double, status: :in_progress,
+      CrimeApplication, applicant: double, kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
       income: double, income_payments: [double], income_benefits: [double], outgoings: double, documents: double,
       application_type: application_type, capital: (double has_premium_bonds: 'yes'), savings: [double],
       investments: [double], national_savings_certificates: [double], properties: [double]

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -8,7 +8,7 @@ describe Summary::Sections::CaseDetails do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      case: kase,
+      kase: kase,
     )
   end
 

--- a/spec/presenters/summary/sections/codefendants_spec.rb
+++ b/spec/presenters/summary/sections/codefendants_spec.rb
@@ -7,7 +7,7 @@ describe Summary::Sections::Codefendants do
     instance_double(
       CrimeApplication,
       in_progress?: true,
-      case: kase,
+      kase: kase,
     )
   end
 

--- a/spec/presenters/summary/sections/first_court_hearing_spec.rb
+++ b/spec/presenters/summary/sections/first_court_hearing_spec.rb
@@ -7,7 +7,7 @@ describe Summary::Sections::FirstCourtHearing do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      case: kase,
+      kase: kase,
     )
   end
 

--- a/spec/presenters/summary/sections/investments_spec.rb
+++ b/spec/presenters/summary/sections/investments_spec.rb
@@ -5,7 +5,7 @@ describe Summary::Sections::Investments do
 
   let(:crime_application) {
     instance_double(CrimeApplication, investments: records, in_progress?: true, capital: double,
-   case: (double case_type:), to_param: 12_345)
+   kase: (double case_type:), to_param: 12_345)
   }
   let(:records) { [Investment.new] }
   let(:case_type) { 'either_way' }

--- a/spec/presenters/summary/sections/national_savings_certificates_spec.rb
+++ b/spec/presenters/summary/sections/national_savings_certificates_spec.rb
@@ -3,10 +3,17 @@ require 'rails_helper'
 describe Summary::Sections::NationalSavingsCertificates do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) {
-    instance_double(CrimeApplication, national_savings_certificates: records, in_progress?: true, capital: double,
-case: (double case_type:), to_param: 12_345)
-  }
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      national_savings_certificates: records,
+      in_progress?: true,
+      capital: double,
+      kase: (double case_type:),
+      to_param: 12_345
+    )
+  end
+
   let(:records) { [NationalSavingsCertificate.new] }
   let(:case_type) { 'either_way' }
 

--- a/spec/presenters/summary/sections/next_court_hearing_spec.rb
+++ b/spec/presenters/summary/sections/next_court_hearing_spec.rb
@@ -7,7 +7,7 @@ describe Summary::Sections::NextCourtHearing do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      case: kase,
+      kase: kase,
     )
   end
 

--- a/spec/presenters/summary/sections/offences_spec.rb
+++ b/spec/presenters/summary/sections/offences_spec.rb
@@ -6,7 +6,7 @@ describe Summary::Sections::Offences do
   let(:crime_application) do
     instance_double(
       CrimeApplication,
-      case: kase,
+      kase: kase,
       in_progress?: true
     )
   end

--- a/spec/presenters/summary/sections/overview_spec.rb
+++ b/spec/presenters/summary/sections/overview_spec.rb
@@ -19,7 +19,7 @@ describe Summary::Sections::Overview do
   let(:status) { :submitted }
 
   before do
-    allow(crime_application).to receive_messages(case: Case.new, in_progress?: false, is_means_tested: 'yes')
+    allow(crime_application).to receive_messages(kase: Case.new, in_progress?: false, is_means_tested: 'yes')
     allow(provider_details).to receive_messages(provider_email: 'provider@example.com', office_code: '123AA')
   end
 

--- a/spec/presenters/summary/sections/properties_spec.rb
+++ b/spec/presenters/summary/sections/properties_spec.rb
@@ -3,10 +3,17 @@ require 'rails_helper'
 describe Summary::Sections::Properties do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) {
-    instance_double(CrimeApplication, properties: records, in_progress?: true, capital: double,
-                    case: (double case_type:), to_param: 12_345)
-  }
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      properties: records,
+      in_progress?: true,
+      capital: double,
+      kase: (double case_type:),
+      to_param: 12_345
+    )
+  end
+
   let(:records) { [Property.new] }
   let(:case_type) { 'either_way' }
 

--- a/spec/presenters/summary/sections/savings_spec.rb
+++ b/spec/presenters/summary/sections/savings_spec.rb
@@ -4,7 +4,7 @@ describe Summary::Sections::Savings do
   subject { described_class.new(crime_application) }
 
   let(:crime_application) {
-    instance_double(CrimeApplication, savings: records, in_progress?: true, capital: double, case: (double case_type:),
+    instance_double(CrimeApplication, savings: records, in_progress?: true, capital: double, kase: (double case_type:),
    to_param: 12_345)
   }
   let(:records) { [Saving.new] }

--- a/spec/presenters/tasks/case_details_spec.rb
+++ b/spec/presenters/tasks/case_details_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Tasks::CaseDetails do
       CrimeApplication,
       to_param: '12345',
       applicant: applicant,
-      case: kase,
+      kase: kase,
     )
   end
 

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SubmissionSerializer::Application do
     let(:documents_scope) { double(stored: [Document.new]) }
 
     before do
-      allow(crime_application).to receive_messages(case: kase, documents: documents_scope,
+      allow(crime_application).to receive_messages(kase: kase, documents: documents_scope,
                                                    income: income, capital: capital)
     end
 

--- a/spec/serializers/submission_serializer/sections/case_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/case_details_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Sections::CaseDetails do
   subject { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication, case: kase) }
+  let(:crime_application) { instance_double(CrimeApplication, kase:) }
   let(:case_concluded_date) { DateTime.new(2023, 3, 2) }
   let(:client_remand_date) { DateTime.new(2023, 3, 2) }
   let(:preorder_work_date) { DateTime.new(2023, 3, 2) }

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       id: 'uuid',
       income: income,
       dependants: dependants_double,
-      case: kase,
+      kase: kase,
     )
   end
 

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -53,9 +53,8 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
   let(:stored_documents) { [] }
 
   before do
-    allow(capital).to receive(:valid?).with(:submission).and_return(true)
-    allow(kase).to receive(:valid?).with(:submission).and_return(true)
-    allow(kase).to receive(:valid?).with(:submission).and_return(true)
+    allow(capital).to receive(:complete?).and_return(true)
+    allow(kase).to receive(:complete?).and_return(true)
   end
 
   context 'MeansPassporter validation' do
@@ -210,7 +209,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
 
     context 'when capital section is not complete' do
       before do
-        expect(capital).to receive(:valid?).with(:submission).and_return(false)
+        expect(capital).to receive(:complete?).and_return(false)
       end
 
       it { is_expected.not_to be_valid }
@@ -223,7 +222,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
 
     context 'when case section is not complete' do
       before do
-        expect(kase).to receive(:valid?).with(:submission).and_return(false)
+        expect(kase).to receive(:complete?).and_return(false)
       end
 
       it { is_expected.not_to be_valid }


### PR DESCRIPTION
## Description of change
Add validation to CYA and final review to indicate where there are incomplete sections. 

## Link to relevant ticket
[CRIMAPP-721](https://dsdmoj.atlassian.net/browse/CRIMAPP-721)
[CRIMAPP-717](https://dsdmoj.atlassian.net/browse/CRIMAPP-717)

## Notes for reviewer

NOTE: this change is as designed. The validation shows before save, and is also shown in a different format to other validations / warnings.

Extracts some of the means logic into a TypeOfMeansAssessment concern, so that it can be used in validations and decision tree, and also the forthcoming task list work. Not mad about this pattern, but we can see if it works when the task list logic added.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1067" alt="Screenshot 2024-04-17 at 10 02 43" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/47b1d7d0-1e72-4b2b-b442-f7e48f8f4f4c">

<img width="1308" alt="Screenshot 2024-04-17 at 09 57 07" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/d04a7b4b-676d-470d-860f-710eee067640">

## How to manually test the feature


[CRIMAPP-721]: https://dsdmoj.atlassian.net/browse/CRIMAPP-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-717]: https://dsdmoj.atlassian.net/browse/CRIMAPP-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ