### PR TITLE
CRIMAPP-773 Fix task list item for additional information section 

### DIFF
--- a/app/controllers/steps/submission/more_information_controller.rb
+++ b/app/controllers/steps/submission/more_information_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(MoreInformationForm, as: :more_information)
       end
-
-      private
-
-      def additional_permitted_params
-        [:need_more_information]
-      end
     end
   end
 end

--- a/app/forms/steps/submission/more_information_form.rb
+++ b/app/forms/steps/submission/more_information_form.rb
@@ -1,35 +1,30 @@
 module Steps
   module Submission
     class MoreInformationForm < Steps::BaseFormObject
+      attribute :additional_information_required, :value_object, source: YesNoAnswer
       attribute :additional_information, :string
 
+      validates :additional_information_required, inclusion: { in: :choices }
+
       validates :additional_information, presence: true,
-        unless: -> { more_information_not_needed? }
+                if: -> { additional_information_needed? }
 
       def persist!
-        self.additional_information = nil if more_information_not_needed?
-
-        crime_application.update(additional_information:)
+        crime_application.update(attributes)
       end
 
       def choices
         YesNoAnswer.values
       end
 
-      def need_more_information
-        return @need_more_information unless @need_more_information.nil?
-
-        YesNoAnswer::YES if crime_application.additional_information.present?
-      end
-
-      def need_more_information=(attr)
-        @need_more_information = YesNoAnswer.new(attr)
-      end
-
       private
 
-      def more_information_not_needed?
-        need_more_information == YesNoAnswer::NO
+      def additional_information_needed?
+        additional_information_required == YesNoAnswer::YES
+      end
+
+      def before_save
+        self.additional_information = nil unless additional_information_needed?
       end
     end
   end

--- a/app/presenters/tasks/more_information.rb
+++ b/app/presenters/tasks/more_information.rb
@@ -13,7 +13,7 @@ module Tasks
     end
 
     def in_progress?
-      crime_application.additional_information.present?
+      crime_application.additional_information_required.present?
     end
 
     def completed?

--- a/app/views/steps/submission/more_information/edit.html.erb
+++ b/app/views/steps/submission/more_information/edit.html.erb
@@ -6,14 +6,14 @@
 
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:need_more_information, legend: { tag: 'h1', size: 'xl' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:additional_information_required, legend: { tag: 'h1', size: 'xl' }) do %>
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice.yes? %>
-            <%= f.govuk_radio_button :need_more_information, choice.value do %>
+            <%= f.govuk_radio_button :additional_information_required, choice.value do %>
               <%= f.govuk_text_area :additional_information %>
             <% end %>
           <% else %>
-            <%= f.govuk_radio_button :need_more_information, choice.value, link_errors: index.zero? %>
+            <%= f.govuk_radio_button :additional_information_required, choice.value, link_errors: index.zero? %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -774,7 +774,9 @@ en:
         steps/submission/more_information_form:
           attributes:
             additional_information:
-              blank: Enter details you need to add to the application or select no
+              blank: Enter details you need to add to the application
+            additional_information_required:
+              inclusion: Select yes if you need to add any more information to this application
         steps/submission/declaration_form:
           attributes:
             legal_rep_first_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -115,7 +115,7 @@ en:
       steps_outgoings_outgoings_payments_form:
         outgoings_payments: Which of these payments does your client pay?
       steps_submission_more_information_form:
-        need_more_information: Do you need to add any more information to this application?
+        additional_information_required: Do you need to add any more information to this application?
       steps_capital_property_type_form:
         property_type: Which assets does your client own or part-own inside or outside the UK?
       steps_capital_saving_type_form:
@@ -553,7 +553,7 @@ en:
       steps_evidence_upload_form:
         upload_files: Upload files
       steps_submission_more_information_form:
-        need_more_information_options: *YESNO
+        additional_information_required_options: *YESNO
         additional_information: Enter details that will help us process this application
       steps_submission_declaration_form:
         legal_rep_first_name: First name

--- a/db/migrate/20240502133510_add_additional_information_required_to_crime_application.rb
+++ b/db/migrate/20240502133510_add_additional_information_required_to_crime_application.rb
@@ -1,0 +1,5 @@
+class AddAdditionalInformationRequiredToCrimeApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :additional_information_required, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_24_103714) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_02_133510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_24_103714) do
     t.text "additional_information"
     t.jsonb "evidence_prompts", default: []
     t.datetime "evidence_last_run_at"
+    t.string "additional_information_required"
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true
   end

--- a/spec/forms/steps/submission/more_information_form_spec.rb
+++ b/spec/forms/steps/submission/more_information_form_spec.rb
@@ -1,63 +1,108 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Submission::MoreInformationForm do
-  subject(:form) { described_class.new(additional_information:, crime_application:) }
+  subject(:form) { described_class.new(arguments) }
 
   let(:crime_application) { instance_double(CrimeApplication) }
-  let(:additional_information) { 'More information about this application.' }
-  let(:record_additional_information) { nil }
+  let(:additional_information_required) { YesNoAnswer::YES }
+  let(:additional_information) { '' }
+  let(:arguments) do
+    {
+      crime_application:,
+    additional_information_required:,
+    additional_information:,
+    }
+  end
 
   before do
     allow(crime_application).to receive(:additional_information)
-      .and_return(record_additional_information)
+      .and_return(additional_information)
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:additional_information) }
+    context 'when additional information is required' do
+      let(:additional_information_required) { YesNoAnswer::YES }
+
+      it { is_expected.to validate_presence_of(:additional_information) }
+    end
 
     context 'when additional information is not needed' do
-      before { form.need_more_information = 'no' }
+      let(:additional_information_required) { YesNoAnswer::NO }
 
       it { is_expected.not_to validate_presence_of(:additional_information) }
     end
   end
 
-  describe '#need_more_information' do
-    subject(:need_more_information) { form.need_more_information }
-
-    context 'when no additional information stored' do
-      it { is_expected.to be_nil }
-    end
-
-    context 'when additional information stored' do
-      let(:record_additional_information) { 'Old information' }
-
-      it { is_expected.to be YesNoAnswer::YES }
-    end
-
-    context 'when a new value is assigned' do
-      before { form.need_more_information = 'no' }
-
-      it { is_expected.to eq YesNoAnswer::NO }
-    end
-  end
-
   describe '#save' do
-    it 'stores the `additional_information`' do
-      expect(crime_application).to receive(:update)
-        .with(additional_information:).and_return(true)
+    context 'when `additional_information_required` is blank' do
+      let(:additional_information_required) { '' }
 
-      expect(form.save).to be true
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:additional_information_required, :inclusion)).to be(true)
+      end
     end
 
-    context 'when additional information is not needed' do
-      before { form.need_more_information = 'no' }
+    context 'when `additional_information_required` is invalid' do
+      let(:additional_information_required) { 'invalid_selection' }
 
-      it 'clears the `additional_information`' do
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:additional_information_required, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `additional_information_required` is `NO`' do
+      let(:additional_information_required) { YesNoAnswer::NO.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:additional_information_required, :invalid)).to be(false)
+      end
+
+      it 'updates the record' do
         expect(crime_application).to receive(:update)
-          .with(additional_information: nil).and_return(true)
+          .with({
+                  'additional_information_required' => YesNoAnswer::NO,
+                                       'additional_information' => nil
+                })
+          .and_return(true)
 
-        expect(form.save).to be true
+        expect(form.save).to be(true)
+      end
+    end
+
+    context 'when `additional_information_required` is `YES`' do
+      let(:additional_information_required) { YesNoAnswer::YES.to_s }
+
+      context 'when `additional_information` is blank' do
+        it 'has is a validation error on the field' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:additional_information, :blank)).to be(true)
+        end
+      end
+
+      context 'when `additional_information` is not blank' do
+        let(:additional_information) { 'More information about this application.' }
+
+        it 'there is no validation error on the field' do
+          expect(form).to be_valid
+          expect(form.errors.of_kind?(:additional_information, :blank)).to be(false)
+        end
+      end
+    end
+
+    context 'when text for `additional_information` was previously recorded' do
+      let(:additional_information) { 'Details entered previously' }
+
+      context 'when NO is selected for `additional_information_required`' do
+        let(:additional_information_required) { YesNoAnswer::NO.to_s }
+
+        it 'resets `additional_information` to nil before saving' do
+          form.send(:before_save)
+          expect(form.attributes['additional_information']).to be_nil
+        end
       end
     end
   end

--- a/spec/presenters/tasks/more_information_spec.rb
+++ b/spec/presenters/tasks/more_information_spec.rb
@@ -51,37 +51,39 @@ RSpec.describe Tasks::MoreInformation do
     before do
       allow(
         crime_application
-      ).to receive(:additional_information).and_return additional_information
+      ).to receive(:additional_information_required).and_return additional_information_required
     end
 
-    context 'when additional information is given' do
-      let(:additional_information) { 'Some info' }
+    context 'when additional information required has been answered' do
+      let(:additional_information_required) { 'Yes' }
 
       it { expect(subject.in_progress?).to be(true) }
     end
 
-    context 'when additional information has not yet been given' do
-      let(:additional_information) { nil }
+    context 'when additional information has not been answered' do
+      let(:additional_information_required) { nil }
 
       it { expect(subject.in_progress?).to be(false) }
     end
   end
 
   describe '#completed?' do
+    let(:additional_information_required) { nil }
+
     before do
       allow(
         crime_application
-      ).to receive(:additional_information).and_return additional_information
+      ).to receive(:additional_information_required).and_return additional_information_required
     end
 
-    context 'when additional information is given' do
-      let(:additional_information) { 'Some info' }
+    context 'when additional information required has been answered' do
+      let(:additional_information_required) { 'Yes' }
 
       it { expect(subject.completed?).to be(true) }
     end
 
-    context 'when additional information has not yet been given' do
-      let(:additional_information) { nil }
+    context 'when additional information has not been answered' do
+      let(:additional_information_required) { nil }
 
       it { expect(subject.completed?).to be(false) }
     end


### PR DESCRIPTION
## Description of change

Previously the task list item 'Add any more information' would show as 'Not started' if you selected 'No' on the 'Do you need to add any more information to this application?' page.
This PR adds a new attribute `additional_information_required` to `CrimeApplication' which is used to check completeness in the task list, and refactors the `more_information` form and specs. 

## Link to relevant ticket

[CRIMAPP-773](https://dsdmoj.atlassian.net/browse/CRIMAPP-773)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1020" alt="Screenshot 2024-05-02 at 17 36 11" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/0135d14f-9569-4cf5-9f9a-1df122ea46b9">

## How to manually test the feature

Start a new application and continue to the 'Do you need to add any more information to this application?' page. Respond 'No' and select 'Save and come back later'. You should be on the task list page with Section 5 'Add any more information' showing with the 'Completed' tag. 
