### PR TITLE
CRIMAPP-937 review task locked until other tasks fulfilled

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -74,7 +74,8 @@ class CrimeApplication < ApplicationRecord
   validates_with PseFulfilmentValidator, on: :submission, if: :post_submission_evidence?
 
   validate on: :client_details do
-    ::ClientDetails::AnswersValidator.new(self).validate
+    ::ClientDetails::AnswersValidator.new(record: self, crime_application: self)
+                                     .validate
   end
 
   validate on: :passporting_benefit do

--- a/app/presenters/tasks/base_task.rb
+++ b/app/presenters/tasks/base_task.rb
@@ -21,7 +21,8 @@ module Tasks
     end
 
     def fulfilled?(task_class)
-      task_class.new(crime_application:).status.completed?
+      task_status = task_class.new(crime_application:).status
+      task_status.not_applicable? || task_status.completed?
     end
 
     # Used by the `Routing` module to build the urls

--- a/app/presenters/tasks/capital_assessment.rb
+++ b/app/presenters/tasks/capital_assessment.rb
@@ -22,6 +22,12 @@ module Tasks
       capital.present?
     end
 
+    # Capital task is only complete when both the AnswersValidator
+    # AND the ConfirmationValidators are complete
+    def completed?
+      super && capital.complete?
+    end
+
     private
 
     def validator

--- a/app/presenters/tasks/client_details.rb
+++ b/app/presenters/tasks/client_details.rb
@@ -4,10 +4,6 @@ module Tasks
       edit_steps_client_details_path
     end
 
-    def not_applicable?
-      false
-    end
-
     # Client details is the first thing a provider can do so it is always true
     def can_start?
       true
@@ -18,8 +14,14 @@ module Tasks
       applicant.present?
     end
 
-    def completed?
-      crime_application.valid?(:client_details)
+    private
+
+    def validator
+      @validator ||= ::ClientDetails::AnswersValidator.new(
+        record:, crime_application:
+      )
     end
+
+    alias record crime_application
   end
 end

--- a/app/presenters/tasks/declaration.rb
+++ b/app/presenters/tasks/declaration.rb
@@ -9,11 +9,7 @@ module Tasks
     end
 
     def can_start?
-      if crime_application.pse?
-        fulfilled?(EvidenceUpload)
-      else
-        fulfilled?(CaseDetails) && crime_application.valid?(:submission)
-      end
+      fulfilled?(Review)
     end
 
     def in_progress?

--- a/app/presenters/tasks/more_information.rb
+++ b/app/presenters/tasks/more_information.rb
@@ -17,7 +17,10 @@ module Tasks
     end
 
     def completed?
-      in_progress?
+      return false if crime_application.additional_information_required.blank?
+      return true if crime_application.additional_information_required == 'no'
+
+      crime_application.additional_information.present?
     end
   end
 end

--- a/app/presenters/tasks/review.rb
+++ b/app/presenters/tasks/review.rb
@@ -9,10 +9,8 @@ module Tasks
     end
 
     def can_start?
-      if crime_application.pse?
-        fulfilled?(EvidenceUpload)
-      else
-        fulfilled?(CaseDetails) && crime_application.valid?(:submission)
+      required_task_classes.all? do |klass|
+        fulfilled?(klass)
       end
     end
 
@@ -25,6 +23,25 @@ module Tasks
       crime_application.values_at(
         :legal_rep_first_name, :legal_rep_last_name, :legal_rep_telephone
       ).any?
+    end
+
+    private
+
+    def required_task_classes # rubocop:disable Metrics/MethodLength
+      if crime_application.pse?
+        [EvidenceUpload, MoreInformation]
+      else
+        [
+          ClientDetails,
+          PassportingBenefitCheck,
+          CaseDetails,
+          Ioj,
+          IncomeAssessment,
+          OutgoingsAssessment,
+          CapitalAssessment,
+          MoreInformation
+        ]
+      end
     end
   end
 end

--- a/app/validators/client_details/answers_validator.rb
+++ b/app/validators/client_details/answers_validator.rb
@@ -1,17 +1,17 @@
 module ClientDetails
-  class AnswersValidator
+  class AnswersValidator < BaseAnswerValidator
     include TypeOfMeansAssessment
 
-    def initialize(record)
-      @record = record
+    def complete?
+      validate
+      errors.empty?
     end
 
-    attr_reader :record
-
-    delegate :errors, :applicant, :kase, :crime_application, :appeal_no_changes?, to: :record
+    def applicable?
+      true
+    end
 
     # Adds the error to the first step name a user would need to go to fix the issue.
-
     def validate # rubocop:disable Metrics/AbcSize
       errors.add(:details, :blank) unless applicant_details_complete?
       errors.add(:case_type, :blank) unless case_type_complete?

--- a/spec/presenters/tasks/capital_assessment_spec.rb
+++ b/spec/presenters/tasks/capital_assessment_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Tasks::CapitalAssessment do
 
   before do
     allow(CapitalAssessment::AnswersValidator).to receive(:new)
-      .with(record: nil, crime_application: crime_application).and_return(validator)
+      .with(record: capital, crime_application: crime_application).and_return(validator)
   end
 
   describe '#path' do
@@ -124,10 +124,18 @@ RSpec.describe Tasks::CapitalAssessment do
   describe '#completed?' do
     subject(:completed?) { task.completed? }
 
-    context 'answers are complete' do
+    context 'when answers and confirmation are complete' do
+      let(:capital) { instance_double(Capital, complete?: true) }
       let(:complete?) { true }
 
       it { is_expected.to be true }
+    end
+
+    context 'when answers are complete but confirmation is not' do
+      let(:capital) { instance_double(Capital, complete?: false) }
+      let(:complete?) { true }
+
+      it { is_expected.to be false }
     end
 
     context 'answers are incomplete' do

--- a/spec/presenters/tasks/client_details_spec.rb
+++ b/spec/presenters/tasks/client_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::ClientDetails do
-  subject { described_class.new(crime_application:) }
+  subject(:task) { described_class.new(crime_application:) }
 
   let(:crime_application) do
     instance_double(
@@ -10,8 +10,21 @@ RSpec.describe Tasks::ClientDetails do
       applicant: applicant,
     )
   end
-
+  let(:applicable?) { true }
+  let(:complete?) { false }
   let(:applicant) { nil }
+
+  let(:validator) do
+    instance_double(
+      ClientDetails::AnswersValidator,
+      complete?: complete?, applicable?: applicable?
+    )
+  end
+
+  before do
+    allow(ClientDetails::AnswersValidator).to receive(:new)
+      .with(record: crime_application, crime_application: crime_application).and_return(validator)
+  end
 
   describe '#path' do
     it { expect(subject.path).to eq('/applications/12345/steps/client/details') }
@@ -38,16 +51,18 @@ RSpec.describe Tasks::ClientDetails do
   end
 
   describe '#completed?' do
-    it 'returns true when client details complete' do
-      allow(crime_application).to receive(:valid?).with(:client_details).and_return(true)
+    subject(:completed?) { task.completed? }
 
-      expect(subject.completed?).to be(true)
+    context 'answers are complete' do
+      let(:complete?) { true }
+
+      it { is_expected.to be true }
     end
 
-    it 'returns false when client details are not complete' do
-      allow(crime_application).to receive(:valid?).with(:client_details).and_return(false)
+    context 'answers are incomplete' do
+      let(:complete?) { false }
 
-      expect(subject.completed?).to be(false)
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/presenters/tasks/declaration_spec.rb
+++ b/spec/presenters/tasks/declaration_spec.rb
@@ -24,58 +24,15 @@ RSpec.describe Tasks::Declaration do
   end
 
   describe '#can_start?' do
-    context 'when an initial application' do
-      before do
-        allow(
-          subject
-        ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details_fulfilled)
-
-        allow(crime_application).to receive(:valid?).with(:submission) { valid_for_submission }
-      end
-
-      context 'when the Case details have been completed' do
-        let(:case_details_fulfilled) { true }
-
-        context 'and the application is valid for submsission' do
-          let(:valid_for_submission) { true }
-
-          it { expect(subject.can_start?).to be(true) }
-        end
-
-        context 'and the application is not valid for submsission' do
-          let(:valid_for_submission) { false }
-
-          it { expect(subject.can_start?).to be(false) }
-        end
-      end
-
-      context 'when the Case details have not been completed' do
-        let(:case_details_fulfilled) { false }
-
-        it { expect(subject.can_start?).to be(false) }
-      end
+    before do
+      allow(subject).to receive(:fulfilled?).with(Tasks::Review)
+                                            .and_return(fulfilled)
     end
 
-    context 'when a post submission evidence application' do
-      before do
-        crime_application.application_type = ApplicationType::POST_SUBMISSION_EVIDENCE
+    context 'when Review has been not been fulfilled' do
+      let(:fulfilled) { false }
 
-        allow(
-          subject
-        ).to receive(:fulfilled?).with(Tasks::EvidenceUpload).and_return(evidence_uploaded?)
-      end
-
-      context 'when supporting evidence has been uploaded' do
-        let(:evidence_uploaded?) { true }
-
-        it { expect(subject.can_start?).to be(true) }
-      end
-
-      context 'when supporting evidence has not been uploaded' do
-        let(:evidence_uploaded?) { false }
-
-        it { expect(subject.can_start?).to be(false) }
-      end
+      it { expect(subject.can_start?).to be(false) }
     end
   end
 

--- a/spec/presenters/tasks/more_information_spec.rb
+++ b/spec/presenters/tasks/more_information_spec.rb
@@ -69,22 +69,35 @@ RSpec.describe Tasks::MoreInformation do
 
   describe '#completed?' do
     let(:additional_information_required) { nil }
+    let(:additional_information) { nil }
 
     before do
-      allow(
-        crime_application
-      ).to receive(:additional_information_required).and_return additional_information_required
+      allow(crime_application).to receive_messages(
+        additional_information_required:,
+        additional_information:
+      )
     end
 
-    context 'when additional information required has been answered' do
+    context 'when additional information is not required' do
+      let(:additional_information_required) { 'no' }
+
+      it { expect(subject.completed?).to be(true) }
+    end
+
+    context 'when additional information is required but none added' do
       let(:additional_information_required) { 'Yes' }
+
+      it { expect(subject.completed?).to be(false) }
+    end
+
+    context 'when additional information is required and has been added' do
+      let(:additional_information_required) { 'Yes' }
+      let(:additional_information) { 'More details....' }
 
       it { expect(subject.completed?).to be(true) }
     end
 
     context 'when additional information has not been answered' do
-      let(:additional_information_required) { nil }
-
       it { expect(subject.completed?).to be(false) }
     end
   end

--- a/spec/validators/client_details/answers_validator_spec.rb
+++ b/spec/validators/client_details/answers_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ClientDetails::AnswersValidator, type: :model do
-  subject(:validator) { described_class.new(record) }
+  subject(:validator) { described_class.new(record: record, crime_application: record) }
 
   let(:record) { instance_double(CrimeApplication, errors:, applicant:, kase:) }
   let(:errors) { double(:errors, empty?: false) }


### PR DESCRIPTION
## Description of change

The 'Review the application’ task cannot be started until all required sections have been completed.
Also, only mark 'more information' task as completed if more information has been provided when answered 'yes'.

## Link to relevant ticket

[CRIMAPP-937](https://dsdmoj.atlassian.net/browse/CRIMAPP-937)

## Notes for reviewer

Previously, if an application was Means Passported or if the means assessment had started, a provider could navigate to the ‘Review the application’ page from the Task List.

However, UCD has confirmed that this is not the desired behavior. The ‘Review the application’ task should be marked as ‘cannot yet start’ until all required sections have been completed. This means that all prior sections, except for ‘Supporting evidence,’ must be marked as either ‘complete’ or ‘not applicable’.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Check the ‘Review the application’ task on the task list after each task in the process of completing a Means Passported application.

Confirm that the ‘Review the application’ task is marked as ‘in progress’ only after the ‘More information’ section is complete.

Go back and change the details so that the application is no longer Means Passported.

Confirm that the ‘Review the application’ task is marked as ‘cannot yet start’ until the means assessment is completed.

Repeat the same process for PSE, ensuring that only the ‘Supporting evidence’ and ‘Additional information’ sections are required.

[CRIMAPP-937]: https://dsdmoj.atlassian.net/browse/CRIMAPP-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ