### PR TITLE
CRIMAPP-945 are partner wages paid into savings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.5'
+    tag: 'v1.1.7'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5611273483540ebd003965e70aef47e08c6e6612
-  tag: v1.1.5
+  revision: e0548d4d659d742887a2ad2e5c7f019367ca0b22
+  tag: v1.1.7
   specs:
-    laa-criminal-legal-aid-schemas (1.1.5)
+    laa-criminal-legal-aid-schemas (1.1.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/forms/steps/capital/savings_form.rb
+++ b/app/forms/steps/capital/savings_form.rb
@@ -13,9 +13,15 @@ module Steps
       attribute :account_number, :string
       attribute :is_overdrawn, :value_object, source: YesNoAnswer
       attribute :are_wages_paid_into_account, :value_object, source: YesNoAnswer
+      attribute :are_partners_wages_paid_into_account, :value_object, source: YesNoAnswer
 
       validates :provider_name, :sort_code, :account_number, :account_balance, presence: true
       validates :is_overdrawn, :are_wages_paid_into_account, inclusion: { in: YesNoAnswer.values }
+
+      validates(
+        :are_partners_wages_paid_into_account,
+        inclusion: { in: YesNoAnswer.values, if: :include_partner_in_means_assessment? }
+      )
 
       def persist!
         record.update(attributes)

--- a/app/models/saving.rb
+++ b/app/models/saving.rb
@@ -1,4 +1,6 @@
 class Saving < ApplicationRecord
+  include TypeOfMeansAssessment
+
   belongs_to :crime_application
 
   attribute :account_balance, :pence
@@ -8,6 +10,9 @@ class Saving < ApplicationRecord
 
   def complete?
     except = %i[id crime_application_id created_at updated_at]
+
+    except << :are_partners_wages_paid_into_account unless include_partner_in_means_assessment?
+
     serializable_hash(except:).values.none?(&:blank?)
   end
 end

--- a/app/presenters/summary/components/saving.rb
+++ b/app/presenters/summary/components/saving.rb
@@ -1,6 +1,8 @@
 module Summary
   module Components
     class Saving < BaseRecord
+      include TypeOfMeansAssessment
+
       alias saving record
 
       private
@@ -8,27 +10,34 @@ module Summary
       def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         [
           Components::FreeTextAnswer.new(
-            :provider_name, saving.provider_name
+            :provider_name, saving.provider_name, show: true
           ),
           Components::FreeTextAnswer.new(
-            :sort_code, saving.sort_code
+            :sort_code, saving.sort_code, show: true
           ),
           Components::FreeTextAnswer.new(
-            :account_number, saving.account_number
+            :account_number, saving.account_number, show: true
           ),
           Components::MoneyAnswer.new(
-            :account_balance, saving.account_balance
+            :account_balance, saving.account_balance, show: true
           ),
           Components::ValueAnswer.new(
-            :is_overdrawn, saving.is_overdrawn
+            :is_overdrawn, saving.is_overdrawn, show: true
           ),
           Components::ValueAnswer.new(
-            :are_wages_paid_into_account, saving.are_wages_paid_into_account
+            :are_wages_paid_into_account,
+            saving.are_wages_paid_into_account,
+            show: true
           ),
           Components::ValueAnswer.new(
-            :saving_ownership_type, saving.ownership_type
+            :are_partners_wages_paid_into_account,
+            saving.are_partners_wages_paid_into_account,
+            show: include_partner_in_means_assessment?
+          ),
+          Components::ValueAnswer.new(
+            :saving_ownership_type, saving.ownership_type, show: true
           )
-        ]
+        ].select(&:show?)
       end
 
       def name
@@ -46,6 +55,8 @@ module Summary
       def remove_path
         confirm_destroy_steps_capital_savings_path(saving_id: record.id)
       end
+
+      delegate :crime_application, to: :record
     end
   end
 end

--- a/app/serializers/submission_serializer/definitions/saving.rb
+++ b/app/serializers/submission_serializer/definitions/saving.rb
@@ -1,7 +1,7 @@
 module SubmissionSerializer
   module Definitions
     class Saving < Definitions::BaseDefinition
-      def to_builder
+      def to_builder # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         Jbuilder.new do |json|
           json.saving_type saving_type
           json.provider_name provider_name
@@ -10,6 +10,9 @@ module SubmissionSerializer
           json.account_balance account_balance_before_type_cast
           json.is_overdrawn is_overdrawn
           json.are_wages_paid_into_account are_wages_paid_into_account
+          if include_partner_in_means_assessment?
+            json.are_partners_wages_paid_into_account are_partners_wages_paid_into_account
+          end
           json.ownership_type ownership_type
         end
       end

--- a/app/views/steps/capital/savings/edit.html.erb
+++ b/app/views/steps/capital/savings/edit.html.erb
@@ -20,6 +20,10 @@
       <%= f.govuk_collection_radio_buttons :is_overdrawn, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
       <%= f.govuk_collection_radio_buttons :are_wages_paid_into_account, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
 
+      <% if f.object.include_partner_in_means_assessment? %>
+        <%= f.govuk_collection_radio_buttons :are_partners_wages_paid_into_account, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
+      <% end %>
+
       <%= render partial: 'steps/shared/ownership_form_fields', locals: { f: } %>
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -679,6 +679,8 @@ en:
               inclusion: Select yes if the account is overdrawn
             are_wages_paid_into_account:
               inclusion: Select yes if your client's wages or benefits are paid into this account
+            are_partners_wages_paid_into_account:
+              inclusion: Select yes if the partner's wages or benefits are paid into this account
             ownership_type:
               inclusion: Select whose name the account is in
             confirm_in_applicants_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -160,6 +160,7 @@ en:
       steps_capital_savings_form:
         is_overdrawn: Is the account overdrawn?
         are_wages_paid_into_account: Are your client’s wages or benefits paid into this account?
+        are_partners_wages_paid_into_account: Are the partner’s wages or benefits paid into this account?
         confirm_in_applicants_name: Confirm the following
         ownership_type: Whose name is the account in?
       steps_capital_savings_summary_form:
@@ -732,6 +733,7 @@ en:
         account_balance: What is the account balance?
         is_overdrawn_options: *YESNO
         are_wages_paid_into_account_options: *YESNO
+        are_partners_wages_paid_into_account_options: *YESNO
         ownership_type_options: *OWNERSHIP_OPTIONS
         confirm_in_applicants_name_options:
           'true': I confirm that the account is in my client's name

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -568,7 +568,11 @@ en:
         question: What is the account number?
         absence_answer: '' 
       are_wages_paid_into_account:
-        question: Are your client’s wages or benefits paid into this account?
+        question: Client's wages or benefits paid into this account?
+        answers: *YESNO
+        absence_answer: '' 
+      are_partners_wages_paid_into_account:
+        question: Partner's wages or benefits paid into this account?
         answers: *YESNO
         absence_answer: '' 
       is_overdrawn:

--- a/db/migrate/20240605084904_add_are_partner_wages_paid_into_account_to_savings.rb
+++ b/db/migrate/20240605084904_add_are_partner_wages_paid_into_account_to_savings.rb
@@ -1,0 +1,5 @@
+class AddArePartnerWagesPaidIntoAccountToSavings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :savings, :are_partners_wages_paid_into_account, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_23_202937) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_05_084904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -177,10 +177,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_23_202937) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_title"
-    t.string "has_no_deductions"
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
+    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 
@@ -388,6 +388,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_23_202937) do
     t.string "ownership_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "are_partners_wages_paid_into_account"
     t.index ["crime_application_id"], name: "index_savings_on_crime_application_id"
   end
 

--- a/spec/serializers/submission_serializer/definitions/saving_spec.rb
+++ b/spec/serializers/submission_serializer/definitions/saving_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe SubmissionSerializer::Definitions::Saving do
   subject { described_class.generate(savings) }
 
   let(:savings) { [saving1, saving2] }
+  let(:include_partner?) { true }
 
   let(:saving1) do
     instance_double(
@@ -16,6 +17,8 @@ RSpec.describe SubmissionSerializer::Definitions::Saving do
       account_balance_before_type_cast: 10_001,
       is_overdrawn: 'yes',
       are_wages_paid_into_account: 'yes',
+      are_partners_wages_paid_into_account: 'no',
+      include_partner_in_means_assessment?: false
     )
   end
 
@@ -30,6 +33,8 @@ RSpec.describe SubmissionSerializer::Definitions::Saving do
       account_balance_before_type_cast: 200_050,
       is_overdrawn: 'no',
       are_wages_paid_into_account: 'no',
+      are_partners_wages_paid_into_account: 'yes',
+      include_partner_in_means_assessment?: true
     )
   end
 
@@ -43,7 +48,7 @@ RSpec.describe SubmissionSerializer::Definitions::Saving do
         account_number: '01234500',
         account_balance: 10_001,
         is_overdrawn: 'yes',
-        are_wages_paid_into_account: 'yes'
+        are_wages_paid_into_account: 'yes',
       },
       {
         saving_type: 'building_society',
@@ -53,7 +58,8 @@ RSpec.describe SubmissionSerializer::Definitions::Saving do
         account_number: '01234500',
         account_balance: 200_050,
         is_overdrawn: 'no',
-        are_wages_paid_into_account: 'no'
+        are_wages_paid_into_account: 'no',
+        are_partners_wages_paid_into_account: 'yes'
       },
     ].as_json
   end


### PR DESCRIPTION
## Description of change

Asks if partner's wages or benefits are paid into a saving account if the partner is included in the means assessment.

## Link to relevant ticket

[CRIMAPP-945](https://dsdmoj.atlassian.net/browse/CRIMAPP-945)

## Notes for reviewer

Schema gem needs updating to official release once merged: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/156

## Screenshots of changes (if applicable)

### Before changes:
<img width="876" alt="Screenshot 2024-06-05 at 12 21 13" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/f654df59-4901-4986-ac88-a1a87b160662">
<img width="655" alt="Screenshot 2024-06-05 at 12 20 36" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/d035ae5e-cb42-4ddf-bc9c-0f82725139a0">

### After changes:



## How to manually test the feature

1. Complete the process of saving an applicant with a partner who has a conflict of interest.
2. Confirm that the question “Are the partner's wages paid into the savings account?” is not asked.
3. Confirm that the savings entry is valid.
4. Update the partner's details to remove the conflict of interest.
5. Confirm that the savings entry is no longer valid on the summary page.
6. Navigate to the savings entry.
7. Confirm that the question “Are the partner's wages paid…” is displayed.
8. Confirm that the correct error message is shown when attempting to save before answering the question.
9. Confirm that once the question is answered, the savings entry can be saved, is valid, and the answer is shown on the savings summary page.

[CRIMAPP-945]: https://dsdmoj.atlassian.net/browse/CRIMAPP-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ