### PR TITLE
CRIMAPP-893 Skip Means Assessment for Crown Court Appeals Without Changes on Apply

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -154,6 +154,7 @@ Naming/PredicateName:
     - has_codefendants_complete?
     - has_charges_complete?
     - has_benefit_evidence_complete?
+    - has_frozen_assets?
 
 # TODO: adjust these values towards the rubocop defaults
 RSpec/MultipleMemoizedHelpers:

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -28,6 +28,6 @@ class Capital < ApplicationRecord
   end
 
   def answers_validator
-    @answers_validator ||= CapitalAssessment::AnswersValidator.new(self)
+    @answers_validator ||= CapitalAssessment::AnswersValidator.new(record: self)
   end
 end

--- a/app/models/concerns/type_of_application.rb
+++ b/app/models/concerns/type_of_application.rb
@@ -30,7 +30,7 @@ module TypeOfApplication
   alias pse? post_submission_evidence?
 
   def appeal_no_changes?
-    return false unless kase
+    return false unless kase&.appeal_original_app_submitted == 'yes'
 
     kase.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s &&
       kase.appeal_financial_circumstances_changed == 'no'

--- a/app/models/concerns/type_of_employment.rb
+++ b/app/models/concerns/type_of_employment.rb
@@ -1,0 +1,13 @@
+module TypeOfEmployment
+  extend ActiveSupport::Concern
+
+  delegate :income, to: :crime_application
+
+  def not_working?
+    income.employment_status.include?(EmploymentStatus::NOT_WORKING.to_s)
+  end
+
+  def ended_employment_within_three_months?
+    income.ended_employment_within_three_months == 'yes'
+  end
+end

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -1,21 +1,22 @@
 module TypeOfMeansAssessment
   extend ActiveSupport::Concern
 
-  delegate :applicant, :kase, :income, :outgoings, :income_payments, :income_benefits, :capital, to: :crime_application
+  delegate :applicant, :kase, :income, :outgoings, :income_payments, :income_benefits, :capital, :appeal_no_changes?,
+           to: :crime_application
 
   def requires_means_assessment?
     return false unless FeatureFlags.means_journey.enabled?
     return false if Passporting::MeansPassporter.new(crime_application).call
+    return false if appeal_no_changes?
 
     !evidence_of_passporting_means_forthcoming?
   end
 
   def requires_full_means_assessment?
     return false unless requires_means_assessment?
-    return true if income_above_threshold?
-    return true unless no_frozen_assets?
+    return true if income_above_threshold? || has_frozen_assets?
 
-    !(summary_only? || (no_property? && no_savings?))
+    !summary_only? && !(no_property? && no_savings?)
   end
 
   def requires_full_capital?
@@ -75,6 +76,10 @@ module TypeOfMeansAssessment
 
   def no_savings?
     income.has_savings == 'no'
+  end
+
+  def has_frozen_assets?
+    income.has_frozen_income_or_assets == 'yes'
   end
 
   def no_frozen_assets?

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -13,6 +13,6 @@ class Income < ApplicationRecord
   end
 
   def answers_validator
-    @answers_validator ||= IncomeAssessment::AnswersValidator.new(self)
+    @answers_validator ||= IncomeAssessment::AnswersValidator.new(record: self)
   end
 end

--- a/app/models/outgoings.rb
+++ b/app/models/outgoings.rb
@@ -17,6 +17,6 @@ class Outgoings < ApplicationRecord
   end
 
   def answers_validator
-    @answers_validator ||= OutgoingsAssessment::AnswersValidator.new(self)
+    @answers_validator ||= OutgoingsAssessment::AnswersValidator.new(record: self)
   end
 end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -1,5 +1,5 @@
 module Summary
-  class HtmlPresenter # rubocop:disable Metrics/ClassLength
+  class HtmlPresenter
     attr_reader :crime_application
 
     delegate :application_type, :appeal_no_changes?, to: :crime_application
@@ -43,22 +43,6 @@ module Summary
         more_information
         legal_representative_details
       ],
-      appeal_with_no_changes: %i[
-        overview
-        client_details
-        contact_details
-        case_details
-        offences
-        codefendants
-        next_court_hearing
-        first_court_hearing
-        justification_for_legal_aid
-        passport_justification_for_legal_aid
-        employment_details
-        supporting_evidence
-        more_information
-        legal_representative_details
-      ],
       capital: %i[
         properties
         savings
@@ -88,11 +72,7 @@ module Summary
     end
 
     def sections
-      if appeal_no_changes?
-        build_sections(:appeal_with_no_changes)
-      else
-        build_sections(application_type.to_sym)
-      end
+      build_sections(application_type.to_sym)
     end
 
     def income_sections

--- a/app/presenters/tasks/capital_assessment.rb
+++ b/app/presenters/tasks/capital_assessment.rb
@@ -11,25 +11,24 @@ module Tasks
     end
 
     def not_applicable?
-      return false unless fulfilled?(ClientDetails)
-      return true unless requires_means_assessment?
-      return false unless fulfilled?(IncomeAssessment)
-
-      !requires_full_means_assessment?
+      applicant.present? && super
     end
 
     def can_start?
-      fulfilled?(IncomeAssessment) && requires_full_means_assessment?
+      fulfilled?(IncomeAssessment)
     end
-
-    delegate :capital, to: :crime_application
 
     def in_progress?
       capital.present?
     end
 
-    def completed?
-      capital.complete?
+    private
+
+    def validator
+      @validator ||= ::CapitalAssessment::AnswersValidator.new(
+        record: capital,
+        crime_application: crime_application
+      )
     end
   end
 end

--- a/app/presenters/tasks/income_assessment.rb
+++ b/app/presenters/tasks/income_assessment.rb
@@ -1,27 +1,28 @@
 module Tasks
   class IncomeAssessment < BaseTask
-    include TypeOfMeansAssessment
-
     def path
       edit_steps_income_employment_status_path
     end
 
     def not_applicable?
-      return false unless applicant
-
-      !requires_means_assessment?
+      applicant.present? && super
     end
 
     def can_start?
-      fulfilled?(CaseDetails) && requires_means_assessment?
+      fulfilled?(CaseDetails)
     end
 
     def in_progress?
-      income.present?
+      crime_application.income.present?
     end
 
-    def completed?
-      income.complete?
+    private
+
+    def validator
+      @validator ||= ::IncomeAssessment::AnswersValidator.new(
+        record: crime_application.income,
+        crime_application: crime_application
+      )
     end
   end
 end

--- a/app/presenters/tasks/outgoings_assessment.rb
+++ b/app/presenters/tasks/outgoings_assessment.rb
@@ -7,23 +7,24 @@ module Tasks
     end
 
     def not_applicable?
-      return false unless fulfilled?(ClientDetails)
-      return true unless requires_means_assessment?
-      return false unless fulfilled?(IncomeAssessment)
-
-      !requires_full_means_assessment?
+      applicant.present? && super
     end
 
     def can_start?
-      fulfilled?(IncomeAssessment) && requires_full_means_assessment?
+      fulfilled?(IncomeAssessment)
     end
 
     def in_progress?
       outgoings.present?
     end
 
-    def completed?
-      outgoings.complete?
+    private
+
+    def validator
+      @validator ||= ::OutgoingsAssessment::AnswersValidator.new(
+        record: crime_application.outgoings,
+        crime_application: crime_application
+      )
     end
   end
 end

--- a/app/services/decisions/case_decision_tree.rb
+++ b/app/services/decisions/case_decision_tree.rb
@@ -98,11 +98,11 @@ module Decisions
     end
 
     def after_ioj
-      if requires_means_assessment? || crime_application.appeal_no_changes?
-        return edit('/steps/income/employment_status')
+      if requires_means_assessment?
+        edit('/steps/income/employment_status')
+      else
+        edit('/steps/evidence/upload')
       end
-
-      edit('/steps/evidence/upload')
     end
 
     def edit_new_charge

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -13,7 +13,7 @@ module Decisions
       when :client_employment_details
         after_client_employment_details
       when :lost_job_in_custody
-        after_lost_job_in_custody
+        edit(:income_before_tax)
       when :income_before_tax
         after_income_before_tax
       when :frozen_income_savings_assets
@@ -65,8 +65,6 @@ module Decisions
       if not_working?
         if ended_employment_within_three_months?
           edit(:lost_job_in_custody)
-        elsif appeal_no_changes?
-          edit('/steps/evidence/upload')
         else
           edit(:income_before_tax)
         end
@@ -93,14 +91,6 @@ module Decisions
       employments = current_crime_application.employments
       current_crime_application.employments.create! if employments.empty?
       edit('/steps/income/client/employer_details', employment_id: employments.first)
-    end
-
-    def after_lost_job_in_custody
-      if appeal_no_changes?
-        edit('/steps/evidence/upload')
-      else
-        edit(:income_before_tax)
-      end
     end
 
     def after_income_before_tax
@@ -184,11 +174,6 @@ module Decisions
 
     def ended_employment_within_three_months?
       form_object.ended_employment_within_three_months&.yes?
-    end
-
-    def appeal_no_changes?
-      kase.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s &&
-        kase.appeal_financial_circumstances_changed == 'no'
     end
 
     def crime_application

--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -2,10 +2,8 @@ module Passporting
   class MeansPassporter < BasePassporter
     def call
       return passported? if resubmission?
-      return true if appeal_no_changes?
 
       means_passport = []
-
       means_passport << MeansPassportType::ON_NOT_MEANS_TESTED if app_not_means_tested?
       means_passport << MeansPassportType::ON_AGE_UNDER18      if applicant_under18?
       means_passport << MeansPassportType::ON_BENEFIT_CHECK    if benefit_check_passed?
@@ -53,13 +51,6 @@ module Passporting
 
     def benefit_check_passed?
       applicant.passporting_benefit.present?
-    end
-
-    def appeal_no_changes?
-      return false unless crime_application.case
-
-      (crime_application.case.case_type == 'appeal_to_crown_court') &&
-        (crime_application.case.appeal_financial_circumstances_changed == 'no')
     end
   end
 end

--- a/app/validators/appeal_details/answers_validator.rb
+++ b/app/validators/appeal_details/answers_validator.rb
@@ -22,8 +22,7 @@ module AppealDetails
       return true if kase.appeal_original_app_submitted == 'no'
       return true if kase.appeal_financial_circumstances_changed == 'yes' && kase.appeal_with_changes_details.present?
 
-      kase.appeal_financial_circumstances_changed == 'no' &&
-        kase.values_at(:appeal_maat_id, :appeal_usn).any?(&:present?)
+      record.appeal_no_changes?
     end
 
     def applicable?

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -30,7 +30,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
   end
 
   def means_valid?
-    return true if Passporting::MeansPassporter.new(record).call
+    return true unless requires_means_assessment?
 
     evidence_present? || means_record_present? || client_remanded_in_custody?
   end

--- a/app/validators/base_answer_validator.rb
+++ b/app/validators/base_answer_validator.rb
@@ -1,0 +1,24 @@
+class BaseAnswerValidator
+  def initialize(record: nil, crime_application: nil)
+    @record = record
+    @crime_application = crime_application || record.crime_application
+  end
+
+  attr_reader :record, :crime_application
+
+  delegate :errors, to: :record
+
+  # :nocov:
+  def applicable?
+    raise 'implement in task subclasses'
+  end
+
+  def complete?
+    raise 'implement in task subclasses'
+  end
+
+  def validate
+    raise 'implement in task subclasses'
+  end
+  # :nocov:
+end

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -1,14 +1,15 @@
 module CapitalAssessment
-  class AnswersValidator
+  class AnswersValidator < BaseAnswerValidator
     include TypeOfMeansAssessment
 
-    def initialize(record)
-      @record = record
+    def applicable?
+      requires_full_means_assessment?
     end
 
-    attr_reader :record
-
-    delegate :errors, :crime_application, to: :record
+    def complete?
+      validate
+      errors.empty?
+    end
 
     def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
       if requires_full_capital?

--- a/app/validators/employment_details/answers_validator.rb
+++ b/app/validators/employment_details/answers_validator.rb
@@ -1,0 +1,43 @@
+module EmploymentDetails
+  class AnswersValidator
+    include TypeOfMeansAssessment
+    include TypeOfEmployment
+
+    def initialize(record)
+      @record = record
+    end
+
+    attr_reader :record
+
+    delegate :errors, :crime_application, to: :record
+
+    def validate
+      return unless applicable?
+      return if complete?
+
+      errors.add :employment_status, :incomplete
+      errors.add :base, :incomplete_records
+    end
+
+    def applicable?
+      requires_means_assessment?
+    end
+
+    def complete?
+      return false if record.employment_status.blank?
+
+      not_working_details_complete?
+    end
+
+    def not_working_details_complete?
+      return true unless not_working?
+      return false if income.ended_employment_within_three_months.blank?
+      return true unless ended_employment_within_three_months?
+      return true if income.lost_job_in_custody == 'no'
+
+      income.date_job_lost.present?
+    end
+
+    alias income record
+  end
+end

--- a/app/validators/income_assessment/answers_validator.rb
+++ b/app/validators/income_assessment/answers_validator.rb
@@ -1,35 +1,28 @@
 module IncomeAssessment
-  class AnswersValidator
+  class AnswersValidator < BaseAnswerValidator
     include TypeOfMeansAssessment
 
-    def initialize(record)
-      @record = record
+    def applicable?
+      requires_means_assessment?
     end
 
-    attr_reader :record
-
-    delegate :errors, to: :record
+    def complete?
+      validate
+      errors.empty?
+    end
 
     def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      errors.add(:employment_status, :incomplete) unless employment_status_complete?
+      return unless applicable?
+
+      EmploymentDetails::AnswersValidator.new(record).validate
 
       errors.add(:income_before_tax, :incomplete) unless income_before_tax_complete?
-
       errors.add(:frozen_income_savings_assets, :incomplete) unless frozen_income_savings_assets_complete?
-
       errors.add(:income_payments, :incomplete) unless income_payments_complete?
-
       errors.add(:income_benefits, :incomplete) unless income_benefits_complete?
-
       errors.add(:dependants, :incomplete) unless dependants_complete?
-
       errors.add(:manage_without_income, :incomplete) unless manage_without_income_complete?
-
       errors.add(:base, :incomplete_records) if errors.present?
-    end
-
-    def employment_status_complete?
-      record.employment_status.present?
     end
 
     def income_before_tax_complete?
@@ -66,7 +59,5 @@ module IncomeAssessment
 
       record.manage_without_income.present?
     end
-
-    delegate :crime_application, to: :record
   end
 end

--- a/app/validators/outgoings_assessment/answers_validator.rb
+++ b/app/validators/outgoings_assessment/answers_validator.rb
@@ -1,30 +1,27 @@
 module OutgoingsAssessment
-  class AnswersValidator
-    def initialize(record)
-      @record = record
+  class AnswersValidator < BaseAnswerValidator
+    include TypeOfMeansAssessment
+
+    def applicable?
+      requires_full_means_assessment?
     end
 
-    attr_reader :record
-
-    delegate :errors, to: :record
+    def complete?
+      validate
+      errors.empty?
+    end
 
     def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      return unless applicable?
+
       errors.add(:housing_payment_type, :incomplete) unless housing_payment_type_complete?
-
       errors.add(:mortgage, :incomplete) unless mortgage_complete?
-
       errors.add(:rent, :incomplete) unless rent_complete?
-
       errors.add(:board_and_lodging, :incomplete) unless board_and_lodging_complete?
-
       errors.add(:council_tax, :incomplete) unless council_tax_complete?
-
       errors.add(:outgoings_payments, :incomplete) unless outgoings_payments_complete?
-
       errors.add(:income_tax_rate, :incomplete) unless income_tax_rate_complete?
-
       errors.add(:outgoings_more_than, :incomplete) unless outgoings_more_than_income_complete?
-
       errors.add(:base, :incomplete_records) if errors.present?
     end
 

--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -11,8 +11,7 @@ module PassportingBenefitCheck
     delegate :errors, :applicant, :crime_application, to: :record
 
     def validate
-      return unless applicable?
-      return if complete?
+      return if !applicable? || complete?
 
       errors.add :benefit_type, :incomplete
       errors.add :base, :incomplete_records

--- a/spec/models/capital_spec.rb
+++ b/spec/models/capital_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Capital, type: :model do
     let(:confirmation_validator) { double('confirmation_validator') }
 
     before do
-      allow(CapitalAssessment::AnswersValidator).to receive(:new).with(capital).and_return(answers_validator)
-      allow(CapitalAssessment::ConfirmationValidator).to receive(:new).with(capital).and_return(confirmation_validator)
+      allow(CapitalAssessment::AnswersValidator).to receive(:new).with(record: capital)
+                                                                 .and_return(answers_validator)
+      allow(CapitalAssessment::ConfirmationValidator).to receive(:new).with(capital)
+                                                                      .and_return(confirmation_validator)
     end
 
     describe 'valid?(:submission)' do

--- a/spec/models/concerns/type_of_application_spec.rb
+++ b/spec/models/concerns/type_of_application_spec.rb
@@ -2,18 +2,19 @@ require 'rails_helper'
 
 RSpec.describe TypeOfApplication do
   let(:crime_application_class) do
-    Struct.new(:reviewed_at, :returned_at, :application_type) do
+    Struct.new(:reviewed_at, :returned_at, :application_type, :kase) do
       include TypeOfApplication
     end
   end
 
   let(:crime_application) do
-    crime_application_class.new(reviewed_at, returned_at, application_type)
+    crime_application_class.new(reviewed_at, returned_at, application_type, kase)
   end
 
   let(:reviewed_at) { 1.day.ago }
   let(:returned_at) { nil }
   let(:application_type) { 'initial' }
+  let(:kase) { nil }
 
   describe '#reviewed?' do
     subject(:reviewed) { crime_application.reviewed? }
@@ -72,6 +73,52 @@ RSpec.describe TypeOfApplication do
 
     context 'when a returned application' do
       let(:returned_at) { 1.day.ago }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#appeal_no_changes?' do
+    subject(:appeal_no_changes?) { crime_application.appeal_no_changes? }
+
+    let(:appeal_original_app_submitted) { 'yes' }
+    let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
+    let(:appeal_financial_circumstances_changed) { 'no' }
+
+    before do
+      allow(crime_application).to receive(:kase).and_return(
+        instance_double(
+          Case, appeal_original_app_submitted:, case_type:, appeal_financial_circumstances_changed:
+        )
+      )
+    end
+
+    context 'with no financial changes since the original application' do
+      it { is_expected.to be true }
+    end
+
+    context 'when no original application' do
+      let(:appeal_original_app_submitted) { 'no' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when not an appeal' do
+      let(:case_type) { CaseType::SUMMARY_ONLY.to_s }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with financial changes' do
+      let(:appeal_financial_circumstances_changed) { 'yes' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when kase nil' do
+      before do
+        allow(crime_application).to receive(:kase)
+      end
 
       it { is_expected.to be false }
     end

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe TypeOfMeansAssessment do
       include TypeOfMeansAssessment
     end
   end
+
   let(:crime_application) do
     instance_double(CrimeApplication, applicant:, kase:, income:)
   end
+
   let(:applicant) { instance_double(Applicant) }
   let(:kase) { instance_double(Case) }
   let(:income) { instance_double(Income) }
@@ -22,6 +24,7 @@ RSpec.describe TypeOfMeansAssessment do
   end
 
   before do
+    allow(crime_application).to receive(:appeal_no_changes?)
     allow(Passporting::MeansPassporter).to receive(:new).and_return(means_passporter)
   end
 
@@ -51,15 +54,6 @@ RSpec.describe TypeOfMeansAssessment do
       let(:nino) { nil }
 
       it { is_expected.to be false }
-    end
-
-    context 'when dwp result contested and has evidence' do
-      before do
-        allow(crime_application).to receive(:confirm_dwp_result).and_return('no')
-        allow(applicant).to receive(:has_benefit_evidence).and_return('yes')
-      end
-
-      it { is_expected.to be true }
     end
 
     context 'when dwp result contested but has not evidence' do
@@ -275,6 +269,18 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'when means passported' do
       let(:means_passporter_result) { true }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when benefit none' do
+      before { allow(applicant).to receive(:benefit_type).and_return('none') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when appeal no changes' do
+      before { allow(crime_application).to receive(:appeal_no_changes?).and_return(true) }
 
       it { is_expected.to be false }
     end

--- a/spec/models/income_spec.rb
+++ b/spec/models/income_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Income, type: :model do
     let(:answers_validator) { double('answers_validator') }
 
     before do
-      allow(IncomeAssessment::AnswersValidator).to receive(:new).with(income).and_return(answers_validator)
+      allow(IncomeAssessment::AnswersValidator).to receive(:new).with(record: income)
+                                                                .and_return(answers_validator)
     end
 
     describe 'valid?(:submission)' do

--- a/spec/models/outgoings_spec.rb
+++ b/spec/models/outgoings_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Outgoings, type: :model do
     let(:answers_validator) { double('answers_validator') }
 
     before do
-      allow(OutgoingsAssessment::AnswersValidator).to receive(:new).with(outgoings).and_return(answers_validator)
+      allow(OutgoingsAssessment::AnswersValidator).to receive(:new).with(record: outgoings)
+                                                                   .and_return(answers_validator)
     end
 
     describe 'valid?(:submission)' do

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -13,7 +13,7 @@ describe Summary::HtmlPresenter do
       CrimeApplication, applicant: double, kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
       income: (double has_no_income_payments: nil, has_no_income_benefits: nil), income_payments: [double],
       outgoings_payments: [instance_double(Payment, payment_type: 'childcare')], income_benefits: [double], outgoings: (double has_no_other_outgoings: nil),
-      documents: double, application_type: application_type, appeal_no_changes?: false,
+      documents: double, application_type: application_type,
       capital: (double has_premium_bonds: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
       savings: [double], investments: [double], national_savings_certificates: [double], properties: [double]
     )
@@ -134,40 +134,6 @@ describe Summary::HtmlPresenter do
         end
 
         it { is_expected.to match_array(expected_sections) }
-
-        context 'when it is an appeal with no changes in financial circumstances' do
-          let(:database_application) do
-            instance_double(
-              CrimeApplication, applicant: double, kase: (
-                double case_type: 'appeal_to_crown_court',
-                       appeal_financial_circumstances_changed: 'no'
-              ),
-              appeal_no_changes?: true,
-              ioj: double, status: :in_progress,
-              income: double, documents: double, application_type: application_type
-            )
-          end
-
-          let(:expected_sections) do
-            %w[
-              Overview
-              ClientDetails
-              ContactDetails
-              CaseDetails
-              Offences
-              Codefendants
-              NextCourtHearing
-              FirstCourtHearing
-              JustificationForLegalAid
-              PassportJustificationForLegalAid
-              EmploymentDetails
-              SupportingEvidence
-              MoreInformation
-            ]
-          end
-
-          it { is_expected.to match_array(expected_sections) }
-        end
       end
 
       context 'for a "submitted" datastore application' do
@@ -208,47 +174,6 @@ describe Summary::HtmlPresenter do
         end
 
         it { is_expected.to match_array(expected_sections) }
-
-        context 'when it is an appeal with no changes in financial circumstances' do
-          let(:datastore_application) do
-            extra = {
-              'means_details' => {
-                'income_details' => {
-                  'employment_status' => 'not_working',
-                  'ended_employment_within_three_months' => 'no'
-                }
-              },
-              'application_type' => application_type,
-              'case_details' => {
-                'case_type' => 'appeal_to_crown_court',
-                'appeal_financial_circumstances_changed' => 'no'
-              }
-            }
-
-            JSON.parse(LaaCrimeSchemas.fixture(1.0).read).deep_merge(extra)
-          end
-
-          let(:expected_sections) do
-            %w[
-              Overview
-              ClientDetails
-              ContactDetails
-              CaseDetails
-              Offences
-              Codefendants
-              NextCourtHearing
-              FirstCourtHearing
-              JustificationForLegalAid
-              PassportJustificationForLegalAid
-              EmploymentDetails
-              SupportingEvidence
-              MoreInformation
-              LegalRepresentativeDetails
-            ]
-          end
-
-          it { is_expected.to match_array(expected_sections) }
-        end
       end
     end
 

--- a/spec/presenters/tasks/capital_assessment_spec.rb
+++ b/spec/presenters/tasks/capital_assessment_spec.rb
@@ -8,20 +8,25 @@ RSpec.describe Tasks::CapitalAssessment do
       CrimeApplication,
       to_param: '12345',
       applicant: applicant,
-      capital: capital,
-      kase: kase,
+      capital: capital
     )
   end
 
+  let(:validator) do
+    instance_double(
+      CapitalAssessment::AnswersValidator,
+      complete?: complete?, applicable?: applicable?
+    )
+  end
+
+  let(:applicable?) { false }
+  let(:complete?) { false }
   let(:applicant) { nil }
-  let(:kase) { nil }
   let(:capital) { nil }
 
   before do
-    allow(task).to receive(:fulfilled?).with(Tasks::ClientDetails) { client_details_fulfilled }
-    allow(task).to receive(:requires_means_assessment?) { needs_means }
-    allow(task).to receive(:fulfilled?).with(Tasks::IncomeAssessment) { income_fulfilled }
-    allow(task).to receive(:requires_full_means_assessment?) { needs_full_means }
+    allow(CapitalAssessment::AnswersValidator).to receive(:new)
+      .with(record: nil, crime_application: crime_application).and_return(validator)
   end
 
   describe '#path' do
@@ -43,44 +48,37 @@ RSpec.describe Tasks::CapitalAssessment do
   end
 
   describe '#not_applicable?' do
-    subject(:not_applicable) { task.not_applicable? }
+    subject(:not_applicable?) { task.not_applicable? }
 
-    context 'client details is not fulfilled' do
-      let(:client_details_fulfilled) { false }
+    context 'when validator applicable' do
+      let(:applicable?) { true }
 
-      it { is_expected.to be false }
-    end
-
-    context 'means assessment details is not required' do
-      let(:client_details_fulfilled) { true }
-      let(:needs_means) { false }
-
-      it { is_expected.to be true }
-    end
-
-    context 'income is not fulfilled' do
-      let(:client_details_fulfilled) { true }
-      let(:needs_means) { true }
-      let(:income_fulfilled) { false }
-
-      it { is_expected.to be false }
-    end
-
-    context 'income is fulfilled' do
-      let(:income_fulfilled) { true }
-      let(:needs_means) { true }
-      let(:client_details_fulfilled) { true }
-
-      context 'and full means assessment required' do
-        let(:needs_full_means) { true }
+      context 'when applicant nil' do
+        let(:applicant) { nil }
 
         it { is_expected.to be false }
       end
 
-      context 'and means assessment is not required' do
-        let(:needs_full_means) { false }
+      context 'when applicant present' do
+        let(:applicant) { instance_double(Applicant) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when validator not applicable' do
+      let(:applicable?) { false }
+
+      context 'when applicant present' do
+        let(:applicant) { instance_double(Applicant) }
 
         it { is_expected.to be true }
+      end
+
+      context 'when applicant nil' do
+        let(:applicant) { nil }
+
+        it { is_expected.to be false }
       end
     end
   end
@@ -88,30 +86,22 @@ RSpec.describe Tasks::CapitalAssessment do
   describe '#can_start?' do
     subject(:can_start) { task.can_start? }
 
-    context 'case details are not fulfilled' do
+    before do
+      allow(task).to receive(:fulfilled?).with(Tasks::IncomeAssessment).and_return(
+        income_fulfilled
+      )
+    end
+
+    context 'when income is not fulfilled' do
       let(:income_fulfilled) { false }
 
       it { is_expected.to be false }
     end
 
-    context 'case details are fulfilled' do
+    context 'when income is fulfilled' do
       let(:income_fulfilled) { true }
 
-      context 'and means assessment required' do
-        let(:needs_full_means) { true }
-
-        before do
-          allow(task).to receive(:requires_means_assessment?) { needs_means }
-        end
-
-        it { is_expected.to be true }
-      end
-
-      context 'and means assessment is not required' do
-        let(:needs_full_means) { false }
-
-        it { is_expected.to be false }
-      end
+      it { is_expected.to be true }
     end
   end
 
@@ -132,20 +122,18 @@ RSpec.describe Tasks::CapitalAssessment do
   end
 
   describe '#completed?' do
-    subject(:completed) { task.completed? }
+    subject(:completed?) { task.completed? }
 
-    let(:capital) { instance_double(Capital) }
-
-    context 'capital is not completed' do
-      before { allow(capital).to receive(:complete?).and_return(false) }
-
-      it { is_expected.to be false }
-    end
-
-    context 'capital is completed' do
-      before { allow(capital).to receive(:complete?).and_return(true) }
+    context 'answers are complete' do
+      let(:complete?) { true }
 
       it { is_expected.to be true }
+    end
+
+    context 'answers are incomplete' do
+      let(:complete?) { false }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/presenters/tasks/outgoings_assessment_spec.rb
+++ b/spec/presenters/tasks/outgoings_assessment_spec.rb
@@ -9,19 +9,25 @@ RSpec.describe Tasks::OutgoingsAssessment do
       to_param: '12345',
       applicant: applicant,
       outgoings: outgoings,
-      kase: kase,
     )
   end
 
   let(:applicant) { nil }
-  let(:kase) { nil }
   let(:outgoings) { nil }
 
+  let(:validator) do
+    instance_double(
+      OutgoingsAssessment::AnswersValidator,
+      complete?: complete?, applicable?: applicable?
+    )
+  end
+
+  let(:applicable?) { false }
+  let(:complete?) { false }
+
   before do
-    allow(task).to receive(:fulfilled?).with(Tasks::ClientDetails) { client_details_fulfilled }
-    allow(task).to receive(:requires_means_assessment?) { needs_means }
-    allow(task).to receive(:fulfilled?).with(Tasks::IncomeAssessment) { income_fulfilled }
-    allow(task).to receive(:requires_full_means_assessment?) { needs_full_means }
+    allow(OutgoingsAssessment::AnswersValidator).to receive(:new)
+      .with(crime_application: crime_application, record: nil).and_return(validator)
   end
 
   describe '#path' do
@@ -29,44 +35,37 @@ RSpec.describe Tasks::OutgoingsAssessment do
   end
 
   describe '#not_applicable?' do
-    subject(:not_applicable) { task.not_applicable? }
+    subject(:not_applicable?) { task.not_applicable? }
 
-    context 'client details is not fulfilled' do
-      let(:client_details_fulfilled) { false }
+    context 'when validator applicable' do
+      let(:applicable?) { true }
 
-      it { is_expected.to be false }
-    end
-
-    context 'means assessment details is not required' do
-      let(:client_details_fulfilled) { true }
-      let(:needs_means) { false }
-
-      it { is_expected.to be true }
-    end
-
-    context 'income is not fulfilled' do
-      let(:client_details_fulfilled) { true }
-      let(:needs_means) { true }
-      let(:income_fulfilled) { false }
-
-      it { is_expected.to be false }
-    end
-
-    context 'income is fulfilled' do
-      let(:income_fulfilled) { true }
-      let(:needs_means) { true }
-      let(:client_details_fulfilled) { true }
-
-      context 'and full means assessment required' do
-        let(:needs_full_means) { true }
+      context 'when applicant nil' do
+        let(:applicant) { nil }
 
         it { is_expected.to be false }
       end
 
-      context 'and means assessment is not required' do
-        let(:needs_full_means) { false }
+      context 'when applicant present' do
+        let(:applicant) { instance_double(Applicant) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when validator not applicable' do
+      let(:applicable?) { false }
+
+      context 'when applicant present' do
+        let(:applicant) { instance_double(Applicant) }
 
         it { is_expected.to be true }
+      end
+
+      context 'when applicant nil' do
+        let(:applicant) { nil }
+
+        it { is_expected.to be false }
       end
     end
   end
@@ -74,30 +73,22 @@ RSpec.describe Tasks::OutgoingsAssessment do
   describe '#can_start?' do
     subject(:can_start) { task.can_start? }
 
-    context 'case details are not fulfilled' do
+    before do
+      allow(task).to receive(:fulfilled?).with(Tasks::IncomeAssessment).and_return(
+        income_fulfilled
+      )
+    end
+
+    context 'when income is not fulfilled' do
       let(:income_fulfilled) { false }
 
       it { is_expected.to be false }
     end
 
-    context 'case details are fulfilled' do
+    context 'when income is fulfilled' do
       let(:income_fulfilled) { true }
 
-      context 'and means assessment required' do
-        let(:needs_full_means) { true }
-
-        before do
-          allow(task).to receive(:requires_means_assessment?) { needs_means }
-        end
-
-        it { is_expected.to be true }
-      end
-
-      context 'and means assessment is not required' do
-        let(:needs_full_means) { false }
-
-        it { is_expected.to be false }
-      end
+      it { is_expected.to be true }
     end
   end
 
@@ -118,20 +109,18 @@ RSpec.describe Tasks::OutgoingsAssessment do
   end
 
   describe '#completed?' do
-    subject(:in_progress) { task.completed? }
+    subject(:completed?) { task.completed? }
 
-    let(:outgoings) { instance_double(Outgoings) }
-
-    context 'outgoings is not completed' do
-      before { allow(outgoings).to receive(:complete?).and_return(false) }
-
-      it { is_expected.to be false }
-    end
-
-    context 'outgoings is completed' do
-      before { allow(outgoings).to receive(:complete?).and_return(true) }
+    context 'answers are complete' do
+      let(:complete?) { true }
 
       it { is_expected.to be true }
+    end
+
+    context 'answers are incomplete' do
+      let(:complete?) { false }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/services/decisions/case_decision_tree_spec.rb
+++ b/spec/services/decisions/case_decision_tree_spec.rb
@@ -7,27 +7,24 @@ RSpec.describe Decisions::CaseDecisionTree do
     instance_double(
       CrimeApplication,
       id: '10',
-      applicant: applicant_double,
-      case: kase,
+      applicant: instance_double(Applicant),
+      case: kase, # TODO: refactor the CaseDecisionTree to use #kase instead of #case
       kase: kase,
-      not_means_tested?: not_means_tested?
+      not_means_tested?: false
     )
   }
 
   let(:kase) do
     instance_double(
       Case,
-      case_type: case_type,
+      case_type: CaseType::SUMMARY_ONLY,
       codefendants: codefendants_double,
       charges: charges_double,
     )
   end
 
-  let(:case_type) { CaseType::SUMMARY_ONLY }
   let(:codefendants_double) { double('codefendants_collection') }
   let(:charges_double) { double('charges_collection') }
-  let(:applicant_double) { instance_double(Applicant) }
-  let(:not_means_tested?) { false }
 
   before do
     allow(
@@ -229,7 +226,6 @@ RSpec.describe Decisions::CaseDecisionTree do
     end
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   context 'when the step is `add_offence_date`' do
     context 'has correct next step' do
       let(:step_name) { :add_offence_date }
@@ -311,31 +307,18 @@ RSpec.describe Decisions::CaseDecisionTree do
       allow(subject).to receive(:requires_means_assessment?).and_return(
         requires_means_assessment?
       )
-      allow(crime_application).to receive(:appeal_no_changes?).and_return(
-        appeal_no_changes?
-      )
     end
 
     context 'when requires means assessment' do
       let(:requires_means_assessment?) { true }
-      let(:appeal_no_changes?) { false }
 
       it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
     end
 
     context 'when does not require mean assessment' do
       let(:requires_means_assessment?) { false }
-      let(:appeal_no_changes?) { false }
 
       it { is_expected.to have_destination('/steps/evidence/upload', :edit, id: crime_application) }
     end
-
-    context 'when requires means assessment but case is appeal no changes' do
-      let(:requires_means_assessment?) { false }
-      let(:appeal_no_changes?) { true }
-
-      it { is_expected.to have_destination('/steps/income/employment_status', :edit, id: crime_application) }
-    end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -41,28 +41,6 @@ RSpec.describe Passporting::MeansPassporter do
       end
     end
 
-    context 'for a appeal to crown court' do
-      let(:case_type) { 'appeal_to_crown_court' }
-
-      context 'with no financial changes' do
-        let(:appeal_financial_circumstances_changed) { 'no' }
-
-        it 'uses the existing values' do
-          expect(crime_application).not_to receive(:update)
-          expect(subject.call).to be(true)
-        end
-      end
-
-      context 'with financial changes' do
-        let(:appeal_financial_circumstances_changed) { 'yes' }
-
-        it 'uses the existing values' do
-          expect(crime_application).to receive(:update)
-          expect(subject.call).to be(false)
-        end
-      end
-    end
-
     context 'means passporting on non-means tested' do
       let(:is_means_tested) { 'no' }
 

--- a/spec/validators/appeal_details/answers_validator_spec.rb
+++ b/spec/validators/appeal_details/answers_validator_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe AppealDetails::AnswersValidator, type: :model do
     subject(:complete?) { validator.complete? }
 
     before do
+      allow(record).to receive(:appeal_no_changes?).and_return(appeal_no_changes?)
       allow(kase).to receive_messages(
         appeal_lodged_date:,
         appeal_original_app_submitted:
@@ -48,6 +49,7 @@ RSpec.describe AppealDetails::AnswersValidator, type: :model do
 
     let(:appeal_lodged_date) { '2023-11-11' }
     let(:appeal_original_app_submitted) { 'yes' }
+    let(:appeal_no_changes?) { false }
 
     context 'when a general details is missing' do
       let(:appeal_lodged_date) { nil }
@@ -94,8 +96,8 @@ RSpec.describe AppealDetails::AnswersValidator, type: :model do
           allow(kase).to receive(:appeal_financial_circumstances_changed).and_return('no')
         end
 
-        context 'and appeal reference given' do
-          let(:appeal_reference) { [nil, '1231'] }
+        context 'appeal no changes' do
+          let(:appeal_no_changes?) { true }
 
           it { is_expected.to be true }
         end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -1,9 +1,14 @@
 require 'rails_helper'
 
 module Test
-  CrimeApplicationValidatable = Struct.new(:is_means_tested, :kase, :ioj, :income, :documents, keyword_init: true) do
+  CrimeApplicationValidatable = Struct.new(:is_means_tested, :kase, :ioj, :income, :documents, :applicant,
+                                           keyword_init: true) do
     include ActiveModel::Validations
     validates_with ApplicationFulfilmentValidator
+
+    def appeal_no_changes?
+      false
+    end
 
     def to_param
       '12345'
@@ -19,6 +24,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
     {
       is_means_tested:,
       kase:,
+      applicant:,
       ioj:,
       income:,
       documents:
@@ -30,6 +36,9 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
   let(:kase) {
     instance_double(Case, case_type:, is_client_remanded:, date_client_remanded:)
   }
+
+  let(:applicant) { instance_double(Applicant, benefit_type: 'none') }
+
   let(:is_client_remanded) { nil }
   let(:date_client_remanded) { nil }
 

--- a/spec/validators/employment_details/answers_validator_spec.rb
+++ b/spec/validators/employment_details/answers_validator_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.describe EmploymentDetails::AnswersValidator, type: :model do
+  subject(:validator) { described_class.new(record) }
+
+  let(:record) do
+    instance_double(
+      Income,
+      errors:,
+      crime_application:,
+      employment_status:
+    )
+  end
+
+  let(:errors) { double(:errors, empty?: false) }
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:employment_status) { [] }
+
+  describe '#applicable?' do
+    subject(:applicable?) { validator.applicable? }
+
+    context 'when means assessment required' do
+      before do
+        allow(validator).to receive(:requires_means_assessment?).and_return(true)
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when means assessment not required' do
+      before do
+        allow(validator).to receive(:requires_means_assessment?).and_return(false)
+      end
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#complete?' do
+    subject(:complete?) { validator.complete? }
+
+    context 'when no employment status' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'when working' do
+      let(:employment_status) { [EmploymentStatus::EMPLOYED.to_s] }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when not working' do
+      let(:employment_status) { [EmploymentStatus::NOT_WORKING.to_s] }
+      let(:ended_employment_within_three_months) { 'yes' }
+      let(:lost_job_in_custody) { 'yes' }
+      let(:date_job_lost) { '2000-01-01' }
+
+      before do
+        allow(record).to receive_messages(
+          ended_employment_within_three_months:,
+          lost_job_in_custody:,
+          date_job_lost:
+        )
+      end
+
+      it { is_expected.to be(true) }
+
+      context 'when lost in custody date is missing' do
+        let(:date_job_lost) { nil }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'when ended employment within three months not answered' do
+        let(:ended_employment_within_three_months) { nil }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'when not ended employment within last three months' do
+        let(:ended_employment_within_three_months) { 'no' }
+        let(:lost_job_in_custody) { nil }
+        let(:date_job_lost) { nil }
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
+
+  describe '#validate' do
+    subject(:validate) { validator.validate }
+
+    context 'when not applicable' do
+      before do
+        allow(validator).to receive(:applicable?).and_return(false)
+      end
+
+      it 'does not add errors' do
+        expect(errors).not_to receive(:add)
+        validate
+      end
+    end
+
+    context 'when applicable' do
+      before do
+        allow(validator).to receive(:applicable?).and_return(true)
+      end
+
+      it 'adds errors to :appeal_details when incomplete' do
+        allow(validator).to receive(:complete?).and_return(false)
+        expect(errors).to receive(:add).with(:employment_status, :incomplete)
+        expect(errors).to receive(:add).with(:base, :incomplete_records)
+
+        validate
+      end
+
+      it 'does not add errors when complete' do
+        allow(validator).to receive(:complete?).and_return(true)
+        expect(errors).not_to receive(:add)
+
+        validate
+      end
+    end
+  end
+end

--- a/spec/validators/outgoings_assessment/answers_validator_spec.rb
+++ b/spec/validators/outgoings_assessment/answers_validator_spec.rb
@@ -3,10 +3,58 @@ require 'rails_helper'
 RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
   # rubocop:disable RSpec/MessageChain
   #
-  subject { described_class.new(record) }
+  subject(:validator) { described_class.new(record:, crime_application:) }
 
-  let(:record) { instance_double(Outgoings, errors:) }
+  let(:record) { instance_double(Outgoings, crime_application:, errors:) }
+  let(:crime_application) { instance_double CrimeApplication }
+
   let(:errors) { [] }
+  let(:requires_full_means_assessment?) { true }
+
+  before do
+    allow(crime_application).to receive_messages(outgoings: record)
+
+    allow(validator).to receive_messages(
+      requires_full_means_assessment?: requires_full_means_assessment?
+    )
+  end
+
+  describe '#applicable?' do
+    subject(:applicable?) { validator.applicable? }
+
+    context 'when full means assessment not required' do
+      let(:requires_full_means_assessment?) { false }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when full means assessment required' do
+      let(:requires_full_means_assessment?) { true }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
+  describe '#complete?' do
+    subject(:complete?) { validator.complete? }
+
+    before do
+      expect(validator).to receive(:validate)
+      expect(errors).to receive(:empty?) { !errors_added? }
+    end
+
+    context 'when validate does not add errors' do
+      let(:errors_added?) { false }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when validate adds errors' do
+      let(:errors_added?) { true }
+
+      it { is_expected.to be(false) }
+    end
+  end
 
   describe '#validate' do
     context 'when all validations pass' do


### PR DESCRIPTION
## Description of change

Skip Means Assessment for Crown Court Appeals Without Changes on Apply
Changes the appeal without changes logic so that means assessment is skipped entirely.
Ensures the `appeal_without_changes?` method handles when an appeal is updated from without changes to with changes.
Moves `#appeal_no_changes` from the `MeansPassporter` to `requires_means_assessment`.
Improves the completeness validation of employment questions.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-893

## Notes for reviewer

This PR introduces a logic change to Apply.

When a case is appealed to Crown Court without changes and an application was submitted for the original case, the caseworker manually copies over the means details in MAAT from the previous application to the Appeal record.

An appeal without changes application is not necessarily Means Passported. It has the same means as the original application.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

1, Confirm that an Appeal to Crown court application with changes can be updated to an Appeal to Crown court without changes
2, Confirm that the Employment question is not asked.
3, Confirm that the application can be returned and resubmitted.
4, On a means tested application, confirm that the task lists updates correctly when the employment information is changed.
