### PR TITLE
CRIMAPP-859 Update employment status page

### DIFF
--- a/app/forms/steps/income/employment_status_form.rb
+++ b/app/forms/steps/income/employment_status_form.rb
@@ -29,7 +29,7 @@ module Steps
       private
 
       def validate_statuses
-        return unless employment_status.empty? || (employment_status - EmploymentStatus.values.map(&:to_s)).any?
+        return unless employment_status.empty? || (employment_status - choices.map(&:to_s)).any?
 
         errors.add(:employment_status,
                    :invalid)

--- a/app/services/evidence/rules/20240426012343_self_employed.rb
+++ b/app/services/evidence/rules/20240426012343_self_employed.rb
@@ -9,8 +9,6 @@ module Evidence
       client do |crime_application|
         self_employed_status = [
           EmploymentStatus::SELF_EMPLOYED.to_s,
-          EmploymentStatus::BUSINESS_PARTNERSHIP.to_s,
-          EmploymentStatus::SHAREHOLDER.to_s,
         ]
 
         self_employed_status.intersect?(

--- a/app/value_objects/employment_status.rb
+++ b/app/value_objects/employment_status.rb
@@ -2,9 +2,6 @@ class EmploymentStatus < ValueObject
   VALUES = [
     EMPLOYED = new(:employed),
     SELF_EMPLOYED = new(:self_employed),
-    BUSINESS_PARTNERSHIP = new(:business_partnership),
-    DIRECTOR = new(:director),
-    SHAREHOLDER = new(:shareholder),
     NOT_WORKING = new(:not_working),
   ].freeze
 end

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -219,7 +219,9 @@ en:
       steps_income_employment_status_form:
         employment_status: Select all that apply.
         employment_status_options:
-          not_working: This includes anyone who has ended employment in the last 3 months, has never had a job, or is a pensioner.
+          employed: They have a job where they are paid by an employer.
+          self_employed: Includes if they are in a business partnership, or are a director or shareholder in a private company.
+          not_working: Includes if they have ended employment in the last 3 months, never had a job, or they are a pensioner.
       steps_income_lost_job_in_custody_form:
         date_job_lost: For example, 27 3 2007
       steps_income_income_payments_form:
@@ -411,10 +413,7 @@ en:
         employment_status_options:
           employed: Employed
           self_employed: Self-employed
-          business_partnership: In a business partnership
-          director: Company director in a private company
-          shareholder: Shareholder in a private company
-          not_working: My client is not working
+          not_working: Not working
         ended_employment_within_three_months_options: *YESNO
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -301,7 +301,7 @@ en:
       employment_status:
         question: What is your client’s employment status?
         answers:
-          'not_working': My client is not working
+          'not_working': Not working
       ended_employment_within_three_months:
         question: Has your client ended employment in the last 3 months?
         answers:

--- a/spec/forms/steps/income/employment_status_form_spec.rb
+++ b/spec/forms/steps/income/employment_status_form_spec.rb
@@ -24,9 +24,6 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
       ).to eq([
                 EmploymentStatus::EMPLOYED,
                 EmploymentStatus::SELF_EMPLOYED,
-                EmploymentStatus::BUSINESS_PARTNERSHIP,
-                EmploymentStatus::DIRECTOR,
-                EmploymentStatus::SHAREHOLDER,
                 EmploymentStatus::NOT_WORKING
               ])
     end
@@ -55,14 +52,14 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
         expect(form).not_to be_valid
         expect(form.errors.of_kind?(:employment_status, :invalid)).to be(true)
       end
+    end
 
-      context 'when `employment_status` selected has a valid and an invalid option' do
-        let(:employment_status) { %w[foo EmploymentStatus::EMPLOYED] }
+    context 'when `employment_status` selected has a valid and an invalid option' do
+      let(:employment_status) { %w[foo EmploymentStatus::EMPLOYED] }
 
-        it 'has is a validation error on the field' do
-          expect(form).not_to be_valid
-          expect(form.errors.of_kind?(:employment_status, :invalid)).to be(true)
-        end
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:employment_status, :invalid)).to be(true)
       end
     end
 

--- a/spec/services/evidence/rules/20240425220057_salaried_employee_spec.rb
+++ b/spec/services/evidence/rules/20240425220057_salaried_employee_spec.rb
@@ -28,17 +28,9 @@ RSpec.describe Evidence::Rules::SalariedEmployee do
     end
 
     context 'when not employed' do
-      let(:income) { Income.new(employment_status: [EmploymentStatus::DIRECTOR]) }
+      let(:income) { Income.new(employment_status: [EmploymentStatus::NOT_WORKING]) }
 
       it { is_expected.to be false }
-    end
-
-    context 'when employed and a director' do
-      let(:income) do
-        Income.new(employment_status: [EmploymentStatus::DIRECTOR, EmploymentStatus::EMPLOYED])
-      end
-
-      it { is_expected.to be true }
     end
 
     context 'when there is no employment status' do

--- a/spec/services/evidence/rules/20240426012343_self_employed_spec.rb
+++ b/spec/services/evidence/rules/20240426012343_self_employed_spec.rb
@@ -19,19 +19,19 @@ RSpec.describe Evidence::Rules::SelfEmployed do
   describe '.client' do
     subject { described_class.new(crime_application).client_predicate }
 
-    context 'when self-employed or shareholder or partnership' do
-      it 'is false' do
-        %w[self_employed shareholder business_partnership].each do |employment_status|
-          crime_application = CrimeApplication.new(income: Income.new(employment_status: [employment_status]))
+    context 'when self-employed' do
+      let(:employment_status) { 'self_employed' }
 
-          expect(described_class.new(crime_application).client_predicate).to be true
-        end
+      it 'is false' do
+        crime_application = CrimeApplication.new(income: Income.new(employment_status: [employment_status]))
+
+        expect(described_class.new(crime_application).client_predicate).to be true
       end
     end
 
-    context 'when employed or director or not working' do
+    context 'when employed or not working' do
       it 'is false' do
-        %w[director not_working employed].each do |employment_status|
+        %w[not_working employed].each do |employment_status|
           crime_application = CrimeApplication.new(income: Income.new(employment_status: [employment_status]))
 
           expect(described_class.new(crime_application).client_predicate).to be false
@@ -56,7 +56,7 @@ RSpec.describe Evidence::Rules::SelfEmployed do
 
   describe '#to_h' do
     let(:income) do
-      Income.new(employment_status: [EmploymentStatus::SHAREHOLDER])
+      Income.new(employment_status: [EmploymentStatus::SELF_EMPLOYED])
     end
 
     let(:expected_hash) do

--- a/spec/value_objects/employment_status_spec.rb
+++ b/spec/value_objects/employment_status_spec.rb
@@ -9,9 +9,6 @@ RSpec.describe EmploymentStatus do
         %w[
           employed
           self_employed
-          business_partnership
-          director
-          shareholder
           not_working
         ]
       )


### PR DESCRIPTION
## Description of change

Remove three checkbox options and update content.

I haven't changed the routing yet (in the Figma if you select `Employed` then you continue down the `Income assessment` route) this will be updated later on when the rest of the Employed journey is actually available. For the time being I think it makes sense to keep the routing the same as it is currently i.e. if you select 'Employed or self-employed' then you are redirected to the 'Please use eForms' page.

## Link to relevant ticket

[CRIMAPP-859](https://dsdmoj.atlassian.net/browse/CRIMAPP-859)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1341" alt="Screenshot 2024-05-08 at 17 50 32" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/c5cfcf7d-4b07-4dad-a81a-c9c518031734">

### After changes:
![Screenshot 2024-05-09 at 15 31 55](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/bb78d8d5-1d87-4dab-b0f9-6a824e4b86ff)

## How to manually test the feature

Navigate to the `Employed Status` page.  Check that the content, checkboxes and error messages are correct.


[CRIMAPP-859]: https://dsdmoj.atlassian.net/browse/CRIMAPP-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ