### PR TITLE
[CRIMAPP-742] Add investment share option

### DIFF
--- a/app/value_objects/investment_type.rb
+++ b/app/value_objects/investment_type.rb
@@ -2,6 +2,7 @@ class InvestmentType < ValueObject
   VALUES = [
     BOND = new(:bond),
     PEP = new(:pep),
+    SHARE = new(:share),
     SHARE_ISA = new(:share_isa),
     STOCK = new(:stock),
     UNIT_TRUST = new(:unit_trust),


### PR DESCRIPTION
## Description of change
Adds missing share option to investment type form

## Link to relevant ticket
[CRIMAPP-742](https://dsdmoj.atlassian.net/browse/CRIMAPP-742)

## Notes for reviewer
I've tested it end to end and works fine 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1071" alt="Screenshot 2024-04-19 at 12 16 37" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/4368468f-d4f0-4e2f-b5f9-e0f1c8b1a7c2">

<img width="1071" alt="Screenshot 2024-04-19 at 12 16 29" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/92eb9fe8-5b5a-4665-8430-c28fa94dc509">

<img width="1638" alt="Screenshot 2024-04-19 at 12 16 05" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/737c54dc-7cd4-43e7-95cb-20560717b11b">

## How to manually test the feature

1. Start an means tested application with an either way case type
2. Enter a nino 
3. Select no to passporting benefit
4. Go through the income, outgoings and capital screens until you get to the investment type page
5. Confirm the share option is visible 
6. Select the share option and add a share investment
7. Finish the rest of the application 
8. Confirm the share investment is visible on the review your application screen 
9. Submit the application 
10. Confirm the share investment is visible on the completed application screen 
11. Open review, navigate to the application and confirm the share investment is visible on review
12. Return the application
13. And check the share investment was rehydrated 

[CRIMAPP-742]: https://dsdmoj.atlassian.net/browse/CRIMAPP-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ