### PR TITLE
[CRIMAPP-785] Asset ownership bug fix

### DIFF
--- a/app/forms/steps/capital/property_owners_form.rb
+++ b/app/forms/steps/capital/property_owners_form.rb
@@ -3,7 +3,8 @@ module Steps
     class PropertyOwnersForm < Steps::BaseFormObject
       delegate :property_owners_attributes=, to: :record
 
-      validates_with CapitalAssessment::PropertyOwnersValidator, unless: :any_marked_for_destruction?
+      validates_with CapitalAssessment::PropertyOwnersValidator,
+                     unless: [:any_marked_for_destruction?, :incomplete_property_owners?]
 
       def property_owners
         @property_owners ||= record.property_owners.map do |property_owner|
@@ -32,6 +33,10 @@ module Steps
       # as we are using `accepts_nested_attributes_for`
       def persist!
         record.save
+      end
+
+      def incomplete_property_owners?
+        step_name.eql?(:add_property_owner)
       end
     end
   end

--- a/app/forms/steps/capital/property_owners_form.rb
+++ b/app/forms/steps/capital/property_owners_form.rb
@@ -4,7 +4,7 @@ module Steps
       delegate :property_owners_attributes=, to: :record
 
       validates_with CapitalAssessment::PropertyOwnersValidator,
-                     unless: [:any_marked_for_destruction?, :incomplete_property_owners?]
+                     unless: [:any_marked_for_destruction?, :adding_property_owner?]
 
       def property_owners
         @property_owners ||= record.property_owners.map do |property_owner|
@@ -35,7 +35,7 @@ module Steps
         record.save
       end
 
-      def incomplete_property_owners?
+      def adding_property_owner?
         step_name.eql?(:add_property_owner)
       end
     end


### PR DESCRIPTION
## Description of change
Fixes issue with adding a property owner when percentage ownership is invalid 
See slack thread: https://mojdt.slack.com/archives/C06DFR460F2/p1713965263582019

## Link to relevant ticket
[CRIMAPP-785](https://dsdmoj.atlassian.net/browse/CRIMAPP-785)

## Notes for reviewer
Sadly the indexed errors are not working 😢 don't think this blocks this though 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/565560b9-9a71-4760-8c8a-c538aa0ed5f5

## How to manually test the feature

1. Navigate to capital assets section and add a property of any type 
2. Enter applicant ownership value under 100% e.g. 80%
3. Select yes to having other owners
4. For additional owner enter ownership e.g. 5%
5. Select option to add another additional owner
6. You should be able to add another owner with no percentage ownership validation errors appearing
7. You should be able to add further owners also whilst ownership is not valid 


[CRIMAPP-785]: https://dsdmoj.atlassian.net/browse/CRIMAPP-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ