### PR TITLE
Update schema to v1.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.2'
+    tag: 'v1.1.3'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: e08b32c0dddf90ccbeef0652eb800c411f294bfd
-  tag: v1.1.2
+  revision: 2e077060151f63fddd728c896032e6da3179ab2c
+  tag: v1.1.3
   specs:
-    laa-criminal-legal-aid-schemas (1.1.2)
+    laa-criminal-legal-aid-schemas (1.1.3)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
`ownership_type` was previously a required field in the schema which was breaking in progress applications 
Fixes sentry error: https://mojdt.slack.com/archives/C056U956ESH/p1716307797032809

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
