### PR TITLE
FIX APPLY-FOR-CRIMINAL-LEGAL-AID-2T

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -21,6 +21,10 @@ module TypeOfMeansAssessment
 
   private
 
+  def summary_only?
+    kase.case_type == CaseType::SUMMARY_ONLY.to_s
+  end
+
   def no_property?
     income.client_owns_property == 'no'
   end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -146,10 +146,6 @@ module Decisions
         kase.appeal_financial_circumstances_changed == 'no'
     end
 
-    def summary_only?
-      kase.case_type == CaseType::SUMMARY_ONLY.to_s
-    end
-
     def crime_application
       form_object.crime_application
     end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -220,6 +220,25 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       end
     end
 
+    context 'when capital section is not required' do
+      let(:income) do
+        instance_double(
+          Income,
+          employment_status: employment_status,
+          income_above_threshold: 'no',
+          has_frozen_income_or_assets: 'no',
+          client_owns_property: 'no',
+          has_savings: 'no'
+        )
+      end
+
+      before do
+        expect(capital).not_to receive(:complete?)
+      end
+
+      it { is_expected.to be_valid }
+    end
+
     context 'when case section is not complete' do
       before do
         expect(kase).to receive(:complete?).and_return(false)


### PR DESCRIPTION
## Description of change
Fulfilment validator can handle income below threshold.

## Link to relevant ticket
https://ministryofjustice.sentry.io/issues/5221747359/

## Notes for reviewer

Fixes bug introduced to staging last night.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Attempt to submit an application with means but income below threshold. You will not be able to do that without this fix.
