### PR TITLE
CRIMAPP-863 Update routing for employed journey

### DIFF
--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -85,10 +85,14 @@ module Decisions
       when [EmploymentStatus::SELF_EMPLOYED.to_s]
         show(:employed_exit)
       when [EmploymentStatus::EMPLOYED.to_s, EmploymentStatus::SELF_EMPLOYED.to_s]
-        employments = current_crime_application.employments
-        current_crime_application.employments.create! if employments.empty?
-        edit('steps/income/client/employer_details', employment_id: employments.first)
+        redirect_to_employer_details
       end
+    end
+
+    def redirect_to_employer_details
+      employments = current_crime_application.employments
+      current_crime_application.employments.create! if employments.empty?
+      edit('/steps/income/client/employer_details', employment_id: employments.first)
     end
 
     def after_lost_job_in_custody
@@ -102,6 +106,8 @@ module Decisions
     def after_income_before_tax
       if income_below_threshold?
         edit(:frozen_income_savings_assets)
+      elsif employed? && FeatureFlags.employment_journey.enabled?
+        redirect_to_employer_details
       else
         edit(:income_payments)
       end
@@ -110,24 +116,28 @@ module Decisions
     def after_frozen_income_savings_assets
       if no_frozen_assets? && !summary_only?
         edit(:client_owns_property)
+      elsif employed? && FeatureFlags.employment_journey.enabled?
+        redirect_to_employer_details
       else
         edit(:income_payments)
       end
     end
 
     def after_has_savings
-      return edit(:income_payments) unless FeatureFlags.employment_journey.enabled?
+      return edit(:income_payments) unless FeatureFlags.employment_journey.enabled? && employed?
 
-      if employed?
-        edit('steps/income/client/employment_income')
+      if requires_full_means_assessment?
+        redirect_to_employer_details
       else
-        edit(:income_payments)
+        edit('/steps/income/client/employment_income')
       end
     end
 
     def after_client_owns_property
       if no_property?
         edit(:has_savings)
+      elsif employed? && FeatureFlags.employment_journey.enabled?
+        redirect_to_employer_details
       else
         edit(:income_payments)
       end
@@ -165,7 +175,7 @@ module Decisions
     end
 
     def employed?
-      crime_application.income.employment_status.include?(EmploymentStatus::EMPLOYED.to_s)
+      !!crime_application.income.employment_status&.include?(EmploymentStatus::EMPLOYED.to_s)
     end
 
     def not_working?

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -96,6 +96,8 @@ en:
         types: Why should your client get legal aid?
       steps_income_employment_status_form:
         employment_status: What is your client's employment status?
+      steps_income_client_employment_income_form:
+        before_or_after_tax: Is this before or after tax?
       steps_income_client_employment_details_form:
         income_payment_attributes:
           before_or_after_tax: Is this before or after tax?


### PR DESCRIPTION
## Description of change

This PR updates the routing to redirect to the employed loop.

Preconditions: 
1. They have selected only 'Employed' on the employment status page
2. The employment journey feature flag is on

If they above conditions are true, then you should be redirected to the 'Employer details' page immediately after answering 'Yes' on any of the following pages:
  -  Is your client’s annual income more than £12475 a year before tax?
  - Does your client have any income, savings or assets under a restraint or freezing order?
  - Does your client own their home, or any other land or property?
  - Does your client have any savings or investments?

If you answer 'No' the flow continues as before. 
If the client is not employed AND/OR the feature flag is not enabled, the flow stays the same as before. 

## Link to relevant ticket

[CRIMAPP-863](https://dsdmoj.atlassian.net/browse/CRIMAPP-863)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

The feature flag should be already set to TRUE.

Start a new application. When you get to the `Employment status` page, select `Employed`. 
Continue to the next page ` Is your client’s annual income more than £12475 a year before tax?`
 - Select YES: you should be on the `Employer details` page showing `Who does the client work for?`
 - Select NO: you should be on the `Does your client have any income, savings or assets under a restraint or freezing order?` page.
 On the Income, Savings and Assets page: 
- Select YES: you should be on the `Employer details` page
 - Select NO: you should be on the `Does your client own their home, or any other land or property?` page.
 On the home, land and property page: 
- Select YES: you should be on the `Employer details` page
 - Select NO: you should be on the `Does your client have any savings or investments?` page.
On the Savings and Investments page:
- Select YES: you should be on the `Employer details` page
 - Select NO: you should be on the `Your client's employment income` page.

[CRIMAPP-863]: https://dsdmoj.atlassian.net/browse/CRIMAPP-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ