### PR TITLE
[CRIMAPP-748] Fix inablity to submit appeal no changes

### DIFF
--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -2,6 +2,7 @@ module Passporting
   class MeansPassporter < BasePassporter
     def call
       return passported? if resubmission?
+      return true if appeal_no_changes?
 
       means_passport = []
       means_passport << MeansPassportType::ON_NOT_MEANS_TESTED if app_not_means_tested?
@@ -53,6 +54,11 @@ module Passporting
 
     def benefit_check_passed?
       applicant.passporting_benefit.present?
+    end
+
+    def appeal_no_changes?
+      (crime_application.case.case_type == 'appeal_to_crown_court') &&
+        (crime_application.case.appeal_financial_circumstances_changed == 'no')
     end
   end
 end


### PR DESCRIPTION
## Description of change
Fix inablity to submit appeal no changes
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-748
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Scenario 1: Appeal no changes
1. Create a means tested application with appeal case type
2. Select yes to original application
3. Select no to financial change and add a ref number
4. Finish application and make sure it submits

Scenario 2: Appeal with changes
1. Create a means tested application with appeal case type
2. Select yes to original application
3. Select yes to financial change and add a desc
4. Finish application and make sure it shows you the nino/ppt pages and submits

Scenario 2: Appeal with changes
1. Create a means tested application with appeal case type
2. Select yes to original application
3. Select yes to financial change and add a desc
5. Fail the DWP check, select to upload evidence, but don't upload evidence
4. Finish application and make sure it blocks submission