### PR TITLE
Fix exception when trust fund not answered

### DIFF
--- a/app/presenters/summary/sections/trust_fund.rb
+++ b/app/presenters/summary/sections/trust_fund.rb
@@ -32,7 +32,7 @@ module Summary
       private
 
       def will_benefit_from_trust_fund?
-        YesNoAnswer.new(capital.will_benefit_from_trust_fund).yes?
+        YesNoAnswer.new(capital.will_benefit_from_trust_fund.to_s).yes?
       end
 
       def change_path

--- a/spec/presenters/summary/sections/trust_fund_spec.rb
+++ b/spec/presenters/summary/sections/trust_fund_spec.rb
@@ -70,5 +70,15 @@ describe Summary::Sections::TrustFund do
         expect(answers.count).to eq(1)
       end
     end
+
+    context 'when question has not yet been answered' do
+      before do
+        allow(capital).to receive(:will_benefit_from_trust_fund).and_return(nil)
+      end
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Fix exception when trust fund not answered

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Visit the submisison/review page with capital section started but not completed (stopped before trust fund question).