### PR TITLE
CRIMAPP 999 add applicant AND partner text to income

### DIFF
--- a/app/forms/concerns/steps/applicant_and_partner.rb
+++ b/app/forms/concerns/steps/applicant_and_partner.rb
@@ -1,14 +1,10 @@
 module Steps
-  module ApplicantOrPartner
+  module ApplicantAndPartner
     extend ActiveSupport::Concern
-
-    def subject
-      I18n.t('dictionary.subject', subject_type: subject_ownership_type)
-    end
 
     def subject_ownership_type
       if include_partner_in_means_assessment?
-        SubjectType::APPLICANT_OR_PARTNER
+        SubjectType::APPLICANT_AND_PARTNER
       else
         SubjectType::APPLICANT
       end

--- a/app/forms/concerns/steps/ownership_confirmation.rb
+++ b/app/forms/concerns/steps/ownership_confirmation.rb
@@ -22,11 +22,7 @@ module Steps
     def set_ownership
       return if include_partner_in_means_assessment?
 
-      self.ownership_type = if confirm_in_applicants_name.blank?
-                              nil
-                            else
-                              OwnershipType::APPLICANT
-                            end
+      self.ownership_type = confirm_in_applicants_name.blank? ? nil : OwnershipType::APPLICANT
     end
   end
 end

--- a/app/forms/steps/income/client_owns_property_form.rb
+++ b/app/forms/steps/income/client_owns_property_form.rb
@@ -2,6 +2,9 @@ module Steps
   module Income
     class ClientOwnsPropertyForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
+      include TypeOfMeansAssessment
+      include ApplicantOrPartner
+
       has_one_association :income
 
       attribute :client_owns_property, :value_object, source: YesNoAnswer

--- a/app/forms/steps/income/has_savings_form.rb
+++ b/app/forms/steps/income/has_savings_form.rb
@@ -2,6 +2,9 @@ module Steps
   module Income
     class HasSavingsForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
+      include TypeOfMeansAssessment
+      include ApplicantOrPartner
+
       has_one_association :income
 
       attribute :has_savings, :value_object, source: YesNoAnswer

--- a/app/forms/steps/income/income_before_tax_form.rb
+++ b/app/forms/steps/income/income_before_tax_form.rb
@@ -2,6 +2,9 @@ module Steps
   module Income
     class IncomeBeforeTaxForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
+      include TypeOfMeansAssessment
+      include ApplicantAndPartner
+
       has_one_association :income
 
       # threshold being £12,475 as of Nov 2023

--- a/app/forms/steps/income/manage_without_income_form.rb
+++ b/app/forms/steps/income/manage_without_income_form.rb
@@ -2,6 +2,9 @@ module Steps
   module Income
     class ManageWithoutIncomeForm < Steps::BaseFormObject
       include Steps::HasOneAssociation
+      include TypeOfMeansAssessment
+      include ApplicantAndPartner
+
       has_one_association :income
 
       attribute :manage_without_income, :value_object, source: ManageWithoutIncomeType

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -88,7 +88,10 @@ module StepsHelper
   end
 
   def translate_with_subject(key, **options)
-    subject_type = current_form_object.try(:subject_ownership_type)
+    subject_type = options.fetch(
+      :subject_type,
+      current_form_object.try(:subject_ownership_type)
+    )
 
     options[:subject] ||= translate('dictionary.subject', subject_type:)
     options[:Subject] = options[:subject].capitalize

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -88,11 +88,11 @@ module StepsHelper
   end
 
   def translate_with_subject(key, **options)
-    options[:subject] ||= translate(
-      'dictionary.subject',
-      ownership_type: current_form_object.try(:subject_ownership_type),
-    )
+    subject_type = current_form_object.try(:subject_ownership_type)
+
+    options[:subject] ||= translate('dictionary.subject', subject_type:)
     options[:Subject] = options[:subject].capitalize
+    options[:count] ||= subject_type&.applicant_and_partner? ? 2 : 1
 
     translate(key, **options)
   end

--- a/app/presenters/summary/components/base_answer.rb
+++ b/app/presenters/summary/components/base_answer.rb
@@ -5,9 +5,9 @@ module Summary
       include ApplicationHelper
       include StepsHelper
 
-      attr_reader :question, :value, :show, :change_path, :i18n_opts
+      attr_reader :question, :value, :show, :change_path
 
-      DEFAULT_OPTIONS = { default: nil, show: nil, change_path: nil, i18n_opts: {} }.freeze
+      DEFAULT_OPTIONS = { default: nil, show: nil, change_path: nil, i18n_opts: {}, subject_ownership_type: nil }.freeze
 
       def initialize(question, value, *args)
         options = extract_supported_options!(args)
@@ -16,6 +16,7 @@ module Summary
         @value = value || options[:default]
         @show = options[:show]
         @change_path = options[:change_path]
+        @subject_ownership_type = options[:subject_ownership_type]
         @i18n_opts = options[:i18n_opts]
       end
 
@@ -51,7 +52,20 @@ module Summary
         I18n.t("summary.questions.#{question}.question_a11y", default: question_text)
       end
 
+      def i18n_opts
+        return @i18n_opts if @i18n_opts.key?(:subject_type)
+
+        @i18n_opts.merge(
+          subject_type: subject_ownership_type,
+          subject: translate("summary.dictionary.subjects.#{subject_ownership_type}")
+        )
+      end
+
       private
+
+      def subject_ownership_type
+        @subject_ownership_type ||= SubjectType.new(:applicant)
+      end
 
       def extract_supported_options!(args)
         options = DEFAULT_OPTIONS.merge(args.extract_options!)

--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -1,11 +1,13 @@
 module Summary
   module Sections
     class IncomeDetails < Sections::BaseSection
+      include TypeOfMeansAssessment
+
       def show?
         income.present? && super
       end
 
-      def answers # rubocop:disable  Metrics/MethodLength
+      def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         [
           Components::ValueAnswer.new(
             :income_above_threshold, income.income_above_threshold,
@@ -17,13 +19,22 @@ module Summary
           ),
           Components::ValueAnswer.new(
             :client_owns_property, income.client_owns_property,
-            change_path: edit_steps_income_client_owns_property_path
+            change_path: edit_steps_income_client_owns_property_path,
+            subject_ownership_type: property_ownership_type
           ),
           Components::ValueAnswer.new(
             :has_savings, income.has_savings,
             change_path: edit_steps_income_has_savings_path
           ),
         ].select(&:show?)
+      end
+
+      private
+
+      def property_ownership_type
+        return unless include_partner_in_means_assessment?
+
+        SubjectType.new(:applicant_or_partner)
       end
     end
   end

--- a/app/presenters/summary/sections/other_income_details.rb
+++ b/app/presenters/summary/sections/other_income_details.rb
@@ -1,6 +1,8 @@
 module Summary
   module Sections
     class OtherIncomeDetails < Sections::BaseSection
+      include TypeOfMeansAssessment
+
       def show?
         income.present? && super
       end
@@ -9,13 +11,22 @@ module Summary
         [
           Components::ValueAnswer.new(
             :manage_without_income, income.manage_without_income,
-            change_path: edit_steps_income_manage_without_income_path
+            change_path: edit_steps_income_manage_without_income_path,
+            subject_ownership_type: subject_ownership_type
           ),
           Components::FreeTextAnswer.new(
             :manage_other_details, income.manage_other_details,
             change_path: edit_steps_income_manage_without_income_path
           ),
         ].select(&:show?)
+      end
+
+      private
+
+      def subject_ownership_type
+        return unless include_partner_in_means_assessment?
+
+        SubjectType.new(:applicant_and_partner)
       end
     end
   end

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -5,6 +5,11 @@ module Adapters
     class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
       include TypeOfApplication
 
+      # TODO: remove when partner details CYA work is available
+      def partner_detail
+        nil
+      end
+
       # `is_means_tested` is not part of Schema, requires calculation
       # rubocop:disable Naming/PredicateName
       def is_means_tested

--- a/app/value_objects/subject_type.rb
+++ b/app/value_objects/subject_type.rb
@@ -1,0 +1,8 @@
+class SubjectType < ValueObject
+  VALUES = [
+    APPLICANT = new(:applicant),
+    APPLICANT_AND_PARTNER = new(:applicant_and_partner),
+    APPLICANT_OR_PARTNER = new(:applicant_or_partner),
+    PARTNER = new(:partner),
+  ].freeze
+end

--- a/app/views/steps/income/client_owns_property/edit.html.erb
+++ b/app/views/steps/income/client_owns_property/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title legend_t(:client_owns_property) %>
 <% step_header %>
 
 <div class="govuk-grid-row">
@@ -8,11 +8,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :client_owns_property, @form_object.choices,
                                            :value, inline: false,
-                                           legend: { text: t('.client_owns_property'), tag: 'h1', size: 'xl' } do %>
-           <span class="govuk-caption-m govuk-!-margin-bottom-4">
-             <%= t('.client_owns_property_info') %>
-           </span>
-        <% end %>
+                                           legend: { text: legend_t(:client_owns_property), tag: 'h1', size: 'xl' } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/income/has_savings/edit.html.erb
+++ b/app/views/steps/income/has_savings/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title legend_t(:has_savings) %>
 <% step_header %>
 
 <div class="govuk-grid-row">
@@ -9,11 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :has_savings, @form_object.choices,
                                            :value, inline: false,
-                                           legend: { text: t('.has_savings'), tag: 'h1', size: 'xl' } do %>
-           <span class="govuk-caption-m govuk-!-margin-bottom-4">
-             <%= t('.has_savings_info') %>
-           </span>
-        <% end %>
+                                           legend: { text: legend_t(:has_savings), tag: 'h1', size: 'xl' } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title legend_t(:income_above_threshold) %>
 <% step_header %>
 
 <div class="govuk-grid-row">
@@ -8,10 +8,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :income_above_threshold, @form_object.choices,
                                            :value, inline: false,
-                                           legend: { text: t('.income_above_threshold'), tag: 'h1', size: 'xl' } do %>
-           <span class="govuk-caption-m govuk-!-margin-bottom-4">
-             <%= t('.income_above_threshold_info') %>
-           </span>
+                                           legend: { text: legend_t(:income_above_threshold), tag: 'h1', size: 'xl' } do %>
         <% end %>
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -8,8 +8,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :income_above_threshold, @form_object.choices,
                                            :value, inline: false,
-                                           legend: { text: legend_t(:income_above_threshold), tag: 'h1', size: 'xl' } do %>
-        <% end %>
+                                           legend: { text: legend_t(:income_above_threshold), tag: 'h1', size: 'xl' } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/income/manage_without_income/edit.html.erb
+++ b/app/views/steps/income/manage_without_income/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title legend_t(:manage_without_income) %>
 <% step_header %>
 
 <div class="govuk-grid-row">
@@ -6,11 +6,11 @@
   <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
-        <%= f.govuk_radio_buttons_fieldset(:manage_without_income, legend: { tag: 'h1', size: 'xl' }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:manage_without_income, legend: { text: legend_t(:manage_without_income), tag: 'h1', size: 'xl' }) do %>
           <% @form_object.choices.each_with_index do |choice, index| %>
             <% if choice == ManageWithoutIncomeType::OTHER %>
               <%= f.govuk_radio_button :manage_without_income, choice.value do %>
-                <% f.govuk_text_area :manage_other_details %>
+                <% f.govuk_text_area :manage_other_details, label: { text: label_t(:manage_other_details) } %>
               <% end %>
             <% else %>
               <%= f.govuk_radio_button :manage_without_income, choice.value, link_errors: index.zero? %>

--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -2,8 +2,8 @@
   en: {
     dictionary: {
       subject: lambda { |key, options|
-        ownership_type = options[:ownership_type] || :applicant
-        I18n.t("dictionary.subjects.#{ownership_type}", conjunction: 'or')
+        subject_type = options[:subject_type] || 'applicant'
+        I18n.t("dictionary.subjects.#{subject_type.to_s}")
       }
     }
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,8 @@ en:
       datetime: '%-d %B %Y %-l:%M%P'  # 3 January 2019 2:45pm
     subjects:
       applicant: 'your client'
-      applicant_and_partner: 'your client %{conjunction} their partner'
+      applicant_and_partner: 'your client and their partner'
+      applicant_or_partner: 'your client or their partner'
       partner: 'the partner'
   service:
     name: Apply for criminal legal aid

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -481,7 +481,7 @@ en:
         steps/income/income_before_tax_form:
           attributes:
             income_above_threshold:
-              inclusion: Select yes if your client’s income is currently more than £12,475 a year before tax
+              inclusion: Select yes if their income is currently more than £12,475 a year before tax
         steps/income/frozen_income_savings_assets_form: &FROZEN_INCOME_ASSETS_VALIDATION
           attributes:
             has_frozen_income_or_assets:
@@ -489,11 +489,11 @@ en:
         steps/income/client_owns_property_form:
           attributes:
             client_owns_property:
-              inclusion: Select yes if your client owns their home, or any other land or property
+              inclusion: Select yes if they own their home, or any other land or property
         steps/income/has_savings_form:
           attributes:
             has_savings:
-              inclusion: Select yes if your client has savings or investments
+              inclusion: Select yes if they have savings or investments
         steps/income/client/employment_income_form:
           attributes:
             amount:
@@ -570,9 +570,9 @@ en:
         steps/income/manage_without_income_form:
           attributes:
             manage_without_income:
-              inclusion: Select how your client manages with no income
+              inclusion: Select how they manage with no income
             manage_other_details:
-              blank: Enter details on how your client manages with no income
+              blank: Enter details on how they manage with no income
         steps/outgoings/housing_payment_type_form:
           attributes:
             housing_payment_type:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -108,6 +108,8 @@ en:
         is_first_court_hearing: Did this court also hear the first hearing?
       steps_case_ioj_form:
         types: Why should your client get legal aid?
+      steps_income_income_before_tax_form:
+        income_above_threshold: "Is %{subject}'s income currently more than £12,475 a year before tax?"
       steps_income_employment_status_form:
         employment_status: What is your client's employment status?
       steps_income_client_employment_income_form:
@@ -134,7 +136,9 @@ en:
       steps_income_lost_job_in_custody_form:
         lost_job_in_custody: Did your client lose their job as a result of being in custody?
       steps_income_manage_without_income_form:
-        manage_without_income: How does your client manage with no income?
+        manage_without_income: 
+          one: How does %{subject} manage with no income?
+          other: How do %{subject} manage with no income?
       steps_outgoings_housing_payment_type_form:
         housing_payment_type: Which of these payments does your client pay where they usually live?
       steps_outgoings_mortgage_form:
@@ -258,6 +262,8 @@ en:
         expert_examination_justification: *ioj_justification_hint
         interest_of_another_justification: *ioj_justification_hint
         other_justification: *ioj_justification_hint
+      steps_income_income_before_tax_form:
+        income_above_threshold: Do not include any employment income if your client has lost their job or ended employment.
       steps_income_employment_status_form:
         employment_status: Select all that apply.
         employment_status_options:
@@ -639,7 +645,9 @@ en:
           living_on_streets: They are living on the streets or homeless
           custody: They have been in custody for more than 3 months
           other: Other
-        manage_other_details: Tell us how your client manages with no income
+        manage_other_details: 
+          one: Tell us how %{subject} manages with no income
+          other: Tell us how %{subject} manage with no income
       steps_outgoings_housing_payment_type_form:
         housing_payment_type_options:
           rent: Rent

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -110,6 +110,11 @@ en:
         types: Why should your client get legal aid?
       steps_income_income_before_tax_form:
         income_above_threshold: "Is %{subject}'s income currently more than £12,475 a year before tax?"
+      steps_income_client_owns_property_form:
+        client_owns_property: Does %{subject} own their home, or any other land or property?
+        client_owns_property_info: Include land or property fully or partly owned, inside or outside the UK.
+      steps_income_has_savings_form:
+        has_savings: Does %{subject} have any savings or investments?
       steps_income_employment_status_form:
         employment_status: What is your client's employment status?
       steps_income_client_employment_income_form:
@@ -264,6 +269,10 @@ en:
         other_justification: *ioj_justification_hint
       steps_income_income_before_tax_form:
         income_above_threshold: Do not include any employment income if your client has lost their job or ended employment.
+      steps_income_client_owns_property_form:
+        client_owns_property: Include land or property fully or partly owned, inside or outside the UK.
+      steps_income_has_savings_form:
+        has_savings: Include any UK or overseas savings and investments.
       steps_income_employment_status_form:
         employment_status: Select all that apply.
         employment_status_options:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -292,16 +292,6 @@ en:
         edit:
           has_frozen_income_or_assets: Does %{subject} have any income, savings or assets under a restraint or freezing order?
           hint: When %{subject} has a court order preventing them from accessing, using or moving certain assets without permission.
-      client_owns_property:
-        edit:
-          page_title: Does your client own their home, or any other land or property?
-          client_owns_property_info: Include land or property fully or partly owned, inside or outside the UK.
-          client_owns_property: Does your client own their home, or any other land or property?
-      has_savings:
-        edit:
-          page_title: Does your client have any savings or investments?
-          has_savings_info: Include savings or investments they have inside or outside the UK.
-          has_savings: Does your client have any savings or investments?
       income_payments:
         edit:
           page_title: Which of these payments does your client get?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -288,11 +288,6 @@ en:
         edit:
           page_title: Did your client lose their job as a result of being in custody?
           date_job_lost: When did they lose their job?
-      income_before_tax:
-        edit:
-          page_title: Is your client's income currently more than £12,475 a year before tax?
-          income_above_threshold_info: Do not include any employment income if your client has lost their job or ended employment.
-          income_above_threshold: Is your client's income currently more than £12,475 a year before tax?
       frozen_income_savings_assets: &FROZEN_INCOME_ASSETS_PAGE_TEXT
         edit:
           has_frozen_income_or_assets: Does %{subject} have any income, savings or assets under a restraint or freezing order?
@@ -332,9 +327,6 @@ en:
           remove_button: Remove %{ordinal} dependant
           add_button: Add another dependant
           deleted_flash: The dependant has been deleted
-      manage_without_income:
-        edit:
-          page_title: How does client manage with no income?
       answers:
         edit:
           page_title: Check your answers - Your client's income

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -26,6 +26,11 @@ en:
         local_authority: Local authority
         partner_with_a_contrary_interest: Partner with a contrary interest
         property_company: Property company
+      subjects:
+        applicant: 'client'
+        applicant_and_partner: 'client and their partner'
+        applicant_or_partner: 'client or their partner'
+        partner: 'partner'
 
     change_link_html: Change <span class="govuk-visually-hidden">%{a11y_question}</span>
 
@@ -336,18 +341,18 @@ en:
 
       # BEGIN income details section
       income_above_threshold:
-        question: Is your client’s income currently more than £12,475 a year before tax?
+        question: Income more than £12,475 a year before tax?
         answers:
           <<: *YESNO
       has_frozen_income_or_assets:
         question: Income, savings or assets under a restraint or freezing order
         answers: *YESNO
       client_owns_property:
-        question: Does your client own their home, or any other land or property?
+        question: "%{Subject} owns home, land or property?"
         answers:
           <<: *YESNO
       has_savings:
-        question: Does your client have any savings or investments?
+        question: Savings or investments?
         answers:
           <<: *YESNO
       # END income details section
@@ -449,7 +454,9 @@ en:
 
       # BEGIN other sources of income details section
       manage_without_income:
-        question: How does your client manage with no income?
+        question: 
+          one: How %{subject} lives with no income?
+          other: How %{subject} live with no income?
         answers:
           friends_sofa: They sleep on a friend's sofa for free
           family: They stay with family for free

--- a/spec/helpers/steps_helper_spec.rb
+++ b/spec/helpers/steps_helper_spec.rb
@@ -197,14 +197,79 @@ data: { module: 'govuk-button', ga_category: 'category', ga_label: 'label' })
   end
 
   describe '#legend_t' do
-    it 'sources legend translations from the same source as the GOV.UK Form Builder' do
+    it 'sources label translations from the same source as the GOV.UK Form Builder' do
       allow(view).to receive(:current_form_object) { Steps::BaseFormObject.new }
-
       expect(helper).to receive(:t).with(
-        :attribute, scope: 'helpers.legend.steps_base_form_object'
+        :attribute, scope: 'helpers.label.steps_base_form_object'
       )
 
-      helper.legend_t(:attribute)
+      helper.label_t(:attribute)
+    end
+
+    # We've included a concrete example here in lieu of an
+    # integration spec to illustrate the use of the I18n helper.
+    #
+    # TODO: consider integration specs for the dynamic subject form content.
+    #
+    context 'when subject could be plural, e.g. ApplicantAndPartner' do
+      before do
+        form_object = Steps::Income::ManageWithoutIncomeForm.new
+        allow(view).to receive(:current_form_object) { form_object }
+        allow(form_object).to receive(:include_partner_in_means_assessment?) { include_partner? }
+      end
+
+      context 'when subject is applicant AND partner' do
+        let(:include_partner?) { true }
+
+        it 'returns the pluralized translation' do
+          expect(helper.legend_t(:manage_without_income)).to eq(
+            'How do your client and their partner manage with no income?'
+          )
+        end
+      end
+
+      context 'when subject is applicant only' do
+        let(:include_partner?) { false }
+
+        it 'returns the singular translation' do
+          expect(helper.legend_t(:manage_without_income)).to eq(
+            'How does your client manage with no income?'
+          )
+        end
+      end
+    end
+  end
+
+  describe '#translate_with_subject' do
+    before do
+      form_object = double(
+        :mock_form_object,
+        model_name: Steps::BaseFormObject,
+        subject_ownership_type: subject_ownership_type
+      )
+
+      allow(view).to receive(:current_form_object).and_return(form_object)
+    end
+
+    let(:subject_ownership_type) { nil }
+
+    it 'injects "subject", capitalized subject ("Subject") and "count" into the I18n options' do
+      expect(helper).to receive(:translate).with(
+        :translation_key,
+        { Subject: 'The subject', count: 1, subject: 'the subject' }
+      )
+
+      helper.translate_with_subject(:translation_key, subject: 'the subject')
+    end
+
+    context 'when form subject is ApplicantAndPartner' do
+      let(:subject_ownership_type) { SubjectType::APPLICANT_AND_PARTNER }
+
+      it 'sets the count to 2' do
+        expect(helper).to receive(:translate).with(:translation_key, hash_including(count: 2))
+
+        helper.translate_with_subject(:translation_key, subject: 'the subject')
+      end
     end
   end
 end

--- a/spec/presenters/summary/components/base_answer_spec.rb
+++ b/spec/presenters/summary/components/base_answer_spec.rb
@@ -77,7 +77,7 @@ describe Summary::Components::BaseAnswer do
       subject { described_class.new(question, value, i18n_opts: { name: 'John' }) }
 
       it 'returns the options' do
-        expect(subject.i18n_opts).to eq({ name: 'John' })
+        expect(subject.i18n_opts[:name]).to eq('John')
       end
     end
   end

--- a/spec/presenters/summary/sections/dependants_spec.rb
+++ b/spec/presenters/summary/sections/dependants_spec.rb
@@ -87,13 +87,13 @@ describe Summary::Sections::Dependants do
         expect(answers[1].question).to eq(:dependant)
         expect(answers[1].change_path).to match('/applications/12345/steps/income/dependants')
         expect(answers[1].value).to eq('17 years old')
-        expect(answers[1].i18n_opts).to eq({ ordinal: 'first' })
+        expect(answers[1].i18n_opts[:ordinal]).to eq('first')
 
         expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answers[2].question).to eq(:dependant)
         expect(answers[2].change_path).to match('/applications/12345/steps/income/dependants')
         expect(answers[2].value).to eq('1 year old')
-        expect(answers[2].i18n_opts).to eq({ ordinal: 'second' })
+        expect(answers[2].i18n_opts[:ordinal]).to eq('second')
       end
     end
   end

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Summary::Sections::IncomeDetails do
-  subject { described_class.new(crime_application) }
+  subject(:section) { described_class.new(crime_application) }
 
   let(:crime_application) do
     instance_double(
@@ -21,14 +21,20 @@ describe Summary::Sections::IncomeDetails do
     )
   end
 
+  let(:include_partner?) { false }
+
+  before do
+    allow(section).to receive(:include_partner_in_means_assessment?).and_return(include_partner?)
+  end
+
   describe '#name' do
-    it { expect(subject.name).to eq(:income_details) }
+    it { expect(section.name).to eq(:income_details) }
   end
 
   describe '#show?' do
     context 'when there is an income_details' do
       it 'shows this section' do
-        expect(subject.show?).to be(true)
+        expect(section.show?).to be(true)
       end
     end
 
@@ -36,7 +42,7 @@ describe Summary::Sections::IncomeDetails do
       let(:income) { nil }
 
       it 'does not show this section' do
-        expect(subject.show?).to be(false)
+        expect(section.show?).to be(false)
       end
     end
   end
@@ -72,6 +78,39 @@ describe Summary::Sections::IncomeDetails do
           income_details_yes_no_row_check(*row, i)
         end
       end
+    end
+  end
+
+  describe 'answer labels' do
+    subject(:labels) { section.answers.map(&:question_text) }
+
+    context 'when partner is included in means assessment' do
+      let(:include_partner?) { true }
+
+      let(:expected_labels) do
+        [
+          'Client or their partner owns home, land or property?',
+          'Income more than £12,475 a year before tax?',
+          'Income, savings or assets under a restraint or freezing order',
+          'Savings or investments?'
+        ]
+      end
+
+      it { is_expected.to match_array expected_labels }
+    end
+
+    context 'when partner is not included means assessment' do
+      let(:include_partner?) { false }
+      let(:expected_labels) do
+        [
+          'Client owns home, land or property?',
+          'Income more than £12,475 a year before tax?',
+          'Income, savings or assets under a restraint or freezing order',
+          'Savings or investments?'
+        ]
+      end
+
+      it { is_expected.to match_array expected_labels }
     end
   end
 

--- a/spec/presenters/summary/sections/other_income_details_spec.rb
+++ b/spec/presenters/summary/sections/other_income_details_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 describe Summary::Sections::OtherIncomeDetails do
-  subject { described_class.new(crime_application) }
+  subject(:section) { described_class.new(crime_application) }
+
+  let(:include_partner?) { false }
 
   let(:crime_application) do
     instance_double(
@@ -19,14 +21,18 @@ describe Summary::Sections::OtherIncomeDetails do
     )
   end
 
+  before do
+    allow(section).to receive(:include_partner_in_means_assessment?).and_return(include_partner?)
+  end
+
   describe '#name' do
-    it { expect(subject.name).to eq(:other_income_details) }
+    it { expect(section.name).to eq(:other_income_details) }
   end
 
   describe '#show?' do
     context 'when there is an income_details' do
       it 'shows this section' do
-        expect(subject.show?).to be(true)
+        expect(section.show?).to be(true)
       end
     end
 
@@ -34,13 +40,13 @@ describe Summary::Sections::OtherIncomeDetails do
       let(:income) { nil }
 
       it 'does not show this section' do
-        expect(subject.show?).to be(false)
+        expect(section.show?).to be(false)
       end
     end
   end
 
   describe '#answers' do
-    let(:answers) { subject.answers }
+    let(:answers) { section.answers }
 
     context 'when there are income details' do
       it 'has the correct rows' do
@@ -54,6 +60,22 @@ describe Summary::Sections::OtherIncomeDetails do
         expect(answers[1].change_path).to match('applications/12345/steps/income/how_manage_with_no_income')
         expect(answers[1].value).to eq('Another way they manage')
       end
+    end
+  end
+
+  describe 'the manage without income label' do
+    subject(:label) { section.answers.first.question_text }
+
+    context 'when partner is included in means assessment' do
+      let(:include_partner?) { true }
+
+      it { is_expected.to eq 'How client and their partner live with no income?' }
+    end
+
+    context 'when partner is not included means assessment' do
+      let(:include_partner?) { false }
+
+      it { is_expected.to eq 'How client lives with no income?' }
     end
   end
 end


### PR DESCRIPTION
## Description of change

Update income pages where they refer to 'your client and their partner' or 'your client or their partner'.

## Link to relevant ticket

[CRIMAPP-999](https://dsdmoj.atlassian.net/browse/CRIMAPP-999)

## Notes for reviewer

This PR introduces changes to handle plural subjects for the first time. When the subject is `ApplicantAndPartner`, translations will automatically have a count of 2; otherwise, the count will be 1. Additionally, a new type, `SubjectType`, is introduced and used in place of `OwnershipType`.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

### PARTNER EXLCUDED FROM MEANS:

<img width="1142" alt="Screenshot 2024-06-06 at 14 54 38" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/72c1c04d-d3ec-4e0c-9896-cbcee59bb8a9">


<img width="1228" alt="Screenshot 2024-06-06 at 14 54 28" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/445809e4-504a-4bd8-ad0a-822893ae4a10">

### PARTNER INCLUDED IN MEANS:

<img width="1290" alt="Screenshot 2024-06-06 at 14 53 37" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/4ae56b95-edbc-4c97-91a5-71322305decb">

<img width="1083" alt="Screenshot 2024-06-06 at 14 53 28" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/01d99071-ea3d-4e64-8801-2f94af675614">

## How to manually test the feature



[CRIMAPP-999]: https://dsdmoj.atlassian.net/browse/CRIMAPP-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ