### PR TITLE
CRIMAPP-915 Task list only includes applicable sections in total count

### DIFF
--- a/app/presenters/task_list/collection.rb
+++ b/app/presenters/task_list/collection.rb
@@ -41,10 +41,14 @@ module TaskList
       all_tasks.select(&:completed?)
     end
 
+    def applicable
+      all_tasks.reject(&:not_applicable?)
+    end
+
     private
 
     def all_tasks
-      map(&:items).flatten
+      @all_tasks ||= map(&:items).flatten
     end
 
     def collection

--- a/app/presenters/task_list/task.rb
+++ b/app/presenters/task_list/task.rb
@@ -1,7 +1,7 @@
 module TaskList
   class Task < BaseRenderer
     delegate :status, to: :task
-    delegate :completed?, to: :status
+    delegate :completed?, :not_applicable?, to: :status
 
     def render
       tag.li class: 'moj-task-list__item' do

--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -12,7 +12,7 @@
     </h2>
 
     <p class="govuk-body govuk-!-margin-bottom-7">
-      <%= t('.progress_counter', completed: @tasklist.completed.size, total: @tasklist.size) %>
+      <%= t('.progress_counter', completed: @tasklist.completed.size, total: @tasklist.applicable.size) %>
     </p>
 
     <%= @tasklist.render %>

--- a/spec/presenters/task_list/collection_spec.rb
+++ b/spec/presenters/task_list/collection_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe TaskList::Collection do
     end
   end
 
+  describe '#applicable' do
+    let(:applicable_task) { double(not_applicable?: false) }
+
+    before do
+      allow(TaskList::Task).to receive(:new).and_return(
+        applicable_task, double(not_applicable?: true)
+      )
+    end
+
+    it 'returns only the applicable tasks' do
+      expect(subject.applicable).to eq([applicable_task])
+    end
+  end
+
   describe '#render' do
     before do
       # We test the Section separately, here we don't need to


### PR DESCRIPTION
## Description of change
Task list only counts applicable tasks when reporting progress.

## Link to relevant ticket
[CRIMAPP-915](https://dsdmoj.atlassian.net/browse/CRIMAPP-915)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1075" alt="Screenshot 2024-05-16 at 14 46 16" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/0b55eebb-1265-4460-af45-9f2e04c3e5ce">


### After changes:

<img width="775" alt="Screenshot 2024-05-16 at 14 45 23" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/ccd5615f-dc0f-4fb6-afa4-f31e0b35b93f">


## How to manually test the feature


[CRIMAPP-915]: https://dsdmoj.atlassian.net/browse/CRIMAPP-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ