### PR TITLE
Redirect to client/benefit_type after dwp fail is confirmed by provider

### DIFF
--- a/app/forms/steps/dwp/confirm_result_form.rb
+++ b/app/forms/steps/dwp/confirm_result_form.rb
@@ -12,7 +12,9 @@ module Steps
       private
 
       def persist!
-        true
+        return true if confirm_result.no?
+
+        crime_application.applicant.update(benefit_type: BenefitType::NONE)
       end
     end
   end

--- a/spec/forms/steps/dwp/confirm_result_form_spec.rb
+++ b/spec/forms/steps/dwp/confirm_result_form_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe Steps::DWP::ConfirmResultForm do
   # NOTE: not using shared examples for form objects yet, to be added
   # once we have some more form objects and some patterns emerge
 
-  subject { described_class.new }
+  subject { described_class.new(crime_application:) }
+
+  let(:crime_application) { instance_double(CrimeApplication, applicant:) }
+  let(:applicant) { instance_double(Applicant) }
 
   describe '#choices' do
     it 'returns the possible choices' do
@@ -27,9 +30,20 @@ RSpec.describe Steps::DWP::ConfirmResultForm do
     end
 
     context 'when `confirm_result` is provided' do
-      it 'returns true' do
-        subject.choices.each do |choice|
-          subject.confirm_result = choice
+      context 'when `confirm_result` is `no`' do
+        it 'returns true' do
+          subject.confirm_result = 'no'
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when `confirm_result` is `yes`' do
+        before do
+          subject.confirm_result = 'yes'
+        end
+
+        it 'returns true and sets the benefit type to `none`' do
+          expect(applicant).to receive(:update).with(benefit_type: BenefitType::NONE).and_return(true)
           expect(subject.save).to be(true)
         end
       end


### PR DESCRIPTION
## Description of change

Set 'benefit_type' to 'none' if provider confirms DWP result "DWP records show that your client does not receive a passporting benefit" is correct.

Previously the provider was able to proceed, with the applicant benefit_type set to a passporting benefit.

## Link to relevant ticket

[CRIMAPP-809](https://dsdmoj.atlassian.net/browse/CRIMAPP-809)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-809]: https://dsdmoj.atlassian.net/browse/CRIMAPP-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ