### PR TITLE
CRIMAPP-959 - Employment status missing from CYA

### DIFF
--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -319,7 +319,9 @@ en:
       employment_status:
         question: What is your client’s employment status?
         answers:
-          'not_working': Not working
+          not_working: Not working
+          employed: Employed
+          self_employed: Self-employed
       ended_employment_within_three_months:
         question: Has your client ended employment in the last 3 months?
         answers:


### PR DESCRIPTION
## Description of change
Fix translation for Employment status

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-959

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1029" alt="Screenshot 2024-05-29 at 07 33 58" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/5927ec6a-80e3-4604-86c5-3b044c6dad90">


### After changes:
<img width="1072" alt="Screenshot 2024-05-29 at 12 18 18" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/4f8b0bd7-f42b-4bbe-928e-812e2dd62a53">

## How to manually test the feature
