### PR TITLE
CRIMAPP-875 - Move column 'applicant_self_assessment_tax_bill'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.10'
+    tag: 'v1.1.11'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 256f2a7fb64d3e1bbd6d056f95e226006373dbae
-  tag: v1.1.10
+  revision: 8c5a2e43aa83a1f40d5d7c7ec6585489a3b00512
+  tag: v1.1.11
   specs:
     laa-criminal-legal-aid-schemas (1.1.10)
       dry-schema (~> 1.13)

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -1,6 +1,8 @@
 module Steps
   module Income
     module Client
+      # 'Self Assessment tax bill' is an outgoings payment but it is part of employment income journey.
+      # That's why we decided to keep it under 'steps/income' namespace
       class SelfAssessmentTaxBillForm < Steps::BaseFormObject
         attribute :applicant_self_assessment_tax_bill, :value_object, source: YesNoAnswer
         attribute :amount, :pence

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -49,11 +49,11 @@ module Steps
 
         def create_or_update_outgoings_attribute!
           if crime_application.outgoings.present?
-            crime_application.outgoings.update(
+            crime_application.outgoings.update!(
               applicant_self_assessment_tax_bill:,
             )
           else
-            crime_application.create_outgoings(
+            crime_application.create_outgoings!(
               applicant_self_assessment_tax_bill:,
             )
           end

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -12,10 +12,10 @@ module Steps
 
         def self.build(crime_application)
           payment = crime_application.outgoings_payments.self_assessment_tax_bill
-          income = crime_application.income
+          outgoings = crime_application.outgoings
           form = new
 
-          form.applicant_self_assessment_tax_bill = income.applicant_self_assessment_tax_bill if income
+          form.applicant_self_assessment_tax_bill = outgoings.applicant_self_assessment_tax_bill if outgoings
 
           if payment
             form.amount = payment.amount
@@ -43,14 +43,20 @@ module Steps
               )
             end
 
-            update_income_attribute!
+            create_or_update_outgoings_attribute!
           end
         end
 
-        def update_income_attribute!
-          crime_application.income.update(
-            applicant_self_assessment_tax_bill:,
-          )
+        def create_or_update_outgoings_attribute!
+          if crime_application.outgoings.present?
+            crime_application.outgoings.update(
+              applicant_self_assessment_tax_bill:,
+            )
+          else
+            crime_application.create_outgoings(
+              applicant_self_assessment_tax_bill:,
+            )
+          end
         end
 
         def reset!

--- a/db/migrate/20240606154545_move_applicant_self_assessment_tax_bill_column.rb
+++ b/db/migrate/20240606154545_move_applicant_self_assessment_tax_bill_column.rb
@@ -1,0 +1,6 @@
+class MoveApplicantSelfAssessmentTaxBillColumn < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :incomes, :applicant_self_assessment_tax_bill, :string
+    add_column :outgoings, :applicant_self_assessment_tax_bill, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -176,10 +176,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_title"
+    t.string "has_no_deductions"
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
-    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_06_080623) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -269,6 +269,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_080623) do
     t.string "pays_council_tax"
     t.string "has_no_other_outgoings"
     t.string "partner_income_tax_rate_above_threshold"
+    t.string "applicant_self_assessment_tax_bill"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -203,7 +203,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
     t.string "partner_employment_status", default: [], array: true
     t.string "partner_has_no_income_payments"
     t.string "partner_has_no_income_benefits"
-    t.string "applicant_self_assessment_tax_bill"
     t.string "applicant_other_work_benefit_received"
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end

--- a/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
   end
 
   let(:crime_application) { CrimeApplication.new }
-  let(:income) { Income.new(crime_application:) }
+  let(:outgoings) { Outgoings.new(crime_application:) }
   let(:outgoings_payment) {
     OutgoingsPayment.new(crime_application: crime_application,
                          payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s)
@@ -43,7 +43,7 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
       allow(crime_application.outgoings_payments).to(
         receive(:self_assessment_tax_bill).and_return(existing_outgoings_payment)
       )
-      income.applicant_self_assessment_tax_bill = 'yes'
+      outgoings.applicant_self_assessment_tax_bill = 'yes'
     end
 
     it 'sets the form attributes from the model' do
@@ -56,7 +56,7 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
   describe '#save' do
     before do
       allow(crime_application.outgoings_payments).to receive(:create!).and_return(true)
-      allow(crime_application).to receive(:income).and_return(income)
+      allow(crime_application).to receive(:outgoings).and_return(outgoings)
     end
 
     context 'when `applicant_self_assessment_tax_bill` is not provided' do


### PR DESCRIPTION
## Description of change
- As `Self Assessment tax bill` is an outgoing payment, it must have an entry in `outgoings` table
- Move column `applicant_self_assessment_tax_bill` from `income. applicant_self_assessment_tax_bill` to `outgoings. applicant_self_assessment_tax_bill`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-875

## Notes for reviewer
> [!NOTE]  
> Initially we were creating outgoings payment of {type: "OutgoingsPayment"} and updating `income. applicant_self_assessment_tax_bill`, which is wrong. 
> Outgoing payments should be associated with outgoings

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
http://localhost:3000/applications/:id/steps/income/client/self_assessment_client
