### PR TITLE
Crimapp 871 employed income shopping basket for jobs loop

### DIFF
--- a/app/controllers/concerns/steps/income/client/employment_update_step.rb
+++ b/app/controllers/concerns/steps/income/client/employment_update_step.rb
@@ -1,0 +1,61 @@
+module Steps
+  module Income
+    module Client
+      module EmploymentUpdateStep
+        extend ActiveSupport::Concern
+
+        def edit
+          @form_object = form_name.build(
+            employment_record, crime_application: current_crime_application
+          )
+        end
+
+        def update
+          update_and_advance(
+            form_name, record: employment_record, as: advance_as, flash: flash_msg
+          )
+        end
+
+        def confirm_destroy
+          @employment = employment_record
+        end
+
+        def destroy
+          employment_record.destroy
+
+          if employments.reload.any?
+            redirect_to edit_steps_income_client_employments_summary_path, success: t('.success_flash')
+          else
+            redirect_to edit_steps_income_employment_status_path, success: t('.success_flash')
+          end
+        end
+
+        private
+
+        def employment_record
+          @employment_record ||= employments.find(params[:employment_id])
+        rescue ActiveRecord::RecordNotFound
+          raise Errors::EmploymentNotFound
+        end
+
+        def employments
+          @employments ||= current_crime_application.employments
+        end
+
+        # :nocov:
+        def advance_as
+          raise NotImplementedError
+        end
+
+        def form_name
+          raise NotImplementedError
+        end
+
+        def flash_msg
+          nil
+        end
+        # :nocov:
+      end
+    end
+  end
+end

--- a/app/controllers/steps/income/client/employer_details_controller.rb
+++ b/app/controllers/steps/income/client/employer_details_controller.rb
@@ -2,27 +2,17 @@ module Steps
   module Income
     module Client
       class EmployerDetailsController < Steps::IncomeStepController
-        def edit
-          @form_object = EmployerDetailsForm.build(
-            employment_record, crime_application: current_crime_application
-          )
+        include Steps::Income::Client::EmploymentUpdateStep
+
+        def advance_as
+          :client_employer_details
         end
 
-        def update
-          update_and_advance(EmployerDetailsForm, record: employment_record, as: :client_employer_details)
+        def form_name
+          EmployerDetailsForm
         end
 
         private
-
-        def employment_record
-          @employment_record ||= employments.find(params[:employment_id])
-        rescue ActiveRecord::RecordNotFound
-          raise Errors::EmploymentNotFound
-        end
-
-        def employments
-          @employments ||= current_crime_application.employments
-        end
 
         def additional_permitted_params
           [address: [:address_line_one, :address_line_two, :city, :country, :postcode]]

--- a/app/controllers/steps/income/client/employment_details_controller.rb
+++ b/app/controllers/steps/income/client/employment_details_controller.rb
@@ -2,26 +2,14 @@ module Steps
   module Income
     module Client
       class EmploymentDetailsController < Steps::IncomeStepController
-        def edit
-          @form_object = EmploymentDetailsForm.build(
-            employment_record, crime_application: current_crime_application
-          )
+        include Steps::Income::Client::EmploymentUpdateStep
+
+        def advance_as
+          :client_employment_details
         end
 
-        def update
-          update_and_advance(EmploymentDetailsForm, record: employment_record, as: :client_employment_details)
-        end
-
-        private
-
-        def employment_record
-          @employment_record ||= employments.find(params[:employment_id])
-        rescue ActiveRecord::RecordNotFound
-          raise Errors::EmploymentNotFound
-        end
-
-        def employments
-          @employments ||= current_crime_application.employments
+        def form_name
+          EmploymentDetailsForm
         end
       end
     end

--- a/app/controllers/steps/income/client/employments_controller.rb
+++ b/app/controllers/steps/income/client/employments_controller.rb
@@ -2,39 +2,7 @@ module Steps
   module Income
     module Client
       class EmploymentsController < Steps::IncomeStepController
-        def edit
-          @form_object = EmploymentIncomeForm.build(
-            current_crime_application
-          )
-        end
-
-        def update
-          update_and_advance(EmploymentIncomeForm, as: :client_employment_income)
-        end
-
-        def confirm_destroy
-          @employment = employment_record
-        end
-
-        def destroy
-          employment_record.destroy
-
-          if employments.reload.any?
-            redirect_to edit_steps_income_client_employments_summary_path, success: t('.success_flash')
-          else
-            redirect_to edit_steps_income_employment_status_path, success: t('.success_flash')
-          end
-        end
-
-        def employment_record
-          @employment_record ||= employments.find(params[:employment_id])
-        rescue ActiveRecord::RecordNotFound
-          raise Errors::EmploymentNotFound
-        end
-
-        def employments
-          @employments ||= current_crime_application.employments
-        end
+        include Steps::Income::Client::EmploymentUpdateStep
       end
     end
   end

--- a/app/controllers/steps/income/client/employments_controller.rb
+++ b/app/controllers/steps/income/client/employments_controller.rb
@@ -1,0 +1,42 @@
+module Steps
+  module Income
+    module Client
+      class EmploymentsController < Steps::IncomeStepController
+        def edit
+          @form_object = EmploymentIncomeForm.build(
+            current_crime_application
+          )
+        end
+
+        def update
+          update_and_advance(EmploymentIncomeForm, as: :client_employment_income)
+        end
+
+        def confirm_destroy
+          @employment = employment_record
+        end
+
+        def destroy
+          employment_record.destroy
+
+          if employments.reload.any?
+            redirect_to edit_steps_income_client_employments_summary_path, success: t('.success_flash')
+          else
+            # If this was the last remaining record, redirect to the property type page
+            redirect_to edit_steps_income_employment_status_path, success: t('.success_flash')
+          end
+        end
+
+        def employment_record
+          @employment_record ||= employments.find(params[:employment_id])
+        rescue ActiveRecord::RecordNotFound
+          raise Errors::EmploymentNotFound
+        end
+
+        def employments
+          @employments ||= current_crime_application.employments
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/steps/income/client/employments_controller.rb
+++ b/app/controllers/steps/income/client/employments_controller.rb
@@ -22,8 +22,8 @@ module Steps
           if employments.reload.any?
             redirect_to edit_steps_income_client_employments_summary_path, success: t('.success_flash')
           else
-            # If this was the last remaining record, redirect to the property type page
-            redirect_to edit_steps_income_employment_status_path, success: t('.success_flash')
+            new_employment = current_crime_application.employments.create!
+            redirect_to edit_steps_income_client_employer_details_path(employment_id: new_employment.id), success: t('.success_flash')
           end
         end
 

--- a/app/controllers/steps/income/client/employments_controller.rb
+++ b/app/controllers/steps/income/client/employments_controller.rb
@@ -22,8 +22,7 @@ module Steps
           if employments.reload.any?
             redirect_to edit_steps_income_client_employments_summary_path, success: t('.success_flash')
           else
-            new_employment = current_crime_application.employments.create!
-            redirect_to edit_steps_income_client_employer_details_path(employment_id: new_employment.id), success: t('.success_flash')
+            redirect_to edit_steps_income_employment_status_path, success: t('.success_flash')
           end
         end
 

--- a/app/controllers/steps/income/client/employments_summary_controller.rb
+++ b/app/controllers/steps/income/client/employments_summary_controller.rb
@@ -2,6 +2,8 @@ module Steps
   module Income
     module Client
       class EmploymentsSummaryController < Steps::IncomeStepController
+        before_action :require_property
+
         def edit
           @form_object = EmploymentsSummaryForm.build(
             current_crime_application
@@ -16,6 +18,12 @@ module Steps
 
         def additional_permitted_params
           [:add_client_employment]
+        end
+
+        def require_property
+          return true if current_crime_application.employments.present?
+
+          redirect_to edit_steps_income_employment_status_path(current_crime_application)
         end
       end
     end

--- a/app/controllers/steps/income/client/employments_summary_controller.rb
+++ b/app/controllers/steps/income/client/employments_summary_controller.rb
@@ -2,7 +2,7 @@ module Steps
   module Income
     module Client
       class EmploymentsSummaryController < Steps::IncomeStepController
-        before_action :require_property
+        before_action :require_employment
 
         def edit
           @form_object = EmploymentsSummaryForm.build(
@@ -20,7 +20,7 @@ module Steps
           [:add_client_employment]
         end
 
-        def require_property
+        def require_employment
           return true if current_crime_application.employments.present?
 
           redirect_to edit_steps_income_employment_status_path(current_crime_application)

--- a/app/controllers/steps/income/client/employments_summary_controller.rb
+++ b/app/controllers/steps/income/client/employments_summary_controller.rb
@@ -1,0 +1,23 @@
+module Steps
+  module Income
+    module Client
+      class EmploymentsSummaryController < Steps::IncomeStepController
+        def edit
+          @form_object = EmploymentsSummaryForm.build(
+            current_crime_application
+          )
+        end
+
+        def update
+          update_and_advance(EmploymentsSummaryForm, as: :employments_summary)
+        end
+
+        private
+
+        def additional_permitted_params
+          [:add_client_employment]
+        end
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/client/employments_summary_form.rb
+++ b/app/forms/steps/income/client/employments_summary_form.rb
@@ -1,0 +1,31 @@
+module Steps
+  module Income
+    module Client
+      class EmploymentsSummaryForm < Steps::BaseFormObject
+        attr_reader :add_client_employment
+
+        validates_inclusion_of :add_client_employment, in: :choices
+
+        delegate :employments, to: :crime_application
+
+        def choices
+          YesNoAnswer.values
+        end
+
+        def add_client_employment=(attribute)
+          return unless attribute
+
+          @add_client_employment = YesNoAnswer.new(attribute)
+        end
+
+        private
+
+        # NOTE: this step is not persisting anything to DB.
+        # We only use `add_employment=` transiently in the decision tree.
+        def persist!
+          true
+        end
+      end
+    end
+  end
+end

--- a/app/models/deduction.rb
+++ b/app/models/deduction.rb
@@ -2,4 +2,15 @@ class Deduction < ApplicationRecord
   belongs_to :employment
   validates :employment_id, uniqueness: { scope: :deduction_type }
   attribute :amount, :pence
+  enum deduction_type: { income_tax: DeductionType::INCOME_TAX.to_s,
+                         national_insurance: DeductionType::NATIONAL_INSURANCE.to_s,
+                         other: DeductionType::OTHER.to_s }
+
+  def complete?
+    values_at(
+      :deduction_type,
+      :amount,
+      :frequency
+    ).all?(&:present?)
+  end
 end

--- a/app/models/deduction.rb
+++ b/app/models/deduction.rb
@@ -1,4 +1,7 @@
 class Deduction < ApplicationRecord
+  # Ordering using deduction_type maintains the deduction order income_tax, national_insurance and other
+  default_scope { order(deduction_type: :asc) }
+
   belongs_to :employment
   validates :employment_id, uniqueness: { scope: :deduction_type }
   attribute :amount, :pence

--- a/app/models/deduction.rb
+++ b/app/models/deduction.rb
@@ -9,10 +9,9 @@ class Deduction < ApplicationRecord
                          national_insurance: DeductionType::NATIONAL_INSURANCE.to_s,
                          other: DeductionType::OTHER.to_s }
 
-  REQUIRED_ATTRIBUTES = [:deduction_type, :amount, :frequency]
-
   def complete?
-    REQUIRED_ATTRIBUTES << :details if deduction_type == DeductionType::OTHER.to_s
-    values_at(*REQUIRED_ATTRIBUTES).all?(&:present?)
+    required_attributes = [:deduction_type, :amount, :frequency]
+    required_attributes << :details if deduction_type == DeductionType::OTHER.to_s
+    values_at(*required_attributes).all?(&:present?)
   end
 end

--- a/app/models/deduction.rb
+++ b/app/models/deduction.rb
@@ -9,11 +9,10 @@ class Deduction < ApplicationRecord
                          national_insurance: DeductionType::NATIONAL_INSURANCE.to_s,
                          other: DeductionType::OTHER.to_s }
 
+  REQUIRED_ATTRIBUTES = [:deduction_type, :amount, :frequency]
+
   def complete?
-    values_at(
-      :deduction_type,
-      :amount,
-      :frequency
-    ).all?(&:present?)
+    REQUIRED_ATTRIBUTES << :details if deduction_type == DeductionType::OTHER.to_s
+    values_at(*REQUIRED_ATTRIBUTES).all?(&:present?)
   end
 end

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -20,7 +20,8 @@ class Employment < ApplicationRecord
     :employer_name,
     :job_title,
     :amount,
-    :frequency
+    :frequency,
+    :before_or_after_tax
   ].freeze
 
   def complete?

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,6 +1,9 @@
 class Employment < ApplicationRecord
   belongs_to :crime_application
 
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
+
   has_many :deductions, -> { order(deduction_type: :asc) }, inverse_of: :employment, dependent: :destroy do
     def complete
       select(&:complete?)
@@ -31,6 +34,8 @@ class Employment < ApplicationRecord
   end
 
   def deductions_complete?
-    deductions.all?(&:complete?) && deductions
+    return true if has_no_deductions == YesNoAnswer::YES.to_s
+
+    deductions.present? && deductions.all?(&:complete?)
   end
 end

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -5,4 +5,8 @@ class Employment < ApplicationRecord
 
   store_accessor :address, :address_line_one, :address_line_two, :city, :country, :postcode
   store_accessor :metadata, [:before_or_after_tax]
+
+  def complete?
+    true
+  end
 end

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,12 +1,36 @@
 class Employment < ApplicationRecord
   belongs_to :crime_application
 
-  has_many :deductions, -> { order(deduction_type: :asc) }, inverse_of: :employment, dependent: :destroy
+  has_many :deductions, -> { order(deduction_type: :asc) }, inverse_of: :employment, dependent: :destroy do
+    def complete
+      select(&:complete?)
+    end
+  end
 
   store_accessor :address, :address_line_one, :address_line_two, :city, :country, :postcode
   store_accessor :metadata, [:before_or_after_tax]
 
+  OPTIONAL_ADDRESS_ATTRIBUTES = %w[address_line_two].freeze
+  REQUIRED_ADDRESS_ATTRIBUTES = Address::ADDRESS_ATTRIBUTES.map(&:to_s).reject { |a| a.in? OPTIONAL_ADDRESS_ATTRIBUTES }
+  REQUIRED_ATTRIBUTES = [
+    :ownership_type,
+    :employer_name,
+    :job_title,
+    :amount,
+    :frequency
+  ].freeze
+
   def complete?
-    true
+    values_at(*REQUIRED_ATTRIBUTES).all?(&:present?) &&
+      address_complete? &&
+      deductions_complete?
+  end
+
+  def address_complete?
+    address.present? && address.values_at(*REQUIRED_ADDRESS_ATTRIBUTES.map(&:to_s)).all?(&:present?)
+  end
+
+  def deductions_complete?
+    deductions.all?(&:complete?) && deductions
   end
 end

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -1,0 +1,73 @@
+module Summary
+  module Components
+    class Employment < BaseRecord # rubocop:disable Metrics/ClassLength
+      alias employment record
+
+      private
+
+      def answers
+        attributes =
+          [
+            Components::FreeTextAnswer.new(
+              :employer_name, employment.employer_name
+            ),
+            Components::FreeTextAnswer.new(
+              :address, full_address(employment.address)
+            ),
+            Components::FreeTextAnswer.new(
+              :job_title, employment.job_title
+            )
+          ]
+
+
+        if employment.income_payment.present?
+          attributes << Components::MoneyAnswer.new(
+          :amount, employment.income_payment.amount
+        )
+          attributes << Components::FreeTextAnswer.new(
+            :frequency, employment.income_payment.frequency.to_s
+          )
+          attributes << Components::PaymentAnswer.new(
+            :frequency, employment.income_payment
+          )
+        end
+
+
+        employment.deductions.each do |deduction|
+          attributes << Components::FreeTextAnswer.new(
+            :deduction_type, deduction.deduction_type
+          )
+          attributes << Components::MoneyAnswer.new(
+            :amount, deduction.amount
+          )
+          attributes << Components::FreeTextAnswer.new(
+            :frequency, deduction.frequency
+          )
+          attributes << Components::FreeTextAnswer.new(
+            :details, deduction.details
+          )
+        end
+
+        attributes
+      end
+
+      def full_address(address)
+        return unless address
+
+        address.values_at(*Address::ADDRESS_ATTRIBUTES.map(&:to_s)).compact_blank.join("\r\n")
+      end
+
+      def change_path
+        edit_steps_income_client_employer_details_path(id: record.crime_application_id, employment_id: employment.id)
+      end
+
+      def summary_path
+        edit_steps_income_client_employments_summary_path(id: record.crime_application_id, employment_id: employment.id)
+      end
+
+      def remove_path
+        confirm_destroy_steps_income_client_employments_path(id: record.crime_application_id, employment_id: employment.id)
+      end
+    end
+  end
+end

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -30,15 +30,19 @@ module Summary
                         )
                       end
 
-        employment.deductions.each do |deduction|
-          attributes << Components::PaymentAnswer.new(
-            "deduction.#{deduction.deduction_type}", deduction
-          )
-          next unless deduction.other?
+        if employment.deductions.present?
+          employment.deductions.each do |deduction|
+            attributes << Components::PaymentAnswer.new(
+              "deduction.#{deduction.deduction_type}", deduction
+            )
+            next unless deduction.other?
 
-          attributes << Components::FreeTextAnswer.new(
-            "deduction.#{deduction.deduction_type}.details", deduction.details
-          )
+            attributes << Components::FreeTextAnswer.new(
+              "deduction.#{deduction.deduction_type}.details", deduction.details
+            )
+          end
+        else
+          attributes << Components::ValueAnswer.new('employment.has_no_deductions', employment.has_no_deductions)
         end
 
         attributes

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -20,15 +20,15 @@ module Summary
             )
           ]
 
-        if employment.amount.present?
-          attributes << Components::PaymentAnswer.new(
-            'employment.salary_or_wage', employment
-          )
-        else
-          attributes << Components::FreeTextAnswer.new(
-            'employment.salary_or_wage', employment.amount
-          )
-        end
+        attributes << if employment.amount.present?
+                        Components::PaymentAnswer.new(
+                          'employment.salary_or_wage', employment
+                        )
+                      else
+                        Components::FreeTextAnswer.new(
+                          'employment.salary_or_wage', employment.amount
+                        )
+                      end
 
         employment.deductions.each do |deduction|
           attributes << Components::PaymentAnswer.new(

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -1,10 +1,11 @@
 module Summary
   module Components
-    class Employment < BaseRecord # rubocop:disable Metrics/ClassLength
+    class Employment < BaseRecord
       alias employment record
 
       private
 
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
         attributes =
           [
@@ -35,6 +36,7 @@ module Summary
 
         attributes
       end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       def full_address(address)
         return unless address

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -16,22 +16,17 @@ module Summary
             ),
             Components::FreeTextAnswer.new(
               :job_title, employment.job_title
+            ),
+            Components::MoneyAnswer.new(
+              :amount, employment.amount
+            ),
+            Components::FreeTextAnswer.new(
+              :frequency, employment.frequency.to_s
+            ),
+            Components::PaymentAnswer.new(
+              :frequency, employment
             )
           ]
-
-
-        if employment.income_payment.present?
-          attributes << Components::MoneyAnswer.new(
-          :amount, employment.income_payment.amount
-        )
-          attributes << Components::FreeTextAnswer.new(
-            :frequency, employment.income_payment.frequency.to_s
-          )
-          attributes << Components::PaymentAnswer.new(
-            :frequency, employment.income_payment
-          )
-        end
-
 
         employment.deductions.each do |deduction|
           attributes << Components::FreeTextAnswer.new(
@@ -58,15 +53,15 @@ module Summary
       end
 
       def change_path
-        edit_steps_income_client_employer_details_path(id: record.crime_application_id, employment_id: employment.id)
+        edit_steps_income_client_employer_details_path(employment_id: employment.id)
       end
 
       def summary_path
-        edit_steps_income_client_employments_summary_path(id: record.crime_application_id, employment_id: employment.id)
+        edit_steps_income_client_employments_summary_path(employment_id: employment.id)
       end
 
       def remove_path
-        confirm_destroy_steps_income_client_employments_path(id: record.crime_application_id, employment_id: employment.id)
+        confirm_destroy_steps_income_client_employments_path(employment_id: employment.id)
       end
     end
   end

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -17,11 +17,18 @@ module Summary
             ),
             Components::FreeTextAnswer.new(
               'employment.job_title', employment.job_title
-            ),
-            Components::PaymentAnswer.new(
-              'employment.salary_or_wage', employment
             )
           ]
+
+        if employment.amount.present?
+          attributes << Components::PaymentAnswer.new(
+            'employment.salary_or_wage', employment
+          )
+        else
+          attributes << Components::FreeTextAnswer.new(
+            'employment.salary_or_wage', employment.amount
+          )
+        end
 
         employment.deductions.each do |deduction|
           attributes << Components::PaymentAnswer.new(
@@ -37,6 +44,10 @@ module Summary
         attributes
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      def name
+        I18n.t('summary.sections.employment')
+      end
 
       def full_address(address)
         return unless address

--- a/app/presenters/summary/components/employment.rb
+++ b/app/presenters/summary/components/employment.rb
@@ -9,37 +9,27 @@ module Summary
         attributes =
           [
             Components::FreeTextAnswer.new(
-              :employer_name, employment.employer_name
+              'employment.employer_name', employment.employer_name
             ),
             Components::FreeTextAnswer.new(
-              :address, full_address(employment.address)
+              'employment.address', full_address(employment.address)
             ),
             Components::FreeTextAnswer.new(
-              :job_title, employment.job_title
-            ),
-            Components::MoneyAnswer.new(
-              :amount, employment.amount
-            ),
-            Components::FreeTextAnswer.new(
-              :frequency, employment.frequency.to_s
+              'employment.job_title', employment.job_title
             ),
             Components::PaymentAnswer.new(
-              :frequency, employment
+              'employment.salary_or_wage', employment
             )
           ]
 
         employment.deductions.each do |deduction|
-          attributes << Components::FreeTextAnswer.new(
-            :deduction_type, deduction.deduction_type
+          attributes << Components::PaymentAnswer.new(
+            "deduction.#{deduction.deduction_type}", deduction
           )
-          attributes << Components::MoneyAnswer.new(
-            :amount, deduction.amount
-          )
+          next unless deduction.other?
+
           attributes << Components::FreeTextAnswer.new(
-            :frequency, deduction.frequency
-          )
-          attributes << Components::FreeTextAnswer.new(
-            :details, deduction.details
+            "deduction.#{deduction.deduction_type}.details", deduction.details
           )
         end
 

--- a/app/presenters/summary/sections/employments.rb
+++ b/app/presenters/summary/sections/employments.rb
@@ -1,0 +1,52 @@
+module Summary
+  module Sections
+    class Employments < Sections::BaseSection
+      def show?
+        shown_question?
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def answers
+        if no_employments?
+          [
+            Components::ValueAnswer.new(
+              :has_employments, 'none',
+              change_path: edit_steps_capital_property_type_path
+            )
+          ]
+        else
+          Summary::Components::GroupedList.new(
+            items: employments,
+            group_by: :ownership_type,
+            item_component: Summary::Components::Employment,
+            show_actions: editable?,
+            show_record_actions: headless?
+          )
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def list?
+        return false if employments.empty?
+
+        true
+      end
+
+      private
+
+      def employments
+        @employments ||= crime_application.employments
+      end
+
+      # def shown_question?
+      #   capital.present? && (no_employments? || employments.present?)
+      # end
+      #
+      def no_employments?
+        return false if crime_application.employments.nil?
+
+        #YesNoAnswer.new(crime_application.employments.nil?).yes?
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/employments.rb
+++ b/app/presenters/summary/sections/employments.rb
@@ -1,30 +1,17 @@
 module Summary
   module Sections
     class Employments < Sections::BaseSection
-      def show?
-        shown_question?
-      end
-
-      # rubocop:disable Metrics/MethodLength
       def answers
-        if no_employments?
-          [
-            Components::ValueAnswer.new(
-              :has_employments, 'none',
-              change_path: edit_steps_capital_property_type_path
-            )
-          ]
-        else
-          Summary::Components::GroupedList.new(
-            items: employments,
-            group_by: :ownership_type,
-            item_component: Summary::Components::Employment,
-            show_actions: editable?,
-            show_record_actions: headless?
-          )
-        end
+        return [] if employments.empty?
+
+        Summary::Components::GroupedList.new(
+          items: employments,
+          group_by: :ownership_type,
+          item_component: Summary::Components::Employment,
+          show_actions: editable?,
+          show_record_actions: headless?
+        )
       end
-      # rubocop:enable Metrics/MethodLength
 
       def list?
         return false if employments.empty?
@@ -36,16 +23,6 @@ module Summary
 
       def employments
         @employments ||= crime_application.employments
-      end
-
-      # def shown_question?
-      #   capital.present? && (no_employments? || employments.present?)
-      # end
-      #
-      def no_employments?
-        return false if crime_application.employments.nil?
-
-        #YesNoAnswer.new(crime_application.employments.nil?).yes?
       end
     end
   end

--- a/app/presenters/summary/sections/employments.rb
+++ b/app/presenters/summary/sections/employments.rb
@@ -4,12 +4,8 @@ module Summary
       def answers
         return [] if employments.empty?
 
-        Summary::Components::GroupedList.new(
-          items: employments,
-          group_by: :ownership_type,
-          item_component: Summary::Components::Employment,
-          show_actions: editable?,
-          show_record_actions: headless?
+        Components::Employment.with_collection(
+          employments, show_actions: editable?, show_record_actions: headless?
         )
       end
 

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -94,6 +94,7 @@ module Decisions
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     # <- to make it easier to reimplement when we do self-employed
     def start_employment_journey
       case form_object.employment_status
@@ -112,6 +113,7 @@ module Decisions
         redirect_to_employer_details(employment)
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def redirect_to_employer_details(employment)
       # employments = current_crime_application.employments

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -109,8 +109,6 @@ module Decisions
     end
 
     def redirect_to_employer_details(employment)
-      # employments = current_crime_application.employments
-      # current_crime_application.employments.create! if employments.empty?
       edit('/steps/income/client/employer_details', employment_id: employment)
     end
 

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -69,7 +69,7 @@ module Decisions
     end
 
     def after_employments_summary
-      return show('/steps/income/employed_exit') if form_object.add_client_employment.no?
+      return edit(:self_assessment_tax_bill) if form_object.add_client_employment.no?
 
       employment = current_crime_application.employments.create!
       redirect_to_employer_details(employment)

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -16,8 +16,6 @@ module Decisions
         after_client_deductions
       when :employments_summary
         after_employments_summary
-      when :add_client_employment
-        after_add_client_employment
       when :lost_job_in_custody
         edit(:income_before_tax)
       when :income_before_tax
@@ -98,7 +96,6 @@ module Decisions
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     # <- to make it easier to reimplement when we do self-employed
     def start_employment_journey
       case form_object.employment_status
@@ -110,7 +107,6 @@ module Decisions
         redirect_to_employer_details(employment)
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def redirect_to_employer_details(employment)
       # employments = current_crime_application.employments

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -102,7 +102,13 @@ module Decisions
       when [EmploymentStatus::SELF_EMPLOYED.to_s]
         show(:self_employed_exit)
       when [EmploymentStatus::EMPLOYED.to_s, EmploymentStatus::SELF_EMPLOYED.to_s]
-        employment = current_crime_application.employments.create!
+
+        employment = if incomplete_employments.empty?
+                       current_crime_application.employments.create!
+                     else
+                       incomplete_employments.first
+                     end
+
         redirect_to_employer_details(employment)
       end
     end
@@ -182,6 +188,10 @@ module Decisions
       else
         edit(:answers)
       end
+    end
+
+    def incomplete_employments
+      crime_application.employments.reject(&:complete?)
     end
 
     def employed?

--- a/app/validators/deductions_validator.rb
+++ b/app/validators/deductions_validator.rb
@@ -13,7 +13,7 @@ class DeductionsValidator < ActiveModel::Validator
 
     return unless record.types.empty?
 
-    record.errors.add(:base, :none_selected) if record.employment.has_no_deductions.blank?
+    record.errors.add(:base, :none_selected) if record.has_no_deductions.blank?
   end
 
   private

--- a/app/validators/deductions_validator.rb
+++ b/app/validators/deductions_validator.rb
@@ -13,7 +13,7 @@ class DeductionsValidator < ActiveModel::Validator
 
     return unless record.types.empty?
 
-    record.errors.add(:base, :none_selected) if record.has_no_deductions.blank?
+    record.errors.add(:base, :none_selected) if record.employment.has_no_deductions.blank?
   end
 
   private

--- a/app/value_objects/income_payment_type.rb
+++ b/app/value_objects/income_payment_type.rb
@@ -10,7 +10,6 @@ class IncomePaymentType < ValueObject
     FINANCIAL_SUPPORT_WITH_ACCESS = new(:financial_support_with_access),
     FROM_FRIENDS_RELATIVES = new(:from_friends_relatives),
     EMPLOYMENT = new(:employment),
-    EMPLOYMENT_INCOME = new(:employment_income),
     OTHER = new(:other)
   ].freeze
 end

--- a/app/views/steps/income/client/employments/confirm_destroy.html.erb
+++ b/app/views/steps/income/client/employments/confirm_destroy.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+<% step_header(path: edit_steps_income_client_employments_summary_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column">
+    <h1 class="govuk-heading-xl">
+      <%=t '.heading' %>
+    </h1>
+
+    <dl class='govuk-summary-list'>
+      <%= render Summary::Components::Employment.new(record: @employment, show_actions: false) %>
+    </dl>
+
+    <%= form_with url: steps_income_client_employments_path, method: :delete do |f| %>
+      <div class="govuk-button-group">
+        <%= f.button t('.confirm_delete_button'),
+                     class: 'govuk-button govuk-button--warning',
+                     'aria-label': t('.confirm_delete_button_a11y'),
+                     data: { module: 'govuk-button' } %>
+
+        <%= link_button t('.cancel_delete_button'), edit_steps_income_client_employments_summary_path,
+                        class: 'govuk-button--primary',
+                        'aria-label': t('.cancel_delete_button_a11y') %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/income/client/employments_summary/edit.html.erb
+++ b/app/views/steps/income/client/employments_summary/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column">
+    <%= render partial: 'shared/flash_banner' %>
+    <%= govuk_error_summary(@form_object) %>
+
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+
+    <h1 class="govuk-heading-xl">
+      <%=t '.heading', count: @form_object.employments.size %>
+    </h1>
+
+    <%= render Summary::Sections::Employments.new(current_crime_application, headless: true) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :add_client_employment, @form_object.choices, :value,
+                                           inline: true %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -887,7 +887,8 @@ en:
               greater_than: Enter amount greater than 0
             frequency:
               blank: Select how often the amount gets deducted
-              inclusion: Select how often the amount gets deducted
+              inclusion: Select how often they get this payment
             details:
               blank: Enter details
               invalid: Details not required
+              

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -107,7 +107,9 @@ en:
         national_insurance:
           frequency: Select how often this gets deducted
         other:
-          frequency: Select how often this gets deducted  
+          frequency: Select how often this gets deducted
+      steps_income_client_employments_summary_form:
+        add_client_employment: Do you want to add another job?
       steps_income_client_self_assessment_tax_bill_form:
         applicant_self_assessment_tax_bill: Does your client pay a Self Assessment tax bill received in the last 2 years?
         frequency: How often do they pay this amount?
@@ -477,7 +479,7 @@ en:
         amount: How much do they pay?
         frequency_options: *frequency_options
       steps_income_client_employments_summary_form:
-        add_employment_options: *YESNO
+        add_client_employment_options: *YESNO
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
       steps_income_income_before_tax_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -476,6 +476,8 @@ en:
         applicant_self_assessment_tax_bill_options: *YESNO
         amount: How much do they pay?
         frequency_options: *frequency_options
+      steps_income_client_employments_summary_form:
+        add_employment_options: *YESNO
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
       steps_income_income_before_tax_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -475,7 +475,7 @@ en:
       steps_income_client_self_assessment_tax_bill_form:
         applicant_self_assessment_tax_bill_options: *YESNO
         amount: How much do they pay?
-        frequency_options: *frequency_options    
+        frequency_options: *frequency_options
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
       steps_income_income_before_tax_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -475,7 +475,7 @@ en:
       steps_income_client_self_assessment_tax_bill_form:
         applicant_self_assessment_tax_bill_options: *YESNO
         amount: How much do they pay?
-        frequency_options: *frequency_options
+        frequency_options: *frequency_options    
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody_options: *YESNO
       steps_income_income_before_tax_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -325,7 +325,23 @@ en:
             page_title: Deductions from your client's pay
             heading: Deductions from your client’s pay
             page_text: You told us your client is employed.
-
+        employments_summary:
+          edit:
+            page_title: Your jobs
+            heading:
+              zero: You have not added jobs yet
+              one: You have added %{count} job
+              other: You have added %{count} jobs
+        employments:
+          confirm_destroy:
+            page_title: Delete job confirmation
+            heading: Are you sure you want to remove this job?
+            confirm_delete_button: Yes, remove it
+            cancel_delete_button: No, do not remove it
+            confirm_delete_button_a11y: Yes, remove this job
+            cancel_delete_button_a11y: No, do not remove this job
+          destroy:
+            success_flash: You removed the job
     outgoings:
       caption: Outgoings assessment
       housing_payment_type:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -717,6 +717,12 @@ en:
           answers:
             description: *payment_answer_format
           absence_answer: ''
+        has_no_deductions:
+          question: Deductions
+          answers:
+            'yes': 'None'
+          absence_answer: *absence_none
+          
       deduction:
         income_tax:
           question: Income Tax

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -94,6 +94,7 @@ en:
       passporting_benefit_check: Passporting benefit check
       trust_fund: Trust funds
       other_capital_details: Other capital
+      employments: Jobs
 
     questions:
       # BEGIN overview section
@@ -699,3 +700,59 @@ en:
         absence_answer: *absence_none
         answers:
           'yes': Confirmed
+
+      employment:
+        employer_name:
+          question: Employer’s name
+          absence_answer: *absence_none
+        address:
+          question: Employer’s address
+          absence_answer: *absence_none
+        job_title:
+          question: Job title
+          absence_answer: *absence_none
+        salary_or_wage:
+          question: Salary or wage
+          answers:
+            description: *payment_answer_format
+          absence_answer: *absence_none
+      deduction:
+        income_tax:
+          question: Income Tax
+          answers:
+            description: *payment_answer_format
+          details:
+            question: income_tax details
+            absence_answer: nil
+        national_insurance:
+          question: National Insurance
+          answers:
+            description: *payment_answer_format
+          details:
+            question: national_insurance details
+            absence_answer: nil
+        other:
+          question: Other deductions total
+          answers:
+            description: *payment_answer_format
+          details:
+            question: Details of other deductions
+            absence_answer: nil
+
+
+      deduction_type:
+        amount:
+          question: ff
+        question: Income Tax
+        answers:
+          description: *payment_answer_format
+
+#      deduction_type:
+#        question: Income Tax
+#        answers:
+#          description: *payment_answer_format
+#
+#      deduction_type:
+#        question: Income Tax
+#        answers:
+#          description: *payment_answer_format

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -95,6 +95,7 @@ en:
       trust_fund: Trust funds
       other_capital_details: Other capital
       employments: Jobs
+      employment: Job
 
     questions:
       # BEGIN overview section
@@ -704,18 +705,18 @@ en:
       employment:
         employer_name:
           question: Employer’s name
-          absence_answer: *absence_none
+          absence_answer: ''
         address:
           question: Employer’s address
-          absence_answer: *absence_none
+          absence_answer: ''
         job_title:
           question: Job title
-          absence_answer: *absence_none
+          absence_answer: ''
         salary_or_wage:
           question: Salary or wage
           answers:
             description: *payment_answer_format
-          absence_answer: *absence_none
+          absence_answer: ''
       deduction:
         income_tax:
           question: Income Tax
@@ -723,21 +724,21 @@ en:
             description: *payment_answer_format
           details:
             question: income_tax details
-            absence_answer: nil
+            absence_answer: ''
         national_insurance:
           question: National Insurance
           answers:
             description: *payment_answer_format
           details:
             question: national_insurance details
-            absence_answer: nil
+            absence_answer: ''
         other:
           question: Other deductions total
           answers:
             description: *payment_answer_format
           details:
             question: Details of other deductions
-            absence_answer: nil
+            absence_answer: ''
 
 
       deduction_type:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -745,21 +745,3 @@ en:
           details:
             question: Details of other deductions
             absence_answer: ''
-
-
-      deduction_type:
-        amount:
-          question: ff
-        question: Income Tax
-        answers:
-          description: *payment_answer_format
-
-#      deduction_type:
-#        question: Income Tax
-#        answers:
-#          description: *payment_answer_format
-#
-#      deduction_type:
-#        question: Income Tax
-#        answers:
-#          description: *payment_answer_format

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,7 +156,7 @@ Rails.application.routes.draw do
 
       namespace :income, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
         edit_step :what_is_clients_employment_status, alias: :employment_status
-        namespace :client do
+        namespace :client, constraints: -> (_) { FeatureFlags.employment_journey.enabled? } do
           crud_step :employments, param: :employment_id
           crud_step :employer_details, alias: :employer_details, param: :employment_id
           crud_step :employment_details, alias: :employment_details, param: :employment_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,11 +157,13 @@ Rails.application.routes.draw do
       namespace :income, constraints: -> (_) { FeatureFlags.means_journey.enabled? } do
         edit_step :what_is_clients_employment_status, alias: :employment_status
         namespace :client do
+          crud_step :employments, param: :employment_id
           crud_step :employer_details, alias: :employer_details, param: :employment_id
           crud_step :employment_details, alias: :employment_details, param: :employment_id
           edit_step :employment_income, alias: :employment_income
           edit_step :self_assessment_client, alias: :self_assessment_tax_bill
           crud_step :deductions_from_pay, alias: :deductions, param: :employment_id
+          edit_step :add_employments, alias: :employments_summary
         end
         show_step :employed_exit
         show_step :self_employed_exit

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,6 +181,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_21_142354) do
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
+    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,7 +181,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_21_142354) do
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
-    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 

--- a/spec/controllers/steps/income/client/deductions_controller_spec.rb
+++ b/spec/controllers/steps/income/client/deductions_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Steps::Income::Client::DeductionsController, type: :controller do
     context 'when valid deduction attributes' do
       it 'redirects to `employed_exit` page' do
         put :update, params: expected_params, session: { crime_application_id: crime_application.id }
-        expect(response).to redirect_to steps_income_employed_exit_path
+        expect(response).to redirect_to steps_income_client_employments_summary_path
         expect(employment.deductions.count).to eq(1)
         expect(employment.deductions.first).to have_attributes({ deduction_type: 'other',
                                                     amount: 300_00,
@@ -77,7 +77,7 @@ RSpec.describe Steps::Income::Client::DeductionsController, type: :controller do
 
       it 'redirects not to `employed_exit` page' do
         put :update, params: expected_params, session: { crime_application_id: crime_application.id }
-        expect(response).not_to redirect_to steps_income_employed_exit_path
+        expect(response).not_to redirect_to steps_income_client_employments_summary_path
         expect(employment.deductions.count).to eq(0)
       end
     end

--- a/spec/controllers/steps/income/client/deductions_controller_spec.rb
+++ b/spec/controllers/steps/income/client/deductions_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Steps::Income::Client::DeductionsController, type: :controller do
     let(:types) { ['other'] }
 
     context 'when valid deduction attributes' do
-      it 'redirects to `employed_exit` page' do
+      it 'redirects to `employments_summary` page' do
         put :update, params: expected_params, session: { crime_application_id: crime_application.id }
         expect(response).to redirect_to steps_income_client_employments_summary_path
         expect(employment.deductions.count).to eq(1)
@@ -75,7 +75,7 @@ RSpec.describe Steps::Income::Client::DeductionsController, type: :controller do
     context 'when invalid deduction attributes' do
       before { other.merge!(amount: nil, frequency: nil) }
 
-      it 'redirects not to `employed_exit` page' do
+      it 'redirects not to `employments_summary` page' do
         put :update, params: expected_params, session: { crime_application_id: crime_application.id }
         expect(response).not_to redirect_to steps_income_client_employments_summary_path
         expect(employment.deductions.count).to eq(0)

--- a/spec/controllers/steps/income/client/employments_controller_spec.rb
+++ b/spec/controllers/steps/income/client/employments_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Steps::Income::Client::EmploymentsController, type: :controller d
       end
 
       context 'when deleting an employment' do
-        context 'when employment the last remaining employment' do
+        context 'when employment is the last remaining employment' do
           it 'renders the employment status page again' do
             delete :destroy, params: expected_params, session: { crime_application_id: crime_application.id }
             expect(Employment.count).to be 0
@@ -39,12 +39,12 @@ RSpec.describe Steps::Income::Client::EmploymentsController, type: :controller d
           end
         end
 
-        context 'when not the last remaining employment' do
+        context 'when employment is not the last remaining employment' do
           before do
             Employment.create!(crime_application:)
           end
 
-          it 'renders the employment page again' do
+          it 'redirects to `employments_summary` page' do
             delete :destroy, params: expected_params, session: { crime_application_id: crime_application.id }
             expect(Employment.count).to be 1
             expect(response).to redirect_to edit_steps_income_client_employments_summary_path

--- a/spec/controllers/steps/income/client/employments_controller_spec.rb
+++ b/spec/controllers/steps/income/client/employments_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::EmploymentsController, type: :controller do
+  let(:form_class) { Steps::Income::Client::EmploymentDetailsForm }
+  let(:decision_tree_class) { Decisions::IncomeDecisionTree }
+
+  let(:crime_application) { CrimeApplication.create }
+
+  describe '#destroy' do
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+
+    let(:expected_params) do
+      {
+        :id => crime_application,
+        :employment_id => employment,
+        form_class_params_name => { foo: 'bar' }
+      }
+    end
+
+    context 'when deleting an employment' do
+      let(:employment) do
+        Employment.create!(crime_application:)
+      end
+
+      describe 'confirm destroy' do
+        it 'renders the employment page again' do
+          get :confirm_destroy, params: expected_params, session: { crime_application_id: crime_application.id }
+          expect(response).not_to have_http_status(:redirect)
+        end
+      end
+
+      context 'when deleting an employment' do
+        context 'when employment the last remaining employment' do
+          it 'renders the employment status page again' do
+            delete :destroy, params: expected_params, session: { crime_application_id: crime_application.id }
+            expect(Employment.count).to be 0
+            expect(response).to redirect_to(%r{/steps/income/what_is_clients_employment_status})
+          end
+        end
+
+        context 'when not the last remaining employment' do
+          before do
+            Employment.create!(crime_application:)
+          end
+
+          it 'renders the employment page again' do
+            delete :destroy, params: expected_params, session: { crime_application_id: crime_application.id }
+            expect(Employment.count).to be 1
+            expect(response).to redirect_to edit_steps_income_client_employments_summary_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/steps/income/client/employments_summary_controller_spec.rb
+++ b/spec/controllers/steps/income/client/employments_summary_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Steps::Income::Client::EmploymentsSummaryController, type: :contr
     let(:employments) { [] }
 
     describe '#edit' do
-      it 'redirects to the employments type page' do
+      it 'redirects to the `employment_status` page' do
         get :edit, params: { id: existing_case }
 
         expect(response).to redirect_to(edit_steps_income_employment_status_path(existing_case))

--- a/spec/controllers/steps/income/client/employments_summary_controller_spec.rb
+++ b/spec/controllers/steps/income/client/employments_summary_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::EmploymentsSummaryController, type: :controller do
+  let(:existing_case) do
+    CrimeApplication.create(employments: employments, applicant: Applicant.new)
+  end
+
+  context 'when employments present' do
+    let(:employments) { [Employment.new] }
+
+    it_behaves_like 'a generic step controller',
+                    Steps::Income::Client::EmploymentsSummaryForm, Decisions::IncomeDecisionTree
+  end
+
+  context 'when employments empty' do
+    let(:employments) { [] }
+
+    describe '#edit' do
+      it 'redirects to the employments type page' do
+        get :edit, params: { id: existing_case }
+
+        expect(response).to redirect_to(edit_steps_income_employment_status_path(existing_case))
+      end
+    end
+  end
+end

--- a/spec/forms/steps/income/client/employments_summary_form_spec.rb
+++ b/spec/forms/steps/income/client/employments_summary_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Steps::Income::Client::EmploymentsSummaryForm do
     context 'when value is not set' do
       let(:value) { nil }
 
-      it 'does not set `#add_property`' do
+      it 'does not set `#add_client_employment`' do
         expect { add_client_employment }.not_to(change(form, :add_client_employment))
       end
     end

--- a/spec/forms/steps/income/client/employments_summary_form_spec.rb
+++ b/spec/forms/steps/income/client/employments_summary_form_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::EmploymentsSummaryForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:
+    }.merge(attributes)
+  end
+
+  let(:attributes) { {} }
+
+  let(:crime_application) do
+    instance_double(CrimeApplication)
+  end
+
+  describe '#add_client_employment=(attribute)' do
+    subject(:add_client_employment) { form.add_client_employment = value }
+
+    context 'when value is not set' do
+      let(:value) { nil }
+
+      it 'does not set `#add_property`' do
+        expect { add_client_employment }.not_to(change(form, :add_client_employment))
+      end
+    end
+
+    context 'when value is set' do
+      let(:value) { 'yes' }
+
+      it 'sets `#add_client_employment` to `yes`' do
+        expect { add_client_employment }.to change(form, :add_client_employment).from(nil).to(YesNoAnswer::YES)
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'for valid details' do
+      let(:attributes) do
+        {
+          add_client_employment: 'yes',
+        }
+      end
+
+      it 'updates the form' do
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/deduction_spec.rb
+++ b/spec/models/deduction_spec.rb
@@ -3,21 +3,22 @@ require 'rails_helper'
 RSpec.describe Deduction, type: :model do
   subject { described_class.new(attributes) }
 
+  let(:crime_application) { CrimeApplication.create! }
+  let(:employment) { Employment.create!(crime_application:) }
+
   let(:attributes) do
     {
       deduction_type: 'income_tax',
       amount: 500,
       frequency: 'week',
       details: nil,
-      employment_id: instance_double(Employment, id: 'uuid').id
+      employment: employment
     }
   end
 
   describe '#complete?' do
     context 'with valid attributes' do
       it 'returns true' do
-        puts 'hiii'
-        puts subject.inspect
         expect(subject.complete?).to be(true)
       end
 

--- a/spec/models/deduction_spec.rb
+++ b/spec/models/deduction_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Deduction, type: :model do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      deduction_type: 'income_tax',
+      amount: 500,
+      frequency: 'week',
+      details: nil,
+      employment_id: instance_double(Employment, id: 'uuid').id
+    }
+  end
+
+  describe '#complete?' do
+    context 'with valid attributes' do
+      it 'returns true' do
+        puts 'hiii'
+        puts subject.inspect
+        expect(subject.complete?).to be(true)
+      end
+
+      context 'when details are missing for `income_tax`' do
+        before { attributes.merge!(deduction_type: 'income_tax', details: nil) }
+
+        it 'returns true' do
+          expect(subject.complete?).to be(true)
+        end
+      end
+    end
+
+    context 'with invalid attributes' do
+      context 'when amount is nil' do
+        before { attributes.merge!(amount: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+
+      context 'when details are missing for `other`' do
+        before { attributes.merge!(deduction_type: 'other', details: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/employment_spec.rb
+++ b/spec/models/employment_spec.rb
@@ -1,5 +1,113 @@
 require 'rails_helper'
 
 RSpec.describe Employment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      crime_application_id: double(CrimeApplication, id: 1).id,
+      ownership_type: 'applicant',
+      employer_name: 'Driscoll Bruce',
+      address: address_attributes,
+      job_title: 'Manager',
+      has_no_deductions: nil,
+      amount: 500,
+      frequency: 'week',
+      before_or_after_tax: { 'value' => 'before_tax' },
+      deductions: [deduction]
+    }
+  end
+
+  let(:address_attributes) do
+    {
+      address_line_one: 'address_line_one',
+      address_line_two: 'address_line_two',
+      city: 'city',
+      country: 'country',
+      postcode: 'postcode'
+    }.as_json
+  end
+
+  let(:deduction_attributes) do
+    {
+      deduction_type: 'income_tax',
+      amount: 500,
+      frequency: 'week'
+    }
+  end
+
+  let(:metadata) do
+    {
+      before_or_after_tax: { value: 'before_tax' }
+    }.as_json
+  end
+
+  let(:deduction) { Deduction.new(deduction_attributes) }
+
+  describe '#complete?' do
+    context 'with valid attributes' do
+      it 'returns true' do
+        expect(subject.complete?).to be(true)
+        expect(subject.deductions.complete).to eq([deduction])
+      end
+
+      context 'when has_no_deductions set to `yes`' do
+        before { attributes.merge!(has_no_deductions: 'yes', deductions: []) }
+
+        it 'returns true' do
+          expect(subject.complete?).to be(true)
+        end
+      end
+    end
+
+    context 'with invalid attributes' do
+      context 'when employer_name is nil' do
+        before { attributes.merge!(employer_name: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+
+      context 'when deductions are missing' do
+        before { attributes.merge!(deductions: []) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+
+      context 'when deductions are incomplete' do
+        before { deduction_attributes.merge!(amount: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+
+      context 'when address is missing' do
+        before { attributes.merge!(address: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+
+      context 'when address is incomplete' do
+        before { address_attributes.merge!(postcode: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+
+      context 'when before_or_after_tax is missing' do
+        before { attributes.merge!(before_or_after_tax: nil) }
+
+        it 'returns false' do
+          expect(subject.complete?).to be(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/summary/components/employment_spec.rb
+++ b/spec/presenters/summary/components/employment_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+RSpec.describe Summary::Components::Employment, type: :component do
+  subject(:component) { render_summary_component(described_class.new(record:)) }
+
+  let(:record) {
+    instance_double(Employment,
+                    complete?: true,
+                    deductions: [deduction1, deduction2],
+                    has_no_deductions: has_no_deductions,
+                    crime_application: crime_application, **attributes)
+  }
+
+  let(:deduction1) {
+    instance_double(Deduction,
+                    deduction_type: 'income_tax',
+                    amount: 500,
+                    other?: false,
+                    frequency: 'week',
+                    details: nil)
+  }
+
+  let(:deduction2) {
+    instance_double(Deduction,
+                    deduction_type: 'other',
+                    amount: 700,
+                    other?: true,
+                    frequency: 'week',
+                    details: 'deduction details')
+  }
+
+  let(:crime_application) { instance_double(CrimeApplication, id: 'APP123') }
+
+  let(:attributes) do
+    {
+      id: 'EMPLOYMENT123',
+      crime_application_id: 'APP123',
+      employer_name: 'Rick',
+      job_title: 'Manager',
+      amount: 1700,
+      frequency: 'week',
+      address: { 'city' => 'london', 'country' => 'United Kingdom', 'postcode' => 'TW7' }
+    }
+  end
+
+  let(:has_no_deductions) { nil }
+
+  before { component }
+
+  describe 'actions' do
+    context 'when show_record_actions set to false' do
+      it 'show the "Edit" change link' do
+        expect(page).to have_link(
+          'Edit',
+          href: '/applications/APP123/steps/income/client/add_employments?employment_id=EMPLOYMENT123',
+          exact_text: 'Edit Job'
+        )
+      end
+    end
+
+    context 'when show_record_actions true' do
+      subject(:component) { render_summary_component(described_class.new(record: record, show_record_actions: true)) }
+
+      describe 'change link' do
+        it 'show the correct change link' do
+          expect(page).to have_link(
+            'Change',
+            href: '/applications/APP123/steps/income/client/employer_details/EMPLOYMENT123',
+            exact_text: 'Change Job'
+          )
+        end
+      end
+
+      describe 'remove link' do
+        it 'show the correct remove link' do
+          expect(page).to have_link(
+            'Remove',
+            href: '/applications/APP123/steps/income/client/employments/EMPLOYMENT123/confirm_destroy',
+            exact_text: 'Remove Job'
+          )
+        end
+      end
+    end
+  end
+
+  describe 'answers' do
+    it 'renders as summary list' do
+      expect(page).to have_summary_row(
+        'Employer’s name',
+        'Rick'
+      )
+      expect(page).to have_summary_row(
+        'Job title',
+        'Manager',
+      )
+      expect(page).to have_summary_row(
+        'Employer’s address',
+        'london TW7 United Kingdom',
+      )
+      expect(page).to have_summary_row(
+        'Salary or wage',
+        '£1,700.00 every week',
+      )
+    end
+
+    context 'when property has deductions' do
+
+      it 'renders as summary list with other deductions' do
+        expect(page).to have_summary_row(
+          'Income Tax',
+          '£500.00 every week',
+        )
+        expect(page).to have_summary_row(
+          'Other deductions total',
+          '£700.00 every week',
+        )
+        expect(page).to have_summary_row(
+          'Details of other deductions',
+          'deduction details',
+        )
+      end
+    end
+
+    context 'when answers are missing' do
+      let(:attributes) do
+        {
+          id: 'EMPLOYMENT123',
+          crime_application_id: 'APP123',
+          employer_name: nil,
+          job_title: nil,
+          amount: nil,
+          frequency: nil,
+          address: nil
+        }
+      end
+
+      it 'renders as summary list with the correct absence_answer' do
+        expect(page).to have_summary_row(
+          'Employer’s name',
+          ''
+        )
+        expect(page).to have_summary_row(
+          'Job title',
+          '',
+        )
+        expect(page).to have_summary_row(
+          'Employer’s address',
+          '',
+        )
+        expect(page).to have_summary_row(
+          'Salary or wage',
+          '',
+        )
+      end
+    end
+  end
+
+  describe 'card heading' do
+    subject(:heading) do
+      page.first('h2.govuk-summary-card__title').text
+    end
+
+    it { is_expected.to eq 'Job' }
+  end
+end

--- a/spec/presenters/summary/components/employment_spec.rb
+++ b/spec/presenters/summary/components/employment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Summary::Components::Employment, type: :component do
   let(:record) {
     instance_double(Employment,
                     complete?: true,
-                    deductions: [deduction1, deduction2],
+                    deductions: deductions,
                     has_no_deductions: has_no_deductions,
                     crime_application: crime_application, **attributes)
   }
@@ -44,6 +44,7 @@ RSpec.describe Summary::Components::Employment, type: :component do
   end
 
   let(:has_no_deductions) { nil }
+  let(:deductions) { [deduction1, deduction2] }
 
   before { component }
 
@@ -103,7 +104,7 @@ RSpec.describe Summary::Components::Employment, type: :component do
       )
     end
 
-    context 'when property has deductions' do
+    context 'when employment has deductions' do
       it 'renders as summary list with other deductions' do
         expect(page).to have_summary_row(
           'Income Tax',
@@ -116,6 +117,18 @@ RSpec.describe Summary::Components::Employment, type: :component do
         expect(page).to have_summary_row(
           'Details of other deductions',
           'deduction details',
+        )
+      end
+    end
+
+    context 'when employment has no deductions' do
+      let(:has_no_deductions) { 'yes' }
+      let(:deductions) { [] }
+
+      it 'renders as summary list with other deductions' do
+        expect(page).to have_summary_row(
+          'Deductions',
+          'None',
         )
       end
     end

--- a/spec/presenters/summary/components/employment_spec.rb
+++ b/spec/presenters/summary/components/employment_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe Summary::Components::Employment, type: :component do
     end
 
     context 'when property has deductions' do
-
       it 'renders as summary list with other deductions' do
         expect(page).to have_summary_row(
           'Income Tax',

--- a/spec/presenters/summary/sections/employments_spec.rb
+++ b/spec/presenters/summary/sections/employments_spec.rb
@@ -28,21 +28,17 @@ describe Summary::Sections::Employments do
 
   describe '#answers' do
     context 'when there are employments' do
-      let(:component) { instance_double(Summary::Components::GroupedList) }
+      let(:component) { instance_double(Summary::Components::Employment) }
 
       before do
-        allow(Summary::Components::GroupedList).to receive(:new) { component }
+        allow(Summary::Components::Employment).to receive(:with_collection) { component }
       end
 
       it 'returns the grouped list component with actions' do
         expect(subject.answers).to be component
 
-        expect(Summary::Components::GroupedList).to have_received(:new).with(
-          items: records,
-          group_by: :ownership_type,
-          item_component: Summary::Components::Employment,
-          show_actions: true,
-          show_record_actions: false
+        expect(Summary::Components::Employment).to have_received(:with_collection).with(
+          records, show_actions: true, show_record_actions: false
         )
       end
 
@@ -54,12 +50,8 @@ describe Summary::Sections::Employments do
         it 'returns the grouped list component without actions' do
           expect(subject.answers).to be component
 
-          expect(Summary::Components::GroupedList).to have_received(:new).with(
-            items: records,
-            group_by: :ownership_type,
-            item_component: Summary::Components::Employment,
-            show_actions: false,
-            show_record_actions: false
+          expect(Summary::Components::Employment).to have_received(:with_collection).with(
+            records, show_actions: false, show_record_actions: false
           )
         end
       end

--- a/spec/presenters/summary/sections/employments_spec.rb
+++ b/spec/presenters/summary/sections/employments_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe Summary::Sections::Employments do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      employments: records,
+      in_progress?: true,
+      to_param: 12_345
+    )
+  end
+
+  let(:records) { [Employment.new] }
+
+  describe '#list?' do
+    context 'when there are employments' do
+      it { expect(subject.list?).to be true }
+    end
+
+    context 'when there are no employments' do
+      let(:records) { [] }
+
+      it { expect(subject.list?).to be false }
+    end
+  end
+
+  describe '#answers' do
+    context 'when there are employments' do
+      let(:component) { instance_double(Summary::Components::GroupedList) }
+
+      before do
+        allow(Summary::Components::GroupedList).to receive(:new) { component }
+      end
+
+      it 'returns the grouped list component with actions' do
+        expect(subject.answers).to be component
+
+        expect(Summary::Components::GroupedList).to have_received(:new).with(
+          items: records,
+          group_by: :ownership_type,
+          item_component: Summary::Components::Employment,
+          show_actions: true,
+          show_record_actions: false
+        )
+      end
+
+      context 'not in progress' do
+        before do
+          allow(crime_application).to receive(:in_progress?).and_return(false)
+        end
+
+        it 'returns the grouped list component without actions' do
+          expect(subject.answers).to be component
+
+          expect(Summary::Components::GroupedList).to have_received(:new).with(
+            items: records,
+            group_by: :ownership_type,
+            item_component: Summary::Components::Employment,
+            show_actions: false,
+            show_record_actions: false
+          )
+        end
+      end
+    end
+
+    context 'when there are no employments' do
+      let(:records) { [] }
+      let(:answers) { subject.answers }
+      let(:has_no_employments) { 'yes' }
+
+      context 'when full capital journey was required' do
+        it 'has the correct rows' do
+          expect(answers.count).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Decisions::IncomeDecisionTree do
       id: 'uuid',
       income: income,
       dependants: dependants_double,
-      employments: [employment_double],
+      employments: [employment],
       kase: kase
     )
   end
 
-  let(:employment_double) { instance_double(Employment, id: 'uuid') }
+  let(:employment) { Employment.new }
   let(:income) { instance_double(Income, employment_status:) }
   let(:employment_status) { nil }
   let(:dependants_double) { double('dependants_collection') }
@@ -144,10 +144,9 @@ RSpec.describe Decisions::IncomeDecisionTree do
 
   context 'when the step is `client_employer_details`' do
     let(:form_object) do
-      double('FormObject', record:)
+      double('FormObject', record: employment)
     end
     let(:step_name) { :client_employer_details }
-    let(:record) { instance_double(Employment) }
 
     it 'redirects to `client_employer_details` page' do
       expect(subject).to have_destination('steps/income/client/employment_details', :edit, id: crime_application)
@@ -156,10 +155,9 @@ RSpec.describe Decisions::IncomeDecisionTree do
 
   context 'when the step is `client_employment_details`' do
     let(:form_object) do
-      double('FormObject', record:)
+      double('FormObject', record: employment)
     end
     let(:step_name) { :client_employment_details }
-    let(:record) { instance_double(Employment) }
 
     it 'redirects to `client deductions` page' do
       expect(subject).to have_destination('/steps/income/client/deductions', :edit, id: crime_application)
@@ -168,13 +166,12 @@ RSpec.describe Decisions::IncomeDecisionTree do
 
   context 'when the step is `client_deductions`' do
     let(:form_object) do
-      double('FormObject', record:)
+      double('FormObject', record: employment)
     end
     let(:step_name) { :client_deductions }
-    let(:record) { instance_double(Employment) }
 
     it 'redirects to `employed_exit` page' do
-      expect(subject).to have_destination('/steps/income/employed_exit', :show, id: crime_application)
+      expect(subject).to have_destination('/steps/income/client/employments_summary', :edit, id: crime_application)
     end
   end
 

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe Decisions::IncomeDecisionTree do
   let(:income) { instance_double(Income, employment_status:) }
   let(:employment_status) { nil }
   let(:dependants_double) { double('dependants_collection') }
-  let(:employments_double) { double('employments_collection', create!: true, reject: []) }
+  let(:employments_double) { double('employments_collection', create!: true, reject: income_employments) }
   let(:kase) { instance_double(Case, case_type:) }
+  let(:income_employments) { [employment_double] }
 
   let(:case_type) { nil }
   let(:feature_flag_employment_journey_enabled) { false }
@@ -106,6 +107,24 @@ RSpec.describe Decisions::IncomeDecisionTree do
 
         it 'redirects to the `employer_details` page' do
           expect(subject).to have_destination('/steps/income/client/employer_details', :edit, id: crime_application)
+        end
+
+        context 'with incomplete employments' do
+          let(:income_employments) { [employment_double] }
+
+          it 'redirects to the `employer_details` page' do
+            expect(subject).to have_destination('/steps/income/client/employer_details', :edit, id: crime_application)
+            expect(employments_double).not_to have_received(:create!)
+          end
+        end
+
+        context 'with no incomplete employments' do
+          let(:income_employments) { [] }
+
+          it 'redirects to the `employer_details` page' do
+            expect(subject).to have_destination('/steps/income/client/employer_details', :edit, id: crime_application)
+            expect(employments_double).to have_received(:create!)
+          end
         end
       end
 


### PR DESCRIPTION
## Description of change

Implement: Employment Loop 
- Add Employment
- Edit Employment
- Remove Employment


## Link to relevant ticket
[CRIMAPP-871](https://dsdmoj.atlassian.net/browse/CRIMAPP-871)

## Notes for reviewer
> [!NOTE]  
> Redirects to 'Employment Status ' page if all employments are deleted from shopping basket

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Start the employment journey and add/update/remove employments from shopping basket

http://localhost:3000/applications/:id/steps/income/what_is_clients_employment_status


[CRIMAPP-871]: https://dsdmoj.atlassian.net/browse/CRIMAPP-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ