### PR TITLE
CRIMAPP-792 Outgoings content bug

### DIFF
--- a/app/presenters/summary/sections/payment_details.rb
+++ b/app/presenters/summary/sections/payment_details.rb
@@ -5,7 +5,7 @@ module Summary
         section.present? && super
       end
 
-      def answers # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def answers # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         if no_payments?
           [
             Components::ValueAnswer.new(
@@ -22,7 +22,7 @@ module Summary
               if payment_details.nil?
                 Components::FreeTextAnswer.new(
                   formatted_payment_name,
-                  I18n.t('summary.does_not_get'),
+                  type_suffix.include?('outgoing') ? I18n.t('summary.does_not_pay') : I18n.t('summary.does_not_get'),
                   change_path:
                 )
               elsif requires_extra_details(payment_name)

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -36,6 +36,7 @@ en:
       month: month
       annual: year
     does_not_get: Does not get
+    does_not_pay: Does not pay
     sections:
       overview: Overview
       case_details: Case details

--- a/spec/presenters/summary/sections/outgoings_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/outgoings_payments_details_spec.rb
@@ -144,7 +144,7 @@ describe Summary::Sections::OutgoingsPaymentsDetails do
           [
             [
               Summary::Components::FreeTextAnswer,
-              'childcare_outgoing', 'Does not get',
+              'childcare_outgoing', 'Does not pay',
               '#steps-outgoings-outgoings-payments-form-types-childcare-field'
             ],
             [
@@ -154,7 +154,7 @@ describe Summary::Sections::OutgoingsPaymentsDetails do
             ],
             [
               Summary::Components::FreeTextAnswer,
-              'legal_aid_contribution_outgoing', 'Does not get',
+              'legal_aid_contribution_outgoing', 'Does not pay',
               '#steps-outgoings-outgoings-payments-form-types-legal-aid-contribution-field'
             ]
           ]


### PR DESCRIPTION
## Description of change

Display `Does not pay` instead of `Does not get` for outgoings payment categories

## Link to relevant ticket

[CRIMAPP-792](https://dsdmoj.atlassian.net/browse/CRIMAPP-792)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1275" alt="Screenshot 2024-04-25 at 11 43 35" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/cc76c1e2-6d38-43b0-922b-f171660819b0">

### After changes:

<img width="1339" alt="Screenshot 2024-04-25 at 11 43 06" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/2de8c0ca-e7f3-4919-b80d-76198c58a4b7">

## How to manually test the feature


[CRIMAPP-792]: https://dsdmoj.atlassian.net/browse/CRIMAPP-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ