### PR TITLE
Fix small spelling and design mismatches

### DIFF
--- a/app/forms/steps/income/lost_job_in_custody_form.rb
+++ b/app/forms/steps/income/lost_job_in_custody_form.rb
@@ -14,19 +14,11 @@ module Steps
                 presence: true,
                 if: -> { lost_job_in_custody? }
 
-      validate :date_job_lost_over_three_months_ago, if: -> { lost_job_in_custody? }
-
       def choices
         YesNoAnswer.values
       end
 
       private
-
-      def date_job_lost_over_three_months_ago
-        return unless date_job_lost.is_a?(Date)
-
-        errors.add(:date_job_lost, :over_three_months_ago) if date_job_lost.beginning_of_day < 3.months.ago
-      end
 
       def persist!
         income.update(

--- a/app/views/steps/capital/premium_bonds/edit.html.erb
+++ b/app/views/steps/capital/premium_bonds/edit.html.erb
@@ -9,8 +9,8 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset(:has_premium_bonds, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
         <%= f.govuk_radio_button :has_premium_bonds, YesNoAnswer::YES do %>
-          <%= f.govuk_number_field :premium_bonds_total_value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
           <%= f.govuk_text_field :premium_bonds_holder_number, autocomplete: 'off', extra_letter_spacing: true, width: 'one-third' %>
+          <%= f.govuk_number_field :premium_bonds_total_value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
         <% end %>
 
         <%= f.govuk_radio_button :has_premium_bonds, YesNoAnswer::NO %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   dictionary:
     DATE_FORMATS: &DATE_FORMATS
-      default: '%-d %b %Y'  # 3 Jan 2019
+      default: '%-d %B %Y'  # 3 January 2019
       compact: '%d/%m/%Y'   # 03/01/2019
       datetime: '%-d %B %Y %-l:%M%P'  # 3 January 2019 2:45pm
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -389,7 +389,7 @@ en:
               invalid_day: Enter a valid day
               invalid_month: Enter a valid month
               invalid_year: Enter a valid year
-              over_three_months_ago: Date they lost their job must be within the last 3 months
+              year_too_early: Date is too far in the past
               future_not_allowed: Date they lost their job must be today or in the past
         steps/income/income_before_tax_form:
           attributes:
@@ -498,7 +498,7 @@ en:
               blank: Enter how much of the board and lodgings payment is for food
               invalid: Payments for food must be a number, like 50
               greater_than_or_equal_to: Payments for food must be 0 or more
-              more_than_board: Payments for food cannot be more than payments for board and lodgings.
+              more_than_board: Payments for food cannot be more than payments for board and lodgings
             frequency:
               inclusion: Select how often they pay for board and lodgings, and food
             payee_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -253,6 +253,8 @@ en:
         description: For example, which companies your client has invested in, the value of each share owned, or when they can access the investment.
       steps_capital_national_savings_certificates_form:
         value: Give an estimate if you do not know the exact value.
+      steps_capital_premium_bonds_form:
+        premium_bonds_total_value: Give an estimate if you do not know the exact value.
       steps_outgoings_outgoings_payments_form:
         outgoings_payments: Select all that apply.
         types_options:
@@ -594,7 +596,7 @@ en:
         ownership_type: Whose name is the investment in?
         ownership_type_options: *OWNERSHIP_OPTIONS
         confirm_in_applicants_name_options:
-          'true': I confirm that the account is in my client's name
+          'true': I confirm that the investment is in my client's name
       steps_capital_national_savings_certificates_form:
         holder_number: What is the customer number or holder number?
         certificate_number: What is the certificate number?
@@ -610,8 +612,8 @@ en:
       steps_capital_national_savings_certificates_summary_form:
         add_national_savings_certificate_options: *YESNO
       steps_capital_premium_bonds_form:
-        premium_bonds_holder_number: Enter the holder number
-        premium_bonds_total_value: Enter the total value of their bonds
+        premium_bonds_holder_number: What is the holder number?
+        premium_bonds_total_value: What is the total value of their bonds?
         has_premium_bonds_options: *YESNO
       steps_capital_has_national_savings_certificates_form:
         has_national_savings_certificates_options: *YESNO

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -75,7 +75,7 @@ en:
         pep: Personal equity plan (PEP)
         share: Shares
         share_isa: Share ISA
-        stock: Stock, including gilts and government bonds
+        stock: Stocks, including gilts and government bonds
         unit_trust: Unit trust
         other: Other lump sum investment
       national_savings_certificates: National Savings Certificates
@@ -346,7 +346,7 @@ en:
         answers:
           description: *payment_answer_format
       state_pension_payment:
-        question: State pensions
+        question: State pension
         answers:
           description: *payment_answer_format
       interest_investment_payment:
@@ -559,9 +559,9 @@ en:
         question: Does your client have any Premium Bonds?
         answers: *YESNO
       premium_bonds_total_value:
-        question: Enter the total value of their bonds
+        question: What is the total value of their bonds?
       premium_bonds_holder_number:
-        question: Enter the holder number
+        question: What is the holder number?
         absence_answer: ''
       # END premium_bonds
 

--- a/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
+++ b/spec/forms/steps/income/lost_job_in_custody_form_spec.rb
@@ -117,20 +117,6 @@ RSpec.describe Steps::Income::LostJobInCustodyForm do
           end
         end
       end
-
-      context 'when `date_job_lost` is over 3 months ago' do
-        let(:lost_job_in_custody) { YesNoAnswer::YES.to_s }
-        let(:date_job_lost) { 4.months.ago.to_date }
-
-        it 'returns false' do
-          expect(form.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(form).not_to be_valid
-          expect(form.errors.of_kind?(:date_job_lost, :over_three_months_ago)).to be(true)
-        end
-      end
     end
   end
 end

--- a/spec/presenters/crime_application_presenter_spec.rb
+++ b/spec/presenters/crime_application_presenter_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CrimeApplicationPresenter do
     end
 
     it 'can output the applicant date of birth in the correct format' do
-      expect(subject.applicant_dob).to eq('1 Feb 1990')
+      expect(subject.applicant_dob).to eq('1 February 1990')
     end
 
     it 'has a reference number' do

--- a/spec/presenters/summary/components/investment_spec.rb
+++ b/spec/presenters/summary/components/investment_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Summary::Components::Investment, type: :component do
     context 'when Stocks' do
       let(:investment_type) { :stock }
 
-      it { is_expected.to eq 'Stock, including gilts and government bonds' }
+      it { is_expected.to eq 'Stocks, including gilts and government bonds' }
     end
 
     context 'when Share ISA' do

--- a/spec/presenters/summary/components/offence_spec.rb
+++ b/spec/presenters/summary/components/offence_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Summary::Components::Offence, type: :component do
       )
       expect(page).to have_summary_row(
         'Offence date',
-        '28 Mar 2023 – 18 Dec 202318 Dec 2023'
+        '28 March 2023 – 18 December 202318 December 2023'
       )
     end
 

--- a/spec/requests/dashboard_lists_spec.rb
+++ b/spec/requests/dashboard_lists_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Dashboard', :authorized do
         assert_select 'tbody.govuk-table__body' do
           assert_select 'tr.govuk-table__row', 2 do
             assert_select 'a', count: 1, text: 'John Doe'
-            assert_select 'td.govuk-table__cell:nth-of-type(1)', '15 Oct 2022'
+            assert_select 'td.govuk-table__cell:nth-of-type(1)', '15 October 2022'
             assert_select 'td.govuk-table__cell:nth-of-type(2)', /[[:digit:]]/
             assert_select 'td.govuk-table__cell:nth-of-type(4)' do
               assert_select 'button.govuk-button', count: 2, text: 'Delete'
@@ -169,7 +169,7 @@ RSpec.describe 'Dashboard', :authorized do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'Kit Pound'
         end
-        assert_select 'td.govuk-table__cell:nth-of-type(1)', '24 Oct 2022'
+        assert_select 'td.govuk-table__cell:nth-of-type(1)', '24 October 2022'
         assert_select 'td.govuk-table__cell:nth-of-type(2)', '6000001'
       end
     end
@@ -221,7 +221,7 @@ RSpec.describe 'Dashboard', :authorized do
         assert_select 'tr.govuk-table__row', 1 do
           assert_select 'a', count: 1, text: 'John POTTER'
         end
-        assert_select 'td.govuk-table__cell:nth-of-type(1)', '27 Sep 2022'
+        assert_select 'td.govuk-table__cell:nth-of-type(1)', '27 September 2022'
         assert_select 'td.govuk-table__cell:nth-of-type(2)', '6000002'
       end
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe 'Dashboard', :authorized do
         assert_select 'p:nth-of-type(3)', 'Doe'
 
         assert_select 'h3:nth-of-type(4)', 'Date of birth'
-        assert_select 'p:nth-of-type(4)', '1 Feb 1990'
+        assert_select 'p:nth-of-type(4)', '1 February 1990'
 
         assert_select 'h3:nth-of-type(5)', 'Date stamp'
         assert_select 'p:nth-of-type(5)', '21 April 2023 12:15am'

--- a/spec/requests/dwp_benefit_checker_spec.rb
+++ b/spec/requests/dwp_benefit_checker_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'DWP passporting sub journey', :authorized do
 
         assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(4)' do
           assert_select 'dt', 'Date of birth'
-          assert_select 'dd', '1 Feb 1990'
+          assert_select 'dd', '1 February 1990'
         end
 
         assert_select 'div.govuk-summary-list__row.govuk-summary-list__row--no-actions:nth-of-type(5)' do


### PR DESCRIPTION
## Description of change
Fix small spelling and design mismatches
Bit of a hodgebodge, sorry!

1. Correct spelling of State Pensions -> State Pension
2. Correct spelling of Stock -> Stocks on investment CYA playback
3. Update premium bond question order, wording and hints
4. Set date defaults to full length month name
5. Remove full stop from error message
6. Correct checkbox copy on investment 'I confirm account is in client's name' -> I confirm investment is in client's name

Remove 3month restriction on date job lost input (to allow for resubmission etc. no validated on eForms)

## Link to relevant ticket
1.https://dsdmoj.atlassian.net/browse/CRIMAPP-737
2. https://dsdmoj.atlassian.net/browse/CRIMAPP-744
3. https://dsdmoj.atlassian.net/browse/CRIMAPP-750
4. https://dsdmoj.atlassian.net/browse/CRIMAPP-718
5. https://docs.google.com/spreadsheets/d/1gdDpuyqWO6MJgUT1SOy0nbHd8AAdp1YebBzh1WDG040/edit?disco=AAABMFws80I
6. https://www.figma.com/file/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?type=design&node-id=8762%3A121907&mode=design&t=PyEkH4FMQm7BCbhu-1

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
