### PR TITLE
CRIMAPP-891 Unable to submit because passporting benefit section appears incorrectly incomplete

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -40,6 +40,7 @@ module TypeOfMeansAssessment
   def nino_forthcoming?
     return false unless has_passporting_benefit?
     return false unless applicant.has_nino == 'no'
+    return false if applicant.will_enter_nino == 'yes'
 
     applicant.will_enter_nino == 'no' || kase.is_client_remanded == 'yes'
   end

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -12,12 +12,10 @@ module TypeOfMeansAssessment
 
   def requires_full_means_assessment?
     return false unless requires_means_assessment?
+    return true if income_above_threshold?
+    return true unless no_frozen_assets?
 
-    if income_below_threshold? && no_frozen_assets?
-      !(summary_only? || (no_property? && no_savings?))
-    else
-      true
-    end
+    !(summary_only? || (no_property? && no_savings?))
   end
 
   def requires_full_capital?
@@ -31,8 +29,6 @@ module TypeOfMeansAssessment
   end
 
   def evidence_of_passporting_means_forthcoming?
-    return false unless has_passporting_benefit?
-
     benefit_evidence_forthcoming? || nino_forthcoming?
   end
 
@@ -42,13 +38,24 @@ module TypeOfMeansAssessment
   # However, if the applicant is not in court custody, submission will be
   # blocked until the NINO or benefit evidence is provided.
   def nino_forthcoming?
+    return false unless has_passporting_benefit?
     return false unless applicant.has_nino == 'no'
 
     applicant.will_enter_nino == 'no' || kase.is_client_remanded == 'yes'
   end
 
   def benefit_evidence_forthcoming?
-    applicant.has_benefit_evidence == 'yes'
+    return false unless has_passporting_benefit?
+    return false if applicant.nino.blank?
+
+    crime_application.confirm_dwp_result == 'no' && applicant.has_benefit_evidence == 'yes'
+  end
+
+  def means_assessment_as_benefit_evidence?
+    return false unless has_passporting_benefit?
+    return false if applicant.nino.blank?
+
+    crime_application.confirm_dwp_result == 'no' && applicant.has_benefit_evidence == 'no'
   end
 
   private
@@ -75,5 +82,9 @@ module TypeOfMeansAssessment
 
   def income_below_threshold?
     income&.income_above_threshold == 'no'
+  end
+
+  def income_above_threshold?
+    !income_below_threshold?
   end
 end

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -52,7 +52,7 @@ module Summary
 
       private
 
-      delegate :kase, :income, :outgoings, :capital, to: :crime_application
+      delegate :requires_means_assessment?, :kase, :income, :outgoings, :capital, to: :crime_application
 
       # :nocov:
       def answers

--- a/app/presenters/tasks/base_task.rb
+++ b/app/presenters/tasks/base_task.rb
@@ -43,7 +43,11 @@ module Tasks
     end
 
     def not_applicable?
-      true
+      !validator.applicable?
+    end
+
+    def completed?
+      validator.complete?
     end
 
     # :nocov:
@@ -55,7 +59,9 @@ module Tasks
       raise 'implement in task subclasses'
     end
 
-    def completed?
+    private
+
+    def validator
       raise 'implement in task subclasses'
     end
     # :nocov:

--- a/app/presenters/tasks/income_assessment.rb
+++ b/app/presenters/tasks/income_assessment.rb
@@ -7,7 +7,7 @@ module Tasks
     end
 
     def not_applicable?
-      return false unless fulfilled?(ClientDetails)
+      return false unless applicant
 
       !requires_means_assessment?
     end

--- a/app/presenters/tasks/passporting_benefit_check.rb
+++ b/app/presenters/tasks/passporting_benefit_check.rb
@@ -4,10 +4,6 @@ module Tasks
       edit_steps_dwp_benefit_type_path
     end
 
-    def not_applicable?
-      applicant&.under18? || crime_application.appeal_no_changes?
-    end
-
     def can_start?
       fulfilled?(ClientDetails)
     end
@@ -16,8 +12,12 @@ module Tasks
       fulfilled?(ClientDetails)
     end
 
-    def completed?
-      crime_application.valid?(:passporting_benefit)
+    private
+
+    def validator
+      @validator ||= ::PassportingBenefitCheck::AnswersValidator.new(
+        crime_application
+      )
     end
   end
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -43,7 +43,7 @@ module Decisions
     private
 
     def after_has_case_concluded
-      return charges_summary_or_edit_new_charge if current_crime_application.not_means_tested?
+      return charges_summary_or_edit_new_charge if crime_application.not_means_tested?
       return edit(:is_client_remanded) if form_object.has_case_concluded.no?
 
       edit(:is_preorder_work_claimed)
@@ -90,7 +90,7 @@ module Decisions
     end
 
     def ioj_or_passported
-      if Passporting::IojPassporter.new(current_crime_application).call
+      if Passporting::IojPassporter.new(crime_application).call
         edit(:ioj_passport)
       else
         edit(:ioj)
@@ -98,7 +98,7 @@ module Decisions
     end
 
     def after_ioj
-      if requires_means_assessment? || kase.appeal_reference_number.present?
+      if requires_means_assessment? || crime_application.appeal_no_changes?
         return edit('/steps/income/employment_status')
       end
 
@@ -116,7 +116,7 @@ module Decisions
     end
 
     def case_charges
-      @case_charges ||= current_crime_application.case.charges
+      @case_charges ||= crime_application.case.charges
     end
 
     def current_charge

--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -10,55 +10,25 @@ module PassportingBenefitCheck
 
     delegate :errors, :applicant, :crime_application, to: :record
 
-    # Adds the error to the first step name a user would need to go to fix the issue.
-
     def validate
+      return unless applicable?
+      return if complete?
+
+      errors.add :benefit_type, :incomplete
+      errors.add :base, :incomplete_records
+    end
+
+    def applicable?
+      !(crime_application.appeal_no_changes? || applicant&.under18?)
+    end
+
+    def complete?
+      return false if applicant.benefit_type.blank?
       return true if Passporting::MeansPassporter.new(crime_application).call
+      return true if applicant.benefit_type == BenefitType::NONE.to_s
+      return true if evidence_of_passporting_means_forthcoming?
 
-      errors.add(:benefit_type, :blank) unless benefit_type_complete?
-
-      benefit_questions_complete? if has_passporting_benefit?
-
-      errors.add :base, :incomplete_records unless errors.empty?
-    end
-
-    def benefit_type_complete?
-      applicant.benefit_type.present?
-    end
-
-    def benefit_questions_complete?
-      # Applicant#passporting_benefit is stored as a boolean
-      return true if applicant.passporting_benefit == true
-
-      errors.add(:will_enter_nino, :blank) unless will_enter_nino_complete?
-      errors.add(:passporting_benefit, :blank) if dwp_check_not_undertaken?
-      errors.add(:confirm_dwp_result, :blank) unless confirm_dwp_result_complete?
-      errors.add(:has_benefit_evidence, :blank) unless has_benefit_evidence_complete?
-    end
-
-    def will_enter_nino_complete?
-      return true unless applicant.has_nino == 'no'
-
-      nino_forthcoming?
-    end
-
-    def confirm_dwp_result_complete?
-      # bypassed as they didn't undertake dwp check
-      return true if applicant.has_nino == 'no'
-
-      record.confirm_dwp_result.present?
-    end
-
-    def has_benefit_evidence_complete?
-      return true unless record.confirm_dwp_result == 'no'
-
-      applicant.has_benefit_evidence.present?
-    end
-
-    def dwp_check_not_undertaken?
-      return false if applicant.has_nino == 'no'
-
-      applicant.passporting_benefit.nil?
+      means_assessment_as_benefit_evidence?
     end
 
     alias crime_application record

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -165,11 +165,20 @@ RSpec.describe TypeOfMeansAssessment do
     end
 
     context 'when will enter NINO' do
-      it 'returns false' do
+      before do
         allow(applicant).to receive(:will_enter_nino).and_return('yes')
+      end
 
-        expect(kase).to receive(:is_client_remanded)
+      it 'returns false' do
+        allow(kase).to receive(:is_client_remanded)
         expect(subject).to be false
+      end
+
+      context 'when remanded in custody' do
+        it 'returns false' do
+          allow(kase).to receive(:is_client_remanded).and_return('yes')
+          expect(subject).to be false
+        end
       end
     end
 

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -1,0 +1,392 @@
+require 'rails_helper'
+
+RSpec.describe TypeOfMeansAssessment do
+  subject(:assessable) do
+    assessable_class.new(crime_application:)
+  end
+
+  let(:assessable_class) do
+    Struct.new(:crime_application) do
+      include TypeOfMeansAssessment
+    end
+  end
+  let(:crime_application) do
+    instance_double(CrimeApplication, applicant:, kase:, income:)
+  end
+  let(:applicant) { instance_double(Applicant) }
+  let(:kase) { instance_double(Case) }
+  let(:income) { instance_double(Income) }
+  let(:means_passporter_result) { false }
+  let(:means_passporter) do
+    instance_double(Passporting::MeansPassporter, call: means_passporter_result)
+  end
+
+  before do
+    allow(Passporting::MeansPassporter).to receive(:new).and_return(means_passporter)
+  end
+
+  describe '#benefit_evidence_forthcoming?' do
+    subject(:benefit_evidence_forthcoming?) { assessable.benefit_evidence_forthcoming? }
+
+    let(:benefit_type) { BenefitType::JSA.to_s }
+    let(:nino) { 'QQ123456A' }
+
+    before do
+      allow(applicant).to receive_messages(benefit_type:, nino:)
+    end
+
+    context 'when passporting benefit not determined' do
+      let(:benefit_type) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when no passporting benefit' do
+      let(:benefit_type) { 'none' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when NINO blank' do
+      let(:nino) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when dwp result contested and has evidence' do
+      before do
+        allow(crime_application).to receive(:confirm_dwp_result).and_return('no')
+        allow(applicant).to receive(:has_benefit_evidence).and_return('yes')
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when dwp result contested but has not evidence' do
+      before do
+        allow(crime_application).to receive(:confirm_dwp_result).and_return('no')
+        allow(applicant).to receive(:has_benefit_evidence).and_return('no')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when dwp result confirmed' do
+      before do
+        allow(crime_application).to receive(:confirm_dwp_result).and_return('yes')
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#means_assessment_as_benefit_evidence?' do
+    subject(:means_assessment_as_benefit_evidence?) { assessable.means_assessment_as_benefit_evidence? }
+
+    let(:benefit_type) { BenefitType::JSA.to_s }
+    let(:nino) { 'QQ123456A' }
+
+    before do
+      allow(applicant).to receive_messages(benefit_type:, nino:)
+    end
+
+    context 'when passporting benefit not determined' do
+      let(:benefit_type) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when no passporting benefit' do
+      let(:benefit_type) { 'none' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when NINO blank' do
+      let(:nino) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when dwp result contested and has evidence' do
+      before do
+        allow(crime_application).to receive(:confirm_dwp_result).and_return('no')
+        allow(applicant).to receive(:has_benefit_evidence).and_return('yes')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when dwp result contested but has not evidence' do
+      before do
+        allow(crime_application).to receive(:confirm_dwp_result).and_return('no')
+        allow(applicant).to receive(:has_benefit_evidence).and_return('no')
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when dwp result confirmed' do
+      before do
+        allow(crime_application).to receive(:confirm_dwp_result).and_return('yes')
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#nino_forthcoming?' do
+    subject(:nino_forthcoming?) { assessable.nino_forthcoming? }
+
+    let(:benefit_type) { BenefitType::JSA.to_s }
+    let(:has_nino) { 'no' }
+
+    before do
+      allow(applicant).to receive_messages(benefit_type:, has_nino:)
+    end
+
+    context 'when passporting benefit not determined' do
+      let(:benefit_type) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when no passporting benefit' do
+      let(:benefit_type) { 'none' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when confirmed will not enter NINO' do
+      it 'returns true' do
+        allow(applicant).to receive(:will_enter_nino).and_return('no')
+        expect(subject).to be true
+      end
+    end
+
+    context 'when will enter NINO' do
+      it 'returns false' do
+        allow(applicant).to receive(:will_enter_nino).and_return('yes')
+
+        expect(kase).to receive(:is_client_remanded)
+        expect(subject).to be false
+      end
+    end
+
+    context 'when not known if will enter NINO' do
+      before { allow(applicant).to receive(:will_enter_nino) }
+
+      context 'when client remanded' do
+        before { allow(kase).to receive(:is_client_remanded).and_return('yes') }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when client not remanded' do
+        before { allow(kase).to receive(:is_client_remanded).and_return('no') }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when not known if client remanded' do
+        before { allow(kase).to receive(:is_client_remanded) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#evidence_of_passporting_means_forthcoming?' do
+    subject(:evidence_of_passporting_means_forthcoming?) { assessable.evidence_of_passporting_means_forthcoming? }
+
+    let(:benefit_type) { BenefitType::JSA.to_s }
+
+    before do
+      allow(applicant).to receive(:benefit_type).and_return(benefit_type)
+    end
+
+    context 'when passporting benefit not determined' do
+      let(:benefit_type) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when no passporting benefit' do
+      let(:benefit_type) { 'none' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when nino forthcoming' do
+      before do
+        allow(assessable).to receive_messages(
+          benefit_evidence_forthcoming?: false,
+          nino_forthcoming?: true
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when benefit evidence is forthcoming' do
+      before do
+        allow(assessable).to receive_messages(
+          benefit_evidence_forthcoming?: true,
+          nino_forthcoming?: false
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when neither benefit evidence nor NINO forthcoming' do
+      before do
+        allow(assessable).to receive_messages(
+          benefit_evidence_forthcoming?: false,
+          nino_forthcoming?: false
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#requires_means_assessment?' do
+    subject(:requires_means_assessment?) { assessable.requires_means_assessment? }
+
+    context 'when means journey FeatureFlag is disabled' do
+      before do
+        allow(FeatureFlags).to receive(:means_journey).and_return(
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when means passported' do
+      let(:means_passporter_result) { true }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when evidence of passporting means forthcoming?' do
+      before do
+        allow(assessable).to receive(:evidence_of_passporting_means_forthcoming?).and_return(true)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when evidence of passporting means is not forthcoming?' do
+      before do
+        allow(assessable).to receive(:evidence_of_passporting_means_forthcoming?).and_return(false)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#requires_full_means_assessment?' do
+    subject(:requires_full_means_assessment?) { assessable.requires_full_means_assessment? }
+
+    context 'when means assessment not required' do
+      before do
+        allow(assessable).to receive(:requires_means_assessment?).and_return(false)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when requires means assessment' do
+      before do
+        allow(assessable).to receive(:requires_means_assessment?).and_return(true)
+      end
+
+      context 'income is above threshold' do
+        before do
+          allow(income).to receive(:income_above_threshold).and_return('yes')
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'client has frozen assets' do
+        before do
+          allow(income).to receive(:income_above_threshold)
+          allow(income).to receive(:has_frozen_income_or_assets).and_return('yes')
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'has no frozen assets and income is below threshold' do
+        before do
+          allow(income).to receive_messages(
+            income_above_threshold: 'no',
+            has_frozen_income_or_assets: 'no'
+          )
+        end
+
+        context 'and case is summary only' do
+          before do
+            allow(kase).to receive(:case_type).and_return('summary_only')
+          end
+
+          it { is_expected.to be false }
+        end
+
+        context 'and has no savings or property' do
+          before do
+            allow(income).to receive_messages(
+              client_owns_property: 'no',
+              has_savings: 'no'
+            )
+
+            allow(kase).to receive(:case_type)
+          end
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+
+  describe '#requires_full_capital?' do
+    subject(:requires_full_capital?) { assessable.requires_full_capital? }
+
+    before { allow(kase).to receive(:case_type).and_return(case_type) }
+
+    let(:case_type) { 'committal' }
+
+    context 'when case is nil' do
+      let(:case_type) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when case is either way' do
+      let(:case_type) { 'either_way' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when case is indictable' do
+      let(:case_type) { 'indictable' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when case is already in crown courst' do
+      let(:case_type) { 'already_in_crown_court' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when case is summary only' do
+      let(:case_type) { 'summary_only' }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -183,10 +183,11 @@ RSpec.describe CrimeApplication, type: :model do
   end
 
   describe '#passporting_benefit_complete?' do
-    # Validation tested in validator spec
-    let(:benefit_type) { nil }
-    let(:applicant) { Applicant.new(benefit_type:) }
     let(:attributes) { { applicant: } }
+
+    let(:applicant) do
+      Applicant.new(benefit_type: nil, date_of_birth: '1970-05-05')
+    end
 
     before do
       allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(false)

--- a/spec/presenters/tasks/base_task_spec.rb
+++ b/spec/presenters/tasks/base_task_spec.rb
@@ -53,10 +53,6 @@ RSpec.describe Tasks::BaseTask do
     it { expect(subject.path).to eq('') }
   end
 
-  describe '#not_applicable?' do
-    it { expect(subject.not_applicable?).to be(true) }
-  end
-
   describe '#status' do
     before do
       allow(subject).to receive_messages(not_applicable?: not_applicable, can_start?: can_start, completed?: completed,

--- a/spec/presenters/tasks/income_assessment_spec.rb
+++ b/spec/presenters/tasks/income_assessment_spec.rb
@@ -24,18 +24,12 @@ RSpec.describe Tasks::IncomeAssessment do
   describe '#not_applicable?' do
     subject(:not_applicable) { task.not_applicable? }
 
-    before do
-      allow(task).to receive(:fulfilled?).with(Tasks::ClientDetails) { fulfilled }
-    end
-
-    context 'client details are not fulfilled' do
-      let(:fulfilled) { false }
-
+    context 'applicant is nil' do
       it { is_expected.to be false }
     end
 
-    context 'client details are fulfilled' do
-      let(:fulfilled) { true }
+    context 'applicant exists' do
+      let(:applicant) { instance_double(Applicant) }
 
       context 'and means assessment required' do
         let(:needs_means) { true }

--- a/spec/presenters/tasks/passporting_benefit_check_spec.rb
+++ b/spec/presenters/tasks/passporting_benefit_check_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Tasks::PassportingBenefitCheck do
       it { is_expected.to be true }
     end
 
-    context 'answers are nicomplete' do
+    context 'answers are incomplete' do
       let(:complete?) { false }
 
       it { is_expected.to be false }

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -1,254 +1,116 @@
 require 'rails_helper'
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record) }
 
-  let(:record) { instance_double(CrimeApplication, errors:, applicant:, kase:, confirm_dwp_result:) }
+  let(:record) { instance_double(CrimeApplication, errors:, applicant:) }
   let(:errors) { double(:errors, empty?: false) }
-  let(:applicant) {
-    instance_double(Applicant, benefit_type:, has_benefit_evidence:, has_nino:, will_enter_nino:, passporting_benefit:)
-  }
-  let(:kase) { instance_double(Case, is_client_remanded:) }
+  let(:applicant) { instance_double(Applicant, benefit_type:) }
   let(:benefit_type) { nil }
-  let(:has_benefit_evidence) { nil }
-  let(:has_nino) { nil }
-  let(:will_enter_nino) { nil }
-  let(:confirm_dwp_result) { nil }
-  let(:passporting_benefit) { nil }
-  let(:is_client_remanded) { nil }
+  let(:appeal_no_changes?) { false }
+  let(:under18?) { false }
+  let(:means_passported?) { false }
+
+  before do
+    allow(record).to receive_messages(appeal_no_changes?: appeal_no_changes?)
+    allow(applicant).to receive_messages(under18?: under18?)
+    allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(means_passported?)
+  end
+
+  describe '#applicable?' do
+    subject(:applicable?) { validator.applicable? }
+
+    it { is_expected.to be(true) }
+
+    context 'when appeal no changes' do
+      let(:appeal_no_changes?) { true }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when under 18' do
+      let(:under18?) { true }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#complete?' do
+    subject(:complete?) { validator.complete? }
+
+    context 'when passporting benefit not known' do
+      let(:benefit_type) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when has passporting benefit' do
+      let(:benefit_type) { BenefitType::JSA.to_s }
+
+      context 'when means passported' do
+        let(:means_passported?) { true }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when has no passporting benefit' do
+        let(:benefit_type) { 'none' }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when evidence of passporting benefit forthcoming' do
+        before do
+          allow(validator).to receive(:evidence_of_passporting_means_forthcoming?).and_return(true)
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'applicant doing means assessment instead' do
+        before do
+          allow(validator).to receive_messages(evidence_of_passporting_means_forthcoming?: false,
+                                               means_assessment_as_benefit_evidence?: true)
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
 
   describe '#validate' do
-    before do
-      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(false)
-    end
+    subject(:validate) { validator.validate }
 
-    context 'when dwp check completed successfully' do
-      let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
-      let(:passporting_benefit) { true }
-
+    context 'when not applicable' do
       before do
-        allow(errors).to receive(:empty?).and_return(true)
+        allow(validator).to receive(:applicable?).and_return(false)
       end
 
-      it 'adds errors for all failed validations' do
-        subject.validate
+      it 'does not add errors' do
+        expect(errors).not_to receive(:add)
+        validate
       end
     end
 
-    context 'when applicant is passported' do
+    context 'when applicable' do
       before do
-        allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
+        allow(validator).to receive(:applicable?).and_return(true)
       end
 
-      it 'adds errors for all failed validations' do
-        subject.validate
-      end
-    end
+      it 'adds errors to :appeal_details when incomplete' do
+        allow(validator).to receive(:complete?).and_return(false)
+        expect(errors).to receive(:add).with(:benefit_type, :incomplete)
+        expect(errors).to receive(:add).with(:base, :incomplete_records)
 
-    context 'when validation fails' do
-      context 'when section has not been started' do
-        it 'adds errors for all failed validations' do
-          expect(errors).to receive(:add).with(:benefit_type, :blank)
-          expect(errors).to receive(:add).with(:base, :incomplete_records)
-
-          subject.validate
-        end
+        validate
       end
 
-      context 'when applicant has benefit but no nino' do
-        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
-        let(:has_nino) { 'no' }
+      it 'does not add errors when complete' do
+        allow(validator).to receive(:complete?).and_return(true)
+        expect(errors).not_to receive(:add)
 
-        it 'adds errors for all failed validations' do
-          expect(errors).to receive(:add).with(:will_enter_nino, :blank)
-          expect(errors).to receive(:add).with(:base, :incomplete_records)
-
-          subject.validate
-        end
-      end
-
-      context 'when dwp check result is no or undetermined' do
-        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
-        let(:has_nino) { 'yes' }
-        let(:passporting_benefit) { false }
-
-        context 'when confirm dwp result is blank' do
-          it 'adds errors for all failed validations' do
-            expect(errors).to receive(:add).with(:confirm_dwp_result, :blank)
-            expect(errors).to receive(:add).with(:base, :incomplete_records)
-
-            subject.validate
-          end
-        end
-
-        context 'when result is contested' do
-          let(:confirm_dwp_result) { 'no' }
-
-          it 'adds errors for all failed validations' do
-            expect(errors).to receive(:add).with(:has_benefit_evidence, :blank)
-            expect(errors).to receive(:add).with(:base, :incomplete_records)
-
-            subject.validate
-          end
-        end
-      end
-
-      context 'when dwp check forthcoming' do
-        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
-        let(:has_nino) { 'yes' }
-        let(:passporting_benefit) { nil }
-
-        context 'when passporting_benefit is blank' do
-          it 'adds errors for all failed validations' do
-            expect(errors).to receive(:add).with(:passporting_benefit, :blank)
-            expect(errors).to receive(:add).with(:confirm_dwp_result, :blank)
-            expect(errors).to receive(:add).with(:base, :incomplete_records)
-
-            subject.validate
-          end
-        end
-      end
-    end
-
-    describe '#benefit_type_complete?' do
-      context 'when benefit_type present' do
-        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
-
-        it 'returns true' do
-          expect(subject.benefit_type_complete?).to be(true)
-        end
-      end
-
-      context 'when benefit_type not present' do
-        it 'returns false' do
-          expect(subject.benefit_type_complete?).to be(false)
-        end
-      end
-    end
-
-    describe '#will_enter_nino_complete?' do
-      let(:has_nino) { 'no' }
-
-      context 'when has_nino' do
-        let(:has_nino) { 'yes' }
-
-        it 'returns true' do
-          expect(subject.will_enter_nino_complete?).to be(true)
-        end
-      end
-
-      context 'when will enter nino present' do
-        let(:will_enter_nino) { 'no' }
-
-        it 'returns true' do
-          expect(subject.will_enter_nino_complete?).to be(true)
-        end
-      end
-
-      context 'when will_enter_nino not present' do
-        it 'returns false' do
-          expect(subject.will_enter_nino_complete?).to be(false)
-        end
-
-        context 'when we know applicant is in court custody?' do
-          let(:is_client_remanded) { 'yes' }
-
-          it 'returns true' do
-            expect(subject.will_enter_nino_complete?).to be(true)
-          end
-        end
-
-        context 'when we know applicant is not in court custody?' do
-          let(:is_client_remanded) { 'no' }
-
-          it 'returns true' do
-            expect(subject.will_enter_nino_complete?).to be(false)
-          end
-        end
-      end
-    end
-
-    describe '#confirm_dwp_result_complete?' do
-      context 'when applicant does not have nino' do
-        let(:has_nino) { 'no' }
-
-        it 'returns true' do
-          expect(subject.confirm_dwp_result_complete?).to be(true)
-        end
-      end
-
-      context 'when applicant does have nino' do
-        let(:has_nino) { 'yes' }
-
-        context 'when confirm_dwp_result is present' do
-          let(:confirm_dwp_result) { 'no' }
-
-          it 'returns true' do
-            expect(subject.confirm_dwp_result_complete?).to be(true)
-          end
-        end
-
-        context 'when confirm_dwp_result not present' do
-          it 'returns false' do
-            expect(subject.confirm_dwp_result_complete?).to be(false)
-          end
-        end
-      end
-    end
-
-    describe '#has_benefit_evidence_complete?' do
-      context 'when applicant confirms dwp result' do
-        let(:confirm_dwp_result) { 'yes' }
-
-        it 'returns true' do
-          expect(subject.has_benefit_evidence_complete?).to be(true)
-        end
-      end
-
-      context 'when applicant contests dwp result' do
-        let(:confirm_dwp_result) { 'no' }
-
-        context 'when has_benefit_evidence is present' do
-          let(:has_benefit_evidence) { 'yes' }
-
-          it 'returns true' do
-            expect(subject.has_benefit_evidence_complete?).to be(true)
-          end
-        end
-
-        context 'when has_benefit_evidence not present' do
-          it 'returns false' do
-            expect(subject.has_benefit_evidence_complete?).to be(false)
-          end
-        end
-      end
-    end
-
-    describe '#dwp_check_not_undertaken?' do
-      context 'when applicant has no nino' do
-        let(:has_nino) { 'no' }
-
-        it 'returns false' do
-          expect(subject.dwp_check_not_undertaken?).to be(false)
-        end
-      end
-
-      context 'when passporting_benefit_check present' do
-        let(:passporting_benefit) { false }
-
-        it 'returns false' do
-          expect(subject.dwp_check_not_undertaken?).to be(false)
-        end
-      end
-
-      context 'when passporting_benefit_check not present' do
-        it 'returns true' do
-          expect(subject.dwp_check_not_undertaken?).to be(true)
-        end
+        validate
       end
     end
   end
 end
-
-# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## Description of change

Validate passporting benefit check based on outcome not answers.
Also shifts testing details of TypeOfMeansAssessment to the concern.
Uses the answer validator for completed and not_applicable  status in the task list, in preparation for using the same logic to decide which answers are displayed/submitted to the datastore.

## Link to relevant ticket

[CRIMAPP-891](https://dsdmoj.atlassian.net/browse/CRIMAPP-891)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

See steps in ticket

[CRIMAPP-891]: https://dsdmoj.atlassian.net/browse/CRIMAPP-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ