### PR TITLE
Fix tasklist issues for u18 and appeal no changes apps

### DIFF
--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -13,6 +13,8 @@ module PassportingBenefitCheck
     # Adds the error to the first step name a user would need to go to fix the issue.
 
     def validate
+      return true if Passporting::MeansPassporter.new(crime_application).call
+
       errors.add(:benefit_type, :blank) unless benefit_type_complete?
 
       benefit_questions_complete? if has_passporting_benefit?

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -188,6 +188,10 @@ RSpec.describe CrimeApplication, type: :model do
     let(:applicant) { Applicant.new(benefit_type:) }
     let(:attributes) { { applicant: } }
 
+    before do
+      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(false)
+    end
+
     it 'returns false' do
       expect(subject.passporting_benefit_complete?).to be false
     end

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -19,12 +19,26 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
   let(:is_client_remanded) { nil }
 
   describe '#validate' do
+    before do
+      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(false)
+    end
+
     context 'when dwp check completed successfully' do
       let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
       let(:passporting_benefit) { true }
 
       before do
         allow(errors).to receive(:empty?).and_return(true)
+      end
+
+      it 'adds errors for all failed validations' do
+        subject.validate
+      end
+    end
+
+    context 'when applicant is passported' do
+      before do
+        allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
       end
 
       it 'adds errors for all failed validations' do


### PR DESCRIPTION
## Description of change

Fixes issue with task list for appeal no changes and u18 apps where the validator was marking the benefit type as incomplete when it was not asked for these application types 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
