### PR TITLE
Fix non means tested application from triggering 'means_test_required?'

### DIFF
--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -41,6 +41,7 @@ module Decisions
     private
 
     def after_has_case_concluded
+      return charges_summary_or_edit_new_charge if current_crime_application.not_means_tested?
       return edit(:is_client_remanded) if form_object.has_case_concluded.no?
 
       edit(:is_preorder_work_claimed)
@@ -91,6 +92,8 @@ module Decisions
     end
 
     def means_test_required?
+      return false if current_crime_application.not_means_tested?
+
       FeatureFlags.means_journey.enabled? && (applicant.has_benefit_evidence == 'no' ||
         ['none', nil].include?(applicant.benefit_type))
     end


### PR DESCRIPTION
## Description of change
Non-means applications are not shown the is client remanded in custody question

Flow also broke in a regression at some point which sent user to means questions so this fixes that too
## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
