### PR TITLE
CRIMAPP-965 Fix self assessment tax form bug

### DIFF
--- a/app/forms/steps/income/client/other_work_benefits_form.rb
+++ b/app/forms/steps/income/client/other_work_benefits_form.rb
@@ -29,7 +29,6 @@ module Steps
         def persist!
           ::IncomePayment.transaction do
             reset!
-            update_income_attribute!
 
             if receives_other_work_benefit?
               crime_application.income_payments.create!(
@@ -38,6 +37,8 @@ module Steps
                 frequency: PaymentFrequencyType::ANNUALLY,
               )
             end
+
+            update_income_attribute!
           end
         end
 

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -32,23 +32,25 @@ module Steps
         end
 
         def persist!
-          crime_application.income.update(
-            applicant_self_assessment_tax_bill:,
-          )
-
-          pays_self_assessment_tax_bill? ? persist_outgoings_payment : reset!
-        end
-
-        def persist_outgoings_payment
           ::OutgoingsPayment.transaction do
             reset!
 
-            crime_application.outgoings_payments.create!(
-              payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.value,
-              amount: amount,
-              frequency: frequency,
-            )
+            if pays_self_assessment_tax_bill?
+              crime_application.outgoings_payments.create!(
+                payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.value,
+                amount: amount,
+                frequency: frequency,
+              )
+            end
+
+            update_income_attribute!
           end
+        end
+
+        def update_income_attribute!
+          crime_application.income.update(
+            applicant_self_assessment_tax_bill:,
+          )
         end
 
         def reset!


### PR DESCRIPTION
## Description of change

Due to the order of actions in the persist method, it would return false if 'No' was selected on the page, meaning that the user does not progress to the next page. This fixes that issue for both the self assessment tax form page and other work benefits page. 

## Link to relevant ticket

[CRIMAPP-965](https://dsdmoj.atlassian.net/browse/CRIMAPP-965)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-965]: https://dsdmoj.atlassian.net/browse/CRIMAPP-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ