### PR TITLE
Fix bug in client decision tree 

### DIFF
--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -183,6 +183,8 @@ module Decisions
 
     def entered_appeal_reference_number?
       kase = current_crime_application.case
+      return false if kase&.case_type.nil?
+
       case_type = CaseType.new(kase.case_type)
       case_type&.appeal? && kase.appeal_reference_number.present?
     end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -267,6 +267,19 @@ RSpec.describe Decisions::ClientDecisionTree do
         )
       }
     end
+
+    context 'when the case type is not present' do
+      let(:case_type) { nil }
+
+      it {
+        expect(subject).to have_destination(
+          '/steps/address/lookup',
+          :edit,
+          id: crime_application,
+          address_id: 'address'
+        )
+      }
+    end
   end
 
   context 'when the step is `contact_details`' do


### PR DESCRIPTION
## Description of change

Add guard clause to `entered_appeal_reference_number?` to prevent  throwing an error when case type is nil

## Link to relevant ticket

[Sentry alert](https://ministryofjustice.sentry.io/issues/5216134617/?alert_rule_id=14332616&alert_type=issue&notification_uuid=dc0ac186-f05b-4a47-9dc9-dfcd66094590&project=6587263&referrer=slack)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
