### PR TITLE
CRIMAPP-818 Skip means assessment when NINO forthcoming

### DIFF
--- a/app/controllers/steps/submission/declaration_controller.rb
+++ b/app/controllers/steps/submission/declaration_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Submission
     class DeclarationController < Steps::SubmissionStepController
+      before_action :ensure_reviewed
+
       def edit
         @form_object = DeclarationForm.new(
           record: current_provider,
@@ -32,6 +34,12 @@ module Steps
           legal_rep_last_name: last_name,
           legal_rep_telephone: telephone,
         }
+      end
+
+      def ensure_reviewed
+        return true if current_crime_application.valid?(:submission_review)
+
+        redirect_to edit_steps_submission_review_path(current_crime_application)
       end
     end
   end

--- a/app/forms/steps/submission/review_form.rb
+++ b/app/forms/steps/submission/review_form.rb
@@ -2,7 +2,7 @@ module Steps
   module Submission
     class ReviewForm < Steps::BaseFormObject
       def persist!
-        crime_application.valid?(:submission)
+        crime_application.valid?(:submission_review)
       end
     end
   end

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -20,10 +20,6 @@ module TypeOfMeansAssessment
     end
   end
 
-  def means_assessment_complete?
-    income.complete? && (!requires_full_means_assessment? || (outgoings&.complete? && capital&.complete?))
-  end
-
   def requires_full_capital?
     return false unless kase&.case_type
 
@@ -35,7 +31,22 @@ module TypeOfMeansAssessment
   end
 
   def evidence_of_passporting_means_forthcoming?
-    has_passporting_benefit? && applicant.has_benefit_evidence == 'yes'
+    return false unless has_passporting_benefit?
+
+    benefit_evidence_forthcoming? || nino_forthcoming?
+  end
+
+  # Relevant when there's a passporting benefit but the NINO is unknown.
+  # We consider the application to be passported on benefits until the
+  # submission declaration.
+  # However, if the applicant is not in court custody, submission will be
+  # blocked until the NINO or benefit evidence is provided.
+  def nino_forthcoming?
+    applicant.has_nino == 'no' && applicant.will_enter_nino == 'no'
+  end
+
+  def benefit_evidence_forthcoming?
+    applicant.has_benefit_evidence == 'yes'
   end
 
   def means_assessment_in_lieu_of_passporting?

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -75,6 +75,10 @@ class CrimeApplication < ApplicationRecord
     ::ClientDetails::AnswersValidator.new(self).validate
   end
 
+  validate on: :submission_review, unless: :post_submission_evidence? do
+    ::SectionsCompletenessValidator.new(self).validate
+  end
+
   def client_details_complete?
     valid?(:client_details)
   end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -5,7 +5,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
 
   # More validations can be added here
   # Errors, when more than one, will maintain the order
-  def perform_validations # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def perform_validations # rubocop:disable Metrics/MethodLength
     errors = []
 
     unless means_valid?
@@ -23,12 +23,6 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
     unless Passporting::IojPassporter.new(record).call || ioj_present?
       errors << [
         :ioj_passport, :blank, { change_path: edit_steps_case_ioj_path }
-      ]
-    end
-
-    unless all_sections_complete?
-      errors << [
-        :base, :incomplete_records, { change_path: edit_steps_submission_review_path }
       ]
     end
 
@@ -51,19 +45,6 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
 
   def client_remanded_in_custody?
     kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
-  end
-
-  def all_sections_complete?
-    return false unless crime_application.client_details_complete?
-    return false unless kase.complete?
-
-    means_sections_complete?
-  end
-
-  def means_sections_complete?
-    return true if income.blank?
-
-    !requires_means_assessment? || means_assessment_complete?
   end
 
   alias crime_application record

--- a/app/validators/client_details/answers_validator.rb
+++ b/app/validators/client_details/answers_validator.rb
@@ -27,7 +27,6 @@ module ClientDetails
     end
 
     def address_complete?
-      return false unless applicant
       return false if applicant.residence_type.blank?
 
       case applicant.correspondence_address_type
@@ -43,8 +42,6 @@ module ClientDetails
     end
 
     def applicant_details_complete?
-      return false unless applicant
-
       applicant.values_at(
         :date_of_birth, :first_name, :last_name,
       ).all?(&:present?)
@@ -57,7 +54,6 @@ module ClientDetails
     end
 
     def passporting_complete?
-      return false unless applicant
       return true if applicant.benefit_type == 'none'
       return true if evidence_of_passporting_means_forthcoming?
       return true if means_assessment_in_lieu_of_passporting?
@@ -66,7 +62,6 @@ module ClientDetails
     end
 
     def has_nino_complete?
-      return false unless applicant
       return false if applicant.has_nino.blank?
       return true if applicant.has_nino == 'no' && !has_passporting_benefit?
       return true if nino_forthcoming?

--- a/app/validators/client_details/answers_validator.rb
+++ b/app/validators/client_details/answers_validator.rb
@@ -27,6 +27,7 @@ module ClientDetails
     end
 
     def address_complete?
+      return false unless applicant
       return false if applicant.residence_type.blank?
 
       case applicant.correspondence_address_type
@@ -42,6 +43,8 @@ module ClientDetails
     end
 
     def applicant_details_complete?
+      return false unless applicant
+
       applicant.values_at(
         :date_of_birth, :first_name, :last_name,
       ).all?(&:present?)
@@ -54,6 +57,7 @@ module ClientDetails
     end
 
     def passporting_complete?
+      return false unless applicant
       return true if applicant.benefit_type == 'none'
       return true if evidence_of_passporting_means_forthcoming?
       return true if means_assessment_in_lieu_of_passporting?
@@ -62,8 +66,10 @@ module ClientDetails
     end
 
     def has_nino_complete?
+      return false unless applicant
       return false if applicant.has_nino.blank?
-      return true if applicant.has_nino == 'no'
+      return true if applicant.has_nino == 'no' && !has_passporting_benefit?
+      return true if nino_forthcoming?
 
       applicant.nino.present?
     end

--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -1,0 +1,49 @@
+class SectionsCompletenessValidator
+  include TypeOfMeansAssessment
+
+  def initialize(record)
+    @record = record
+  end
+
+  attr_reader :record
+  alias crime_application record
+
+  delegate :errors, to: :record
+
+  def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    if client_details_complete?
+      errors.add(:case_details, :incomplete) unless kase&.complete?
+      errors.add(:income_assessment, :incomplete) unless income_assessment_complete?
+
+      errors.add(:outgoings_assessment, :incomplete) unless outgoings_assessment_complete?
+      errors.add(:capital_assessment, :incomplete) unless capital_assessment_complete?
+    else
+      errors.add(:client_details, :incomplete)
+    end
+
+    errors.add :base, :incomplete_records unless errors.empty?
+  end
+
+  delegate :client_details_complete?, to: :crime_application
+
+  def income_assessment_complete?
+    return true unless requires_means_assessment?
+    return false unless income
+
+    income.complete?
+  end
+
+  def outgoings_assessment_complete?
+    return true unless requires_full_means_assessment?
+    return false unless outgoings
+
+    outgoings.complete?
+  end
+
+  def capital_assessment_complete?
+    return true unless requires_full_means_assessment?
+    return false unless capital
+
+    capital.complete?
+  end
+end

--- a/app/views/steps/submission/review/edit.html.erb
+++ b/app/views/steps/submission/review/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column">
-    <% unless current_crime_application.valid?(:submission) %>
+    <% unless current_crime_application.valid?(:submission_review) %>
       <%= render partial: 'steps/shared/error_warning' %>
     <% end %>
 

--- a/spec/controllers/steps/submission/declaration_controller_spec.rb
+++ b/spec/controllers/steps/submission/declaration_controller_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Steps::Submission::DeclarationController, type: :controller do
     end
 
     context 'when application is found' do
-      let(:existing_case) { CrimeApplication.create(legal_rep_attrs) }
+      let(:existing_case) {
+        CrimeApplication.create(applicant: Applicant.new(date_of_birth: '2000-10-10'), **legal_rep_attrs)
+      }
 
       context 'when it has been reviewed' do
         before do

--- a/spec/forms/steps/submission/review_form_spec.rb
+++ b/spec/forms/steps/submission/review_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Steps::Submission::ReviewForm do
   describe '#save' do
     context 'when no submission validation issues' do
       before do
-        allow(crime_application).to receive(:valid?).with(:submission).and_return(true)
+        allow(crime_application).to receive(:valid?).with(:submission_review).and_return(true)
       end
 
       it 'succeeds' do
@@ -19,7 +19,7 @@ RSpec.describe Steps::Submission::ReviewForm do
 
     context 'when submission validation issues' do
       before do
-        allow(crime_application).to receive(:valid?).with(:submission).and_return(false)
+        allow(crime_application).to receive(:valid?).with(:submission_review).and_return(false)
       end
 
       it 'fails to save' do

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -300,6 +300,7 @@ RSpec.describe Decisions::CaseDecisionTree do
 
   context 'when the step is `ioj`' do
     let(:form_object) { double('FormObject') }
+    let(:has_nino) { nil }
     let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
     let(:has_benefit_evidence) { nil }
     let(:step_name) { :ioj }
@@ -314,7 +315,11 @@ RSpec.describe Decisions::CaseDecisionTree do
         Evidence::Requirements
       ).to receive(:any?).and_return(evidence_required)
 
-      allow(applicant_double).to receive_messages(has_benefit_evidence:, benefit_type:)
+      allow(applicant_double).to receive_messages(
+        has_benefit_evidence:,
+        benefit_type:,
+        has_nino:
+      )
 
       allow(FeatureFlags).to receive(:means_journey) {
         instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_means_journey_enabled)
@@ -325,9 +330,10 @@ RSpec.describe Decisions::CaseDecisionTree do
       let(:means_passported) { false }
       let(:evidence_required) { nil }
 
-      context 'when has benefit evidence is no' do
+      context 'when has a passporting benefit no evidence or nino forthcoming' do
         let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
         let(:has_benefit_evidence) { 'no' }
+        let(:has_nino) { 'yes' }
 
         it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
       end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -1,17 +1,12 @@
 require 'rails_helper'
 
 module Test
-  CrimeApplicationValidatable = Struct.new(:is_means_tested, :kase, :ioj, :income, :outgoings,
-                                           :applicant, :capital, :documents, :means_passport, keyword_init: true) do
+  CrimeApplicationValidatable = Struct.new(:is_means_tested, :kase, :ioj, :income, :documents, keyword_init: true) do
     include ActiveModel::Validations
     validates_with ApplicationFulfilmentValidator
 
     def to_param
       '12345'
-    end
-
-    def client_details_complete?
-      true
     end
   end
 end
@@ -26,50 +21,28 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       kase:,
       ioj:,
       income:,
-      outgoings:,
-      capital:,
-      documents:,
-      means_passport:,
-      applicant:
+      documents:
     }
   end
 
   let(:is_means_tested) { 'yes' }
-  let(:means_passport) { nil }
 
   let(:kase) {
-    instance_double(Case, case_type:, appeal_original_app_submitted:, appeal_reference_number:, appeal_usn:,
-is_client_remanded:, date_client_remanded:)
+    instance_double(Case, case_type:, is_client_remanded:, date_client_remanded:)
   }
-
-  let(:outgoings) { instance_double(Outgoings) }
-  let(:capital) { instance_double(Capital) }
-
   let(:is_client_remanded) { nil }
   let(:date_client_remanded) { nil }
 
   let(:case_type) { 'either_way' }
-  let(:appeal_original_app_submitted) { nil }
-  let(:appeal_reference_number) { nil }
-  let(:appeal_usn) { nil }
-  let(:applicant) { instance_double(Applicant, has_benefit_evidence: nil, benefit_type: nil) }
 
   let(:ioj) { instance_double(Ioj, types: ioj_types) }
   let(:ioj_types) { [] }
 
-  let(:income) { instance_double(Income, employment_status: employment_status, income_above_threshold: 'yes') }
-
+  let(:income) { instance_double(Income, employment_status:) }
   let(:employment_status) { [] }
 
   let(:documents) { double(stored: stored_documents) }
   let(:stored_documents) { [] }
-
-  before do
-    allow(kase).to receive(:complete?).and_return(true)
-    allow(capital).to receive(:complete?).and_return(true)
-    allow(outgoings).to receive(:complete?).and_return(true)
-    allow(income).to receive(:complete?).and_return(true)
-  end
 
   context 'MeansPassporter validation' do
     before do
@@ -209,92 +182,6 @@ is_client_remanded:, date_client_remanded:)
           expect(subject.errors.of_kind?(:base, :case_type_missing)).to be(true)
           expect(subject.errors.first.details[:change_path]).to eq('/applications/12345/steps/client/case_type')
         end
-      end
-    end
-  end
-
-  describe 'validating section completeness' do
-    before do
-      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(means_result)
-      allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(true)
-    end
-
-    let(:means_result) { true }
-
-    it { is_expected.to be_valid }
-
-    context 'when case section is not complete' do
-      before do
-        expect(kase).to receive(:complete?).and_return(false)
-      end
-
-      it { is_expected.not_to be_valid }
-
-      it 'adds the incomplete record error to base' do
-        subject.valid?
-        expect(subject.errors.of_kind?(:base, :incomplete_records)).to be(true)
-      end
-    end
-
-    context 'when client details section is not complete' do
-      before do
-        expect(subject).to receive(:client_details_complete?).and_return(false)
-      end
-
-      it { is_expected.not_to be_valid }
-
-      it 'adds the incomplete record error to base' do
-        subject.valid?
-        expect(subject.errors.of_kind?(:base, :incomplete_records)).to be(true)
-      end
-    end
-
-    context 'when not means tested' do
-      let(:is_means_tested) { 'no' }
-
-      context 'and capital section is not complete' do
-        it { is_expected.to be_valid }
-      end
-    end
-
-    context 'when means tested and not means-passported' do
-      let(:is_means_tested) { 'yes' }
-      let(:means_result) { false }
-      let(:employment_status) { ['not_working'] }
-
-      context 'and capital section is not complete' do
-        before do
-          expect(capital).to receive(:complete?).and_return(false)
-        end
-
-        it { is_expected.not_to be_valid }
-
-        it 'adds the incomplete record error to base' do
-          subject.valid?
-          expect(subject.errors.of_kind?(:base, :incomplete_records)).to be(true)
-        end
-      end
-
-      context 'and capital section is not required' do
-        let(:income) do
-          instance_double(
-            Income,
-            employment_status: employment_status,
-            income_above_threshold: 'no',
-            has_frozen_income_or_assets: 'no',
-            client_owns_property: 'no',
-            has_savings: 'no'
-          )
-        end
-
-        before do
-          expect(capital).not_to receive(:complete?)
-          expect(outgoings).not_to receive(:complete?)
-
-          subject.valid?
-        end
-
-        it { is_expected.to be_valid }
       end
     end
   end

--- a/spec/validators/sections_completeness_validator_spec.rb
+++ b/spec/validators/sections_completeness_validator_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+RSpec.describe SectionsCompletenessValidator, type: :model do
+  subject(:validator) { described_class.new(record) }
+
+  let(:record) { instance_double(CrimeApplication, errors:) }
+  let(:errors) { double(:errors, empty?: false) }
+
+  describe '#validate' do
+    before { allow(record).to receive_messages(**attributes) }
+
+    context 'when means assessment not required' do
+      before do
+        allow(subject).to receive(:requires_means_assessment?).and_return(false)
+      end
+
+      context 'when case complete' do
+        let(:errors) { [] }
+
+        let(:attributes) do
+          { client_details_complete?: true, kase: double(complete?: true) }
+        end
+
+        it 'does not add any errors' do
+          subject.validate
+        end
+      end
+
+      context 'when case incomplete' do
+        let(:attributes) do
+          { client_details_complete?: false }
+        end
+
+        it 'adds errors to case details' do
+          expect(errors).to receive(:add).with(:client_details, :incomplete)
+          expect(errors).to receive(:add).with(:base, :incomplete_records)
+
+          subject.validate
+        end
+      end
+    end
+
+    context 'when partial means assessment required' do
+      before do
+        allow(subject).to receive_messages(requires_means_assessment?: true, requires_full_means_assessment?: false)
+      end
+
+      let(:errors) { [] }
+
+      let(:attributes) do
+        {
+          client_details_complete?: true,
+          kase: double(complete?: true),
+          income: double(complete?: true)
+        }
+      end
+
+      it 'does not add any errors' do
+        subject.validate
+      end
+    end
+
+    context 'when a full means assessment required' do
+      before do
+        allow(subject).to receive_messages(requires_means_assessment?: true, requires_full_means_assessment?: true)
+      end
+
+      context 'when all sections complete' do
+        let(:errors) { [] }
+
+        let(:attributes) do
+          {
+            client_details_complete?: true,
+            kase: double(complete?: true),
+            income: double(complete?: true),
+            outgoings: double(complete?: true),
+            capital: double(complete?: true)
+          }
+        end
+
+        it 'does not add any errors' do
+          subject.validate
+        end
+      end
+
+      context 'when kase, income, outgoings and capital incomplete' do
+        let(:attributes) do
+          {
+            client_details_complete?: true,
+            kase: double(complete?: false),
+            income: double(complete?: false),
+            outgoings: double(complete?: false),
+            capital: double(complete?: false)
+          }
+        end
+
+        it 'adds errors to all sections and base' do
+          expect(errors).to receive(:add).with(:case_details, :incomplete)
+          expect(errors).to receive(:add).with(:income_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:outgoings_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:capital_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:base, :incomplete_records)
+
+          subject.validate
+        end
+      end
+
+      context 'when income, outgoings and capital are missing' do
+        let(:attributes) do
+          {
+            client_details_complete?: true,
+            kase: double(complete?: true),
+            income: nil,
+            outgoings: nil,
+            capital: nil
+          }
+        end
+
+        it 'adds errors to all sections and base' do
+          expect(errors).to receive(:add).with(:income_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:outgoings_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:capital_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:base, :incomplete_records)
+
+          subject.validate
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
 
Skip means assessment when nino forthcoming
Submission/declaration redirects to submission/review unless all sections complete
Extract section completeness validations from the fulfilment validator

## Link to relevant ticket
[CRIMAPP-818](https://dsdmoj.atlassian.net/browse/CRIMAPP-818)

## Notes for reviewer

This PR introduces a behaviour change with submission validation. Previously section completeness was combined with fulfilment validation. When showing incomplete sections on submission/review was introduced it caused a regression in existing fulfilment validation handling for the nino. This pr separates section completeness validation from fulfilment_validation and only undertakes section completness validation on submission/review and fulfilment_validation on submission/declaration.

Section completness validation for fulfilment is now enforced by the submission/declration controller which now redirects to submission/review if there are incomplete sections.

The pr also updates evidence_of_passporting_means_forthcoming? to include applications with a passporting benefit but without a nino.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

See ticket for acceptance


[CRIMAPP-818]: https://dsdmoj.atlassian.net/browse/CRIMAPP-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ