### PR TITLE
[CRIMAPP-896] Add partner to benefit check task list validation

### DIFF
--- a/app/validators/passporting_benefit_check/answers_validator.rb
+++ b/app/validators/passporting_benefit_check/answers_validator.rb
@@ -22,9 +22,9 @@ module PassportingBenefitCheck
     end
 
     def complete?
-      return false if applicant.benefit_type.blank?
+      return false if benefit_check_recipient.benefit_type.blank?
       return true if Passporting::MeansPassporter.new(crime_application).call
-      return true if applicant.benefit_type == BenefitType::NONE.to_s
+      return true if benefit_check_recipient.benefit_type == BenefitType::NONE.to_s
       return true if evidence_of_passporting_means_forthcoming?
 
       means_assessment_as_benefit_evidence?

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -3,13 +3,15 @@ require 'rails_helper'
 RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record) }
 
-  let(:record) { instance_double(CrimeApplication, errors:, applicant:) }
+  let(:record) { instance_double(CrimeApplication, errors:, applicant:, partner:, partner_detail:) }
   let(:errors) { double(:errors, empty?: false) }
   let(:applicant) { instance_double(Applicant, benefit_type:) }
   let(:benefit_type) { nil }
   let(:appeal_no_changes?) { false }
   let(:under18?) { false }
   let(:means_passported?) { false }
+  let(:partner) { nil }
+  let(:partner_detail) { nil }
 
   before do
     allow(record).to receive_messages(appeal_no_changes?: appeal_no_changes?)
@@ -75,6 +77,17 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
 
         it { is_expected.to be(true) }
       end
+    end
+
+    context 'when the partner is the benefit check recipient' do
+      let(:partner_detail) { double(PartnerDetail, involvement_in_case: 'none') }
+      let(:benefit_type) { BenefitType::NONE.to_s }
+      let(:partner) {
+        double(Partner, id: '234', benefit_type: BenefitType::UNIVERSAL_CREDIT.to_s,
+                             nino: 'AB123456A', has_benefit_evidence: 'yes')
+      }
+
+      it { is_expected.to be(true) }
     end
   end
 


### PR DESCRIPTION
## Description of change
Updates the passporting benefit check answers validator to be partner aware 

## Link to relevant ticket
[CRIMAPP-896](https://dsdmoj.atlassian.net/browse/CRIMAPP-896)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Test the scenarios shown [here in figma](https://www.figma.com/design/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=13705-65710&t=QLp9kyj63Y6lJAIG-0)

[CRIMAPP-896]: https://dsdmoj.atlassian.net/browse/CRIMAPP-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ