### PR TITLE
CRIMAPP-871 Fix employment amount

### DIFF
--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -10,6 +10,8 @@ class Employment < ApplicationRecord
     end
   end
 
+  attribute :amount, :pence
+
   store_accessor :address, :address_line_one, :address_line_two, :city, :country, :postcode
   store_accessor :metadata, [:before_or_after_tax]
 


### PR DESCRIPTION
## Description of change
employments.amount was returning as multiple of 100

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-871

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
For Job 1 I entered 45,000 per year but it shows up as 4,500,000
For Job 2 I entered 250 per week but it shows up as 25,000

![Screenshot 2024-05-28 at 15 58 11](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/d0f2c9f9-6478-48b9-8685-fa1bd64359d4)
![Screenshot 2024-05-28 at 16 01 20](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/d3df6a73-b5fc-4160-8caa-5a341bacb21d)

### After changes:

## How to manually test the feature
