### PR TITLE
[CRIMAPP-799] Reset attributes when form answers updated

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -47,6 +47,7 @@ module DeveloperTools
       find_or_create_applicant(
         dob: rand(15..17).years.ago,
         nino: nil,
+        will_enter_nino: nil,
         benefit_type: nil,
         last_jsa_appointment_date: nil,
         passporting_benefit: nil,

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -48,6 +48,7 @@ module DeveloperTools
         dob: rand(15..17).years.ago,
         nino: nil,
         will_enter_nino: nil,
+        has_benefit_evidence: nil,
         benefit_type: nil,
         last_jsa_appointment_date: nil,
         passporting_benefit: nil,

--- a/app/forms/steps/client/appeal_reference_number_form.rb
+++ b/app/forms/steps/client/appeal_reference_number_form.rb
@@ -28,6 +28,10 @@ module Steps
       end
 
       def persist!
+        reset_home_address
+        reset_correspondence_address
+        crime_application.applicant.update(applicant_attributes_to_reset)
+
         self.case.update(
           attributes
         )
@@ -36,6 +40,34 @@ module Steps
       def before_save
         self.appeal_maat_id = nil unless maat_id_selected?
         self.appeal_usn = nil unless usn_selected?
+      end
+
+      def applicant_attributes_to_reset
+        {
+          'residence_type' => nil,
+          'correspondence_address_type' => nil,
+          'telephone_number' => nil,
+          'has_nino' => nil,
+          'nino' => nil,
+          'will_enter_nino' => nil,
+          'benefit_type' => nil,
+          'last_jsa_appointment_date' => nil,
+          'passporting_benefit' => nil,
+          'has_benefit_evidence' => nil
+        }
+      end
+
+      # TODO: Duplicate of method in residence type form, is there somewhere this could live?
+      def reset_home_address
+        return unless crime_application.applicant.home_address?
+
+        crime_application.applicant.home_address.destroy!
+      end
+
+      def reset_correspondence_address
+        return unless crime_application.applicant.correspondence_address?
+
+        crime_application.applicant.correspondence_address.destroy!
       end
     end
   end

--- a/app/forms/steps/client/benefit_type_form.rb
+++ b/app/forms/steps/client/benefit_type_form.rb
@@ -37,7 +37,8 @@ module Steps
 
       def attributes_to_reset
         {
-          'last_jsa_appointment_date' => (last_jsa_appointment_date if jsa?)
+          'last_jsa_appointment_date' => (last_jsa_appointment_date if jsa?),
+          'has_benefit_evidence' => nil,
         }
       end
 

--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -40,9 +40,15 @@ module Steps
       def attributes_to_reset
         return {} unless changed?(:last_name, :date_of_birth)
 
+        # Do i need to reset it here also?
+        # If dwp check needs to be re run then arguably yes they both need to be reset
+        # If nino is being reset, then it makes sense to reset will enter nino
+        # Not sure if has benefit evidence should be reset
         {
           has_nino: nil,
           nino: nil,
+          # will_enter_nino: nil,
+          # has_benefit_evidence: nil,
           benefit_type: nil,
           last_jsa_appointment_date: nil,
           passporting_benefit: nil,

--- a/app/forms/steps/client/details_form.rb
+++ b/app/forms/steps/client/details_form.rb
@@ -40,15 +40,11 @@ module Steps
       def attributes_to_reset
         return {} unless changed?(:last_name, :date_of_birth)
 
-        # Do i need to reset it here also?
-        # If dwp check needs to be re run then arguably yes they both need to be reset
-        # If nino is being reset, then it makes sense to reset will enter nino
-        # Not sure if has benefit evidence should be reset
         {
           has_nino: nil,
           nino: nil,
-          # will_enter_nino: nil,
-          # has_benefit_evidence: nil,
+          will_enter_nino: nil,
+          has_benefit_evidence: nil,
           benefit_type: nil,
           last_jsa_appointment_date: nil,
           passporting_benefit: nil,

--- a/app/forms/steps/client/has_nino_form.rb
+++ b/app/forms/steps/client/has_nino_form.rb
@@ -47,6 +47,8 @@ module Steps
           'benefit_type' => nil,
           'last_jsa_appointment_date' => nil,
           'passporting_benefit' => nil,
+          'will_enter_nino' => nil,
+          'has_benefit_evidence' => nil,
           'nino' => nino_attr
         }
       end

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -24,6 +24,7 @@ module Summary
                        ))
         end
 
+        # TODO: display home address and telephone number always?
         unless residence_of_type?('none')
           answers.push(Components::FreeTextAnswer.new(
                          :home_address, full_address(home_address), show: true,

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -25,9 +25,9 @@ module Summary
         end
 
         answers.push(Components::FreeTextAnswer.new(
-          :home_address, full_address(home_address), show: show_home_address?,
+                       :home_address, full_address(home_address), show: show_home_address?,
           change_path: change_path(home_address)
-        ))
+                     ))
 
         answers << [
           Components::ValueAnswer.new(

--- a/app/presenters/summary/sections/contact_details.rb
+++ b/app/presenters/summary/sections/contact_details.rb
@@ -24,13 +24,10 @@ module Summary
                        ))
         end
 
-        # TODO: display home address and telephone number always?
-        unless residence_of_type?('none')
-          answers.push(Components::FreeTextAnswer.new(
-                         :home_address, full_address(home_address), show: true,
-            change_path: change_path(home_address)
-                       ))
-        end
+        answers.push(Components::FreeTextAnswer.new(
+          :home_address, full_address(home_address), show: show_home_address?,
+          change_path: change_path(home_address)
+        ))
 
         answers << [
           Components::ValueAnswer.new(
@@ -96,6 +93,10 @@ module Summary
 
       def residence_type?
         crime_application.applicant.residence_type.present?
+      end
+
+      def show_home_address?
+        !residence_of_type?('none')
       end
     end
   end

--- a/spec/forms/steps/client/appeal_reference_number_form_spec.rb
+++ b/spec/forms/steps/client/appeal_reference_number_form_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Steps::Client::AppealReferenceNumberForm do
   subject { described_class.new(arguments) }
 
@@ -12,12 +13,36 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication, case: case_record) }
+  let(:crime_application) { instance_double(CrimeApplication, case: case_record, applicant: applicant_record) }
   let(:case_record) { Case.new(case_type: CaseType::APPEAL_TO_CROWN_COURT.to_s) }
+  let(:applicant_record) {
+    instance_double(Applicant, home_address?: home_address?,
+                                           correspondence_address?: correspondence_address?,
+                                           home_address: home_address, correspondence_address: correspondence_address)
+  }
 
   let(:appeal_reference_number) { nil }
   let(:appeal_maat_id) { nil }
   let(:appeal_usn) { nil }
+  let(:home_address?) { false }
+  let(:correspondence_address?) { false }
+  let(:home_address) { instance_double(HomeAddress, destroy!: true) }
+  let(:correspondence_address) { instance_double(CorrespondenceAddress, destroy!: true) }
+
+  let(:applicant_attributes_to_reset) {
+    {
+      'residence_type' => nil,
+      'correspondence_address_type' => nil,
+      'telephone_number' => nil,
+      'has_nino' => nil,
+      'nino' => nil,
+      'will_enter_nino' => nil,
+      'benefit_type' => nil,
+      'last_jsa_appointment_date' => nil,
+      'passporting_benefit' => nil,
+      'has_benefit_evidence' => nil
+    }
+  }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:appeal_reference_number) }
@@ -58,6 +83,9 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
   end
 
   describe '#save' do
+    let(:home_address?) { true }
+    let(:correspondence_address?) { true }
+
     before do
       allow(subject).to receive(:kase).and_return(case_record)
     end
@@ -75,6 +103,8 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
           }
         ).and_return(true)
 
+        expect(applicant_record).to receive(:update).with(applicant_attributes_to_reset).and_return(true)
+
         expect(subject.save).to be(true)
       end
     end
@@ -88,12 +118,15 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
           {
             'appeal_reference_number' => appeal_reference_number,
             'appeal_maat_id' => nil,
-            'appeal_usn' => appeal_usn,
+            'appeal_usn' => appeal_usn
           }
         ).and_return(true)
+
+        expect(applicant_record).to receive(:update).with(applicant_attributes_to_reset).and_return(true)
 
         expect(subject.save).to be(true)
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/forms/steps/client/benefit_type_form_spec.rb
+++ b/spec/forms/steps/client/benefit_type_form_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Steps::Client::BenefitTypeForm do
                       association_name: :applicant,
                       expected_attributes: {
                         'benefit_type' => BenefitType::UNIVERSAL_CREDIT,
-                        'last_jsa_appointment_date' => nil
+                        'last_jsa_appointment_date' => nil,
+                        'has_benefit_evidence' => nil,
                       }
 
       context 'when `benefit_type` answer is not jsa' do
@@ -119,7 +120,8 @@ RSpec.describe Steps::Client::BenefitTypeForm do
                       association_name: :applicant,
                       expected_attributes: {
                         'benefit_type' => BenefitType::UNIVERSAL_CREDIT,
-                        'last_jsa_appointment_date' => nil
+                        'last_jsa_appointment_date' => nil,
+                        'has_benefit_evidence' => nil,
                       }
     end
 

--- a/spec/forms/steps/client/details_form_spec.rb
+++ b/spec/forms/steps/client/details_form_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Steps::Client::DetailsForm do
                             :benefit_type => nil,
                             :passporting_benefit => nil,
                             :last_jsa_appointment_date => nil,
+                            :will_enter_nino => nil,
+                            :has_benefit_evidence => nil,
                           }
         end
 
@@ -75,6 +77,8 @@ RSpec.describe Steps::Client::DetailsForm do
                             :benefit_type => nil,
                             :passporting_benefit => nil,
                             :last_jsa_appointment_date => nil,
+                            :will_enter_nino => nil,
+                            :has_benefit_evidence => nil,
                           }
         end
       end

--- a/spec/forms/steps/client/has_nino_form_spec.rb
+++ b/spec/forms/steps/client/has_nino_form_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe Steps::Client::HasNinoForm do
                           'benefit_type' => nil,
                           'last_jsa_appointment_date' => nil,
                           'passporting_benefit' => nil,
+                          'will_enter_nino' => nil,
+                          'has_benefit_evidence' => nil,
                         }
       end
 
@@ -205,6 +207,8 @@ RSpec.describe Steps::Client::HasNinoForm do
                           'benefit_type' => nil,
                           'last_jsa_appointment_date' => nil,
                           'passporting_benefit' => nil,
+                          'will_enter_nino' => nil,
+                          'has_benefit_evidence' => nil,
                         }
 
         context 'when `has_nino` answer is no' do


### PR DESCRIPTION
## Description of change

Resets `has_benefit_evidence`  if a user 
1. User selects None for Passporting benefit
2. User updates DoB to be u18
3. User changes case type to Appeal no changes (i.e. there is an appeal_reference_number present)

Reset `will_enter_nino` if:
1. NINO is subsequently entered
2. User updates DoB to be u18 and/or client's last name
3. User changes case type to Appeal no changes (i.e. there is an appeal_reference_number present)

User changes case type to Appeal no changes, all client details are reset if the question is no longer applicable. This affects

Residence type, Home address, Correspondence address, telephone number, nino, benefit type and other applicable attributes

## Link to relevant ticket
[CRIMAPP-799](https://dsdmoj.atlassian.net/browse/CRIMAPP-799)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Test the scenarios listed in the above description

[CRIMAPP-799]: https://dsdmoj.atlassian.net/browse/CRIMAPP-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ