### PR TITLE
Update partner routing

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -18,6 +18,8 @@ class CrimeApplicationsController < DashboardController
     initialize_crime_application do |crime_application|
       if FeatureFlags.non_means_tested.enabled?
         redirect_to edit_steps_client_is_means_tested_path(crime_application)
+      elsif FeatureFlags.partner_journey.enabled?
+        redirect_to edit_crime_application_path(crime_application)
       else
         redirect_to edit_steps_client_has_partner_path(crime_application)
       end

--- a/app/services/decisions/client_decision_tree.rb
+++ b/app/services/decisions/client_decision_tree.rb
@@ -158,6 +158,8 @@ module Decisions
 
     # TODO: Consider whether !crime_application.age_passported? is more appropriate?
     def start_partner_journey?
+      return false unless FeatureFlags.partner_journey.enabled?
+
       form_object.client_has_partner.yes? &&
         !current_crime_application.not_means_tested? &&
         !applicant.under18?

--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -76,7 +76,7 @@ module Decisions
       # TODO: refactor to use has_partner in partner_details table instead of client_has_partner
 
       form_object.benefit_type.none? &&
-        FeatureFlags.passported_partner_journey.enabled? &&
+        FeatureFlags.partner_journey.enabled? &&
         current_crime_application.client_has_partner == 'yes'
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,14 +35,6 @@ feature_flags:
     local: true
     staging: true
     production: false
-  passported_partner_journey:
-    local: true
-    staging: true
-    production: false
-  unemployment_partner_journey:
-    local: true
-    staging: true
-    production: false
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,7 +21,7 @@ feature_flags:
     production: true
   non_means_tested:
     local: false
-    staging: true
+    staging: false
     production: false
   unemployed_partner_journey:
     local: true

--- a/spec/forms/steps/income/client/other_work_benefits_form_spec.rb
+++ b/spec/forms/steps/income/client/other_work_benefits_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
   describe '#save' do
     before do
       allow(crime_application.income_payments).to receive(:create!).and_return(true)
-      allow(crime_application.income).to receive(:update).and_return(true)
+      allow(crime_application).to receive(:income).and_return(income)
     end
 
     context 'when `applicant_other_work_benefit_received` is not provided' do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -32,11 +32,26 @@ RSpec.describe 'Dashboard', :authorized do
         }
       end
 
-      it 'creates a new `crime_application` record' do
+      context 'when the `partner journey` feature flag is enabled' do
+        before do
+          allow(FeatureFlags).to receive(:partner_journey) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
+        end
+
+        it 'creates a new `crime_application` record and redirects to the does client have partner screen' do
+          expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(/does_client_have_partner/)
+        end
+      end
+
+      it 'creates a new `crime_application` record and redirects to the task list' do
         expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
 
         expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(/does_client_have_partner/)
+        expect(response).to redirect_to(/edit/)
       end
     end
   end

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Decisions::DWPDecisionTree do
     let(:has_nino) { YesNoAnswer::YES }
     let(:feature_flag_means_journey_enabled) { false }
     let(:client_has_partner) { 'no' }
-    let(:passported_partner_journey_enabled) { false }
+    let(:partner_journey_enabled) { false }
 
     before do
       allow(crime_application).to receive_messages(applicant: applicant_double,
@@ -89,8 +89,8 @@ RSpec.describe Decisions::DWPDecisionTree do
         instance_double(FeatureFlags::EnabledFeature, enabled?: feature_flag_means_journey_enabled)
       }
 
-      allow(FeatureFlags).to receive(:passported_partner_journey) {
-        instance_double(FeatureFlags::EnabledFeature, enabled?: passported_partner_journey_enabled)
+      allow(FeatureFlags).to receive(:partner_journey) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: partner_journey_enabled)
       }
     end
 
@@ -107,8 +107,8 @@ RSpec.describe Decisions::DWPDecisionTree do
         it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
       end
 
-      context 'and feature flag `passported_partner_journey` is enabled and client has a partner' do
-        let(:passported_partner_journey_enabled) { true }
+      context 'and feature flag `partner_journey` is enabled and client has a partner' do
+        let(:partner_journey_enabled) { true }
         let(:client_has_partner) { 'yes' }
 
         it { is_expected.to have_destination(:partner_benefit_type, :edit, id: crime_application) }


### PR DESCRIPTION
## Description of change

- Routes to the task list when an application started if the partner journey is enabled and routes to the does client have partner page if the partner journey is not enabled
- Removes partner journey feature flags that are no longer required 
- Sets non means tested ff to false on staging to allow for regression testing on staging and prepare for deployment

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Toggle the partner journey feature flag and test the routing is as expected for different application types (means assessed application, non means assessed application, u18 application, appeal no changes etc..)
