### PR TITLE
CRIMAPP-917 Nino not required when passported on age

### DIFF
--- a/app/services/decisions/submission_decision_tree.rb
+++ b/app/services/decisions/submission_decision_tree.rb
@@ -1,5 +1,9 @@
 module Decisions
   class SubmissionDecisionTree < BaseDecisionTree
+    include TypeOfMeansAssessment
+
+    alias crime_application current_crime_application
+
     def destination
       case step_name
       when :more_information
@@ -42,11 +46,10 @@ module Decisions
     end
 
     def requires_nino?
-      return false if current_crime_application.not_means_tested? || current_crime_application.appeal_no_changes?
+      return false if current_crime_application.not_means_tested?
+      return false if current_crime_application.appeal_no_changes?
 
-      applicant.benefit_type != 'none' &&
-        applicant.has_nino == 'no' &&
-        current_crime_application.case.is_client_remanded == 'no'
+      nino_forthcoming? && current_crime_application.case.is_client_remanded != 'yes'
     end
 
     def applicant

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -30,7 +30,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
   end
 
   def means_valid?
-    return true unless requires_means_assessment?
+    return true if Passporting::MeansPassporter.new(record).call
 
     evidence_present? || means_record_present? || client_remanded_in_custody?
   end

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -54,12 +54,24 @@ RSpec.describe Decisions::SubmissionDecisionTree do
     context 'when nino not provided' do
       let(:has_nino) { YesNoAnswer::NO.to_s }
 
-      context 'and is required to submit' do
-        let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT }
-        let(:is_client_remanded) { YesNoAnswer::NO.to_s }
+      context 'but is forthcoming' do
         let(:not_means_tested) { false }
 
-        it { is_expected.to have_destination(:cannot_submit_without_nino, :edit, id: crime_application) }
+        before do
+          allow(subject).to receive(:nino_forthcoming?).and_return(true)
+        end
+
+        context 'when in custody' do
+          let(:is_client_remanded) { YesNoAnswer::YES.to_s }
+
+          it { is_expected.to have_destination(:declaration, :edit, id: crime_application) }
+        end
+
+        context 'when not in custody' do
+          let(:is_client_remanded) { YesNoAnswer::NO.to_s }
+
+          it { is_expected.to have_destination(:cannot_submit_without_nino, :edit, id: crime_application) }
+        end
       end
 
       context 'and is not required to submit for an appeal no changes' do


### PR DESCRIPTION
## Description of change

Fix bug where Nino was incorrectly being required when benefit_type nil.
Also fixes a regression where applicants without NINO and not in custody could access the declaration page from the task list.

## Link to relevant ticket
[CRIMAPP-917](https://dsdmoj.atlassian.net/browse/CRIMAPP-917)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

See ticket
