### PR TITLE
CRIMAPP-960 fix routing for frozen assets page

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -70,6 +70,10 @@ module TypeOfMeansAssessment
     kase.case_type == CaseType::SUMMARY_ONLY.to_s
   end
 
+  def committal?
+    kase.case_type == CaseType::COMMITTAL.to_s
+  end
+
   def no_property?
     income.client_owns_property == 'no'
   end
@@ -80,10 +84,6 @@ module TypeOfMeansAssessment
 
   def has_frozen_assets?
     income.has_frozen_income_or_assets == 'yes'
-  end
-
-  def no_frozen_assets?
-    income.has_frozen_income_or_assets == 'no'
   end
 
   def income_below_threshold?

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -125,12 +125,12 @@ module Decisions
     end
 
     def after_frozen_income_savings_assets
-      if no_frozen_assets? && !summary_only?
-        edit(:client_owns_property)
-      elsif employed? && FeatureFlags.employment_journey.enabled?
-        redirect_to_employer_details(employment)
+      if has_frozen_assets?
+        employed? ? redirect_to_employer_details(employment) : edit(:income_payments)
+      elsif summary_only? || committal?
+        employed? ? edit('/steps/income/client/employment_income') : edit(:income_payments)
       else
-        edit(:income_payments)
+        edit(:client_owns_property)
       end
     end
 
@@ -190,7 +190,8 @@ module Decisions
     end
 
     def employed?
-      !!crime_application.income.employment_status&.include?(EmploymentStatus::EMPLOYED.to_s)
+      crime_application.income.employment_status&.include?(EmploymentStatus::EMPLOYED.to_s) &&
+        FeatureFlags.employment_journey.enabled?
     end
 
     def not_working?

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -279,16 +279,48 @@ RSpec.describe Decisions::IncomeDecisionTree do
     context 'when they do not have frozen income or assets' do
       let(:has_frozen_income_or_assets) { YesNoAnswer::NO.to_s }
 
-      context 'when case type is not summary only' do
-        let(:case_type) { 'indictable' }
-
-        it { is_expected.to have_destination(:client_owns_property, :edit, id: crime_application) }
-      end
-
       context 'when case type is summary only' do
         let(:case_type) { 'summary_only' }
 
-        it { is_expected.to have_destination(:income_payments, :edit, id: crime_application) }
+        context 'when the client is employed' do
+          let(:employment_status) { EmploymentStatus::EMPLOYED.to_s }
+          let(:feature_flag_employment_journey_enabled) { true }
+
+          it 'redirects to the `employment_income` page' do
+            expect(subject).to have_destination('/steps/income/client/employment_income', :edit, id: crime_application)
+          end
+        end
+
+        context 'when the client is not employed' do
+          let(:employment_status) { EmploymentStatus::NOT_WORKING.to_s }
+
+          it { is_expected.to have_destination(:income_payments, :edit, id: crime_application) }
+        end
+      end
+
+      context 'when case type is committal' do
+        let(:case_type) { 'committal' }
+
+        context 'when the client is employed' do
+          let(:employment_status) { EmploymentStatus::EMPLOYED.to_s }
+          let(:feature_flag_employment_journey_enabled) { true }
+
+          it 'redirects to the `employment_income` page' do
+            expect(subject).to have_destination('/steps/income/client/employment_income', :edit, id: crime_application)
+          end
+        end
+
+        context 'when the client is not employed' do
+          let(:employment_status) { EmploymentStatus::NOT_WORKING.to_s }
+
+          it { is_expected.to have_destination(:income_payments, :edit, id: crime_application) }
+        end
+      end
+
+      context 'when case type is not summary only or committal' do
+        let(:case_type) { 'indictable' }
+
+        it { is_expected.to have_destination(:client_owns_property, :edit, id: crime_application) }
       end
     end
 
@@ -391,7 +423,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       context 'when they do not have savings' do
         before { allow(subject).to receive(:requires_full_means_assessment?).and_return(false) }
 
-        it 'redirects to the `employer_details` page' do
+        it 'redirects to the `employment_income` page' do
           expect(subject).to have_destination('/steps/income/client/employment_income', :edit, id: crime_application)
         end
       end


### PR DESCRIPTION
## Description of change

Fix routing for both employed journey and unemployed journey, for the 'Does your client have any income, savings or assets under a restraint or freezing order?' page

## Link to relevant ticket

[CRIMAPP-960](https://dsdmoj.atlassian.net/browse/CRIMAPP-960)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

EMPLOYED JOURNEY:
Employed and feature flag is on:
- If they select 'Yes' they should go to 'Who does your client work for'
- If they select 'No' AND case type is not summary only or committal they should go to the property page.
- If they select 'No' AND case type is summary only or committal they should go to the 'Your client's employment income' page

UNEMPLOYED JOURNEY:
Not working OR feature flag not on:
- If they select 'Yes' they should go to 'Income payments'
- If they select 'No' AND case type is not summary only or committal they should go to the property page.
- If they select 'No' AND case type is summary only or committal they should go to 'Income payments' 

[CRIMAPP-960]: https://dsdmoj.atlassian.net/browse/CRIMAPP-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ