### PR TITLE
CRIMAPP-968 update income payment type

### DIFF
--- a/app/controllers/steps/income/income_payments_controller.rb
+++ b/app/controllers/steps/income/income_payments_controller.rb
@@ -14,7 +14,7 @@ module Steps
       end
 
       def additional_permitted_params
-        payment_types = IncomePaymentType.values.map(&:to_s)
+        payment_types = IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.map(&:to_s)
         fieldset_attributes = Steps::Income::IncomePaymentFieldsetForm.attribute_names
 
         [

--- a/app/forms/steps/income/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/income_payment_fieldset_form.rb
@@ -17,7 +17,7 @@ module Steps
       validate :details_only_when_other?
 
       def payment_types
-        LaaCrimeSchemas::Types::OtherIncomePaymentType.values - ['none']
+        IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.map(&:to_s) - ['none']
       end
 
       def frequencies

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -6,7 +6,7 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :income
 
-      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::IncomePaymentType.values
+      PAYMENT_TYPES_ORDER = LaaCrimeSchemas::Types::OtherIncomePaymentType.values
 
       attr_writer :types
       attr_reader :new_payments
@@ -15,7 +15,7 @@ module Steps
 
       validates_with IncomePaymentsValidator
 
-      IncomePaymentType.values.each do |type| # rubocop:disable Style/HashEachMethods
+      IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.each do |type| # rubocop:disable Style/HashEachMethods
         attribute type.to_s, :string
 
         # Used by govuk form component to retrieve values to populate the fields_for
@@ -49,7 +49,7 @@ module Steps
       end
 
       def ordered_payment_types
-        LaaCrimeSchemas::Types::OtherIncomePaymentType.values & PAYMENT_TYPES_ORDER
+        IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.map(&:to_s) & PAYMENT_TYPES_ORDER
       end
 
       def types

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -15,7 +15,7 @@ module Steps
 
       validates_with IncomePaymentsValidator
 
-      IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.each do |type| # rubocop:disable Style/HashEachMethods
+      IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.each do |type|
         attribute type.to_s, :string
 
         # Used by govuk form component to retrieve values to populate the fields_for

--- a/app/value_objects/income_payment_type.rb
+++ b/app/value_objects/income_payment_type.rb
@@ -15,15 +15,15 @@ class IncomePaymentType < ValueObject
   ].freeze
 
   OTHER_INCOME_PAYMENT_TYPES = [
-    IncomePaymentType::MAINTENANCE,
-    IncomePaymentType::PRIVATE_PENSION,
-    IncomePaymentType::STATE_PENSION,
-    IncomePaymentType::INTEREST_INVESTMENT,
-    IncomePaymentType::STUDENT_LOAN_GRANT,
-    IncomePaymentType::BOARD,
-    IncomePaymentType::RENT,
-    IncomePaymentType::FINANCIAL_SUPPORT_WITH_ACCESS,
-    IncomePaymentType::FROM_FRIENDS_RELATIVES,
-    IncomePaymentType::OTHER
+    MAINTENANCE,
+    PRIVATE_PENSION,
+    STATE_PENSION,
+    INTEREST_INVESTMENT,
+    STUDENT_LOAN_GRANT,
+    BOARD,
+    RENT,
+    FINANCIAL_SUPPORT_WITH_ACCESS,
+    FROM_FRIENDS_RELATIVES,
+    OTHER
   ].freeze
 end

--- a/app/value_objects/income_payment_type.rb
+++ b/app/value_objects/income_payment_type.rb
@@ -13,4 +13,17 @@ class IncomePaymentType < ValueObject
     EMPLOYMENT = new(:employment),
     WORK_BENEFITS = new(:work_benefits)
   ].freeze
+
+  OTHER_INCOME_PAYMENT_TYPES = [
+    IncomePaymentType::MAINTENANCE,
+    IncomePaymentType::PRIVATE_PENSION,
+    IncomePaymentType::STATE_PENSION,
+    IncomePaymentType::INTEREST_INVESTMENT,
+    IncomePaymentType::STUDENT_LOAN_GRANT,
+    IncomePaymentType::BOARD,
+    IncomePaymentType::RENT,
+    IncomePaymentType::FINANCIAL_SUPPORT_WITH_ACCESS,
+    IncomePaymentType::FROM_FRIENDS_RELATIVES,
+    IncomePaymentType::OTHER
+  ].freeze
 end

--- a/app/value_objects/outgoings_payment_type.rb
+++ b/app/value_objects/outgoings_payment_type.rb
@@ -11,14 +11,14 @@ class OutgoingsPaymentType < ValueObject
   ].freeze
 
   OTHER_PAYMENT_TYPES = [
-    OutgoingsPaymentType::CHILDCARE,
-    OutgoingsPaymentType::MAINTENANCE,
-    OutgoingsPaymentType::LEGAL_AID_CONTRIBUTION,
+    CHILDCARE,
+    MAINTENANCE,
+    LEGAL_AID_CONTRIBUTION,
   ].freeze
 
   HOUSING_PAYMENT_TYPES = [
-    OutgoingsPaymentType::RENT,
-    OutgoingsPaymentType::MORTGAGE,
-    OutgoingsPaymentType::BOARD_AND_LODGING,
+    RENT,
+    MORTGAGE,
+    BOARD_AND_LODGING,
   ].freeze
 end


### PR DESCRIPTION
## Description of change

Create a separate subset of IncomePaymentType for other income payment types that do not include employment-related types (work_benefit and employment). This prevents employment payment type categories from appearing on the income payments page and in the income payments section on the CYA and RTA pages, and fixes the translation missing error. 

Also updates the schema version.

This needs to be merged AFTER https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/886 , then tests should also be passing 

## Link to relevant ticket

[CRIMAPP-968](https://dsdmoj.atlassian.net/browse/CRIMAPP-968)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1122" alt="Screenshot 2024-06-06 at 14 44 42" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/988f304a-3858-43d5-9a2a-0514aa5f7406">
<img width="1216" alt="Screenshot 2024-06-06 at 14 45 07" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/c4ca8b23-c583-4c68-b67b-df8d4496581e">

### After changes:
![Screenshot 2024-06-06 at 14 46 03](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/e2e8a7f9-3b7c-4351-9fb9-c9f07407c7b9)
![Screenshot 2024-06-06 at 14 45 50](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/a34868ad-13e5-4296-a97c-d503f4b67cec)



## How to manually test the feature


[CRIMAPP-968]: https://dsdmoj.atlassian.net/browse/CRIMAPP-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ