### PR TITLE
CRIMAPP-873 Add client self assessment tax bill page

### DIFF
--- a/app/controllers/steps/income/client/self_assessment_tax_bill_controller.rb
+++ b/app/controllers/steps/income/client/self_assessment_tax_bill_controller.rb
@@ -1,0 +1,17 @@
+module Steps
+  module Income
+    module Client
+      class SelfAssessmentTaxBillController < Steps::IncomeStepController
+        def edit
+          @form_object = SelfAssessmentTaxBillForm.build(
+            current_crime_application
+          )
+        end
+
+        def update
+          update_and_advance(SelfAssessmentTaxBillForm, as: :client_self_assessment_tax_bill)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -1,0 +1,67 @@
+module Steps
+  module Income
+    module Client
+      class SelfAssessmentTaxBillForm < Steps::BaseFormObject
+        attribute :applicant_self_assessment_tax_bill, :value_object, source: YesNoAnswer
+        attribute :amount, :pence
+        attribute :frequency, :value_object, source: PaymentFrequencyType
+
+        validates :applicant_self_assessment_tax_bill, inclusion: { in: YesNoAnswer.values }
+        validates :amount, numericality: { greater_than: 0 }, if: -> { pays_self_assessment_tax_bill? }
+        validates :frequency, inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
+
+        def self.build(crime_application)
+          payment = crime_application.outgoings_payments.self_assessment_tax_bill
+          income = crime_application.income
+          form = new
+
+          form.applicant_self_assessment_tax_bill = income.applicant_self_assessment_tax_bill if income
+
+          if payment
+            form.amount = payment.amount
+            form.frequency = payment.frequency
+          end
+
+          form
+        end
+
+        private
+
+        def pays_self_assessment_tax_bill?
+          applicant_self_assessment_tax_bill&.yes?
+        end
+
+        def persist!
+          crime_application.income.update(
+            applicant_self_assessment_tax_bill:,
+          )
+
+          persist_outgoings_payment if pays_self_assessment_tax_bill?
+        end
+
+        def persist_outgoings_payment
+          ::OutgoingsPayment.transaction do
+            reset!
+
+            crime_application.outgoings_payments.create!(
+              payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.value,
+              amount: amount,
+              frequency: frequency,
+            )
+          end
+        end
+
+        def reset!
+          crime_application.outgoings_payments.self_assessment_tax_bill&.destroy
+        end
+
+        def before_save
+          return if pays_self_assessment_tax_bill?
+
+          self.amount = nil
+          self.frequency = nil
+        end
+      end
+    end
+  end
+end

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -36,6 +36,10 @@ class OutgoingsPayment < Payment
     where(payment_type: OutgoingsPaymentType::MAINTENANCE.value).order(created_at: :desc).first
   end
 
+  def self.self_assessment_tax_bill
+    where(payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.value).order(created_at: :desc).first
+  end
+
   # Manually cast food_amount and board_amount
   # because Rails will not convert to :pence as they are
   # store_accessor attributes

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -1,6 +1,6 @@
 module Decisions
   class IncomeDecisionTree < BaseDecisionTree # rubocop:disable Metrics/ClassLength
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize, Lint/DuplicateBranch
     #
     include TypeOfMeansAssessment
 
@@ -23,6 +23,8 @@ module Decisions
       when :has_savings
         after_has_savings
       when :client_employment_income
+        edit('/steps/income/income_payments')
+      when :client_self_assessment_tax_bill
         edit('/steps/income/income_payments')
       when :income_payments
         edit(:income_benefits)
@@ -52,7 +54,7 @@ module Decisions
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize, Lint/DuplicateBranch
 
     private
 

--- a/app/value_objects/outgoings_payment_type.rb
+++ b/app/value_objects/outgoings_payment_type.rb
@@ -6,7 +6,8 @@ class OutgoingsPaymentType < ValueObject
     COUNCIL_TAX = new(:council_tax),
     CHILDCARE = new(:childcare),
     MAINTENANCE = new(:maintenance),
-    LEGAL_AID_CONTRIBUTION = new(:legal_aid_contribution)
+    LEGAL_AID_CONTRIBUTION = new(:legal_aid_contribution),
+    SELF_ASSESSMENT_TAX_BILL = new(:self_assessment_tax_bill)
   ].freeze
 
   OTHER_PAYMENT_TYPES = [

--- a/app/views/steps/income/client/self_assessment_tax_bill/edit.html.erb
+++ b/app/views/steps/income/client/self_assessment_tax_bill/edit.html.erb
@@ -1,0 +1,30 @@
+<% title t('steps.income.caption') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+    <%= govuk_error_summary(@form_object) %>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+    <p class="govuk-body">
+      <%= t('.page_text') %>
+    </p>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :applicant_self_assessment_tax_bill, legend: { tag: 'h1', size: 'xl', hidden: true } do %>
+        <%= f.govuk_radio_button :applicant_self_assessment_tax_bill, YesNoAnswer::YES do %>
+          <%= f.govuk_number_field(:amount,
+                                   prefix_text: '£',
+                                   width: 'one-half') %>
+          <%= f.govuk_collection_radio_buttons(:frequency,
+                                               PaymentFrequencyType.values,
+                                               :value,
+                                               legend: { size: 's',
+                                                         class: 'govuk-!-font-weight-regular' }) %>
+        <% end %>
+        <%= f.govuk_radio_button :applicant_self_assessment_tax_bill, YesNoAnswer::NO %>
+      <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -440,6 +440,14 @@ en:
               inclusion: Select before or after tax
             frequency:
               inclusion: Select how often they get this payment
+        steps/income/client/self_assessment_tax_bill_form:
+          attributes:
+            applicant_self_assessment_tax_bill:
+              inclusion: Select yes if your client pays a Self Assessment tax bill received in the last 2 years
+            amount:
+              not_a_number: Enter the amount they pay
+            frequency:
+              inclusion: Select how often they pay this amount
         steps/income/client_has_dependants_form:
           attributes:
             client_has_dependants:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -102,6 +102,9 @@ en:
         income_payment_attributes:
           before_or_after_tax: Is this before or after tax?
           frequency: How often do they get this payment?
+      steps_income_client_self_assessment_tax_bill_form:
+        applicant_self_assessment_tax_bill: Does your client pay a Self Assessment tax bill received in the last 2 years?
+        frequency: How often do they pay this amount?
       steps_income_income_payments_form:
         income_payments: Which of these payments does your client get?
       steps_income_income_benefits_form:
@@ -442,6 +445,10 @@ en:
             before_tax: Before tax
             after_tax: After tax
           frequency_options: *frequency_options
+      steps_income_client_self_assessment_tax_bill_form:
+        applicant_self_assessment_tax_bill_options: *YESNO
+        amount: How much do they pay?
+        frequency_options: *frequency_options
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
       steps_income_income_before_tax_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -315,6 +315,11 @@ en:
             page_title: Your client's employment income
             heading: Your client's employment income
             page_text: You told us your client is employed.
+        self_assessment_tax_bill:
+          edit:
+            page_title: Does your client pay a Self Assessment tax bill received in the last 2 years?
+            heading: Does your client pay a Self Assessment tax bill received in the last 2 years?
+            page_text: This will be a bill from HM Revenue and Customs (HMRC).
 
     outgoings:
       caption: Outgoings assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,7 +159,8 @@ Rails.application.routes.draw do
         namespace :client do
           crud_step :employer_details, alias: :employer_details, param: :employment_id
           crud_step :employment_details, alias: :employment_details, param: :employment_id
-          edit_step :employment_income
+          edit_step :employment_income, alias: :employment_income
+          edit_step :self_assessment_client, alias: :self_assessment_tax_bill
         end
         show_step :employed_exit
         show_step :self_employed_exit

--- a/db/migrate/20240516140643_add_applicant_self_assessment_tax_bill_to_income.rb
+++ b/db/migrate/20240516140643_add_applicant_self_assessment_tax_bill_to_income.rb
@@ -1,0 +1,5 @@
+class AddApplicantSelfAssessmentTaxBillToIncome < ActiveRecord::Migration[7.0]
+  def change
+    add_column :incomes, :applicant_self_assessment_tax_bill, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,6 +190,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_20_102040) do
     t.string "partner_employment_status", default: [], array: true
     t.string "partner_has_no_income_payments"
     t.string "partner_has_no_income_benefits"
+    t.string "applicant_self_assessment_tax_bill"
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 

--- a/spec/controllers/steps/income/client/self_assessment_tax_bill_controller_spec.rb
+++ b/spec/controllers/steps/income/client/self_assessment_tax_bill_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillController, type: :controller do
+  it_behaves_like 'a generic step controller',
+                  Steps::Income::Client::SelfAssessmentTaxBillForm, Decisions::IncomeDecisionTree
+end

--- a/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      applicant_self_assessment_tax_bill:,
+      amount:,
+      frequency:,
+    }
+  end
+
+  let(:crime_application) { CrimeApplication.new }
+  let(:income) { Income.new(crime_application:) }
+  let(:outgoings_payment) {
+    OutgoingsPayment.new(crime_application: crime_application,
+                         payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s)
+  }
+
+  let(:applicant_self_assessment_tax_bill) { nil }
+  let(:amount) { nil }
+  let(:frequency) { nil }
+
+  before do
+    allow(crime_application.outgoings_payments).to receive(:find_by).with(
+      { payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s }
+    ).and_return(outgoings_payment)
+  end
+
+  describe '#build' do
+    subject(:form) { described_class.build(crime_application) }
+
+    let(:existing_outgoings_payment) {
+      OutgoingsPayment.new(crime_application: crime_application,
+                           payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s,
+                           amount: 50,
+                           frequency: 'four_weeks')
+    }
+
+    before do
+      allow(crime_application.outgoings_payments).to(
+        receive(:self_assessment_tax_bill).and_return(existing_outgoings_payment)
+      )
+      income.applicant_self_assessment_tax_bill = 'yes'
+    end
+
+    it 'sets the form attributes from the model' do
+      expect(form.amount).to eq Money.new(50)
+      expect(form.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
+      expect(form.applicant_self_assessment_tax_bill).to eq(YesNoAnswer::YES)
+    end
+  end
+
+  describe '#save' do
+    before do
+      allow(crime_application.outgoings_payments).to receive(:create!).and_return(true)
+      allow(crime_application.income).to receive(:update).and_return(true)
+    end
+
+    context 'when `applicant_self_assessment_tax_bill` is not provided' do
+      let(:applicant_self_assessment_tax_bill) { nil }
+
+      it 'returns false' do
+        expect(form.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `applicant_self_assessment_tax_bill` is `Yes`' do
+      let(:applicant_self_assessment_tax_bill) { YesNoAnswer::YES.to_s }
+
+      context 'when `amount` is not provided' do
+        it 'returns false' do
+          expect(form.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:amount, :not_a_number)).to be(true)
+        end
+      end
+
+      context 'when `frequency` is not valid' do
+        let(:frequency) { 'every six weeks' }
+
+        it 'returns false' do
+          expect(form.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:frequency, :inclusion)).to be(true)
+        end
+      end
+
+      context 'when all attributes are valid' do
+        let(:amount) { '100' }
+        let(:frequency) { PaymentFrequencyType::MONTHLY.to_s }
+
+        it { is_expected.to be_valid }
+
+        it 'passes validation' do
+          expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
+        end
+
+        it 'updates the outgoings payment with the correct attributes' do
+          expect(crime_application.outgoings_payments).to receive(:create!).with(
+            payment_type: :self_assessment_tax_bill,
+            amount: Money.new(100_00),
+            frequency: PaymentFrequencyType::MONTHLY,
+          )
+
+          form.save
+        end
+      end
+    end
+
+    context 'when `applicant_self_assessment_tax_bill` is `No`' do
+      let(:applicant_self_assessment_tax_bill) { YesNoAnswer::NO.to_s }
+
+      context 'when `amount` is not provided' do
+        it 'passes validation' do
+          expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
+        end
+      end
+
+      context 'when `frequency` is not valid' do
+        let(:frequency) { 'every six weeks' }
+
+        it 'passes validation' do
+          expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
+        end
+      end
+
+      context 'when previous values have been recorded' do
+        let(:existing_outgoings_payment) {
+          OutgoingsPayment.new(crime_application: crime_application,
+                               payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s,
+                               amount: 50,
+                               frequency: 'four_weeks')
+        }
+
+        before do
+          allow(crime_application.outgoings_payments).to(
+            receive(:self_assessment_tax_bill).and_return(existing_outgoings_payment)
+          )
+        end
+
+        it 'resets the attributes before saving' do
+          form.send(:before_save)
+          expect(form.attributes['amount']).to be_nil
+          expect(form.attributes['frequency']).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -351,6 +351,13 @@ RSpec.describe Decisions::IncomeDecisionTree do
     it { is_expected.to have_destination('/steps/income/income_payments', :edit, id: crime_application) }
   end
 
+  context 'when the step is `client_self_assessment_tax_bill`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :client_self_assessment_tax_bill }
+
+    it { is_expected.to have_destination('/steps/income/income_payments', :edit, id: crime_application) }
+  end
+
   context 'when the step is `income payments`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :income_payments }

--- a/spec/value_objects/outgoings_payment_type_spec.rb
+++ b/spec/value_objects/outgoings_payment_type_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe OutgoingsPaymentType do
           childcare
           maintenance
           legal_aid_contribution
+          self_assessment_tax_bill
         ]
       )
     end


### PR DESCRIPTION
## Description of change

Add the page 'Does your client pay a Self Assessment tax bill received in the last 2 years?'. This page follows on from the shopping basket page which is in progress, so does not currently exist in the flow, but can be accessed directly via the URL. 

## Link to relevant ticket

[CRIMAPP-873](https://dsdmoj.atlassian.net/browse/CRIMAPP-873)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

![Screenshot 2024-05-22 at 09 46 56](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/7fba0dd4-fde7-4433-95c1-cc32457cbb0d)

## How to manually test the feature

Proceed to the employment status page. Change the URL ending to `/client/self_asssessment_tax_bill`


[CRIMAPP-873]: https://dsdmoj.atlassian.net/browse/CRIMAPP-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ