### PR TITLE
Fix task list for returned applications

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -42,7 +42,9 @@ module TypeOfMeansAssessment
   # However, if the applicant is not in court custody, submission will be
   # blocked until the NINO or benefit evidence is provided.
   def nino_forthcoming?
-    applicant.has_nino == 'no' && applicant.will_enter_nino == 'no'
+    return false unless applicant.has_nino == 'no'
+
+    applicant.will_enter_nino == 'no' || kase.is_client_remanded == 'yes'
   end
 
   def benefit_evidence_forthcoming?

--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -20,11 +20,10 @@ module Passporting
     end
 
     def not_means_tested?
-      return passported_on?(MeansPassportType::ON_NOT_MEANS_TESTED) if resubmission?
-
       app_not_means_tested?
     end
 
+    # Age based passporting persists on resubmission
     def age_passported?
       return passported_on?(MeansPassportType::ON_AGE_UNDER18) if resubmission?
 
@@ -32,8 +31,6 @@ module Passporting
     end
 
     def benefit_check_passported?
-      return passported_on?(MeansPassportType::ON_BENEFIT_CHECK) if resubmission?
-
       benefit_check_passed?
     end
 

--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -25,8 +25,8 @@ module PassportingBenefitCheck
     end
 
     def benefit_questions_complete?
-      # passed the dwp check
-      return true if applicant.passporting_benefit == 'true'
+      # Applicant#passporting_benefit is stored as a boolean
+      return true if applicant.passporting_benefit == true
 
       errors.add(:will_enter_nino, :blank) unless will_enter_nino_complete?
 
@@ -54,7 +54,6 @@ module PassportingBenefitCheck
     end
 
     def dwp_check_not_undertaken?
-      # could be because the checker is down or applicant has no pp benefit or nino
       applicant.passporting_benefit.nil?
     end
 

--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -37,7 +37,9 @@ module PassportingBenefitCheck
     end
 
     def will_enter_nino_complete?
-      applicant.has_nino == 'no' ? applicant.will_enter_nino.present? : true
+      return true unless applicant.has_nino == 'no'
+
+      nino_forthcoming?
     end
 
     def confirm_dwp_result_complete?

--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -29,9 +29,7 @@ module PassportingBenefitCheck
       return true if applicant.passporting_benefit == true
 
       errors.add(:will_enter_nino, :blank) unless will_enter_nino_complete?
-
-      return false if dwp_check_not_undertaken?
-
+      errors.add(:passporting_benefit, :blank) if dwp_check_not_undertaken?
       errors.add(:confirm_dwp_result, :blank) unless confirm_dwp_result_complete?
       errors.add(:has_benefit_evidence, :blank) unless has_benefit_evidence_complete?
     end
@@ -56,6 +54,8 @@ module PassportingBenefitCheck
     end
 
     def dwp_check_not_undertaken?
+      return false if applicant.has_nino == 'no'
+
       applicant.passporting_benefit.nil?
     end
 

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -213,16 +213,12 @@ RSpec.describe Passporting::MeansPassporter do
         allow(crime_application).to receive(:means_passport).and_return(means_passport)
       end
 
-      context 'passported on benefit check' do
+      context 'origionally passported on benefit check' do
         let(:means_passport) { [MeansPassportType::ON_BENEFIT_CHECK.to_s] }
 
-        it { expect(subject.benefit_check_passported?).to be(false) }
-      end
-
-      context 'not passported on benefit check' do
-        let(:means_passport) { [MeansPassportType::ON_AGE_UNDER18.to_s] }
-
-        it { expect(subject.benefit_check_passported?).to be(false) }
+        it 'ignores the origional means_passport' do
+          expect(subject.benefit_check_passported?).to be(false)
+        end
       end
     end
   end

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -213,10 +213,10 @@ RSpec.describe Passporting::MeansPassporter do
         allow(crime_application).to receive(:means_passport).and_return(means_passport)
       end
 
-      context 'origionally passported on benefit check' do
+      context 'originally passported on benefit check' do
         let(:means_passport) { [MeansPassportType::ON_BENEFIT_CHECK.to_s] }
 
-        it 'ignores the origional means_passport' do
+        it 'ignores the original means_passport' do
           expect(subject.benefit_check_passported?).to be(false)
         end
       end

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Passporting::MeansPassporter do
       context 'passported on benefit check' do
         let(:means_passport) { [MeansPassportType::ON_BENEFIT_CHECK.to_s] }
 
-        it { expect(subject.benefit_check_passported?).to be(true) }
+        it { expect(subject.benefit_check_passported?).to be(false) }
       end
 
       context 'not passported on benefit check' do

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
           end
         end
       end
+
+      context 'when dwp check forthcoming' do
+        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
+        let(:has_nino) { 'yes' }
+        let(:passporting_benefit) { nil }
+
+        context 'when passporting_benefit is blank' do
+          it 'adds errors for all failed validations' do
+            expect(errors).to receive(:add).with(:passporting_benefit, :blank)
+            expect(errors).to receive(:add).with(:confirm_dwp_result, :blank)
+            expect(errors).to receive(:add).with(:base, :incomplete_records)
+
+            subject.validate
+          end
+        end
+      end
     end
 
     describe '#benefit_type_complete?' do
@@ -196,6 +212,14 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
     end
 
     describe '#dwp_check_not_undertaken?' do
+      context 'when applicant has no nino' do
+        let(:has_nino) { 'no' }
+
+        it 'returns false' do
+          expect(subject.dwp_check_not_undertaken?).to be(false)
+        end
+      end
+
       context 'when passporting_benefit_check present' do
         let(:passporting_benefit) { false }
 

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
   let(:passporting_benefit) { nil }
 
   describe '#validate' do
+    context 'when dwp check completed successfully' do
+      let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
+      let(:passporting_benefit) { true }
+
+      before do
+        allow(errors).to receive(:empty?).and_return(true)
+      end
+
+      it 'adds errors for all failed validations' do
+        subject.validate
+      end
+    end
+
     context 'when validation fails' do
       context 'when section has not been started' do
         it 'adds errors for all failed validations' do

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record) }
 
@@ -8,13 +9,14 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
   let(:applicant) {
     instance_double(Applicant, benefit_type:, has_benefit_evidence:, has_nino:, will_enter_nino:, passporting_benefit:)
   }
-  let(:kase) { instance_double(Case) }
+  let(:kase) { instance_double(Case, is_client_remanded:) }
   let(:benefit_type) { nil }
   let(:has_benefit_evidence) { nil }
   let(:has_nino) { nil }
   let(:will_enter_nino) { nil }
   let(:confirm_dwp_result) { nil }
   let(:passporting_benefit) { nil }
+  let(:is_client_remanded) { nil }
 
   describe '#validate' do
     context 'when dwp check completed successfully' do
@@ -98,6 +100,14 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
     describe '#will_enter_nino_complete?' do
       let(:has_nino) { 'no' }
 
+      context 'when has_nino' do
+        let(:has_nino) { 'yes' }
+
+        it 'returns true' do
+          expect(subject.will_enter_nino_complete?).to be(true)
+        end
+      end
+
       context 'when will enter nino present' do
         let(:will_enter_nino) { 'no' }
 
@@ -109,6 +119,22 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
       context 'when will_enter_nino not present' do
         it 'returns false' do
           expect(subject.will_enter_nino_complete?).to be(false)
+        end
+
+        context 'when we know applicant is in court custody?' do
+          let(:is_client_remanded) { 'yes' }
+
+          it 'returns true' do
+            expect(subject.will_enter_nino_complete?).to be(true)
+          end
+        end
+
+        context 'when we know applicant is not in court custody?' do
+          let(:is_client_remanded) { 'no' }
+
+          it 'returns true' do
+            expect(subject.will_enter_nino_complete?).to be(false)
+          end
         end
       end
     end
@@ -186,3 +212,5 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
     end
   end
 end
+
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## Description of change
Returned applications can become passported.
We consider will_enter_nino complete if we already know applicant in custody.

## Link to relevant ticket
[CRIMAPP-841](https://dsdmoj.atlassian.net/browse/CRIMAPP-841)
[CRIMAPP-820](https://dsdmoj.atlassian.net/browse/CRIMAPP-820)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

See ticket

[CRIMAPP-841]: https://dsdmoj.atlassian.net/browse/CRIMAPP-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRIMAPP-820]: https://dsdmoj.atlassian.net/browse/CRIMAPP-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ