### PR TITLE
Fix/remove eforms exit for means journey

### DIFF
--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -15,7 +15,11 @@ module Decisions
 
     def after_confirm_result
       if form_object.confirm_result.yes?
-        show(:benefit_check_result_exit)
+        if FeatureFlags.means_journey.enabled?
+          edit('steps/case/urn')
+        else
+          show(:benefit_check_result_exit)
+        end
       else
         edit(:confirm_details)
       end

--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -14,7 +14,7 @@ module Decisions
     private
 
     def after_confirm_result
-      if form_object.confirm_result.yes?
+      if form_object.confirm_result.yes? # Do we want to reset their ppt benefit to None if they select Yes here?
         if FeatureFlags.means_journey.enabled?
           edit('steps/case/urn')
         else

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -22,7 +22,23 @@ RSpec.describe Decisions::DWPDecisionTree do
     context 'and the answer is `yes`' do
       let(:confirm_result) { YesNoAnswer::YES }
 
-      it { is_expected.to have_destination(:benefit_check_result_exit, :show, id: crime_application) }
+      before do
+        allow(FeatureFlags).to receive(:means_journey) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: means_enabled?)
+        }
+      end
+
+      context 'with means journey enabled' do
+        let(:means_enabled?) { true }
+
+        it { is_expected.to have_destination('steps/case/urn', :edit, id: crime_application) }
+      end
+
+      context 'with means journey disabled' do
+        let(:means_enabled?) { false }
+
+        it { is_expected.to have_destination(:benefit_check_result_exit, :show, id: crime_application) }
+      end
     end
 
     context 'and the answer is `no`' do


### PR DESCRIPTION
## Description of change
If user fails the DWP check, then answer Yes when asked if the DWP records are correct, the app shows the eForms exit page (on the previous assumption that they couldn't continue the application as we didn't have means pages). If means pages are available, we can allow the user to continue

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
