### PR TITLE
CRIMAPP-867 Add employment income page

### DIFF
--- a/app/controllers/steps/income/client/employment_income_controller.rb
+++ b/app/controllers/steps/income/client/employment_income_controller.rb
@@ -9,7 +9,7 @@ module Steps
         end
 
         def update
-          update_and_advance(EmploymentIncomeForm, as: :employment_income)
+          update_and_advance(EmploymentIncomeForm, as: :client_employment_income)
         end
       end
     end

--- a/app/controllers/steps/income/client/employment_income_controller.rb
+++ b/app/controllers/steps/income/client/employment_income_controller.rb
@@ -1,0 +1,17 @@
+module Steps
+  module Income
+    module Client
+      class EmploymentIncomeController < Steps::IncomeStepController
+        def edit
+          @form_object = EmploymentIncomeForm.build(
+            current_crime_application
+          )
+        end
+
+        def update
+          update_and_advance(EmploymentIncomeForm, as: :employment_income)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/client/employment_income_form.rb
+++ b/app/forms/steps/income/client/employment_income_form.rb
@@ -1,0 +1,53 @@
+module Steps
+  module Income
+    module Client
+      class EmploymentIncomeForm < Steps::BaseFormObject
+        attribute :amount, :pence
+        attribute :before_or_after_tax, :value_object, source: BeforeOrAfterTax
+        attribute :frequency, :value_object, source: PaymentFrequencyType
+
+        validates :amount, numericality: {
+          greater_than: 0
+        }
+        validates :before_or_after_tax, inclusion: { in: :before_or_after_tax_options }
+        validates :frequency, inclusion: { in: PaymentFrequencyType.values }
+
+        def before_or_after_tax_options
+          BeforeOrAfterTax.values
+        end
+
+        def self.build(crime_application)
+          payment = crime_application.income_payments.employment
+          form = new
+
+          if payment
+            form.amount = payment.amount
+            form.before_or_after_tax = payment.before_or_after_tax
+            form.frequency = payment.frequency
+          end
+
+          form
+        end
+
+        private
+
+        def persist!
+          ::IncomePayment.transaction do
+            # reset!
+
+            crime_application.income_payments.create!(
+              payment_type: IncomePayment::EMPLOYMENT.value,
+              amount: amount,
+              frequency: frequency,
+              before_or_after_tax: before_or_after_tax,
+            )
+          end
+        end
+
+        # def reset!
+        #   crime_application.income_payments.employment_payments.destroy_all
+        # end
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/client/employment_income_form.rb
+++ b/app/forms/steps/income/client/employment_income_form.rb
@@ -33,10 +33,10 @@ module Steps
 
         def persist!
           ::IncomePayment.transaction do
-            # reset!
+            reset!
 
             crime_application.income_payments.create!(
-              payment_type: IncomePayment::EMPLOYMENT.value,
+              payment_type: IncomePaymentType::EMPLOYMENT.value,
               amount: amount,
               frequency: frequency,
               before_or_after_tax: before_or_after_tax,
@@ -44,9 +44,9 @@ module Steps
           end
         end
 
-        # def reset!
-        #   crime_application.income_payments.employment_payments.destroy_all
-        # end
+        def reset!
+          crime_application.income_payments.employment&.destroy_all
+        end
       end
     end
   end

--- a/app/forms/steps/income/client/employment_income_form.rb
+++ b/app/forms/steps/income/client/employment_income_form.rb
@@ -22,7 +22,7 @@ module Steps
 
           if payment
             form.amount = payment.amount
-            form.before_or_after_tax = payment.before_or_after_tax
+            form.before_or_after_tax = payment.before_or_after_tax['value']
             form.frequency = payment.frequency
           end
 
@@ -45,7 +45,7 @@ module Steps
         end
 
         def reset!
-          crime_application.income_payments.employment&.destroy_all
+          crime_application.income_payments.employment&.destroy
         end
       end
     end

--- a/app/models/income_payment.rb
+++ b/app/models/income_payment.rb
@@ -1,4 +1,7 @@
 class IncomePayment < Payment
+  store_accessor :metadata,
+                 :before_or_after_tax
+
   def self.private_pension
     where(payment_type: IncomePaymentType::PRIVATE_PENSION.value).order(created_at: :desc).first
   end

--- a/app/models/income_payment.rb
+++ b/app/models/income_payment.rb
@@ -1,6 +1,6 @@
 class IncomePayment < Payment
   store_accessor :metadata,
-                 :before_or_after_tax
+                 [:before_or_after_tax]
 
   def self.private_pension
     where(payment_type: IncomePaymentType::PRIVATE_PENSION.value).order(created_at: :desc).first

--- a/app/models/income_payment.rb
+++ b/app/models/income_payment.rb
@@ -15,6 +15,10 @@ class IncomePayment < Payment
     where(payment_type: IncomePaymentType::RENT.value).order(created_at: :desc).first
   end
 
+  def self.employment
+    where(payment_type: IncomePaymentType::EMPLOYMENT.value).order(created_at: :desc).first
+  end
+
   def self.other
     where(payment_type: IncomePaymentType::OTHER.value).order(created_at: :desc).first
   end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -21,7 +21,7 @@ module Decisions
       when :has_savings
         after_has_savings
       when :client_employment_income
-        edit(:income_payments)
+        edit('/steps/income/income_payments')
       when :income_payments
         edit(:income_benefits)
       when :income_benefits

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -114,6 +114,8 @@ module Decisions
     end
 
     def after_has_savings
+      return edit(:income_payments) unless FeatureFlags.employment_journey.enabled?
+
       if employed?
         edit('steps/income/client/employment_income')
       else

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -19,6 +19,8 @@ module Decisions
       when :client_owns_property
         after_client_owns_property
       when :has_savings
+        after_has_savings
+      when :client_employment_income
         edit(:income_payments)
       when :income_payments
         edit(:income_benefits)
@@ -111,6 +113,14 @@ module Decisions
       end
     end
 
+    def after_has_savings
+      if employed?
+        edit('steps/income/client/employment_income')
+      else
+        edit(:income_payments)
+      end
+    end
+
     def after_client_owns_property
       if no_property?
         edit(:has_savings)
@@ -148,6 +158,10 @@ module Decisions
       else
         edit(:answers)
       end
+    end
+
+    def employed?
+      crime_application.income.employment_status.include?(EmploymentStatus::EMPLOYED.to_s)
     end
 
     def not_working?

--- a/app/value_objects/before_or_after_tax.rb
+++ b/app/value_objects/before_or_after_tax.rb
@@ -1,0 +1,6 @@
+class BeforeOrAfterTax < ValueObject
+  VALUES = [
+    BEFORE = new(:before_tax),
+    AFTER = new(:after_tax)
+  ].freeze
+end

--- a/app/value_objects/income_payment_type.rb
+++ b/app/value_objects/income_payment_type.rb
@@ -9,6 +9,7 @@ class IncomePaymentType < ValueObject
     RENT = new(:rent),
     FINANCIAL_SUPPORT_WITH_ACCESS = new(:financial_support_with_access),
     FROM_FRIENDS_RELATIVES = new(:from_friends_relatives),
+    EMPLOYMENT = new(:employment),
     OTHER = new(:other)
   ].freeze
 end

--- a/app/views/steps/income/client/employment_income/edit.html.erb
+++ b/app/views/steps/income/client/employment_income/edit.html.erb
@@ -1,0 +1,30 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+    <p class="govuk-body">
+      <%= t('.page_text') %>
+    </p>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_number_field(:amount,
+                               prefix_text: '£',
+                               width: 'one-half') %>
+      <%= f.govuk_collection_radio_buttons(:before_or_after_tax,
+                                           @form_object.before_or_after_tax_options,
+                                           :value,
+                                           legend: { size: 's',
+                                                     class: 'govuk-!-font-weight-regular' }) %>
+      <%= f.govuk_collection_radio_buttons(:frequency,
+                                           PaymentFrequencyType.values,
+                                           :value,
+                                           legend: { size: 's',
+                                                     class: 'govuk-!-font-weight-regular' }) %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -414,6 +414,14 @@ en:
           attributes:
             has_savings:
               inclusion: Select yes if your client has savings or investments
+        steps/income/client/employment_income_form:
+          attributes:
+            amount:
+              not_a_number: Enter their salary or wage
+            before_or_after_tax:
+              inclusion: Select before or after tax
+            frequency:
+              inclusion: Select how often they get this payment
         steps/income/client_has_dependants_form:
           attributes:
             client_has_dependants:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -94,6 +94,9 @@ en:
         types: Why should your client get legal aid?
       steps_income_employment_status_form:
         employment_status: What is your client's employment status?
+      steps_income_client_employment_income_form:
+        before_or_after_tax: Is this before or after tax?
+        frequency: How often do they get this payment?
       steps_income_income_payments_form:
         income_payments: Which of these payments does your client get?
       steps_income_income_benefits_form:
@@ -433,6 +436,12 @@ en:
         client_owns_property_options: *YESNO
       steps_income_has_savings_form:
         has_savings_options: *YESNO
+      steps_income_client_employment_income_form:
+        amount: What is their salary or wage?
+        before_or_after_tax_options:
+          before_tax: Before tax
+          after_tax: After tax
+        frequency_options: *frequency_options
       steps_income_income_payments_form:
         types_options:
           maintenance: Maintenance payments

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -299,6 +299,11 @@ en:
             page_title: Who is your client employed by?
             heading: Who does the client work for?
             subheading: Add the name and address of your client’s employer. If they have more than one employer, you can add more.
+        employment_income:
+          edit:
+            page_title: Your client's employment income
+            heading: Your client's employment income
+            page_text: You told us your client is employed.
 
     outgoings:
       caption: Outgoings assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
         edit_step :what_is_clients_employment_status, alias: :employment_status
         namespace :client do
           crud_step :employer_details, alias: :employer_details, param: :employment_id
+          edit_step :employment_income
         end
         show_step :employed_exit
         edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody

--- a/spec/controllers/steps/income/client/employment_income_controller_spec.rb
+++ b/spec/controllers/steps/income/client/employment_income_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::EmploymentIncomeController, type: :controller do
+  it_behaves_like 'a generic step controller',
+                  Steps::Income::Client::EmploymentIncomeForm, Decisions::IncomeDecisionTree
+end

--- a/spec/forms/steps/income/client/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/client/employment_income_form_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
                         payment_type: IncomePaymentType::EMPLOYMENT.to_s,
                         amount: 600,
                         frequency: 'four_weeks',
-                        metadata: { 'before_or_after_tax' => BeforeOrAfterTax::AFTER.to_s })
+                        metadata: { 'before_or_after_tax' => { value: BeforeOrAfterTax::AFTER.to_s } })
     }
 
     before do

--- a/spec/forms/steps/income/client/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/client/employment_income_form_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      amount:,
+      before_or_after_tax:,
+      frequency:,
+    }
+  end
+
+  let(:crime_application) { CrimeApplication.new }
+  let(:income_payment) {
+    IncomePayment.new(crime_application: crime_application,
+                      payment_type: IncomePaymentType::EMPLOYMENT.to_s)
+  }
+
+  let(:amount) { nil }
+  let(:before_or_after_tax) { nil }
+  let(:frequency) { nil }
+
+  before do
+    allow(crime_application.income_payments).to receive(:find_by).with(
+      { payment_type: IncomePaymentType::EMPLOYMENT.to_s }
+    ).and_return(income_payment)
+  end
+
+  describe '#before_or_after_tax_options' do
+    it 'returns the possible options' do
+      expect(
+        form.before_or_after_tax_options
+      ).to eq([
+                BeforeOrAfterTax::BEFORE,
+                BeforeOrAfterTax::AFTER,
+              ])
+    end
+  end
+
+  describe '#build' do
+    subject(:form) { described_class.build(crime_application) }
+
+    let(:existing_employment_income_payment) {
+      IncomePayment.new(crime_application: crime_application,
+                        payment_type: IncomePaymentType::EMPLOYMENT.to_s,
+                        amount: 600,
+                        frequency: 'four_weeks',
+                        metadata: { 'before_or_after_tax' => BeforeOrAfterTax::AFTER.to_s })
+    }
+
+    before do
+      allow(crime_application.income_payments).to(
+        receive(:employment).and_return(existing_employment_income_payment)
+      )
+    end
+
+    it 'sets the form attributes from the model metadata' do
+      expect(form.amount).to eq Money.new(600)
+      expect(form.before_or_after_tax).to eq(BeforeOrAfterTax::AFTER)
+      expect(form.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
+    end
+  end
+
+  describe '#save' do
+    before do
+      allow(crime_application.income_payments).to receive(:create!).and_return(true)
+    end
+
+    context 'when `amount` is not provided' do
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:amount, :not_a_number)).to be(true)
+      end
+    end
+
+    context 'when `before_or_after_tax` is not valid' do
+      let(:before_or_after_tax) { 'foo' }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:before_or_after_tax, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `frequency` is not valid' do
+      let(:frequency) { 'every six weeks' }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:frequency, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when all attributes are valid' do
+      let(:amount) { '600' }
+      let(:frequency) { PaymentFrequencyType::MONTHLY.to_s }
+      let(:before_or_after_tax) { BeforeOrAfterTax::AFTER.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
+      end
+
+      it 'updates the income employment payment with the correct attributes' do
+        expect(crime_application.income_payments).to receive(:create!).with(
+          payment_type: :employment,
+          amount: Money.new(60_000),
+          before_or_after_tax: BeforeOrAfterTax::AFTER,
+          frequency: PaymentFrequencyType::MONTHLY,
+        )
+
+        form.save
+      end
+    end
+  end
+end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -287,6 +287,13 @@ RSpec.describe Decisions::IncomeDecisionTree do
     end
   end
 
+  context 'when the step is `client_employment_income`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :client_employment_income }
+
+    it { is_expected.to have_destination('/steps/income/income_payments', :edit, id: crime_application) }
+  end
+
   context 'when the step is `income payments`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :income_payments }

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -274,7 +274,15 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :has_savings }
 
-    context 'has correct next step' do
+    context 'when client is employed' do
+      let(:employment_status) { ['employed'] }
+
+      it { is_expected.to have_destination('steps/income/client/employment_income', :edit, id: crime_application) }
+    end
+
+    context 'when client is not working' do
+      let(:employment_status) { ['not_working'] }
+
       it { is_expected.to have_destination(:income_payments, :edit, id: crime_application) }
     end
   end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -274,16 +274,32 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :has_savings }
 
-    context 'when client is employed' do
-      let(:employment_status) { ['employed'] }
-
-      it { is_expected.to have_destination('steps/income/client/employment_income', :edit, id: crime_application) }
+    before do
+      allow(FeatureFlags).to receive(:employment_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_employment_journey_enabled)
+      }
     end
 
-    context 'when client is not working' do
-      let(:employment_status) { ['not_working'] }
+    context 'when the employed journey is not enabled' do
+      let(:feature_flag_employment_journey_enabled) { false }
 
       it { is_expected.to have_destination(:income_payments, :edit, id: crime_application) }
+    end
+
+    context 'when the employed journey is enabled' do
+      let(:feature_flag_employment_journey_enabled) { true }
+
+      context 'when client is employed' do
+        let(:employment_status) { ['employed'] }
+
+        it { is_expected.to have_destination('steps/income/client/employment_income', :edit, id: crime_application) }
+      end
+
+      context 'when client is not working' do
+        let(:employment_status) { ['not_working'] }
+
+        it { is_expected.to have_destination(:income_payments, :edit, id: crime_application) }
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change

Add the new page 'Your client's employment income' which follows the `has_savings` page. 
This page is currently behind the employed journey feature flag. 

## Link to relevant ticket

[CRIMAPP-867](https://dsdmoj.atlassian.net/browse/CRIMAPP-867)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
![Screenshot 2024-05-15 at 12 14 42](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/d4480503-3f85-4dab-8c6b-234800807fe7)

## How to manually test the feature

This page is behind a feature flag but is also not accessible via the flow yet (see [CRIMAPP-863](https://dsdmoj.atlassian.net/browse/CRIMAPP-863)). Start a new application. When you get to the `employment_status` page, remove the end of the URL `what_is_clients_employment_status` and replace it with `client/employment_income`. You should now be on the new client Employment Income page. If you continue from this page, you should be on the 'Which of these payments does your client get?' page. 


[CRIMAPP-867]: https://dsdmoj.atlassian.net/browse/CRIMAPP-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRIMAPP-863]: https://dsdmoj.atlassian.net/browse/CRIMAPP-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ