### PR TITLE
[CRIMAPP-649] Change evidence upload page titles

### DIFF
--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -57,7 +57,7 @@ en:
       no_records: There are no %{status} applications
     show:
       page_title: Application representation order
-      heading: 
+      heading:
         initial: Application for a criminal legal aid representation order
         post_submission_evidence: Supporting evidence
       laa_reference: "Reference number:"
@@ -69,7 +69,7 @@ en:
         phone: 'Telephone: 0300 200 2020'
         hours: 9am to 5pm, Monday to Friday (excluding bank holidays)
       action:
-        create_pse: Add supporting evidence
+        create_pse: Upload supporting evidence
     return_notification:
       title: Important
       heading:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -527,8 +527,8 @@ en:
     evidence:
       upload:
         edit:
-          page_title: Add supporting evidence
-          heading: Add supporting evidence
+          page_title: Upload supporting evidence
+          heading: Upload supporting evidence
           optional: No supporting evidence is required based on your current application, but you may upload any documents that will help your application.
           required: 'Based on your answers, use this page to provide:'
           recent_docs: All evidence must be from the last 3 months.

--- a/config/locales/en/tasklist.yml
+++ b/config/locales/en/tasklist.yml
@@ -3,7 +3,7 @@ en:
   tasklist:
     heading_text:
       initial: Make a new application
-      post_submission_evidence: Add supporting evidence
+      post_submission_evidence: Upload supporting evidence
     heading:
       client_details: About your client
       case_details: About the case

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe 'Dashboard', :authorized do
       assert_select 'button.govuk-button', count: 0, text: 'Update application'
     end
 
-    it 'does not have a button to "Add supporting evidence"' do
-      assert_select 'button.govuk-button', count: 0, text: 'Add supporting evidence'
+    it 'does not have a button to "Upload supporting evidence"' do
+      assert_select 'button.govuk-button', count: 0, text: 'Upload supporting evidence'
     end
 
     context 'when the application has been reviewed' do
@@ -72,8 +72,8 @@ RSpec.describe 'Dashboard', :authorized do
         LaaCrimeSchemas.fixture(1.0) { |data| data.merge('reviewed_at' => 1.day.ago) }.to_json
       end
 
-      it 'has a button to "Add supporting evidence"' do
-        assert_select 'button.govuk-button', count: 1, text: 'Add supporting evidence'
+      it 'has a button to "Upload supporting evidence"' do
+        assert_select 'button.govuk-button', count: 1, text: 'Upload supporting evidence'
       end
 
       it 'creates a new PSE application' do
@@ -85,7 +85,7 @@ RSpec.describe 'Dashboard', :authorized do
 
         follow_redirect!
 
-        assert_select 'h1', 'Add supporting evidence'
+        assert_select 'h1', 'Upload supporting evidence'
       end
 
       context 'when PSE feature flag is not enabled' do
@@ -97,8 +97,8 @@ RSpec.describe 'Dashboard', :authorized do
           get completed_crime_application_path(application_fixture_id)
         end
 
-        it 'does not have a button to "Add supporting evidence"' do
-          assert_select 'button.govuk-button', count: 0, text: 'Add supporting evidence'
+        it 'does not have a button to "Upload supporting evidence"' do
+          assert_select 'button.govuk-button', count: 0, text: 'Upload supporting evidence'
         end
       end
     end
@@ -216,8 +216,8 @@ RSpec.describe 'Dashboard', :authorized do
       assert_select 'h1', 'Application for a criminal legal aid representation order'
     end
 
-    it 'does not have a button to "Add supporting evidence"' do
-      assert_select 'button.govuk-button', count: 0, text: 'Add supporting evidence'
+    it 'does not have a button to "Upload supporting evidence"' do
+      assert_select 'button.govuk-button', count: 0, text: 'Upload supporting evidence'
     end
 
     # rubocop:disable Layout/LineLength

--- a/spec/requests/evidence_upload_spec.rb
+++ b/spec/requests/evidence_upload_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Evidence upload page', :authorized do
     it 'lists the uploaded documents with their details' do
       expect(response).to have_http_status(:success)
 
-      assert_select 'h1', 'Add supporting evidence'
+      assert_select 'h1', 'Upload supporting evidence'
 
       assert_select 'tbody.govuk-table__body' do
         assert_select 'tr.govuk-table__row:nth-of-type(1)' do


### PR DESCRIPTION
## Description of change
Alters the 'Add supporting evidence' title to 'Upload supporting evidence'

## Link to relevant ticket

## Notes for reviewer
Not sure if all the buttons etc should change to match the new title.

## Screenshots of changes (if applicable)

### Before changes:

<img width="706" alt="Screenshot 2024-04-24 at 06 18 51" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/6cf81451-a9f5-49f1-94d6-e0a65d2a6b8f">

### After changes:
<img width="676" alt="Screenshot 2024-04-24 at 10 05 36" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/47113046/60e20593-e592-4912-b6eb-9c9499e01d4a">


