### PR TITLE
CRIMAPP-720 Fix bug in displaying other outgoings

### DIFF
--- a/app/forms/steps/outgoings/outgoings_more_than_income_form.rb
+++ b/app/forms/steps/outgoings/outgoings_more_than_income_form.rb
@@ -23,6 +23,12 @@ module Steps
           attributes
         )
       end
+
+      def before_save
+        return if outgoings_more_than_income&.yes?
+
+        self.how_manage = nil
+      end
     end
   end
 end

--- a/spec/forms/steps/outgoings/outgoings_more_than_income_form_spec.rb
+++ b/spec/forms/steps/outgoings/outgoings_more_than_income_form_spec.rb
@@ -91,5 +91,18 @@ RSpec.describe Steps::Outgoings::OutgoingsMoreThanIncomeForm do
         end
       end
     end
+
+    context 'when text for `how_manage` was previously recorded' do
+      let(:how_manage) { 'Details entered previously' }
+
+      context 'when NO is selected for `outgoings_more_than_income`' do
+        let(:outgoings_more_than_income) { YesNoAnswer::NO.to_s }
+
+        it 'resets `how_manage` to nil before saving' do
+          form.send(:before_save)
+          expect(form.attributes['how_manage']).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change

Reset the `how_manage` attribute when no is selected before saving

## Link to relevant ticket

[CRIMAPP-720](https://dsdmoj.atlassian.net/browse/CRIMAPP-720)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

1. In Apply, process an application to navigate to the OUTGOINGS Are your client’s outgoings more than their income? question
2. Answer YES. Text box with extra question How does your client manage if their outgoings are more than their income? appears
3. Enter text into the text field and Save and Continue
4. On the CYA page under Other Outgoings' section, the answer and supporting text displays as expected
5. Go back to Are your client’s outgoings more than their income? question
6. Change answer to NO. Text field is no longer present. Save and Continue
7. **On the CYA page under Other Outgoings' section, the answer has changed to NO and the supporting text which was incorrectly displaying previously should now not be there**


[CRIMAPP-720]: https://dsdmoj.atlassian.net/browse/CRIMAPP-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ