### PR TITLE
Switch on non means tested

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -16,7 +16,9 @@ class CrimeApplicationsController < DashboardController
 
   def create
     initialize_crime_application do |crime_application|
-      if FeatureFlags.non_means_tested.enabled?
+      if FeatureFlags.passported_partner_journey.enabled?
+        redirect_to edit_crime_application_path(crime_application)
+      elsif FeatureFlags.non_means_tested.enabled?
         redirect_to edit_steps_client_is_means_tested_path(crime_application)
       else
         redirect_to edit_steps_client_has_partner_path(crime_application)

--- a/app/presenters/tasks/client_details.rb
+++ b/app/presenters/tasks/client_details.rb
@@ -1,7 +1,11 @@
 module Tasks
   class ClientDetails < BaseTask
     def path
-      edit_steps_client_details_path
+      if FeatureFlags.non_means_tested.enabled? && FeatureFlags.passported_partner_journey.enabled?
+        edit_steps_client_is_means_tested_path
+      else
+        edit_steps_client_details_path
+      end
     end
 
     # Client details is the first thing a provider can do so it is always true

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -7,8 +7,6 @@ module Decisions
       case step_name
       when :is_means_tested
         after_is_means_tested
-      when :has_partner
-        after_has_partner
       when :details
         after_client_details
       when :case_type
@@ -27,6 +25,8 @@ module Decisions
         after_contact_details
       when :has_nino
         after_has_nino
+      when :has_partner
+        after_has_partner
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -36,17 +36,10 @@ module Decisions
     private
 
     def after_is_means_tested
-      if form_object.is_means_tested.yes?
+      if FeatureFlags.passported_partner_journey.enabled?
+        edit(:details)
+      elsif form_object.is_means_tested.yes?
         edit(:has_partner)
-      else
-        # Task list
-        edit('/crime_applications')
-      end
-    end
-
-    def after_has_partner
-      if form_object.client_has_partner.yes?
-        show(:partner_exit)
       else
         # Task list
         edit('/crime_applications')
@@ -128,8 +121,27 @@ module Decisions
     def after_has_nino
       if current_crime_application.not_means_tested?
         edit('/steps/case/urn')
+      elsif FeatureFlags.passported_partner_journey.enabled?
+        edit(:has_partner)
       else
         edit('/steps/dwp/benefit_type')
+      end
+    end
+
+    def after_has_partner
+      if form_object.client_has_partner.yes?
+        if FeatureFlags.passported_partner_journey.enabled?
+          # TODO: route to relationship to partner page
+          edit('/steps/dwp/benefit_type') # placeholder
+        else
+          show(:partner_exit)
+        end
+      elsif FeatureFlags.passported_partner_journey.enabled? # i.e. has_partner: no
+        # TODO: route to relationship to partner page
+        edit('/steps/dwp/benefit_type')
+      else
+        # Task list
+        edit('/crime_applications')
       end
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,8 +20,8 @@ feature_flags:
     staging: true
     production: true
   non_means_tested:
-    local: false
-    staging: false
+    local: true
+    staging: true
     production: false
   employment_journey:
     local: true
@@ -35,7 +35,6 @@ feature_flags:
     local: true
     staging: true
     production: false
-
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/spec/presenters/tasks/client_details_spec.rb
+++ b/spec/presenters/tasks/client_details_spec.rb
@@ -27,7 +27,23 @@ RSpec.describe Tasks::ClientDetails do
   end
 
   describe '#path' do
-    it { expect(subject.path).to eq('/applications/12345/steps/client/details') }
+    before do
+      allow(FeatureFlags).to receive(:passported_partner_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: passported_partner_journey_enabled)
+      }
+    end
+
+    context 'when passported partner journey is enabled' do
+      let(:passported_partner_journey_enabled) { true }
+
+      it { expect(subject.path).to eq('/applications/12345/steps/client/is_application_means_tested') }
+    end
+
+    context 'when passported partner journey not is enabled' do
+      let(:passported_partner_journey_enabled) { false }
+
+      it { expect(subject.path).to eq('/applications/12345/steps/client/details') }
+    end
   end
 
   describe '#not_applicable?' do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -10,33 +10,82 @@ RSpec.describe 'Dashboard', :authorized do
   let(:returned_application_fixture_id) { '47a93336-7da6-48ec-b139-808ddd555a41' }
 
   describe 'start a new application' do
-    context 'when non_means_tested feature flag is enabled' do
-      before do
-        allow(FeatureFlags).to receive(:non_means_tested) {
-          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-        }
+    # before do
+    #   allow(FeatureFlags).to receive(:non_means_tested) {
+    #     instance_double(FeatureFlags::EnabledFeature, enabled?: non_means_tested_enabled)
+    #   }
+    #   allow(FeatureFlags).to receive(:passported_partner_journey) {
+    #                            instance_double(FeatureFlags::EnabledFeature,
+    #                                            enabled?: passported_partner_journey_enabled)
+    #                          }
+    # end
+    before do
+      allow(FeatureFlags).to receive_messages(
+        non_means_tested: instance_double(FeatureFlags::EnabledFeature, enabled?: non_means_tested_enabled),
+        passported_partner_journey: instance_double(FeatureFlags::EnabledFeature,
+                                                    enabled?: passported_partner_journey_enabled)
+      )
+    end
+
+    let(:non_means_tested_enabled) { nil }
+
+    context 'when passported partner journey feature flag is not enabled' do
+      let(:passported_partner_journey_enabled) { false }
+
+      context 'when non_means_tested feature flag is enabled' do
+        let(:non_means_tested_enabled) { true }
+
+        it 'creates a new `crime_application` record' do
+          expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(/is_application_means_tested/)
+        end
       end
 
-      it 'creates a new `crime_application` record' do
-        expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+      context 'when `non means tested` feature flag is not enabled' do
+        before do
+          allow(FeatureFlags).to receive(:non_means_tested) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
+        end
 
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(/is_application_means_tested/)
+        it 'creates a new `crime_application` record' do
+          expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(/has_partner/)
+        end
       end
     end
 
-    context 'when `non means tested` feature flag is not enabled' do
-      before do
-        allow(FeatureFlags).to receive(:non_means_tested) {
-          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
-        }
+    context 'when passported partner journey feature flag is enabled' do
+      let(:passported_partner_journey_enabled) { true }
+
+      context 'when non_means_tested feature flag is enabled' do
+        let(:non_means_tested_enabled) { true }
+
+        it 'creates a new `crime_application` record' do
+          expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(/applications/)
+        end
       end
 
-      it 'creates a new `crime_application` record' do
-        expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+      context 'when `non means tested` feature flag is not enabled' do
+        before do
+          allow(FeatureFlags).to receive(:non_means_tested) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
+        end
 
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(/has_partner/)
+        it 'creates a new `crime_application` record' do
+          expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(/applications/)
+        end
       end
     end
   end

--- a/spec/services/decisions/client_decision_tree_spec.rb
+++ b/spec/services/decisions/client_decision_tree_spec.rb
@@ -30,16 +30,48 @@ RSpec.describe Decisions::ClientDecisionTree do
     let(:form_object) { double('FormObject', is_means_tested:) }
     let(:step_name) { :is_means_tested }
 
-    context 'and answer is `yes`' do
-      let(:is_means_tested) { YesNoAnswer::YES }
-
-      it { is_expected.to have_destination(:has_partner, :edit, id: crime_application) }
+    before do
+      allow(FeatureFlags).to receive(:passported_partner_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_passported_partner_journey_enabled)
+      }
     end
 
-    context 'and answer is `no`' do
-      let(:is_means_tested) { YesNoAnswer::NO }
+    context 'and the passported partner feature flag is enabled' do
+      let(:feature_flag_passported_partner_journey_enabled) { true }
 
-      it { is_expected.to have_destination('/crime_applications', :edit, id: crime_application) }
+      context 'and answer is `yes`' do
+        let(:is_means_tested) { YesNoAnswer::YES }
+
+        it { is_expected.to have_destination(:details, :edit, id: crime_application) }
+      end
+
+      context 'and answer is `no`' do
+        let(:is_means_tested) { YesNoAnswer::NO }
+
+        it { is_expected.to have_destination(:details, :edit, id: crime_application) }
+      end
+    end
+
+    context 'and the passported partner feature flag is not enabled' do
+      before do
+        allow(FeatureFlags).to receive(:passported_partner_journey) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_passported_partner_journey_enabled)
+        }
+      end
+
+      let(:feature_flag_passported_partner_journey_enabled) { false }
+
+      context 'and answer is `yes`' do
+        let(:is_means_tested) { YesNoAnswer::YES }
+
+        it { is_expected.to have_destination(:has_partner, :edit, id: crime_application) }
+      end
+
+      context 'and answer is `no`' do
+        let(:is_means_tested) { YesNoAnswer::NO }
+
+        it { is_expected.to have_destination('/crime_applications', :edit, id: crime_application) }
+      end
     end
   end
 
@@ -47,16 +79,42 @@ RSpec.describe Decisions::ClientDecisionTree do
     let(:form_object) { double('FormObject', client_has_partner:) }
     let(:step_name) { :has_partner }
 
-    context 'and answer is `no`' do
-      let(:client_has_partner) { YesNoAnswer::NO }
-
-      it { is_expected.to have_destination('/crime_applications', :edit, id: crime_application) }
+    before do
+      allow(FeatureFlags).to receive(:passported_partner_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_passported_partner_journey_enabled)
+      }
     end
 
-    context 'and answer is `yes`' do
-      let(:client_has_partner) { YesNoAnswer::YES }
+    context 'and the passported partner feature flag is not enabled' do
+      let(:feature_flag_passported_partner_journey_enabled) { false }
 
-      it { is_expected.to have_destination(:partner_exit, :show, id: crime_application) }
+      context 'and answer is `no`' do
+        let(:client_has_partner) { YesNoAnswer::NO }
+
+        it { is_expected.to have_destination('/crime_applications', :edit, id: crime_application) }
+      end
+
+      context 'and answer is `yes`' do
+        let(:client_has_partner) { YesNoAnswer::YES }
+
+        it { is_expected.to have_destination(:partner_exit, :show, id: crime_application) }
+      end
+    end
+
+    context 'and the passported partner feature flag is enabled' do
+      let(:feature_flag_passported_partner_journey_enabled) { true }
+
+      context 'and answer is `no`' do
+        let(:client_has_partner) { YesNoAnswer::NO }
+
+        it { is_expected.to have_destination('/steps/dwp/benefit_type', :edit, id: crime_application) }
+      end
+
+      context 'and answer is `yes`' do
+        let(:client_has_partner) { YesNoAnswer::YES }
+
+        it { is_expected.to have_destination('/steps/dwp/benefit_type', :edit, id: crime_application) }
+      end
     end
   end
 
@@ -297,8 +355,24 @@ RSpec.describe Decisions::ClientDecisionTree do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :has_nino }
 
+    before do
+      allow(FeatureFlags).to receive(:passported_partner_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_passported_partner_journey_enabled)
+      }
+    end
+
     context 'when the application is means tested' do
-      it { is_expected.to have_destination('/steps/dwp/benefit_type', :edit, id: crime_application) }
+      context 'and the passported partner feature flag is enabled' do
+        let(:feature_flag_passported_partner_journey_enabled) { true }
+
+        it { is_expected.to have_destination(:has_partner, :edit, id: crime_application) }
+      end
+
+      context 'and the passported partner feature flag is not enabled' do
+        let(:feature_flag_passported_partner_journey_enabled) { false }
+
+        it { is_expected.to have_destination('/steps/dwp/benefit_type', :edit, id: crime_application) }
+      end
     end
 
     context 'when the application is not means tested' do


### PR DESCRIPTION
## Description of change
Switch on no means tested feature flag, and show page
Move has partner page if passported partner ff enabled
If has partner page before tasklist, non means q shows before that
If has partner page in new position (after has nino) non means is first question

## How to test

**Scenario 1 ppt partner on, non means tested on**
Start a new application
First page is now tasklist
Click Client details, first page is means test
Answer yes to means test q, continue through, as usual
Go back, answer no to means tested q
Continue to complete app
    Check:
        Datestamp received after client details
        No case type asked
        No DWP check 
        No means questions asked
        
        
**Scenario 2 ppt partner off, non means tested on**
Turn off passported partner feature flag - restart server
Start a new application
See Means tested q  - answer yes - see partner q
Go back, answer no to means tested q - see tasklist 
Continue to complete app
    Check:
        Datestamp received after client details
        No case type asked
        No DWP check 
        No means questions asked
 
**Scenario 3 ppt partner off, non means tested off**
Turn off passported partner feature flag and means test feature flag - restart server
Start a new application
See has partner q
Continue to complete app
    Check:
        Datestamp received after case type
        DWP check run, means questions asked if appropriate
 
