### PR TITLE
Do not create record when save and come back later selected

### DIFF
--- a/app/forms/steps/capital/other_investment_type_form.rb
+++ b/app/forms/steps/capital/other_investment_type_form.rb
@@ -15,6 +15,8 @@ module Steps
       private
 
       def persist!
+        return true if investment_type == ''
+
         @investment = crime_application.investments.create!(investment_type:)
       end
     end

--- a/app/forms/steps/capital/other_property_type_form.rb
+++ b/app/forms/steps/capital/other_property_type_form.rb
@@ -14,6 +14,8 @@ module Steps
       private
 
       def persist!
+        return true if property_type == ''
+
         @property = incomplete_property_for_type || crime_application.properties.create!(property_type:)
       end
 

--- a/app/forms/steps/capital/other_saving_type_form.rb
+++ b/app/forms/steps/capital/other_saving_type_form.rb
@@ -14,6 +14,8 @@ module Steps
       private
 
       def persist!
+        return true if saving_type == ''
+
         @saving = crime_application.savings.create!(saving_type:)
       end
     end

--- a/spec/forms/steps/capital/other_investment_type_form_spec.rb
+++ b/spec/forms/steps/capital/other_investment_type_form_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe Steps::Capital::OtherInvestmentTypeForm do
         expect(investments).to have_received(:create!).with(investment_type:)
       end
     end
+
+    context 'when investment type is an empty string' do
+      let(:investment_type) { '' }
+
+      it 'does not create an investment' do
+        expect(investments).not_to have_received(:create!).with(investment_type:)
+      end
+    end
   end
 end

--- a/spec/forms/steps/capital/other_property_type_form_spec.rb
+++ b/spec/forms/steps/capital/other_property_type_form_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe Steps::Capital::OtherPropertyTypeForm do
       end
     end
 
+    context 'when property type is an empty string' do
+      let(:property_type) { '' }
+
+      it 'does not create a property' do
+        expect(properties).not_to have_received(:create!)
+      end
+    end
+
     context 'when a property of the type exists' do
       let(:existing_properties) { [existing_property] }
 

--- a/spec/forms/steps/capital/other_saving_type_form_spec.rb
+++ b/spec/forms/steps/capital/other_saving_type_form_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe Steps::Capital::OtherSavingTypeForm do
         expect(savings).to have_received(:create!).with(saving_type:)
       end
     end
+
+    context 'when saving type is an empty string' do
+      let(:saving_type) { '' }
+
+      it 'does not create a saving' do
+        expect(savings).not_to have_received(:create!).with(saving_type:)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Bug reported in qa where an instance of an incomplete property is created and then a user clicks to create another asset and selects save and come back later to the other property type form. Then when they click capital assessment from the task list the app breaks 

This is because an instance of a property with a property type of '' is being created when save and come back later is selected on the other property type form 

This also impacts the other saving type and other investment type forms and fix has been implemented for all forms 

## Link to relevant ticket
[Slack thread here](https://mojdt.slack.com/archives/C06DFR460F2/p1714055720215749?thread_ts=1714050467.447539&cid=C06DFR460F2)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/e5265596-fc2e-4c55-96ce-321e91229009

### After changes:

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/3611f02e-e18e-4d9c-9144-74abeb1a6f3e

## How to manually test the feature

1. Select 'Either way' case type
2. Navigate through to capital section
3. Select to add residential property
4. Save and continue
5. From 'Your client’s residential property' select BACK link
6. From Shopping basket page select Save and come back later
7. From task list select 'Capital Assessment' link
8. Select to add another asset
9. Select residential radio button. Save and continue
10. Select BACK link. (Goes back to 'which other assets......') page
11. Select 'Save and come back later'
12. From task list select 'Capital Assessment' link
13. You should be able to view the property summary page whereas previously you would get an error page

Repeat the testing for the savings loop and investments loop 
