### PR TITLE
[CRIMAPP-786] Add guard to check if income/outgoings present

### DIFF
--- a/app/presenters/summary/sections/income_benefits_details.rb
+++ b/app/presenters/summary/sections/income_benefits_details.rb
@@ -4,7 +4,9 @@ module Summary
   module Sections
     class IncomeBenefitsDetails < Sections::PaymentDetails
       def show?
-        income&.has_no_income_benefits == 'yes' || super
+        return false if income.blank?
+
+        income.has_no_income_benefits == 'yes' || super
       end
 
       private

--- a/app/presenters/summary/sections/income_payments_details.rb
+++ b/app/presenters/summary/sections/income_payments_details.rb
@@ -4,7 +4,9 @@ module Summary
   module Sections
     class IncomePaymentsDetails < Sections::PaymentDetails
       def show?
-        income&.has_no_income_payments == 'yes' || super
+        return false if income.blank?
+
+        income.has_no_income_payments == 'yes' || super
       end
 
       private

--- a/app/presenters/summary/sections/outgoings_payments_details.rb
+++ b/app/presenters/summary/sections/outgoings_payments_details.rb
@@ -2,7 +2,9 @@ module Summary
   module Sections
     class OutgoingsPaymentsDetails < Sections::PaymentDetails
       def show?
-        outgoings&.has_no_other_outgoings == 'yes' || super
+        return false if outgoings.blank?
+
+        outgoings.has_no_other_outgoings == 'yes' || super
       end
 
       private

--- a/spec/presenters/summary/sections/income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/income_benefits_details_spec.rb
@@ -84,6 +84,14 @@ describe Summary::Sections::IncomeBenefitsDetails do
   end
 
   describe '#show?' do
+    context 'when there is no income data' do
+      let(:income) { nil }
+
+      it 'shows this section' do
+        expect(subject.show?).to be false
+      end
+    end
+
     context 'when there are income benefits' do
       let(:income_benefits) { [child_benefit_payment] }
 

--- a/spec/presenters/summary/sections/income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/income_payments_details_spec.rb
@@ -120,6 +120,14 @@ describe Summary::Sections::IncomePaymentsDetails do
   end
 
   describe '#show?' do
+    context 'when there is no income data' do
+      let(:income) { nil }
+
+      it 'shows this section' do
+        expect(subject.show?).to be false
+      end
+    end
+
     context 'when there are income payments' do
       let(:income_payments) { [maintenance_payment] }
 

--- a/spec/presenters/summary/sections/outgoings_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/outgoings_payments_details_spec.rb
@@ -56,6 +56,14 @@ describe Summary::Sections::OutgoingsPaymentsDetails do
   end
 
   describe '#show?' do
+    context 'when there are no outgoings' do
+      let(:outgoings) { nil }
+
+      it 'shows this section' do
+        expect(subject.show?).to be false
+      end
+    end
+
     context 'when there are outgoings payments' do
       let(:outgoings_payments) { [childcare_outgoing] }
 


### PR DESCRIPTION
## Description of change
Fixes error on completed application page for applications that did not go through means assessment (e.g. nino = yes, passporting benefit = yes, has benefit evidence = yes). 

Adds a guard to prevent checking attributes on the income/outgoings object when they are not present

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
