### PR TITLE
[CRIMAPP-953] Partner trust fund

### DIFF
--- a/app/controllers/steps/capital/partner_trust_fund_controller.rb
+++ b/app/controllers/steps/capital/partner_trust_fund_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Capital
+    class PartnerTrustFundController < Steps::CapitalStepController
+      def edit
+        @form_object = PartnerTrustFundForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(PartnerTrustFundForm, as: :partner_trust_fund)
+      end
+    end
+  end
+end

--- a/app/forms/steps/capital/partner_trust_fund_form.rb
+++ b/app/forms/steps/capital/partner_trust_fund_form.rb
@@ -20,12 +20,10 @@ module Steps
       private
 
       def persist!
-        binding.pry
         capital.update(attributes)
       end
 
       def before_save
-        binding.pry
         return if partner_will_benefit_from_trust_fund&.yes?
 
         self.partner_trust_fund_amount_held = nil

--- a/app/forms/steps/capital/partner_trust_fund_form.rb
+++ b/app/forms/steps/capital/partner_trust_fund_form.rb
@@ -1,0 +1,36 @@
+module Steps
+  module Capital
+    class PartnerTrustFundForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :capital
+
+      attribute :partner_will_benefit_from_trust_fund, :value_object, source: YesNoAnswer
+      attribute :partner_trust_fund_amount_held, :pence
+      attribute :partner_trust_fund_yearly_dividend, :pence
+
+      validates :partner_will_benefit_from_trust_fund, inclusion: { in: YesNoAnswer.values }
+
+      validates(
+        :partner_trust_fund_amount_held,
+        :partner_trust_fund_yearly_dividend,
+        presence: true,
+        if: -> { partner_will_benefit_from_trust_fund&.yes? }
+      )
+
+      private
+
+      def persist!
+        binding.pry
+        capital.update(attributes)
+      end
+
+      def before_save
+        binding.pry
+        return if partner_will_benefit_from_trust_fund&.yes?
+
+        self.partner_trust_fund_amount_held = nil
+        self.partner_trust_fund_yearly_dividend = nil
+      end
+    end
+  end
+end

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -3,6 +3,8 @@ class Capital < ApplicationRecord
   attribute :premium_bonds_total_value, :pence
   attribute :trust_fund_amount_held, :pence
   attribute :trust_fund_yearly_dividend, :pence
+  attribute :partner_trust_fund_amount_held, :pence
+  attribute :partner_trust_fund_yearly_dividend, :pence
   has_many :savings, through: :crime_application
   has_many :investments, through: :crime_application
   has_many :national_savings_certificates, through: :crime_application

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -35,6 +35,7 @@ module Summary
         national_savings_certificates
         investments
         trust_fund
+        partner_trust_fund
         other_capital_details
         supporting_evidence
         more_information
@@ -54,6 +55,7 @@ module Summary
         national_savings_certificates
         investments
         trust_fund
+        partner_trust_fund
         other_capital_details
       ],
       outgoings: %i[

--- a/app/presenters/summary/sections/partner_trust_fund.rb
+++ b/app/presenters/summary/sections/partner_trust_fund.rb
@@ -3,7 +3,6 @@ module Summary
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     class PartnerTrustFund < Sections::BaseSection
       def show?
-        binding.pry
         capital.present? && capital.partner_will_benefit_from_trust_fund.present?
       end
 

--- a/app/presenters/summary/sections/partner_trust_fund.rb
+++ b/app/presenters/summary/sections/partner_trust_fund.rb
@@ -1,0 +1,41 @@
+module Summary
+  module Sections
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    class PartnerTrustFund < Sections::BaseSection
+      def show?
+        binding.pry
+        capital.present? && capital.partner_will_benefit_from_trust_fund.present?
+      end
+
+      def answers
+        [
+          Components::ValueAnswer.new(
+            :partner_will_benefit_from_trust_fund,
+            crime_application.capital.partner_will_benefit_from_trust_fund,
+            change_path: edit_steps_capital_partner_trust_fund_path(crime_application),
+            show: true
+          ),
+          Components::MoneyAnswer.new(
+            :partner_trust_fund_amount_held,
+            crime_application.capital.partner_trust_fund_amount_held,
+            change_path: edit_steps_capital_partner_trust_fund_path(crime_application),
+            show: partner_will_benefit_from_trust_fund?
+          ),
+          Components::MoneyAnswer.new(
+            :partner_trust_fund_yearly_dividend,
+            crime_application.capital.partner_trust_fund_yearly_dividend,
+            change_path: edit_steps_capital_partner_trust_fund_path(crime_application),
+            show: partner_will_benefit_from_trust_fund?
+          )
+        ].select(&:show?)
+      end
+
+      private
+
+      def partner_will_benefit_from_trust_fund?
+        YesNoAnswer.new(capital.partner_will_benefit_from_trust_fund.to_s).yes?
+      end
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  end
+end

--- a/app/serializers/submission_serializer/sections/capital_details.rb
+++ b/app/serializers/submission_serializer/sections/capital_details.rb
@@ -2,7 +2,7 @@ module SubmissionSerializer
   module Sections
     class CapitalDetails < Sections::BaseSection
       def to_builder # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-        Jbuilder.new do |json|
+        Jbuilder.new do |json| # rubocop:disable Metrics/BlockLength
           next unless capital && requires_full_means_assessment?
 
           if requires_full_capital?
@@ -25,6 +25,9 @@ module SubmissionSerializer
           json.will_benefit_from_trust_fund capital.will_benefit_from_trust_fund
           json.trust_fund_amount_held capital.trust_fund_amount_held_before_type_cast
           json.trust_fund_yearly_dividend capital.trust_fund_yearly_dividend_before_type_cast
+          json.partner_will_benefit_from_trust_fund capital.partner_will_benefit_from_trust_fund
+          json.partner_trust_fund_amount_held capital.partner_trust_fund_amount_held_before_type_cast
+          json.partner_trust_fund_yearly_dividend capital.partner_trust_fund_yearly_dividend_before_type_cast
 
           unless income.has_frozen_income_or_assets.present? || capital.has_frozen_income_or_assets.blank?
             json.has_frozen_income_or_assets capital.has_frozen_income_or_assets

--- a/app/services/adapters/structs/capital_details.rb
+++ b/app/services/adapters/structs/capital_details.rb
@@ -1,11 +1,19 @@
 module Adapters
   module Structs
     class CapitalDetails < BaseStructAdapter
+      def trust_fund_amount_held
+        cast_to_pounds(super)
+      end
+
       def trust_fund_yearly_dividend
         cast_to_pounds(super)
       end
 
-      def trust_fund_amount_held
+      def partner_trust_fund_amount_held
+        cast_to_pounds(super)
+      end
+
+      def partner_trust_fund_yearly_dividend
         cast_to_pounds(super)
       end
 

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -101,7 +101,8 @@ module Adapters
       end
 
       delegate :savings, :investments, :national_savings_certificates, :properties,
-               :premium_bonds_total_value, :trust_fund_amount_held, :trust_fund_yearly_dividend, to: :capital
+               :premium_bonds_total_value, :trust_fund_amount_held, :trust_fund_yearly_dividend,
+               :partner_trust_fund_amount_held, :partner_trust_fund_yearly_dividend, to: :capital
 
       def documents
         supporting_evidence.map do |struct|

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -1,5 +1,6 @@
 module Decisions
   class CapitalDecisionTree < BaseDecisionTree # rubocop:disable Metrics/ClassLength
+    include TypeOfMeansAssessment
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
     def destination
       case step_name
@@ -42,6 +43,8 @@ module Decisions
       when :investments_summary
         after_investments_summary
       when :trust_fund
+        after_client_trust_fund
+      when :partner_trust_fund
         after_trust_fund
       when :frozen_income_savings_assets_capital
         edit(:answers)
@@ -95,6 +98,14 @@ module Decisions
       return edit(:saving_type) if form_object.add_property.no?
 
       edit(:other_property_type)
+    end
+
+    def after_client_trust_fund
+      if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+        edit(:partner_trust_fund)
+      else
+        after_trust_fund
+      end
     end
 
     def after_trust_fund
@@ -157,6 +168,10 @@ module Decisions
 
     def income_frozen_assets_unanswered?
       form_object.crime_application.income.has_frozen_income_or_assets.nil?
+    end
+
+    def crime_application
+      form_object.crime_application
     end
   end
 end

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -24,6 +24,7 @@ module CapitalAssessment
       end
 
       errors.add :trust_fund, :blank unless trust_fund_complete?
+      errors.add :partner_trust_fund, :blank unless partner_trust_fund_complete?
       errors.add :frozen_income_savings_assets_capital, :blank unless frozen_income_savings_assets_complete?
 
       errors.add(:base, :incomplete_records) if errors.present?
@@ -80,6 +81,14 @@ module CapitalAssessment
       return false unless record.will_benefit_from_trust_fund == 'yes'
 
       record.trust_fund_amount_held.present? && record.trust_fund_yearly_dividend.present?
+    end
+
+    def partner_trust_fund_complete?
+      return true unless FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      return true if record.partner_will_benefit_from_trust_fund == 'no'
+      return false unless record.partner_will_benefit_from_trust_fund == 'yes'
+
+      record.partner_trust_fund_amount_held.present? && record.partner_trust_fund_yearly_dividend.present?
     end
 
     def frozen_income_savings_assets_complete?

--- a/app/views/steps/capital/partner_trust_fund/edit.html.erb
+++ b/app/views/steps/capital/partner_trust_fund/edit.html.erb
@@ -1,0 +1,22 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:partner_will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
+        <%= f.govuk_radio_button :partner_will_benefit_from_trust_fund, YesNoAnswer::YES do %>
+          <%= f.govuk_number_field :partner_trust_fund_amount_held, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :partner_trust_fund_yearly_dividend, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+        <% end %>
+
+        <%= f.govuk_radio_button :partner_will_benefit_from_trust_fund, YesNoAnswer::NO %>
+      <% end %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -717,6 +717,14 @@ en:
               blank: Enter the yearly dividend
             will_benefit_from_trust_fund:
               inclusion: Select yes if your client stands to benefit from a trust fund inside or outside the UK
+        steps/capital/partner_trust_fund_form:
+          attributes:
+            partner_trust_fund_amount_held:
+              blank: Enter the amount held in the fund
+            partner_trust_fund_yearly_dividend:
+              blank: Enter the yearly dividend
+            partner_will_benefit_from_trust_fund:
+              inclusion: Select yes if the partner stands to benefit from a trust fund inside or outside the UK
         steps/capital/residential_form:
           attributes:
             house_type:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -831,6 +831,10 @@ en:
         trust_fund_amount_held: Enter the amount held in the fund
         trust_fund_yearly_dividend: Enter the yearly dividend
         will_benefit_from_trust_fund_options: *YESNO
+      steps_capital_partner_trust_fund_form:
+        partner_trust_fund_amount_held: Enter the amount held in the fund
+        partner_trust_fund_yearly_dividend: Enter the yearly dividend
+        partner_will_benefit_from_trust_fund_options: *YESNO
       steps_capital_residential_form:
         house_type_options:
           bungalow: Bungalow

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -511,6 +511,10 @@ en:
         edit:
           page_title: Does your client stand to benefit from a trust fund inside or outside the UK?
           heading: Does your client stand to benefit from a trust fund inside or outside the UK?
+      partner_trust_fund:
+        edit:
+          page_title: Does the partner stand to benefit from a trust fund inside or outside the UK?
+          heading: Does the partner stand to benefit from a trust fund inside or outside the UK?
 
       properties:
         confirm_destroy:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -103,7 +103,8 @@ en:
           <<: *RELATIONSHIP
       passporting_benefit_check: 'Passporting benefit check: client'
       passporting_benefit_check_partner: 'Passporting benefit check: partner'
-      trust_fund: Trust funds
+      trust_fund: 'Trust funds: client'
+      partner_trust_fund: 'Trust funds: partner'
       other_capital_details: Other capital
       employments: Jobs
       employment: Job
@@ -745,13 +746,23 @@ en:
 
       # START trust_fund
       will_benefit_from_trust_fund:
-        question: Does your client stand to benefit from a trust fund inside or outside the UK?
+        question: Trust fund
         answers: *YESNO
       trust_fund_amount_held:
-        question: Enter the amount held in the fund
+        question: Amount in fund
       trust_fund_yearly_dividend:
-        question: Enter the yearly dividend
+        question: Yearly dividend
       # END trust_fund
+
+      # START partner_trust_fund
+      partner_will_benefit_from_trust_fund:
+        question: Trust fund
+        answers: *YESNO
+      partner_trust_fund_amount_held:
+        question: Amount in fund
+      partner_trust_fund_yearly_dividend:
+        question: Yearly dividend
+      # END partner_trust_fund
 
       has_no_other_assets:
         question: Client has no other assets or capital

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,6 +236,7 @@ Rails.application.routes.draw do
 
         edit_step :client_any_premium_bonds, alias: :premium_bonds
         edit_step :client_benefit_from_trust_fund, alias: :trust_fund
+        edit_step :partner_benefit_from_trust_fund, alias: :partner_trust_fund
         edit_step :income_savings_assets_under_restraint_freezing_order, alias: :frozen_income_savings_assets_capital
 
         edit_step :check_your_answers_capital, alias: :answers

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -176,10 +176,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_title"
-    t.string "has_no_deductions"
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
+    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 

--- a/spec/controllers/steps/capital/partner_trust_fund_controller_spec.rb
+++ b/spec/controllers/steps/capital/partner_trust_fund_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PartnerTrustFundController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Capital::PartnerTrustFundForm,
+                  Decisions::CapitalDecisionTree
+end

--- a/spec/forms/steps/capital/partner_trust_fund_form_spec.rb
+++ b/spec/forms/steps/capital/partner_trust_fund_form_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::PartnerTrustFundForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
+      record: capital,
+    }.merge(attributes)
+  end
+
+  let(:attributes) { {} }
+
+  let(:capital) { instance_double(Capital) }
+
+  let(:crime_application) do
+    instance_double(CrimeApplication, capital:)
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_is_a(:partner_will_benefit_from_trust_fund, YesNoAnswer) }
+
+    context 'when `partner_will_benefit_from_trust_fund` answered yes' do
+      before { form.partner_will_benefit_from_trust_fund = 'yes' }
+
+      it { is_expected.to validate_presence_of(:partner_trust_fund_amount_held) }
+      it { is_expected.to validate_presence_of(:partner_trust_fund_yearly_dividend) }
+    end
+
+    context 'when `partner_will_benefit_from_trust_fund` answered no' do
+      before { form.partner_will_benefit_from_trust_fund = 'no' }
+
+      it { is_expected.not_to validate_presence_of(:partner_trust_fund_amount_held) }
+      it { is_expected.not_to validate_presence_of(:partner_trust_fund_yearly_dividend) }
+    end
+  end
+
+  describe '#save' do
+    context 'for valid details' do
+      before do
+        allow(capital).to receive(:update).and_return(true)
+
+        form.partner_will_benefit_from_trust_fund = partner_will_benefit_from_trust_fund
+        form.partner_trust_fund_amount_held = '100023.00'
+        form.partner_trust_fund_yearly_dividend = '2000.00'
+
+        subject.save
+      end
+
+      context 'when `partner_will_benefit_from_trust_fund` answered yes' do
+        let(:partner_will_benefit_from_trust_fund) { 'yes' }
+
+        let(:expected_args) do
+          {
+            partner_will_benefit_from_trust_fund: YesNoAnswer::YES,
+            partner_trust_fund_amount_held: Money.new(10_002_300),
+            partner_trust_fund_yearly_dividend: Money.new(200_000)
+          }
+        end
+
+        it 'updates capital with trust fund details' do
+          expect(capital).to have_received(:update).with(expected_args.stringify_keys)
+        end
+      end
+
+      context 'when `partner_will_benefit_from_trust_fund` answered no' do
+        let(:partner_will_benefit_from_trust_fund) { 'no' }
+
+        let(:expected_args) do
+          {
+            partner_will_benefit_from_trust_fund: YesNoAnswer::NO,
+            partner_trust_fund_amount_held: nil,
+            partner_trust_fund_yearly_dividend: nil
+          }.stringify_keys
+        end
+
+        it 'updates the record and sets the detail attributes to nil' do
+          expect(capital).to have_received(:update).with(expected_args)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -15,7 +15,7 @@ describe Summary::HtmlPresenter do
       income: (double has_no_income_payments: nil, has_no_income_benefits: nil), income_payments: [double],
       outgoings_payments: [instance_double(Payment, payment_type: 'childcare')], income_benefits: [double], outgoings: (double has_no_other_outgoings: nil),
       documents: double, application_type: application_type,
-      capital: (double has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
+      capital: (double has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', partner_will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
       savings: [double], investments: [double], national_savings_certificates: [double], properties: [double]
     )
   end
@@ -171,6 +171,7 @@ describe Summary::HtmlPresenter do
             NationalSavingsCertificates
             Investments
             TrustFund
+            PartnerTrustFund
             OtherCapitalDetails
             SupportingEvidence
             MoreInformation
@@ -214,6 +215,7 @@ describe Summary::HtmlPresenter do
             NationalSavingsCertificates
             Investments
             TrustFund
+            PartnerTrustFund
             OtherCapitalDetails
             SupportingEvidence
             MoreInformation
@@ -280,6 +282,7 @@ describe Summary::HtmlPresenter do
       Properties
       Savings
       TrustFund
+      PartnerTrustFund
     ]
 
     context 'when an initial application' do

--- a/spec/presenters/summary/sections/partner_trust_fund_spec.rb
+++ b/spec/presenters/summary/sections/partner_trust_fund_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe Summary::Sections::PartnerTrustFund do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { instance_double(CrimeApplication, capital: capital, in_progress?: true, to_param: 12_345) }
+
+  let(:capital) do
+    instance_double(
+      Capital,
+      partner_will_benefit_from_trust_fund: 'yes',
+      partner_trust_fund_amount_held: '1000.01',
+      partner_trust_fund_yearly_dividend: '100.01'
+    )
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:partner_trust_fund) }
+  end
+
+  describe '#show?' do
+    context 'when there is capital' do
+      it 'shows this section' do
+        expect(subject.show?).to be(true)
+      end
+    end
+
+    context 'when there is no capital' do
+      let(:capital) { nil }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    context 'when partner benefits from a trust fund' do
+      let(:expected_change_path) do
+        'applications/12345/steps/capital/partner_benefit_from_trust_fund'
+      end
+
+      it 'shows all answers' do
+        expect(answers.count).to eq(3)
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:partner_will_benefit_from_trust_fund)
+        expect(answers[0].change_path).to match(expected_change_path)
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(Summary::Components::MoneyAnswer)
+        expect(answers[1].question).to eq(:partner_trust_fund_amount_held)
+        expect(answers[1].change_path).to match(expected_change_path)
+        expect(answers[1].value).to eq('1000.01')
+
+        expect(answers[2]).to be_an_instance_of(Summary::Components::MoneyAnswer)
+        expect(answers[2].question).to eq(:partner_trust_fund_yearly_dividend)
+        expect(answers[1].change_path).to match(expected_change_path)
+        expect(answers[2].value).to eq('100.01')
+      end
+    end
+
+    context 'when partner does not benefit from a trust fund' do
+      before do
+        allow(capital).to receive(:partner_will_benefit_from_trust_fund).and_return('no')
+      end
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+      end
+    end
+
+    context 'when question has not yet been answered' do
+      before do
+        allow(capital).to receive(:partner_will_benefit_from_trust_fund).and_return(nil)
+      end
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/serializers/submission_serializer/sections/capital_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/capital_details_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
       will_benefit_from_trust_fund: 'yes',
       trust_fund_amount_held_before_type_cast: 1000,
       trust_fund_yearly_dividend_before_type_cast: 2000,
+      partner_will_benefit_from_trust_fund: 'yes',
+      partner_trust_fund_amount_held_before_type_cast: 2000,
+      partner_trust_fund_yearly_dividend_before_type_cast: 200,
       savings: [],
       investments: [],
       national_savings_certificates: [],
@@ -47,6 +50,9 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
           will_benefit_from_trust_fund: 'yes',
           trust_fund_amount_held: 1000,
           trust_fund_yearly_dividend: 2000,
+          partner_will_benefit_from_trust_fund: 'yes',
+          partner_trust_fund_amount_held: 2000,
+          partner_trust_fund_yearly_dividend: 200,
           savings: [],
           investments: [],
           national_savings_certificates: [],
@@ -73,6 +79,9 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
           will_benefit_from_trust_fund: 'yes',
           trust_fund_amount_held: 1000,
           trust_fund_yearly_dividend: 2000,
+          partner_will_benefit_from_trust_fund: 'yes',
+          partner_trust_fund_amount_held: 2000,
+          partner_trust_fund_yearly_dividend: 200,
           has_frozen_income_or_assets: 'yes'
         }.as_json
       end
@@ -88,7 +97,10 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
           {
             will_benefit_from_trust_fund: 'yes',
             trust_fund_amount_held: 1000,
-            trust_fund_yearly_dividend: 2000
+            trust_fund_yearly_dividend: 2000,
+            partner_will_benefit_from_trust_fund: 'yes',
+            partner_trust_fund_amount_held: 2000,
+            partner_trust_fund_yearly_dividend: 200
           }.as_json
         end
 

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Decisions::CapitalDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   let(:crime_application) do
     instance_double(
       CrimeApplication,
@@ -491,7 +492,7 @@ RSpec.describe Decisions::CapitalDecisionTree do
         it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
       end
     end
-    
+
     context 'when there is a partner' do
       context 'when partner is not included' do
         let(:involvement_in_case) { PartnerInvolvementType::VICTIM.to_s }
@@ -573,4 +574,5 @@ RSpec.describe Decisions::CapitalDecisionTree do
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe Decisions::CapitalDecisionTree do
       CrimeApplication,
       id: 'uuid',
       income: income,
-      capital: capital
+      capital: capital,
+      partner_detail: partner_detail
     )
   end
 
   let(:capital) { instance_double(Capital) }
   let(:income) { instance_double(Income, has_frozen_income_or_assets:) }
   let(:has_frozen_income_or_assets) { nil }
+  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:, conflict_of_interest:) }
+  let(:involvement_in_case) { nil }
+  let(:conflict_of_interest) { nil }
 
   before do
     allow(form_object).to receive_messages(crime_application:)
@@ -473,6 +477,47 @@ RSpec.describe Decisions::CapitalDecisionTree do
   context 'when the step is `trust_fund`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :trust_fund }
+
+    context 'when there is no partner' do
+      let(:partner_detail) { nil }
+
+      context 'when has_frozen_income_or_assets is nil' do
+        it { is_expected.to have_destination(:frozen_income_savings_assets_capital, :edit, id: crime_application) }
+      end
+
+      context 'when has_frozen_income_or_assets is set' do
+        let(:has_frozen_income_or_assets) { YesNoAnswer::YES.to_s }
+
+        it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
+      end
+    end
+    
+    context 'when there is a partner' do
+      context 'when partner is not included' do
+        let(:involvement_in_case) { PartnerInvolvementType::VICTIM.to_s }
+
+        context 'when has_frozen_income_or_assets is nil' do
+          it { is_expected.to have_destination(:frozen_income_savings_assets_capital, :edit, id: crime_application) }
+        end
+
+        context 'when has_frozen_income_or_assets is set' do
+          let(:has_frozen_income_or_assets) { YesNoAnswer::YES.to_s }
+
+          it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
+        end
+      end
+
+      context 'when partner is included' do
+        let(:involvement_in_case) { PartnerInvolvementType::NONE.to_s }
+
+        it { is_expected.to have_destination(:partner_trust_fund, :edit, id: crime_application) }
+      end
+    end
+  end
+
+  context 'when the step is `partner_trust_fund`' do
+    let(:form_object) { double('FormObject') }
+    let(:step_name) { :partner_trust_fund }
 
     context 'when has_frozen_income_or_assets is nil' do
       it { is_expected.to have_destination(:frozen_income_savings_assets_capital, :edit, id: crime_application) }


### PR DESCRIPTION
## Description of change
Add partner trust fund page
Add to serializer, struct, CYA, validator

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-953

## Notes for reviewer
This does not cover changing Partner from YES to NO - resetting etc needs to be done as a wider piece.

## Screenshots of changes (if applicable)
<img width="992" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/d83a788f-2834-47fd-b105-7fdf0c959e74">

## How to manually test the feature
Start an application, 
Case type Indictable
Partner Yes
Income £12475 Yes
Continue to Capital
Check errors when nothing select
Check errors when Yes selected and no numbers input
Complete page, check shows correctly on Capital CYA
Complete App, check shows correctly on app CYA