### PR TITLE
CRIMAPP-877 - Add employments to CYA's page

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -61,6 +61,7 @@ module Summary
       income: %i[
         employment_details
         income_details
+        employments
         income_payments_details
         income_benefits_details
         dependants

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -290,6 +290,7 @@ describe Summary::HtmlPresenter do
     expected_sections = %w[
       EmploymentDetails
       IncomeDetails
+      Employments
       IncomePaymentsDetails
       IncomeBenefitsDetails
       Dependants

--- a/spec/requests/employments_summary_spec.rb
+++ b/spec/requests/employments_summary_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Employments summary page', :authorized do
+  let(:crime_application) { CrimeApplication.create! }
+  let!(:employment) { crime_application.employments.create! }
+
+  describe 'list of added employments in summary page' do
+    before do
+      get edit_steps_income_client_employments_summary_path(id: crime_application)
+    end
+
+    it 'lists the employments with their details and action links' do
+      expect(response).to have_http_status(:success)
+      assert_select '.govuk-summary-card'
+      assert_select 'h1', 'You have added 1 job'
+
+      # confirm action are shown
+      assert_select 'li.govuk-summary-card__action', count: 2
+    end
+  end
+
+  describe 'delete an employment' do
+    before do
+      get confirm_destroy_steps_income_client_employments_path(id: crime_application, employment_id: employment)
+    end
+
+    it 'allows a user to confirm before deleting a employment' do
+      assert_select '.govuk-summary-card'
+      # confirm action are not shown
+      assert_select 'li.govuk-summary-card__action', count: 0
+
+      expect(response.body).to include('Are you sure you want to remove this job?')
+      expect(response.body).to include('Yes, remove it')
+      expect(response.body).to include('No, do not remove it')
+    end
+
+    context 'when there are other employments' do
+      it 'deletes the employment and redirects back to the summary page' do
+        employment_1 = crime_application.employments.create!
+
+        expect do
+          delete steps_income_client_employments_path(id: crime_application, employment_id: employment_1)
+        end.to change(Employment, :count).by(-1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(edit_steps_income_client_employments_summary_path(crime_application))
+
+        follow_redirect!
+
+        assert_select 'div.govuk-notification-banner--success', 1 do
+          assert_select 'h2', 'Success'
+          assert_select 'p', 'You removed the job'
+        end
+      end
+    end
+
+    context 'when there are no more employments' do
+      it 'deletes the employment and redirects to the employment status page' do
+        expect do
+          delete steps_income_client_employments_path(id: crime_application, employment_id: employment)
+        end.to change(Employment, :count).by(-1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(edit_steps_income_employment_status_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Add employments(jobs) sections to CYAs page

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-877

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

### Employments: Shopping basket Page
<img width="843" alt="Screenshot 2024-05-30 at 15 55 24" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/02062236-1e32-40d3-8e81-5fd01bac1dba">

### Check your answers page
<img width="772" alt="Screenshot 2024-05-30 at 15 57 21" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/f5379e7a-cb71-4cdb-8e10-0d9893572f67">


## How to manually test the feature

Employments: Shopping basket Page URL
http://localhost:3000/applications/:id/steps/income/client/add_employments

Check your answers page URL
http://localhost:3000/applications/:id/steps/income/check_your_answers_income
