### PR TITLE
[CRIMAPP-889] Add partner benefit type screen

### DIFF
--- a/app/controllers/steps/dwp/partner_benefit_type_controller.rb
+++ b/app/controllers/steps/dwp/partner_benefit_type_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module DWP
+    class PartnerBenefitTypeController < Steps::DWPStepController
+      def edit
+        @form_object = PartnerBenefitTypeForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(PartnerBenefitTypeForm, as: :partner_benefit_type)
+      end
+    end
+  end
+end

--- a/app/forms/steps/dwp/partner_benefit_type_form.rb
+++ b/app/forms/steps/dwp/partner_benefit_type_form.rb
@@ -1,0 +1,24 @@
+module Steps
+  module DWP
+    class PartnerBenefitTypeForm < Steps::DWP::BenefitTypeForm
+      include Steps::HasOneAssociation
+      has_one_association :partner
+
+      private
+
+      def changed?
+        # The attribute is a `value_object`, overriding generic `#changed?`
+        !partner.benefit_type.eql?(benefit_type.to_s) ||
+          !partner.last_jsa_appointment_date.eql?(last_jsa_appointment_date)
+      end
+
+      def persist!
+        return true unless changed?
+
+        partner.update(
+          attributes.merge(attributes_to_reset)
+        )
+      end
+    end
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,5 +1,2 @@
 class Applicant < Person
-  def has_passporting_benefit?
-    BenefitType.passporting.map(&:value).include?(benefit_type&.to_sym)
-  end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,3 +1,2 @@
 class Partner < Person
-  # NOTE: partner is not yet used
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -16,4 +16,8 @@ class Person < ApplicationRecord
   def correspondence_address?
     correspondence_address&.address_line_one.present?
   end
+
+  def has_passporting_benefit?
+    BenefitType.passporting.map(&:value).include?(benefit_type&.to_sym)
+  end
 end

--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -1,10 +1,13 @@
 module Decisions
+  # rubocop:disable Metrics/ClassLength
   class DWPDecisionTree < BaseDecisionTree
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     def destination
       case step_name
       when :benefit_type
         after_benefit_type
+      when :partner_benefit_type
+        after_partner_benefit_type
       when :benefit_check_result
         edit('/steps/case/urn')
       when :has_benefit_evidence
@@ -46,17 +49,35 @@ module Decisions
     end
 
     def after_benefit_type
+      return edit(:partner_benefit_type) if partner_benefit_type_required?
+
+      benefit_check_routing(applicant)
+    end
+
+    def after_partner_benefit_type
+      benefit_check_routing(partner)
+    end
+
+    def benefit_check_routing(person)
       if form_object.benefit_type.none?
         if FeatureFlags.means_journey.enabled?
           edit('/steps/case/urn')
         else
           show(:benefit_exit)
         end
-      elsif !applicant_has_nino
+      elsif !has_nino(person)
         edit(:cannot_check_benefit_status)
       else
-        determine_dwp_result_page
+        determine_dwp_result_page(person)
       end
+    end
+
+    def partner_benefit_type_required?
+      # TODO: refactor to use has_partner in partner_details table instead of client_has_partner
+
+      form_object.benefit_type.none? &&
+        FeatureFlags.passported_partner_journey.enabled? &&
+        current_crime_application.client_has_partner == 'yes'
     end
 
     def after_has_benefit_evidence
@@ -75,14 +96,14 @@ module Decisions
       end
     end
 
-    def determine_dwp_result_page
+    def determine_dwp_result_page(person)
       return edit(:benefit_check_result) if current_crime_application.benefit_check_passported?
 
-      DWP::UpdateBenefitCheckResultService.call(applicant)
+      DWP::UpdateBenefitCheckResultService.call(person)
 
-      if applicant.passporting_benefit.nil?
+      if person.passporting_benefit.nil?
         edit(:cannot_check_dwp_status)
-      elsif applicant.passporting_benefit
+      elsif person.passporting_benefit
         edit(:benefit_check_result)
       else
         edit(:confirm_result)
@@ -90,17 +111,30 @@ module Decisions
     end
 
     def after_cannot_check_dwp_status
-      determine_dwp_result_page
+      person = benefit_check_recipient
+
+      determine_dwp_result_page(person)
     end
 
-    def applicant_has_nino
+    def has_nino(person)
       return true unless FeatureFlags.means_journey.enabled?
 
-      applicant.has_nino == 'yes'
+      person.has_nino == 'yes'
     end
 
     def applicant
       @applicant ||= current_crime_application.applicant
     end
+
+    def partner
+      @partner ||= current_crime_application.partner
+    end
+
+    def benefit_check_recipient
+      return partner if partner&.has_passporting_benefit?
+
+      applicant
+    end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/views/steps/dwp/partner_benefit_type/edit.html.erb
+++ b/app/views/steps/dwp/partner_benefit_type/edit.html.erb
@@ -1,0 +1,32 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :benefit_type, legend: { tag: 'h1', size: 'xl' } do %>
+        <% @form_object.choices.each_with_index do |option, index| %>
+
+        <% if option.jsa? %>
+            <%= f.govuk_radio_button :benefit_type, option.value do %>
+              <%= f.govuk_date_field :last_jsa_appointment_date, maxlength_enabled: true,
+                                      legend: {
+                                        text: t('.last_jsa_appointment_date'),
+                                        size: 's', class: 'govuk-!-font-weight-regular'
+                                      } %>
+            <% end %>
+          <% elsif option.none? %>
+            <%= f.govuk_radio_divider %>
+            <%= f.govuk_radio_button :benefit_type, option, link_errors: index.zero? %>
+          <% else %>
+            <%= f.govuk_radio_button :benefit_type, option, link_errors: index.zero? %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -148,6 +148,24 @@ en:
               invalid_year: Enter a valid year
               year_too_early: Date your client last attended an appointment with their JSA work coach is too far in the past
               future_not_allowed: Date your client last attended an appointment with their JSA work coach must be today or in the past
+        steps/dwp/partner_benefit_type_form:
+          attributes:
+            benefit_type:
+              inclusion: Select a benefit type
+            last_jsa_appointment_date:
+              blank: Enter the date the partner last attended an appointment with their JSA work coach
+              blank_day: Date the partner last attended an appointment with their JSA work coach must include a day
+              blank_month: Date the partner last attended an appointment with their JSA work coach must include a month
+              blank_year: Date the partner last attended an appointment with their JSA work coach must include a year
+              blank_day_month: Date the partner last attended an appointment with their JSA work coach must include a day and month
+              blank_day_year: Date the partner last attended an appointment with their JSA work coach must include a day and year
+              blank_month_year: Date the partner last attended an appointment with their JSA work coach must include a month and year
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Date the partner last attended an appointment with their JSA work coach is too far in the past
+              future_not_allowed: Date the partner last attended an appointment with their JSA work coach must be today or in the past
         steps/dwp/has_benefit_evidence_form:
           attributes:
             has_benefit_evidence:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -63,6 +63,8 @@ en:
         appeal_reference_number: What is the reference number of the original application?
       steps_dwp_benefit_type_form:
         benefit_type: Does your client get one of these passporting benefits?
+      steps_dwp_partner_benefit_type_form:
+        benefit_type: Does the partner get one of these passporting benefits?
       steps_client_residence_type_form:
         residence_type: Where does your client usually live?
       steps_client_contact_details_form:
@@ -173,9 +175,10 @@ en:
       steps_client_has_nino_form:
         has_nino: It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
         nino: For example, QQ 12 34 56 C
-      steps_dwp_benefit_type_form:
+      steps_dwp_benefit_type_form: &BENEFIT_TYPE_HINT
         benefit_type: This will help us review your application. It will not affect the DWP check.
         last_jsa_appointment_date: This is sometimes known as ‘signing on’.
+      steps_dwp_partner_benefit_type_form: *BENEFIT_TYPE_HINT
       steps_dwp_cannot_check_benefit_status_form:
         will_enter_nino_options:
           'no': You may not be able to submit your application without the National Insurance number
@@ -329,13 +332,15 @@ en:
           providers_office_address: Provider’s office
           other_address: Somewhere else
       steps_dwp_benefit_type_form:
-        benefit_type_options:
+        benefit_type_options: &BENEFIT_TYPE_OPTIONS
           universal_credit: Universal Credit
           guarantee_pension: Guarantee Credit element of Pension Credit
           jsa: Income-based Jobseeker's Allowance (JSA)
           esa: Income-related Employment and Support Allowance (ESA)
           income_support: Income Support
-          none: My client does not get any of these passporting benefits
+          none: None of these
+      steps_dwp_partner_benefit_type_form:
+        benefit_type_options: *BENEFIT_TYPE_OPTIONS
       steps_dwp_has_benefit_evidence_form:
         has_benefit_evidence_options: *YESNO
       steps_dwp_cannot_check_benefit_status_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -75,11 +75,11 @@ en:
       benefit_type:
         edit:
           page_title: Does your client get one of these passporting benefits?
-          last_jsa_appointment_date: Enter when your client last attended an appointment with their JSA work coach
+          last_jsa_appointment_date: &JSA_DATE_QUESTION When did they last attend an appointment with their JSA work coach?
       partner_benefit_type:
         edit:
           page_title: Does the partner get one of these passporting benefits?
-          last_jsa_appointment_date: Enter when the partner last attended an appointment with their JSA work coach
+          last_jsa_appointment_date: *JSA_DATE_QUESTION
       benefit_exit:
         show:
           page_title: Use eForms for this application

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -76,6 +76,10 @@ en:
         edit:
           page_title: Does your client get one of these passporting benefits?
           last_jsa_appointment_date: Enter when your client last attended an appointment with their JSA work coach
+      partner_benefit_type:
+        edit:
+          page_title: Does the partner get one of these passporting benefits?
+          last_jsa_appointment_date: Enter when the partner last attended an appointment with their JSA work coach
       benefit_exit:
         show:
           page_title: Use eForms for this application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
 
       namespace :dwp do
         edit_step :benefit_type
+        edit_step :partner_benefit_type
         show_step :benefit_exit
         edit_step :benefit_check_result
         edit_step :cannot_check_benefit_status

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,14 @@ feature_flags:
     local: true
     staging: true
     production: false
+  passported_partner_journey:
+    local: true
+    staging: true
+    production: false
+  unemployment_partner_journey:
+    local: true
+    staging: true
+    production: false
 
 
 # NOTE: consider if the setting you are adding here

--- a/spec/controllers/steps/dwp/partner_benefit_type_controller_spec.rb
+++ b/spec/controllers/steps/dwp/partner_benefit_type_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::DWP::PartnerBenefitTypeController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::DWP::PartnerBenefitTypeForm, Decisions::DWPDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::DWP::PartnerBenefitTypeForm
+end

--- a/spec/forms/steps/dwp/partner_benefit_type_form_spec.rb
+++ b/spec/forms/steps/dwp/partner_benefit_type_form_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe Steps::DWP::PartnerBenefitTypeForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      record:,
+      benefit_type:,
+      last_jsa_appointment_date:
+    }
+  end
+
+  let(:crime_application) { instance_double(CrimeApplication, partner: record) }
+  let(:record) { Partner.new }
+
+  let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+  let(:last_jsa_appointment_date) { nil }
+
+  describe 'validations' do
+    context 'when `benefit_type` is blank' do
+      let(:benefit_type) { '' }
+
+      it 'has is a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:benefit_type, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `benefit_type` is invalid' do
+      let(:benefit_type) { 'invalid_type' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:benefit_type, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `benefit_type` is valid' do
+      let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+
+      it { is_expected.to be_valid }
+
+      it 'passes validation' do
+        expect(form.errors.of_kind?(:benefit_type, :invalid)).to be(false)
+      end
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :partner,
+                      expected_attributes: {
+                        'benefit_type' => BenefitType::UNIVERSAL_CREDIT,
+                        'last_jsa_appointment_date' => nil,
+                        'has_benefit_evidence' => nil,
+                      }
+
+      context 'when `benefit_type` answer is not jsa' do
+        context 'when a `last_jsa_appointment_date` was previously recorded' do
+          let(:last_jsa_appointment_date) { 1.month.ago.to_date }
+
+          it { is_expected.to be_valid }
+
+          it 'can make last_jsa_appointment_date field nil if no longer required' do
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['last_jsa_appointment_date']).to be_nil
+          end
+        end
+      end
+
+      context 'when `benefit_type` answer is jsa' do
+        context 'when a `last_jsa_appointment_date` was previously recorded' do
+          let(:benefit_type) { BenefitType::JSA.to_s }
+          let(:last_jsa_appointment_date) { 1.month.ago.to_date }
+
+          it 'is valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :last_jsa_appointment_date,
+                :present
+              )
+            ).to be(false)
+          end
+
+          it 'cannot reset `last_jsa_appointment_date` as it is relevant' do
+            record.update(benefit_type: BenefitType::JSA.to_s)
+
+            attributes = form.send(:attributes_to_reset)
+            expect(attributes['last_jsa_appointment_date']).to eq(last_jsa_appointment_date)
+          end
+        end
+
+        context 'when a `last_jsa_appointment_date` was not previously recorded' do
+          let(:benefit_type) { BenefitType::JSA.to_s }
+          let(:last_jsa_appointment_date) { 1.month.ago.to_date }
+
+          it 'is also valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :last_jsa_appointment_date,
+                :present
+              )
+            ).to be(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#save' do
+    before do
+      allow(record).to receive(:benefit_type).and_return(previous_benefit_type)
+    end
+
+    context 'when the benefit type has changed' do
+      let(:previous_benefit_type) { BenefitType::GUARANTEE_PENSION.to_s }
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :partner,
+                      expected_attributes: {
+                        'benefit_type' => BenefitType::UNIVERSAL_CREDIT,
+                        'last_jsa_appointment_date' => nil,
+                        'has_benefit_evidence' => nil,
+                      }
+    end
+
+    context 'when benefit type is the same as in the persisted record' do
+      let(:previous_benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
+
+      it 'does not save the record but returns true' do
+        expect(record).not_to receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Decisions::DWPDecisionTree do
     end
   end
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   context 'when the step is `benefit_type`' do
     let(:form_object) { double('FormObject', benefit_type:) }
     let(:applicant_double) { double(Applicant, has_nino:) }
@@ -72,9 +73,12 @@ RSpec.describe Decisions::DWPDecisionTree do
     let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
     let(:has_nino) { YesNoAnswer::YES }
     let(:feature_flag_means_journey_enabled) { false }
+    let(:client_has_partner) { 'no' }
+    let(:passported_partner_journey_enabled) { false }
 
     before do
       allow(crime_application).to receive_messages(applicant: applicant_double,
+                                                   client_has_partner: client_has_partner,
                                                    benefit_check_passported?: benefit_check_passported)
 
       allow(applicant_double).to receive_messages(passporting_benefit:)
@@ -84,10 +88,13 @@ RSpec.describe Decisions::DWPDecisionTree do
       allow(FeatureFlags).to receive(:means_journey) {
         instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_means_journey_enabled)
       }
+
+      allow(FeatureFlags).to receive(:passported_partner_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: passported_partner_journey_enabled)
+      }
     end
 
     context 'and the benefit type is `none`' do
-      let(:feature_flag_means_journey_enabled) { false }
       let(:benefit_type) { BenefitType::NONE }
       let(:benefit_check_passported) { false }
       let(:passporting_benefit) { nil }
@@ -98,6 +105,13 @@ RSpec.describe Decisions::DWPDecisionTree do
         let(:feature_flag_means_journey_enabled) { true }
 
         it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
+      end
+
+      context 'and feature flag `passported_partner_journey` is enabled and client has a partner' do
+        let(:passported_partner_journey_enabled) { true }
+        let(:client_has_partner) { 'yes' }
+
+        it { is_expected.to have_destination(:partner_benefit_type, :edit, id: crime_application) }
       end
     end
 
@@ -148,6 +162,45 @@ RSpec.describe Decisions::DWPDecisionTree do
 
         it { is_expected.to have_destination(:cannot_check_benefit_status, :edit, id: crime_application) }
       end
+    end
+  end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
+
+  context 'when the step is `partner_benefit_type`' do
+    let(:form_object) { double('FormObject', benefit_type:) }
+    let(:partner_double) { double(Partner, has_nino:) }
+    let(:step_name) { :partner_benefit_type }
+    let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
+    let(:has_nino) { YesNoAnswer::YES }
+    let(:feature_flag_means_journey_enabled) { true }
+
+    before do
+      allow(crime_application).to receive_messages(partner: partner_double,
+                                                   benefit_check_passported?: benefit_check_passported)
+
+      allow(partner_double).to receive_messages(passporting_benefit:)
+
+      allow(DWP::UpdateBenefitCheckResultService).to receive(:call).with(partner_double).and_return(true)
+
+      allow(FeatureFlags).to receive(:means_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_means_journey_enabled)
+      }
+    end
+
+    context 'and the benefit type is `none`' do
+      let(:benefit_type) { BenefitType::NONE }
+      let(:benefit_check_passported) { false }
+      let(:passporting_benefit) { nil }
+
+      it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
+    end
+
+    context 'when the partner does not have a nino' do
+      let(:passporting_benefit) { nil }
+      let(:benefit_check_passported) { false }
+      let(:has_nino) { YesNoAnswer::NO }
+
+      it { is_expected.to have_destination(:cannot_check_benefit_status, :edit, id: crime_application) }
     end
   end
 
@@ -214,9 +267,12 @@ RSpec.describe Decisions::DWPDecisionTree do
     let(:benefit_check_passported) { false }
     let(:passporting_benefit) { false }
     let(:applicant_double) { double(Applicant) }
+    let(:partner_double) { double(Partner, has_passporting_benefit?: partner_has_benefit) }
+    let(:partner_has_benefit) { false }
 
     before do
       allow(crime_application).to receive_messages(applicant: applicant_double,
+                                                   partner: partner_double,
                                                    benefit_check_passported?: benefit_check_passported)
 
       allow(applicant_double).to receive_messages(passporting_benefit:)
@@ -225,5 +281,17 @@ RSpec.describe Decisions::DWPDecisionTree do
     end
 
     it { is_expected.to have_destination(:confirm_result, :edit, id: crime_application) }
+
+    context 'when benefit check is performed on partner details' do
+      let(:partner_has_benefit) { true }
+
+      before do
+        allow(partner_double).to receive_messages(passporting_benefit:)
+
+        allow(DWP::UpdateBenefitCheckResultService).to receive(:call).with(partner_double).and_return(true)
+      end
+
+      it { is_expected.to have_destination(:confirm_result, :edit, id: crime_application) }
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Adds screen to select partners benefit type 
Also updates routing of related screens

## Link to relevant ticket
[CRIMAPP-889](https://dsdmoj.atlassian.net/browse/CRIMAPP-889)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1177" alt="Screenshot 2024-05-15 at 14 01 09" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/d05ef59c-10c7-4e0a-8755-bf2562997ae2">
<img width="1177" alt="Screenshot 2024-05-15 at 14 01 17" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/61551311-9769-4d2e-9d55-e80dbb68892c">
<img width="1177" alt="Screenshot 2024-05-15 at 14 01 48" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/e1fd45f6-f360-434b-9039-d92e05dabb27">

## How to manually test the feature

To test the screen itself 

1. Start an application and fill in client details and navigate to `/steps/dwp/partner_benefit_type `
2. Verify the validation is in place when no option is selected and when no jsa date is inputted 
3. Select an option and select save and continue and verify you are able to continue to another screen 

To test the routing 

1. Start an application and select yes to having a partner. 
2. You will be shown the partner exit screen but you can use the url to navigate to the task list to begin the application (`/edit`)
3. Create a over 18 client, summary only application where the client does not have a nino or a passporting benefit 
4. After selecting no benefit on the client passporting benefit screen, you should be routed to the partner passporting benefit screen 
5. Select a benefit for the partner and you should be navigated to the dwp check 
6. Select none for the partner and you should be routed to the case urn screen 

[CRIMAPP-889]: https://dsdmoj.atlassian.net/browse/CRIMAPP-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ