### PR TITLE
CRIMAPP-993 summary cards use latest content

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -30,10 +30,10 @@ module TypeOfMeansAssessment
   end
 
   def include_partner_in_means_assessment?
-    return true if partner_detail&.involvement_in_case == PartnerInvolvementType::NONE.to_s
-    return false unless partner_detail&.involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
+    return true if partner_involvement_in_case == PartnerInvolvementType::NONE.to_s
+    return false unless partner_involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
 
-    partner_detail.conflict_of_interest == 'no'
+    partner_conflict_of_interest == 'no'
   end
 
   def evidence_of_passporting_means_forthcoming?
@@ -76,6 +76,18 @@ module TypeOfMeansAssessment
   end
 
   private
+
+  # involvement_in_case is stored on partner_detail when a database applications and
+  # partner when a datastore application.
+  def partner_involvement_in_case
+    partner_detail&.involvement_in_case || partner&.involvement_in_case
+  end
+
+  # conflict_of_interest is stored on partner_detail when a database applications and
+  # partner when a datastore application.
+  def partner_conflict_of_interest
+    partner_detail&.conflict_of_interest || partner&.conflict_of_interest
+  end
 
   def has_passporting_benefit?
     BenefitType.passporting.include?(BenefitType.new(benefit_check_recipient.benefit_type.to_s))

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -90,7 +90,7 @@ module TypeOfMeansAssessment
   # partner when a datastore application.
   def partner_conflict_of_interest
     return partner_detail.conflict_of_interest if partner_detail
-    
+
     partner&.conflict_of_interest
   end
 

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -80,13 +80,17 @@ module TypeOfMeansAssessment
   # involvement_in_case is stored on partner_detail when a database applications and
   # partner when a datastore application.
   def partner_involvement_in_case
-    partner_detail&.involvement_in_case || partner&.involvement_in_case
+    return partner_detail.involvement_in_case if partner_detail
+
+    partner&.involvement_in_case
   end
 
   # conflict_of_interest is stored on partner_detail when a database applications and
   # partner when a datastore application.
   def partner_conflict_of_interest
-    partner_detail&.conflict_of_interest || partner&.conflict_of_interest
+    return partner_detail.conflict_of_interest if partner_detail
+    
+    partner&.conflict_of_interest
   end
 
   def has_passporting_benefit?

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -30,6 +30,7 @@ module TypeOfMeansAssessment
   end
 
   def include_partner_in_means_assessment?
+    return false unless partner.present? || partner_detail.present?
     return true if partner_involvement_in_case == PartnerInvolvementType::NONE.to_s
     return false unless partner_involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
 

--- a/app/presenters/summary/components/property.rb
+++ b/app/presenters/summary/components/property.rb
@@ -91,16 +91,15 @@ module Summary
         ].select(&:show?)
 
         property.property_owners.each_with_index do |owner, index|
+          owner_i18n_opts = i18n_opts.merge(index: index + 1)
           attributes << Components::FreeTextAnswer.new(
-            :name, owner.name, i18n_opts: { index: (index + 1).ordinalize_fully }
+            :name, owner.name, i18n_opts: owner_i18n_opts
           )
           attributes << Components::FreeTextAnswer.new(
             :relationship, relationship(owner)
           )
           attributes << Components::PercentageAnswer.new(
-            :percentage_owned, owner.percentage_owned, i18n_opts: {
-              asset:
-            }
+            :percentage_owned, owner.percentage_owned, i18n_opts: owner_i18n_opts
           )
         end
 
@@ -120,7 +119,7 @@ module Summary
       end
 
       def i18n_opts
-        { asset: }
+        { asset: asset, Asset: asset.capitalize }
       end
 
       def name

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -30,7 +30,7 @@ module Summary
           name,
           scope: 'summary.sections',
           subject: I18n.t('summary.dictionary.subject', subject_type:),
-          count: subject_type.applicant_and_partner? ? 2 : 1
+          count: subject_type.to_s == SubjectType::APPLICANT_AND_PARTNER.to_s ? 2 : 1
         )
       end
 

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -25,6 +25,15 @@ module Summary
         self.class.name.split('::').last.underscore.to_sym
       end
 
+      def title
+        I18n.t(
+          name,
+          scope: 'summary.sections',
+          subject: I18n.t('summary.dictionary.subject', subject_type:),
+          count: subject_type.applicant_and_partner? ? 2 : 1
+        )
+      end
+
       # May be overridden in subclasses to hide/show if appropriate
       def show?
         answers.any?
@@ -59,6 +68,10 @@ module Summary
       private
 
       delegate :requires_means_assessment?, :kase, :income, :outgoings, :capital, to: :crime_application
+
+      def subject_type
+        SubjectType.new(:applicant)
+      end
 
       # :nocov:
       def answers

--- a/app/presenters/summary/sections/dependants.rb
+++ b/app/presenters/summary/sections/dependants.rb
@@ -17,7 +17,7 @@ module Summary
             Components::FreeTextAnswer.new(
               :dependant, age(dependant),
               change_path: edit_steps_income_dependants_path,
-              i18n_opts: { ordinal: index.ordinalize_fully }
+              i18n_opts: { ordinal: index }
             )
           end
         ].flatten.select(&:show?)
@@ -27,8 +27,7 @@ module Summary
       private
 
       def age(dependant)
-        format = dependant.age == 1 ? 'one' : 'other'
-        I18n.t("summary.questions.dependant.answers.age.#{format}", age: dependant.age)
+        I18n.t('summary.questions.dependant.answers.age', age: dependant.age, count: dependant.age)
       end
 
       def dependants

--- a/app/presenters/summary/sections/other_income_details.rb
+++ b/app/presenters/summary/sections/other_income_details.rb
@@ -12,7 +12,7 @@ module Summary
           Components::ValueAnswer.new(
             :manage_without_income, income.manage_without_income,
             change_path: edit_steps_income_manage_without_income_path,
-            subject_type: manage_without_income_subject
+            subject_type: subject_type
           ),
           Components::FreeTextAnswer.new(
             :manage_other_details, income.manage_other_details,
@@ -23,7 +23,7 @@ module Summary
 
       private
 
-      def manage_without_income_subject
+      def subject_type
         return unless include_partner_in_means_assessment?
 
         SubjectType.new(:applicant_and_partner)

--- a/app/views/steps/income/income_before_tax/edit.html.erb
+++ b/app/views/steps/income/income_before_tax/edit.html.erb
@@ -8,7 +8,8 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :income_above_threshold, @form_object.choices,
                                            :value, inline: false,
-                                           legend: { text: legend_t(:income_above_threshold), tag: 'h1', size: 'xl' } %>
+                                           legend: { text: legend_t(:income_above_threshold), tag: 'h1', size: 'xl' },
+                                           hint: { text: hint_t(:income_above_threshold) } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/submission/shared/_section.html.erb
+++ b/app/views/steps/submission/shared/_section.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_card title: t(section.name, scope: 'summary.sections') do |card| %>
+<%= govuk_summary_card title: section.title do |card| %>
   <% if section.editable? && section.change_path %>
       <% card.with_action { govuk_link_to('Change', section.change_path, no_visited_state: true) } %>
   <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -126,7 +126,9 @@ en:
       steps_case_ioj_form:
         types: Why should your client get legal aid?
       steps_income_income_before_tax_form:
-        income_above_threshold: "Is %{subject}'s income currently more than £12,475 a year before tax?"
+        income_above_threshold: 
+          one: Is your client's annual income currently more than £12,475 a year before tax?
+          other: Is your client and their partner's joint annual income more than £12,475 a year before tax?
       steps_income_client_owns_property_form:
         client_owns_property: Does %{subject} own their home, or any other land or property?
         client_owns_property_info: Include land or property fully or partly owned, inside or outside the UK.
@@ -298,7 +300,9 @@ en:
         interest_of_another_justification: *ioj_justification_hint
         other_justification: *ioj_justification_hint
       steps_income_income_before_tax_form:
-        income_above_threshold: Do not include any employment income if your client has lost their job or ended employment.
+        income_above_threshold: 
+          one: Do not include any employment income if your client has lost their job or ended employment.
+          other: Do not include any employment income if your client or their partner has lost their job or ended employment.
       steps_income_client_owns_property_form:
         client_owns_property: Include land or property fully or partly owned, inside or outside the UK.
       steps_income_has_savings_form:
@@ -892,7 +896,7 @@ en:
             partner_with_a_contrary_interest: Partner with a contrary interest
             property_company: Property company
             other: Their relationship is not listed
-          other_relationship: Enter their relationship
+          other_relationship: What is their relationship?
       steps_capital_frozen_income_savings_assets_form:
         has_frozen_income_or_assets_options: *YESNO
       steps_capital_answers_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -459,7 +459,7 @@ en:
             stock: Stocks, including gilts and government bonds
             unit_trust: Unit trusts
             other: Other lump sum investments
-          info: You told us your %{subject} has investments.
+          info: You told us %{subject} has investments.
         confirm_destroy:
           page_title: Delete investment confirmation
           heading: Are you sure you want to remove this investment?
@@ -486,7 +486,7 @@ en:
           heading:  Does your client have any Premium Bonds?
       has_national_savings_certificates:
         edit:
-          heading:  Does your %{subject} have any National Savings Certificates?
+          heading:  Does %{subject} have any National Savings Certificates?
       national_savings_certificates:
         edit:
           heading: National Savings Certificates

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -29,8 +29,8 @@ en:
         property_company: Property company
       subjects:
         applicant: 'client'
-        applicant_and_partner: 'client and their partner'
-        applicant_or_partner: 'client or their partner'
+        applicant_and_partner: 'client and partner'
+        applicant_or_partner: 'client or partner'
         partner: 'partner'
 
     change_link_html: Change <span class="govuk-visually-hidden">%{a11y_question}</span>
@@ -66,7 +66,9 @@ en:
       income_details: Income
       income_payments_details: Payments your client gets
       income_benefits_details: Benefits your client gets
-      other_income_details: Other sources of income
+      other_income_details: 
+        one: "Other sources of income"
+        other: "Other sources of income: client and partner"
       housing_payments: Housing Payments
       outgoings_payments_details: 
         one: Payments %{subject} makes
@@ -165,7 +167,7 @@ en:
 
       # BEGIN contact details section
       residence_type:
-        question: Where the client lives
+        question: Where the client usually lives
         answers:
           rented: In rented accommodation
           temporary: In temporary accommodation
@@ -178,7 +180,7 @@ en:
       relationship_to_owner_of_usual_home_address:
         question: Relationship to client
       home_address:
-        question: Home address
+        question: Usual home address
         absence_answer: *absence_none
       correspondence_address:
         question: Correspondence address
@@ -369,21 +371,21 @@ en:
 
       # BEGIN employment details section
       employment_status:
-        question: What is your client’s employment status?
+        question: Client’s employment status?
         answers:
           not_working: Not working
           employed: Employed
           self_employed: Self-employed
       ended_employment_within_three_months:
-        question: Has your client ended employment in the last 3 months?
+        question: Employment ended in last 3 months?
         answers:
           <<: *YESNO
       lost_job_in_custody:
-        question: Did your client lose their job as a result of being in custody?
+        question: Employment ended because they were in custody?
         answers:
           <<: *YESNO
       date_job_lost:
-        question: When did they lose their job?
+        question: Date employment ended
       # END employment details section
 
       # BEGIN income details section
@@ -406,22 +408,22 @@ en:
 
       # BEGIN dependants section
       client_has_dependants:
-        question: Does your client have any dependants?
+        question: Any dependants?
         answers:
           <<: *YESNO
       dependant:
-        question: How old is the %{ordinal} dependant?
+        question: Age of dependant %{ordinal}
         answers:
           age:
-            one: "%{age} year old"
-            other: "%{age} years old"
+            one: "%{count} year old"
+            other: "%{count} years old"
       # END dependants section
 
       # BEGIN income payments details section
       which_payments:
-        question: Which of these payments does your client get?
+        question: Payments your client gets
         answers:
-          none: My client gets none of these payments
+          none: None
       maintenance_payment:
         question: Maintenance payments
         answers:
@@ -443,7 +445,7 @@ en:
         answers:
           description: *payment_answer_format
       board_from_family_payment:
-        question: Board from family members living with your client
+        question: Board from family members
         answers:
           description: *payment_answer_format
       rent_payment:
@@ -451,7 +453,7 @@ en:
         answers:
           description: *payment_answer_format
       financial_support_with_access_payment:
-        question: Financial support from someone who allows your client access to their assets or money
+        question: Financial support from someone who allows access to their assets or money
         answers:
           description: *payment_answer_format
       from_friends_relatives_payment:
@@ -463,14 +465,14 @@ en:
         answers:
           description: *payment_answer_format
       other_payment_details:
-        question: Details of other sources of income
+        question: Other sources of income details
       # END income payments details section
 
       # BEGIN income benefits details section
       which_benefits:
-        question: Which of these benefits does your client get?
+        question: Benefits your client gets?
         answers:
-          none: My client gets none of these benefits
+          none: None 
       child_benefit:
         question: Child Benefit
         answers:
@@ -488,7 +490,7 @@ en:
         answers:
           description: *payment_answer_format
       jsa_benefit:
-        question: Contribution-based Jobseeker’s Allowance (JSA)
+        question: Jobseeker’s Allowance
         answers:
           description: *payment_answer_format
       other_benefit:
@@ -502,8 +504,8 @@ en:
       # BEGIN other sources of income details section
       manage_without_income:
         question:
-          one: How %{subject} lives with no income?
-          other: How %{subject} live with no income?
+          one: How %{subject} lives with no income
+          other: How %{subject} live with no income
         answers:
           friends_sofa: They sleep on a friend's sofa for free
           family: They stay with family for free
@@ -610,20 +612,20 @@ en:
       supporting_evidence:
         question: File name
       additional_information:
-        question: Details that will help us process this application
+        question: Any additional information? 
         absence_answer: *absence_none
       # END supporting evidence section
 
       # BEGIN saving
       account_balance:
-        question: What is the account balance?
+        question: Account balance
         absence_answer: ''
       saving_ownership_type:
-        question: Whose name is the account in?
+        question: Name the account is in
         answers: *OWNERSHIP_TYPE
         absence_answer: ''
       account_number:
-        question: What is the account number?
+        question: Account number
         absence_answer: ''
       are_wages_paid_into_account:
         question: Client's wages or benefits paid into this account?
@@ -634,114 +636,114 @@ en:
         answers: *YESNO
         absence_answer: ''
       is_overdrawn:
-        question: Is the account overdrawn?
+        question: Account overdrawn?
         answers: *YESNO
         absence_answer: ''
       provider_name:
-        question: What is the name of the bank, building society or other holder of the savings?
+        question: Bank or building society
         absence_answer: ''
       sort_code:
-        question: What is the sort code or branch name?
+        question: Sort code or branch name
         absence_answer: ''
       has_capital_savings:
-        question: Which savings does %{subject} have inside or outside the UK?
+        question: Savings %{subject} has 
         answers:
           'none': *absence_none
       # END saving
       #
       # START premium_bonds
       has_premium_bonds:
-        question: Does your client have any Premium Bonds?
+        question: Any Premium Bonds?
         answers: *YESNO
       premium_bonds_total_value:
-        question: What is the total value of their bonds?
+        question: Total value
       premium_bonds_holder_number:
-        question: What is the holder number?
+        question: Holder number
         absence_answer: ''
       # END premium_bonds
 
       # START investments
       description:
-        question: Describe the investment
+        question: Investment description
         absence_answer: ''
       value:
-        question: What is the value of the investment?
+        question: Value
         absence_answer: *absence_none
       ownership_type:
-        question: Whose name is the investment in?
+        question: Name the investment is in
         answers: *OWNERSHIP_TYPE
         absence_answer: ''
       has_investments:
-        question: Which investments does your client have inside or outside the UK?
+        question: Investments?
         answers:
           'none': *absence_none
       # END investments
 
       # START national_savings_certificates
       national_savings_certificate_holder_number:
-        question: What is the customer number or holder number?
+        question: Customer or holder number
         absence_answer: ''
       national_savings_certificate_certificate_number:
-        question: 'What is the certificate number?'
+        question: Certificate number
         absence_answer: ''
       national_savings_certificate_value:
-        question: What is the value of the certificate?
+        question: Value 
         absence_answer: ''
       national_savings_certificate_ownership_type:
-        question: Whose name is the certificate in?
+        question: Who owns the certificate?
         answers: *OWNERSHIP_TYPE
         absence_answer: ''
       has_national_savings_certificate:
-        question: Does your client have any National Savings Certificates?
+        question: Any National Savings Certificates?
         answers:
           <<: *YESNO
       # END national_savings_certificates
 
       # BEGIN property, address and owners
       house_type:
-        question: Which type of property is it?
+        question: Type of property
         absence_answer: *absence_none
       bedrooms:
-        question: How many bedrooms are there?
+        question: Bedrooms
         absence_answer: *absence_none
       size_in_acres:
-        question: What size is the land?
+        question: Size of land 
         absence_answer: *absence_none
       usage:
-        question: How is the %{asset} used?
+        question: How %{asset} used 
         absence_answer: *absence_none
       # TODO :: Temporary fix to avoid duplicate keys
       property_value:
-        question: How much is the %{asset} worth?
+        question: '%{Asset} value'
         absence_answer: *absence_none
       outstanding_mortgage:
-        question: How much is left to pay on the mortgage?
+        question: Mortgage amount left
         absence_answer: *absence_none
       percentage_applicant_owned:
-        question: What percentage of the %{asset} does your client own?
+        question: Percentage client owns
         absence_answer: *absence_none
       percentage_partner_owned:
-        question: What percentage of the %{asset} does your client’s partner own?
+        question: Percentage partner owns
         absence_answer: *absence_none
       is_home_address:
-        question: Is the address of the %{asset} the same as your client’s home address?
+        question: Address same as client’s home
         answers: *YESNO
         absence_answer: *absence_none
       has_other_owners:
-        question: Does anyone else own part of the %{asset}?
+        question: Other owners
         answers: *YESNO
         absence_answer: *absence_none
       address:
         question: Address
         absence_answer: *absence_none
       name:
-        question: What is the name of the %{index} other owner?
+        question: Name of other owner %{index}
         absence_answer: *absence_none
       relationship:
-        question: What is their relationship to your client?
+        question: Relationship to %{subject} 
         absence_answer: *absence_none
       percentage_owned:
-        question: What percentage of the %{asset} do they own?
+        question: Percentage owner %{index} owns
         absence_answer: *absence_none
       has_assets:
         question: Assets %{subject} owns
@@ -751,7 +753,7 @@ en:
 
       # START trust_fund
       will_benefit_from_trust_fund:
-        question: Trust fund
+        question: Stands to benefit from a trust fund?
         answers: *YESNO
       trust_fund_amount_held:
         question: Amount in fund

--- a/spec/forms/steps/capital/other_investment_type_form_spec.rb
+++ b/spec/forms/steps/capital/other_investment_type_form_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe Steps::Capital::OtherInvestmentTypeForm do
   subject(:form) { described_class.new(crime_application:) }
 
-  let(:crime_application) { instance_double(CrimeApplication, investments:, partner_detail:) }
+  let(:crime_application) { instance_double(CrimeApplication, investments:, partner_detail:, partner:) }
   let(:investments) { double }
   let(:investment_type) { InvestmentType.values.sample.to_s }
   let(:new_investment) { instance_double(Investment) }
   let(:partner_detail) { nil }
+  let(:partner) { nil }
 
   describe '#choices' do
     it 'returns investment types' do

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TypeOfMeansAssessment do
   end
 
   let(:applicant) { instance_double(Applicant, has_benefit_evidence:) }
-  let(:partner) { instance_double(Partner) }
+  let(:partner) { nil }
   let(:benefit_check_recipient) { applicant }
   let(:has_benefit_evidence) { nil }
   let(:kase) { instance_double(Case) }

--- a/spec/presenters/summary/components/investment_spec.rb
+++ b/spec/presenters/summary/components/investment_spec.rb
@@ -59,15 +59,15 @@ RSpec.describe Summary::Components::Investment, type: :component do
   describe 'answers' do
     it 'renders as summary list' do
       expect(page).to have_summary_row(
-        'Describe the investment',
+        'Investment description',
         'About the shares'
       )
       expect(page).to have_summary_row(
-        'What is the value of the investment?',
+        'Value',
         '£100.00'
       )
       expect(page).to have_summary_row(
-        'Whose name is the investment in?',
+        'Name the investment is in',
         'Client'
       )
     end
@@ -86,15 +86,15 @@ RSpec.describe Summary::Components::Investment, type: :component do
 
       it 'renders as summary list with the correct absence_answer' do
         expect(page).to have_summary_row(
-          'Describe the investment',
+          'Investment description',
           ''
         )
         expect(page).to have_summary_row(
-          'What is the value of the investment?',
+          'Value',
           ''
         )
         expect(page).to have_summary_row(
-          'Whose name is the investment in?',
+          'Name the investment is in',
           ''
         )
       end

--- a/spec/presenters/summary/components/national_savings_certificate_spec.rb
+++ b/spec/presenters/summary/components/national_savings_certificate_spec.rb
@@ -66,19 +66,19 @@ RSpec.describe Summary::Components::NationalSavingsCertificate, type: :component
   describe 'answers' do
     it 'renders as summary list' do
       expect(page).to have_summary_row(
-        'What is the customer number or holder number?',
+        'Customer or holder number',
         'A1'
       )
       expect(page).to have_summary_row(
-        'What is the certificate number?',
+        'Certificate number',
         'B2'
       )
       expect(page).to have_summary_row(
-        'What is the value of the certificate?',
+        'Value',
         '£100.00'
       )
       expect(page).to have_summary_row(
-        'Whose name is the certificate in?',
+        'Who owns the certificate?',
         'Client'
       )
     end
@@ -98,19 +98,19 @@ RSpec.describe Summary::Components::NationalSavingsCertificate, type: :component
 
       it 'renders as summary list with the correct absence_answer' do
         expect(page).to have_summary_row(
-          'What is the customer number or holder number?',
+          'Customer or holder number',
           ''
         )
         expect(page).to have_summary_row(
-          'What is the certificate number?',
+          'Certificate number',
           ''
         )
         expect(page).to have_summary_row(
-          'What is the value of the certificate?',
+          'Value',
           ''
         )
         expect(page).to have_summary_row(
-          'Whose name is the certificate in?',
+          'Who owns the certificate?',
           ''
         )
       end

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -90,31 +90,31 @@ RSpec.describe Summary::Components::Property, type: :component do
   describe 'answers' do
     it 'renders as summary list' do # rubocop:disable RSpec/ExampleLength
       expect(page).to have_summary_row(
-        'Which type of property is it?',
+        'Type of property',
         'other_house_type'
       )
       expect(page).to have_summary_row(
-        'How many bedrooms are there?',
+        'Bedrooms',
         '3',
       )
       expect(page).to have_summary_row(
-        'How much is the property worth?',
+        'Property value',
         '£200,000.00',
       )
       expect(page).to have_summary_row(
-        'How much is left to pay on the mortgage?',
+        'Mortgage amount left',
         '£100,000.00',
       )
       expect(page).to have_summary_row(
-        'What percentage of the property does your client own?',
+        'Percentage client owns',
         '70.54%',
       )
       expect(page).to have_summary_row(
-        'Is the address of the property the same as your client’s home address?',
+        'Address same as client’s home',
         'Yes',
       )
       expect(page).to have_summary_row(
-        'Does anyone else own part of the property?',
+        'Other owners',
         'Yes',
       )
     end
@@ -124,13 +124,16 @@ RSpec.describe Summary::Components::Property, type: :component do
 
       it 'renders address in as summary list' do
         expect(page).to have_summary_row(
-          'Is the address of the property the same as your client’s home address?',
+          'Address same as client’s home',
           'No',
         )
-        expect(page).to have_summary_row(
-          'Address',
-          'london TW7 United Kingdom',
-        )
+
+        within(page.first('.govuk-summary-card')) do
+          expect(page).to have_summary_row(
+            'Address',
+            'london TW7 United Kingdom',
+          )
+        end
       end
     end
 
@@ -139,14 +142,14 @@ RSpec.describe Summary::Components::Property, type: :component do
 
       it 'renders address in as summary list' do
         expect(page).to have_summary_row(
-          'Is the address of the property the same as your client’s home address?',
+          'Address same as client’s home',
           'Yes',
         )
       end
     end
 
     describe 'summary list partner percentage' do
-      let(:partner_percent_text) { 'What percentage of the property does your client’s partner own?' }
+      let(:partner_percent_text) { 'Percentage partner owns' }
 
       context 'when client has partner' do
         let(:client_has_partner) { true }
@@ -170,42 +173,33 @@ RSpec.describe Summary::Components::Property, type: :component do
 
       it 'renders as summary list with other owners' do
         expect(page).to have_summary_row(
-          'Does anyone else own part of the property?',
+          'Other owners',
           'Yes',
         )
         expect(page).to have_summary_row(
-          'What is the name of the first other owner?',
+          'Name of other owner 1',
           'Joe',
         )
         expect(page).to have_summary_row(
-          'What is their relationship to your client?',
+          'Relationship to client',
           'Friends',
         )
         expect(page).to have_summary_row(
-          'What percentage of the property do they own?',
+          'Percentage owner 1 owns',
           '10.57%',
         )
-      end
-
-      context 'when land' do
-        let(:property_type) { 'land' }
-
-        it 'renders correct percentage ownership text' do
-          expect(page).to have_summary_row(
-            'What percentage of the land do they own?',
-            '10.57%',
-          )
-        end
       end
 
       context 'when other relationship' do
         let(:relationship) { 'other' }
 
         it 'renders as summary list with non-listed relationship' do
-          expect(page).to have_summary_row(
-            'What is their relationship to your client?',
-            'xyz',
-          )
+          within('div.govuk-notification-banner__heading') do
+            expect(page).to have_summary_row(
+              'Relationship to client',
+              'xyz',
+            )
+          end
         end
       end
     end
@@ -215,7 +209,7 @@ RSpec.describe Summary::Components::Property, type: :component do
 
       it 'renders as summary list with other owners' do
         expect(page).to have_summary_row(
-          'Does anyone else own part of the property?',
+          'Other owners',
           'No',
         )
       end
@@ -243,23 +237,23 @@ RSpec.describe Summary::Components::Property, type: :component do
 
       it 'renders as summary list with the correct absence_answer' do # rubocop:disable RSpec/ExampleLength
         expect(page).to have_summary_row(
-          'Which type of property is it?',
+          'Type of property',
           'None'
         )
         expect(page).to have_summary_row(
-          'How many bedrooms are there?',
+          'Bedrooms',
           'None',
         )
         expect(page).to have_summary_row(
-          'How much is the property worth?',
+          'Property value',
           '',
         )
         expect(page).to have_summary_row(
-          'How much is left to pay on the mortgage?',
+          'Mortgage amount left',
           '',
         )
         expect(page).to have_summary_row(
-          'Does anyone else own part of the property?',
+          'Other owners',
           '',
         )
       end

--- a/spec/presenters/summary/components/saving_spec.rb
+++ b/spec/presenters/summary/components/saving_spec.rb
@@ -69,23 +69,23 @@ RSpec.describe Summary::Components::Saving, type: :component do
   describe 'answers' do
     it 'renders as summary list' do # rubocop:disable RSpec/ExampleLength
       expect(page).to have_summary_row(
-        'What is the name of the bank, building society or other holder of the savings?',
+        'Bank or building society',
         'Bank of Test'
       )
       expect(page).to have_summary_row(
-        'What is the sort code or branch name?',
+        'Sort code or branch name',
         '01-01-01',
       )
       expect(page).to have_summary_row(
-        'What is the account number?',
+        'Account number',
         '01234500',
       )
       expect(page).to have_summary_row(
-        'What is the account balance?',
+        'Account balance',
         '£100.01',
       )
       expect(page).to have_summary_row(
-        'Is the account overdrawn?',
+        'Account overdrawn?',
         'No',
       )
       expect(page).to have_summary_row(
@@ -93,7 +93,7 @@ RSpec.describe Summary::Components::Saving, type: :component do
         'Yes',
       )
       expect(page).to have_summary_row(
-        'Whose name is the account in?',
+        'Name the account is in',
         'Client'
       )
     end
@@ -135,29 +135,14 @@ RSpec.describe Summary::Components::Saving, type: :component do
         }
       end
 
-      it 'renders as summary list with the correct absence_answer' do # rubocop:disable RSpec/ExampleLength
-        expect(page).to have_summary_row(
-          'What is the name of the bank, building society or other holder of the savings?', ''
-        )
-        expect(page).to have_summary_row(
-          'What is the sort code or branch name?', ''
-        )
-        expect(page).to have_summary_row(
-          'What is the account number?', ''
-        )
-        expect(page).to have_summary_row(
-          'What is the account balance?',
-          '',
-        )
-        expect(page).to have_summary_row(
-          'Is the account overdrawn?', ''
-        )
-        expect(page).to have_summary_row(
-          "Client's wages or benefits paid into this account?", ''
-        )
-        expect(page).to have_summary_row(
-          'Whose name is the account in?', ''
-        )
+      it 'renders as summary list with the correct absence_answer' do
+        expect(page).to have_summary_row('Bank or building society', '')
+        expect(page).to have_summary_row('Sort code or branch name', '')
+        expect(page).to have_summary_row('Account number', '')
+        expect(page).to have_summary_row('Account balance', '')
+        expect(page).to have_summary_row('Account overdrawn?', '')
+        expect(page).to have_summary_row("Client's wages or benefits paid into this account?", '')
+        expect(page).to have_summary_row('Name the account is in', '')
       end
     end
   end

--- a/spec/presenters/summary/sections/dependants_spec.rb
+++ b/spec/presenters/summary/sections/dependants_spec.rb
@@ -87,13 +87,13 @@ describe Summary::Sections::Dependants do
         expect(answers[1].question).to eq(:dependant)
         expect(answers[1].change_path).to match('/applications/12345/steps/income/dependants')
         expect(answers[1].value).to eq('17 years old')
-        expect(answers[1].i18n_opts[:ordinal]).to eq('first')
+        expect(answers[1].i18n_opts[:ordinal]).to eq(1)
 
         expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answers[2].question).to eq(:dependant)
         expect(answers[2].change_path).to match('/applications/12345/steps/income/dependants')
         expect(answers[2].value).to eq('1 year old')
-        expect(answers[2].i18n_opts[:ordinal]).to eq('second')
+        expect(answers[2].i18n_opts[:ordinal]).to eq(2)
       end
     end
   end

--- a/spec/presenters/summary/sections/dwp_details_spec.rb
+++ b/spec/presenters/summary/sections/dwp_details_spec.rb
@@ -9,6 +9,7 @@ describe Summary::Sections::DWPDetails do
       to_param: '12345',
       client_has_partner: 'no',
       partner_detail: nil,
+      partner: nil,
       applicant: applicant
     )
   end

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -89,7 +89,7 @@ describe Summary::Sections::IncomeDetails do
 
       let(:expected_labels) do
         [
-          'Client or their partner owns home, land or property?',
+          'Client or partner owns home, land or property?',
           'Income more than £12,475 a year before tax?',
           'Income, savings or assets under a restraint or freezing order',
           'Savings or investments?'

--- a/spec/presenters/summary/sections/other_income_details_spec.rb
+++ b/spec/presenters/summary/sections/other_income_details_spec.rb
@@ -69,13 +69,13 @@ describe Summary::Sections::OtherIncomeDetails do
     context 'when partner is included in means assessment' do
       let(:include_partner?) { true }
 
-      it { is_expected.to eq 'How client and their partner live with no income?' }
+      it { is_expected.to eq 'How client and partner live with no income' }
     end
 
     context 'when partner is not included means assessment' do
       let(:include_partner?) { false }
 
-      it { is_expected.to eq 'How client lives with no income?' }
+      it { is_expected.to eq 'How client lives with no income' }
     end
   end
 end

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Decisions::CapitalDecisionTree do
       id: 'uuid',
       income: income,
       capital: capital,
-      partner_detail: partner_detail
+      partner_detail: partner_detail,
+      partner: nil
     )
   end
 

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Decisions::DWPDecisionTree do
   let(:applicant) { double(Applicant, benefit_check_result:) }
   let(:benefit_check_result) { false }
   let(:benefit_check_recipient) { applicant }
-  let(:partner) { double(Partner, has_passporting_benefit?: has_passporting_benefit) }
+  let(:partner) { nil }
   let(:has_passporting_benefit) { false }
   let(:partner_detail) { nil }
 
@@ -71,6 +71,7 @@ RSpec.describe Decisions::DWPDecisionTree do
       end
 
       context 'when the benefit check recipient is the partner' do
+        let(:partner) { double(Partner, has_passporting_benefit?: has_passporting_benefit) }
         let(:has_passporting_benefit) { true }
 
         it { is_expected.to have_destination('steps/partner/details', :edit, id: crime_application) }
@@ -273,6 +274,7 @@ RSpec.describe Decisions::DWPDecisionTree do
 
       context 'when the benefit check recipient is the partner' do
         let(:has_passporting_benefit) { true }
+        let(:partner) { double(Partner, has_passporting_benefit?: has_passporting_benefit) }
 
         it { is_expected.to have_destination('steps/partner/nino', :edit, id: crime_application) }
       end

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Decisions::IncomeDecisionTree do
       dependants: dependants_double,
       employments: employments_double,
       kase: kase,
-      partner_detail: partner_detail
+      partner_detail: partner_detail,
+      partner: nil
     )
   end
 
@@ -27,6 +28,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
   let(:case_type) { nil }
   let(:feature_flag_employment_journey_enabled) { false }
   let(:partner_detail) { nil }
+  let(:partner) { nil }
 
   before do
     allow(

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       id: 'uuid',
       outgoings: outgoings,
       kase: kase,
-      partner_detail: partner_detail
+      partner_detail: partner_detail,
+      partner: partner
     )
   end
 
@@ -17,6 +18,7 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
   let(:kase) { instance_double(Case, case_type:) }
   let(:case_type) { nil }
   let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:, conflict_of_interest:) }
+  let(:partner) { instance_double(Partner) }
   let(:involvement_in_case) { nil }
   let(:conflict_of_interest) { nil }
 

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -132,6 +132,10 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       context 'when there is no partner' do
         let(:partner_detail) { nil }
 
+        before do
+          allow(crime_application).to receive(:partner)
+        end
+
         it { is_expected.to have_destination(:outgoings_more_than_income, :edit, id: crime_application) }
       end
 

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Decisions::SubmissionDecisionTree do
       applicant: applicant,
       case: kase,
       partner_detail: nil,
+      partner: nil
     )
   end
 

--- a/spec/services/dwp/benefit_check_status_service_spec.rb
+++ b/spec/services/dwp/benefit_check_status_service_spec.rb
@@ -30,10 +30,7 @@ RSpec.describe DWP::BenefitCheckStatusService do
     )
   end
 
-  let(:partner) do
-    double(Partner, id: '234')
-  end
-
+  let(:partner) { nil }
   let(:partner_detail) { nil }
   let(:id) { '1234' }
   let(:benefit_type) { nil }

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Passporting::MeansPassporter do
       applicant: applicant,
       resubmission?: resubmission?,
       is_means_tested: is_means_tested,
-      partner_detail: nil
+      partner_detail: nil,
+      partner: nil
     )
   }
 

--- a/spec/validators/capital_assessment/answers_validator_spec.rb
+++ b/spec/validators/capital_assessment/answers_validator_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record:, crime_application:) }
 
   let(:record) { instance_double(Capital, crime_application:, errors:) }
-  let(:crime_application) { instance_double(CrimeApplication, income:, partner_detail:) }
+  let(:crime_application) { instance_double(CrimeApplication, income:, partner_detail:, partner:) }
   let(:income) { instance_double(Income) }
   let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:partner) { nil }
   let(:errors) { double(:errors) }
   let(:involvement_in_case) { nil }
   let(:requires_full_means_assessment?) { true }

--- a/spec/validators/employment_details/answers_validator_spec.rb
+++ b/spec/validators/employment_details/answers_validator_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe EmploymentDetails::AnswersValidator, type: :model do
   end
 
   let(:errors) { double(:errors, empty?: false) }
-  let(:crime_application) { instance_double(CrimeApplication, partner_detail:) }
+  let(:crime_application) { instance_double(CrimeApplication, partner_detail:, partner:) }
   let(:employment_status) { [] }
   let(:partner_employment_status) { nil }
   let(:partner_detail) { nil }
+  let(:partner) { nil }
 
   describe '#applicable?' do
     subject(:applicable?) { validator.applicable? }

--- a/spec/validators/outgoings_assessment/answers_validator_spec.rb
+++ b/spec/validators/outgoings_assessment/answers_validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record:, crime_application:) }
 
   let(:record) { instance_double(Outgoings, crime_application:, errors:) }
-  let(:crime_application) { instance_double CrimeApplication }
+  let(:crime_application) { instance_double(CrimeApplication, partner: nil) }
 
   let(:errors) { [] }
   let(:requires_full_means_assessment?) { true }


### PR DESCRIPTION
## Description of change

Update summary card labels to the latest values.

Also fixes an issue where final submission/review and submitted applications where not correctly understanding if partner should be included in means assessment.

## Link to relevant ticket

[CRIMAPP-993](https://dsdmoj.atlassian.net/browse/CRIMAPP-993)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-993]: https://dsdmoj.atlassian.net/browse/CRIMAPP-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ