### PR TITLE
CRIMAPP-699 Fix food amount validation error

### DIFF
--- a/app/forms/steps/outgoings/board_and_lodging_form.rb
+++ b/app/forms/steps/outgoings/board_and_lodging_form.rb
@@ -8,10 +8,18 @@ module Steps
       attribute :payee_relationship_to_client, :string
 
       validates :board_amount, presence: true, numericality: { greater_than: 0 }
-      validates :food_amount, presence: true, numericality: { greater_than: 0 }
+      validates :food_amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
       validates :frequency, inclusion: { in: PaymentFrequencyType.values }
       validates :payee_name, presence: true
       validates :payee_relationship_to_client, presence: true
+
+      validate :board_greater_than_food
+
+      def board_greater_than_food
+        return unless board_amount.present? && food_amount.present?
+
+        errors.add(:food_amount, :more_than_board) if food_amount.to_f > board_amount.to_f
+      end
 
       def self.build(crime_application)
         payment = crime_application.outgoings_payments.board_and_lodging

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -493,7 +493,8 @@ en:
             food_amount:
               blank: Enter how much of the board and lodgings payment is for food
               invalid: Payments for food must be a number, like 50
-              greater_than: Payments for food must be more than 0
+              greater_than_or_equal_to: Payments for food must be 0 or more
+              more_than_board: Payments for food cannot be more than payments for board and lodgings.
             frequency:
               inclusion: Select how often they pay for board and lodgings, and food
             payee_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -236,7 +236,7 @@ en:
           jsa: This includes New Style JSA.
           other: Disregarded benefits include Housing Benefit and Personal Independence Payment (PIP).
       steps_outgoings_board_and_lodging_form:
-        food_amount_in_pounds: For example, '0' or '50'.
+        food_amount: Enter '0' if none.
       steps_submission_declaration_form:
         legal_rep_telephone: For example, 01632 960 001 or +44 808 157 0192
       steps_capital_property_type_form:

--- a/spec/forms/steps/outgoings/board_and_lodging_form_spec.rb
+++ b/spec/forms/steps/outgoings/board_and_lodging_form_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe Steps::Outgoings::BoardAndLodgingForm do
       end
     end
 
+    context 'when `food_amount` is greater than `board_amount`' do
+      let(:board_amount) { '400' }
+      let(:food_amount) { '450' }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:food_amount, :more_than_board)).to be(true)
+      end
+    end
+
     context 'when `frequency` is not valid' do
       let(:frequency) { 'every six weeks' }
 
@@ -154,6 +168,20 @@ RSpec.describe Steps::Outgoings::BoardAndLodgingForm do
         )
 
         form.save
+      end
+
+      context 'when `food_amount` is entered as 0' do
+        let(:food_amount) { '0' }
+
+        it 'returns true' do
+          expect(form.save).to be(true)
+        end
+
+        it { is_expected.to be_valid }
+
+        it 'does not have an error' do
+          expect(form.errors.of_kind?(:food_amount, :greater_than_or_equal_to)).to be(false)
+        end
       end
 
       context 'when amounts were previously recorded' do


### PR DESCRIPTION
## Description of change

Fix validation to allow food amount to be 0, but not less. 
Add missing validation to check that food amount is less than board amount
Update hint text on food amount field

## Link to relevant ticket

[CRIMAPP-699](https://dsdmoj.atlassian.net/browse/CRIMAPP-699)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1153" alt="Screenshot 2024-04-17 at 11 52 14" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/7cfcd177-e842-4e4c-8196-38023b4ea609">

<img width="1096" alt="Screenshot 2024-04-17 at 11 52 29" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/62ded1ce-6320-4bcb-b129-07f700d8902f">

### After changes:

<img width="1236" alt="Screenshot 2024-04-17 at 12 07 43" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/a10cd65f-1c4c-4633-9a07-c6cddc7bbde5">

<img width="1285" alt="Screenshot 2024-04-17 at 12 08 13" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/77822c3e-dafa-4ebb-992c-6da84dcf3947">


## How to manually test the feature


[CRIMAPP-699]: https://dsdmoj.atlassian.net/browse/CRIMAPP-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ