### PR TITLE
CRIMAPP-875- Refactor self-assessment-tax-bill

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '25363597a4c1cd9f6de38898d0881636b9652019'
+    ref: 'v1.1.12'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.11'
+    ref: '25363597a4c1cd9f6de38898d0881636b9652019'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 8c5a2e43aa83a1f40d5d7c7ec6585489a3b00512
-  tag: v1.1.11
+  revision: 25363597a4c1cd9f6de38898d0881636b9652019
+  ref: 25363597a4c1cd9f6de38898d0881636b9652019
   specs:
-    laa-criminal-legal-aid-schemas (1.1.10)
+    laa-criminal-legal-aid-schemas (1.1.11)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 25363597a4c1cd9f6de38898d0881636b9652019
-  ref: 25363597a4c1cd9f6de38898d0881636b9652019
+  revision: 64c052fd93b1cfa4760b0136393cfdc88b9cf0a1
+  ref: v1.1.12
   specs:
     laa-criminal-legal-aid-schemas (1.1.11)
       dry-schema (~> 1.13)

--- a/app/controllers/steps/income/client/self_assessment_tax_bill_controller.rb
+++ b/app/controllers/steps/income/client/self_assessment_tax_bill_controller.rb
@@ -4,12 +4,12 @@ module Steps
       class SelfAssessmentTaxBillController < Steps::IncomeStepController
         def edit
           @form_object = SelfAssessmentTaxBillForm.build(
-            current_crime_application.income, crime_application: current_crime_application
+            current_crime_application
           )
         end
 
         def update
-          update_and_advance(SelfAssessmentTaxBillForm, record: current_crime_application.income, as: :client_self_assessment_tax_bill)
+          update_and_advance(SelfAssessmentTaxBillForm, as: :client_self_assessment_tax_bill)
         end
       end
     end

--- a/app/controllers/steps/income/client/self_assessment_tax_bill_controller.rb
+++ b/app/controllers/steps/income/client/self_assessment_tax_bill_controller.rb
@@ -4,12 +4,12 @@ module Steps
       class SelfAssessmentTaxBillController < Steps::IncomeStepController
         def edit
           @form_object = SelfAssessmentTaxBillForm.build(
-            current_crime_application
+            current_crime_application.income, crime_application: current_crime_application
           )
         end
 
         def update
-          update_and_advance(SelfAssessmentTaxBillForm, as: :client_self_assessment_tax_bill)
+          update_and_advance(SelfAssessmentTaxBillForm, record: current_crime_application.income, as: :client_self_assessment_tax_bill)
         end
       end
     end

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -15,7 +15,6 @@ module Steps
         validates :applicant_self_assessment_tax_bill_frequency,
                   inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
 
-
         private
 
         def persist!

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -1,27 +1,25 @@
 module Steps
   module Income
     module Client
-      # 'Self Assessment tax bill' is an outgoings payment but it is part of employment income journey.
-      # That's why we decided to keep it under 'steps/income' namespace
       class SelfAssessmentTaxBillForm < Steps::BaseFormObject
         attribute :applicant_self_assessment_tax_bill, :value_object, source: YesNoAnswer
-        attribute :amount, :pence
-        attribute :frequency, :value_object, source: PaymentFrequencyType
+        attribute :applicant_self_assessment_tax_bill_amount, :pence
+        attribute :applicant_self_assessment_tax_bill_frequency, :value_object, source: PaymentFrequencyType
 
         validates :applicant_self_assessment_tax_bill, inclusion: { in: YesNoAnswer.values }
-        validates :amount, numericality: { greater_than: 0 }, if: -> { pays_self_assessment_tax_bill? }
-        validates :frequency, inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
+        validates :applicant_self_assessment_tax_bill_amount,
+                  numericality: { greater_than: 0 }, if: -> { pays_self_assessment_tax_bill? }
+        validates :applicant_self_assessment_tax_bill_frequency,
+                  inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
 
         def self.build(crime_application)
-          payment = crime_application.outgoings_payments.self_assessment_tax_bill
-          outgoings = crime_application.outgoings
+          income = crime_application.income
           form = new
 
-          form.applicant_self_assessment_tax_bill = outgoings.applicant_self_assessment_tax_bill if outgoings
-
-          if payment
-            form.amount = payment.amount
-            form.frequency = payment.frequency
+          if income
+            form.applicant_self_assessment_tax_bill = income.applicant_self_assessment_tax_bill
+            form.applicant_self_assessment_tax_bill_amount = income.applicant_self_assessment_tax_bill_amount
+            form.applicant_self_assessment_tax_bill_frequency = income.applicant_self_assessment_tax_bill_frequency
           end
 
           form
@@ -29,40 +27,19 @@ module Steps
 
         private
 
+        def persist!
+          crime_application.income.update!(attributes)
+        end
+
         def pays_self_assessment_tax_bill?
           applicant_self_assessment_tax_bill&.yes?
         end
 
-        def persist!
-          ::OutgoingsPayment.transaction do
-            reset!
+        def before_save
+          return if pays_self_assessment_tax_bill?
 
-            if pays_self_assessment_tax_bill?
-              crime_application.outgoings_payments.create!(
-                payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.value,
-                amount: amount,
-                frequency: frequency,
-              )
-            end
-
-            create_or_update_outgoings_attribute!
-          end
-        end
-
-        def create_or_update_outgoings_attribute!
-          if crime_application.outgoings.present?
-            crime_application.outgoings.update!(
-              applicant_self_assessment_tax_bill:,
-            )
-          else
-            crime_application.create_outgoings!(
-              applicant_self_assessment_tax_bill:,
-            )
-          end
-        end
-
-        def reset!
-          crime_application.outgoings_payments.self_assessment_tax_bill&.destroy
+          self.applicant_self_assessment_tax_bill_amount = nil
+          self.applicant_self_assessment_tax_bill_frequency = nil
         end
       end
     end

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -2,6 +2,9 @@ module Steps
   module Income
     module Client
       class SelfAssessmentTaxBillForm < Steps::BaseFormObject
+        include Steps::HasOneAssociation
+        has_one_association :income
+
         attribute :applicant_self_assessment_tax_bill, :value_object, source: YesNoAnswer
         attribute :applicant_self_assessment_tax_bill_amount, :pence
         attribute :applicant_self_assessment_tax_bill_frequency, :value_object, source: PaymentFrequencyType
@@ -16,7 +19,7 @@ module Steps
         private
 
         def persist!
-          record.update!(attributes)
+          income.update!(attributes)
         end
 
         def pays_self_assessment_tax_bill?

--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -12,23 +12,11 @@ module Steps
         validates :applicant_self_assessment_tax_bill_frequency,
                   inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
 
-        def self.build(crime_application)
-          income = crime_application.income
-          form = new
-
-          if income
-            form.applicant_self_assessment_tax_bill = income.applicant_self_assessment_tax_bill
-            form.applicant_self_assessment_tax_bill_amount = income.applicant_self_assessment_tax_bill_amount
-            form.applicant_self_assessment_tax_bill_frequency = income.applicant_self_assessment_tax_bill_frequency
-          end
-
-          form
-        end
 
         private
 
         def persist!
-          crime_application.income.update!(attributes)
+          record.update!(attributes)
         end
 
         def pays_self_assessment_tax_bill?

--- a/app/models/employments_payment.rb
+++ b/app/models/employments_payment.rb
@@ -1,4 +1,0 @@
-class EmploymentsPayment < ApplicationRecord
-  belongs_to :employment
-  belongs_to :payment
-end

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -4,6 +4,8 @@ class Income < ApplicationRecord
   has_many :income_benefits, through: :crime_application
   has_many :dependants, through: :crime_application
 
+  attribute :applicant_self_assessment_tax_bill_amount, :pence
+
   validate on: :submission do
     answers_validator.validate
   end

--- a/app/models/outgoings_payment.rb
+++ b/app/models/outgoings_payment.rb
@@ -36,10 +36,6 @@ class OutgoingsPayment < Payment
     where(payment_type: OutgoingsPaymentType::MAINTENANCE.value).order(created_at: :desc).first
   end
 
-  def self.self_assessment_tax_bill
-    where(payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.value).order(created_at: :desc).first
-  end
-
   # Manually cast food_amount and board_amount
   # because Rails will not convert to :pence as they are
   # store_accessor attributes

--- a/app/presenters/summary/sections/self_assessment_tax_bill.rb
+++ b/app/presenters/summary/sections/self_assessment_tax_bill.rb
@@ -1,21 +1,23 @@
 module Summary
   module Sections
     class SelfAssessmentTaxBill < Sections::BaseSection
+      SelfAssessmentTaxBillPayment = Struct.new(:amount, :frequency)
+
       def show?
-        outgoings.present? && outgoings.applicant_self_assessment_tax_bill.present?
+        income.present? && income.applicant_self_assessment_tax_bill.present?
       end
 
       def answers # rubocop:disable Metrics/MethodLength
         answers = [
           Components::ValueAnswer.new(
-            :self_assessment_tax_bill, outgoings.applicant_self_assessment_tax_bill,
+            :self_assessment_tax_bill, income.applicant_self_assessment_tax_bill,
             change_path: edit_steps_income_client_self_assessment_tax_bill_path
           )
         ]
 
-        if outgoings.applicant_self_assessment_tax_bill == YesNoAnswer::YES.to_s
+        if income.applicant_self_assessment_tax_bill == YesNoAnswer::YES.to_s
           answers << Components::PaymentAnswer.new(
-            :self_assessment_tax_bill_payment, self_assessment_tax_bill,
+            :self_assessment_tax_bill_payment, self_assessment_tax_bill_payment,
             change_path: edit_steps_income_client_self_assessment_tax_bill_path
           )
         end
@@ -23,13 +25,12 @@ module Summary
         answers
       end
 
-      # :nocov:
-      def self_assessment_tax_bill
-        crime_application
-          .outgoings_payments
-          .detect { |payment| payment.payment_type == OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s }
+      def self_assessment_tax_bill_payment
+        SelfAssessmentTaxBillPayment.new(
+          amount: income.applicant_self_assessment_tax_bill_amount,
+          frequency: income.applicant_self_assessment_tax_bill_frequency
+        )
       end
-      # :nocov:
     end
   end
 end

--- a/app/serializers/submission_serializer/sections/income_details.rb
+++ b/app/serializers/submission_serializer/sections/income_details.rb
@@ -22,6 +22,9 @@ module SubmissionSerializer
           json.has_no_income_benefits income.has_no_income_benefits
           json.partner_employment_type income.partner_employment_status
           json.applicant_other_work_benefit_received income.applicant_other_work_benefit_received
+          json.applicant_self_assessment_tax_bill income.applicant_self_assessment_tax_bill
+          json.applicant_self_assessment_tax_bill_amount income.applicant_self_assessment_tax_bill_amount_before_type_cast # rubocop:disable Layout/LineLength
+          json.applicant_self_assessment_tax_bill_frequency income.applicant_self_assessment_tax_bill_frequency
         end
       end
     end

--- a/app/serializers/submission_serializer/sections/outgoings_details.rb
+++ b/app/serializers/submission_serializer/sections/outgoings_details.rb
@@ -13,7 +13,6 @@ module SubmissionSerializer
           json.how_manage outgoings.how_manage
           json.pays_council_tax outgoings.pays_council_tax
           json.has_no_other_outgoings outgoings.has_no_other_outgoings
-          json.applicant_self_assessment_tax_bill outgoings.applicant_self_assessment_tax_bill
         end
       end
     end

--- a/app/services/adapters/structs/income_details.rb
+++ b/app/services/adapters/structs/income_details.rb
@@ -6,6 +6,10 @@ module Adapters
         employment_type || []
       end
 
+      def applicant_self_assessment_tax_bill_amount
+        Money.new(super)
+      end
+
       def partner_employment_status
         partner_employment_type || []
       end

--- a/app/value_objects/outgoings_payment_type.rb
+++ b/app/value_objects/outgoings_payment_type.rb
@@ -6,8 +6,7 @@ class OutgoingsPaymentType < ValueObject
     COUNCIL_TAX = new(:council_tax),
     CHILDCARE = new(:childcare),
     MAINTENANCE = new(:maintenance),
-    LEGAL_AID_CONTRIBUTION = new(:legal_aid_contribution),
-    SELF_ASSESSMENT_TAX_BILL = new(:self_assessment_tax_bill)
+    LEGAL_AID_CONTRIBUTION = new(:legal_aid_contribution)
   ].freeze
 
   OTHER_PAYMENT_TYPES = [

--- a/app/views/steps/income/client/self_assessment_tax_bill/edit.html.erb
+++ b/app/views/steps/income/client/self_assessment_tax_bill/edit.html.erb
@@ -13,10 +13,10 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset :applicant_self_assessment_tax_bill, legend: { tag: 'h1', size: 'xl', hidden: true } do %>
         <%= f.govuk_radio_button :applicant_self_assessment_tax_bill, YesNoAnswer::YES do %>
-          <%= f.govuk_number_field(:amount,
+          <%= f.govuk_number_field(:applicant_self_assessment_tax_bill_amount,
                                    prefix_text: '£',
                                    width: 'one-half') %>
-          <%= f.govuk_collection_radio_buttons(:frequency,
+          <%= f.govuk_collection_radio_buttons(:applicant_self_assessment_tax_bill_frequency,
                                                PaymentFrequencyType.values,
                                                :value,
                                                legend: { size: 's',

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -514,9 +514,9 @@ en:
           attributes:
             applicant_self_assessment_tax_bill:
               inclusion: Select yes if your client pays a Self Assessment tax bill received in the last 2 years
-            amount:
+            applicant_self_assessment_tax_bill_amount:
               not_a_number: Enter the amount they pay
-            frequency:
+            applicant_self_assessment_tax_bill_frequency:
               inclusion: Select how often they pay this amount
         steps/income/client/other_work_benefits_form:
           attributes:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -154,7 +154,7 @@ en:
         add_client_employment: Do you want to add another job?
       steps_income_client_self_assessment_tax_bill_form:
         applicant_self_assessment_tax_bill: Does your client pay a Self Assessment tax bill received in the last 2 years?
-        frequency: How often do they pay this amount?
+        applicant_self_assessment_tax_bill_frequency: How often do they pay this amount?
       steps_income_income_payments_form:
         income_payments: Which of these payments does your client get?
       steps_income_income_benefits_form:
@@ -596,8 +596,8 @@ en:
           details: Enter details of other deductions
       steps_income_client_self_assessment_tax_bill_form:
         applicant_self_assessment_tax_bill_options: *YESNO
-        amount: How much do they pay?
-        frequency_options: *frequency_options
+        applicant_self_assessment_tax_bill_amount: How much do they pay?
+        applicant_self_assessment_tax_bill_frequency_options: *frequency_options
       steps_income_client_employments_summary_form:
         add_client_employment_options: *YESNO
       steps_income_client_other_work_benefits_form:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -847,7 +847,7 @@ en:
         question: Does the client pay a Self Assessment tax bill?
         answers: *YESNO
       self_assessment_tax_bill_payment:
-        question: Enter the amount
+        question: Amount
         answers:
           description: *payment_answer_format
 
@@ -855,6 +855,6 @@ en:
         question: Does your client receive any other benefits from work?
         answers: *YESNO
       work_benefits_payment:
-        question: Enter the total value every year
+        question: Total value every year
         answers:
           description: *payment_answer_format

--- a/db/migrate/20240612111633_add_self_assessment_tax_bill_columns_to_incomes.rb
+++ b/db/migrate/20240612111633_add_self_assessment_tax_bill_columns_to_incomes.rb
@@ -1,0 +1,9 @@
+class AddSelfAssessmentTaxBillColumnsToIncomes < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :outgoings, :applicant_self_assessment_tax_bill, :string
+
+    add_column :incomes, :applicant_self_assessment_tax_bill, :string
+    add_column :incomes, :applicant_self_assessment_tax_bill_amount, :bigint
+    add_column :incomes, :applicant_self_assessment_tax_bill_frequency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_12_111633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -176,10 +176,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_title"
+    t.string "has_no_deductions"
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
-    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 
@@ -204,6 +204,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
     t.string "partner_has_no_income_payments"
     t.string "partner_has_no_income_benefits"
     t.string "applicant_other_work_benefit_received"
+    t.string "applicant_self_assessment_tax_bill"
+    t.bigint "applicant_self_assessment_tax_bill_amount"
+    t.string "applicant_self_assessment_tax_bill_frequency"
     t.index ["crime_application_id"], name: "index_incomes_on_crime_application_id"
   end
 
@@ -268,7 +271,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_154545) do
     t.string "pays_council_tax"
     t.string "has_no_other_outgoings"
     t.string "partner_income_tax_rate_above_threshold"
-    t.string "applicant_self_assessment_tax_bill"
     t.index ["crime_application_id"], name: "index_outgoings_on_crime_application_id", unique: true
   end
 

--- a/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
@@ -19,16 +19,6 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
   let(:applicant_self_assessment_tax_bill_amount) { 100_000 }
   let(:applicant_self_assessment_tax_bill_frequency) { 'four_weeks' }
 
-  # describe '#build' do
-  #   subject(:form) { described_class.build(crime_application) }
-  #
-  #   it 'sets the form attributes from the model' do
-  #     expect(form.applicant_self_assessment_tax_bill_amount).to eq Money.new(50)
-  #     expect(form.applicant_self_assessment_tax_bill_frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
-  #     expect(form.applicant_self_assessment_tax_bill).to eq(YesNoAnswer::YES)
-  #   end
-  # end
-
   describe '#save' do
     context 'when `applicant_self_assessment_tax_bill` is not provided' do
       let(:applicant_self_assessment_tax_bill) { nil }
@@ -73,40 +63,14 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
       end
 
       context 'when all attributes are valid' do
-        let(:amount) { '100' }
-        let(:frequency) { PaymentFrequencyType::MONTHLY.to_s }
+        let(:applicant_self_assessment_tax_bill_amount) { '100' }
+        let(:applicant_self_assessment_tax_bill_frequency) { PaymentFrequencyType::MONTHLY.to_s }
 
         it { is_expected.to be_valid }
 
         it 'passes validation' do
           expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
-
-        # context 'when crime_application.income is present' do
-        #   # before do
-        #   #   allow(crime_application).to receive(:income).and_return(income)
-        #   # end
-        #
-        #   it 'updates the outgoings payment with the correct attributes' do
-        #     expect(crime_application.income).to receive(:update!).with(
-        #       applicant_self_assessment_tax_bill: YesNoAnswer::YES,
-        #       applicant_self_assessment_tax_bill_amount: Money.new(applicant_self_assessment_tax_bill_amount),
-        #       applicant_self_assessment_tax_bill_frequency: PaymentFrequencyType::MONTHLY,
-        #     )
-        #     form.save
-        #   end
-        # end
-
-        # context 'when crime_application.outgoings is not present' do
-        #   let(:outgoings) { nil }
-        #
-        #   it 'creates an outgoings with the correct attributes' do
-        #     expect(crime_application).to receive(:create_outgoings!).with(
-        #       applicant_self_assessment_tax_bill: YesNoAnswer::YES
-        #     )
-        #     form.save
-        #   end
-        # end
       end
     end
 
@@ -114,13 +78,15 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
       let(:applicant_self_assessment_tax_bill) { YesNoAnswer::NO.to_s }
 
       context 'when `amount` is not provided' do
+        let(:applicant_self_assessment_tax_bill_amount) { nil }
+
         it 'passes validation' do
           expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
       end
 
       context 'when `frequency` is not valid' do
-        let(:frequency) { 'every six weeks' }
+        let(:applicant_self_assessment_tax_bill_frequency) { 'every six weeks' }
 
         it 'passes validation' do
           expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)

--- a/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
@@ -7,57 +7,29 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
     {
       crime_application:,
       applicant_self_assessment_tax_bill:,
-      amount:,
-      frequency:,
+      applicant_self_assessment_tax_bill_amount:,
+      applicant_self_assessment_tax_bill_frequency:
     }
   end
 
-  let(:crime_application) { CrimeApplication.new }
-  let(:outgoings) { Outgoings.new(crime_application:) }
-  let(:outgoings_payment) {
-    OutgoingsPayment.new(crime_application: crime_application,
-                         payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s)
-  }
+  let(:crime_application) { CrimeApplication.new(income:) }
+  let(:income) { Income.new }
 
-  let(:applicant_self_assessment_tax_bill) { nil }
-  let(:amount) { nil }
-  let(:frequency) { nil }
+  let(:applicant_self_assessment_tax_bill) { 'yes' }
+  let(:applicant_self_assessment_tax_bill_amount) { 100_000 }
+  let(:applicant_self_assessment_tax_bill_frequency) { 'four_weeks' }
 
-  before do
-    allow(crime_application.outgoings_payments).to receive(:find_by).with(
-      { payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s }
-    ).and_return(outgoings_payment)
-  end
-
-  describe '#build' do
-    subject(:form) { described_class.build(crime_application) }
-
-    let(:existing_outgoings_payment) {
-      OutgoingsPayment.new(crime_application: crime_application,
-                           payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s,
-                           amount: 50,
-                           frequency: 'four_weeks')
-    }
-
-    before do
-      allow(crime_application.outgoings_payments).to(
-        receive(:self_assessment_tax_bill).and_return(existing_outgoings_payment)
-      )
-      outgoings.applicant_self_assessment_tax_bill = 'yes'
-    end
-
-    it 'sets the form attributes from the model' do
-      expect(form.amount).to eq Money.new(50)
-      expect(form.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
-      expect(form.applicant_self_assessment_tax_bill).to eq(YesNoAnswer::YES)
-    end
-  end
+  # describe '#build' do
+  #   subject(:form) { described_class.build(crime_application) }
+  #
+  #   it 'sets the form attributes from the model' do
+  #     expect(form.applicant_self_assessment_tax_bill_amount).to eq Money.new(50)
+  #     expect(form.applicant_self_assessment_tax_bill_frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
+  #     expect(form.applicant_self_assessment_tax_bill).to eq(YesNoAnswer::YES)
+  #   end
+  # end
 
   describe '#save' do
-    before do
-      allow(crime_application.outgoings_payments).to receive(:create!).and_return(true)
-    end
-
     context 'when `applicant_self_assessment_tax_bill` is not provided' do
       let(:applicant_self_assessment_tax_bill) { nil }
 
@@ -75,18 +47,20 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
       let(:applicant_self_assessment_tax_bill) { YesNoAnswer::YES.to_s }
 
       context 'when `amount` is not provided' do
+        let(:applicant_self_assessment_tax_bill_amount) { nil }
+
         it 'returns false' do
           expect(form.save).to be(false)
         end
 
         it 'has a validation error on the field' do
           expect(form).not_to be_valid
-          expect(form.errors.of_kind?(:amount, :not_a_number)).to be(true)
+          expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :not_a_number)).to be(true)
         end
       end
 
       context 'when `frequency` is not valid' do
-        let(:frequency) { 'every six weeks' }
+        let(:applicant_self_assessment_tax_bill_frequency) { 'every six weeks' }
 
         it 'returns false' do
           expect(form.save).to be(false)
@@ -94,7 +68,7 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
 
         it 'has a validation error on the field' do
           expect(form).not_to be_valid
-          expect(form.errors.of_kind?(:frequency, :inclusion)).to be(true)
+          expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_frequency, :inclusion)).to be(true)
         end
       end
 
@@ -105,34 +79,34 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
         it { is_expected.to be_valid }
 
         it 'passes validation' do
-          expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
+          expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
 
-        context 'when crime_application.outgoings is present' do
-          before do
-            allow(crime_application).to receive(:outgoings).and_return(outgoings)
-          end
+        # context 'when crime_application.income is present' do
+        #   # before do
+        #   #   allow(crime_application).to receive(:income).and_return(income)
+        #   # end
+        #
+        #   it 'updates the outgoings payment with the correct attributes' do
+        #     expect(crime_application.income).to receive(:update!).with(
+        #       applicant_self_assessment_tax_bill: YesNoAnswer::YES,
+        #       applicant_self_assessment_tax_bill_amount: Money.new(applicant_self_assessment_tax_bill_amount),
+        #       applicant_self_assessment_tax_bill_frequency: PaymentFrequencyType::MONTHLY,
+        #     )
+        #     form.save
+        #   end
+        # end
 
-          it 'updates the outgoings payment with the correct attributes' do
-            expect(crime_application.outgoings_payments).to receive(:create!).with(
-              payment_type: :self_assessment_tax_bill,
-              amount: Money.new(100_00),
-              frequency: PaymentFrequencyType::MONTHLY,
-            )
-            form.save
-          end
-        end
-
-        context 'when crime_application.outgoings is not present' do
-          let(:outgoings) { nil }
-
-          it 'creates an outgoings with the correct attributes' do
-            expect(crime_application).to receive(:create_outgoings!).with(
-              applicant_self_assessment_tax_bill: YesNoAnswer::YES
-            )
-            form.save
-          end
-        end
+        # context 'when crime_application.outgoings is not present' do
+        #   let(:outgoings) { nil }
+        #
+        #   it 'creates an outgoings with the correct attributes' do
+        #     expect(crime_application).to receive(:create_outgoings!).with(
+        #       applicant_self_assessment_tax_bill: YesNoAnswer::YES
+        #     )
+        #     form.save
+        #   end
+        # end
       end
     end
 
@@ -141,7 +115,7 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
 
       context 'when `amount` is not provided' do
         it 'passes validation' do
-          expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
+          expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
       end
 
@@ -149,28 +123,7 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
         let(:frequency) { 'every six weeks' }
 
         it 'passes validation' do
-          expect(form.errors.of_kind?(:amount, :invalid)).to be(false)
-        end
-      end
-
-      context 'when previous values have been recorded' do
-        let(:existing_outgoings_payment) {
-          OutgoingsPayment.new(crime_application: crime_application,
-                               payment_type: OutgoingsPaymentType::SELF_ASSESSMENT_TAX_BILL.to_s,
-                               amount: 50,
-                               frequency: 'four_weeks')
-        }
-
-        before do
-          allow(crime_application.outgoings_payments).to(
-            receive(:self_assessment_tax_bill).and_return(existing_outgoings_payment)
-          )
-        end
-
-        it 'resets the attributes before saving' do
-          form.send(:before_save)
-          expect(form.attributes['amount']).to be_nil
-          expect(form.attributes['frequency']).to be_nil
+          expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
       end
     end

--- a/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
 
         it { is_expected.to be_valid }
 
+        it 'returns true' do
+          expect(subject.save).to be(true)
+        end
+
         it 'passes validation' do
           expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end

--- a/spec/models/employments_payment_spec.rb
+++ b/spec/models/employments_payment_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe EmploymentsPayment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -12,7 +12,8 @@ describe Summary::HtmlPresenter do
     instance_double(
       CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'), partner: (double Partner),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
-      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil,  applicant_self_assessment_tax_bill: nil, has_no_income_payments: nil, has_no_income_benefits: nil), income_payments: [double(payment_type: 'maintenance')],
+      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, applicant_self_assessment_tax_bill: nil, has_no_income_payments: nil, has_no_income_benefits: nil),
+      income_payments: [double(payment_type: 'maintenance')],
       outgoings_payments: [instance_double(Payment, payment_type: 'childcare')], income_benefits: [double], outgoings: (double has_no_other_outgoings: nil),
       documents: double, application_type: application_type,
       capital: (double has_premium_bonds: 'yes', partner_has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', partner_will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -12,7 +12,7 @@ describe Summary::HtmlPresenter do
     instance_double(
       CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'), partner: (double Partner),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
-      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, applicant_self_assessment_tax_bill: nil, has_no_income_payments: nil, has_no_income_benefits: nil),
+      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, applicant_self_assessment_tax_bill: 'no', has_no_income_payments: nil, has_no_income_benefits: nil),
       income_payments: [double(payment_type: 'maintenance')],
       outgoings_payments: [instance_double(Payment, payment_type: 'childcare')], income_benefits: [double], outgoings: (double has_no_other_outgoings: nil),
       documents: double, application_type: application_type,
@@ -167,6 +167,7 @@ describe Summary::HtmlPresenter do
             Employments
             Dependants
             PartnerEmploymentDetails
+            SelfAssessmentTaxBill
             IncomePaymentsDetails
             IncomeBenefitsDetails
             OtherIncomeDetails
@@ -351,6 +352,7 @@ describe Summary::HtmlPresenter do
       EmploymentDetails
       IncomeDetails
       Employments
+      SelfAssessmentTaxBill
       IncomePaymentsDetails
       IncomeBenefitsDetails
       Dependants

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -12,8 +12,8 @@ describe Summary::HtmlPresenter do
     instance_double(
       CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'), partner: (double Partner),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
-      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, has_no_income_payments: nil, has_no_income_benefits: nil), income_payments: [double(payment_type: 'maintenance')],
-      outgoings_payments: [instance_double(Payment, payment_type: 'childcare')], income_benefits: [double], outgoings: (double has_no_other_outgoings: nil, applicant_self_assessment_tax_bill: nil),
+      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil,  applicant_self_assessment_tax_bill: nil, has_no_income_payments: nil, has_no_income_benefits: nil), income_payments: [double(payment_type: 'maintenance')],
+      outgoings_payments: [instance_double(Payment, payment_type: 'childcare')], income_benefits: [double], outgoings: (double has_no_other_outgoings: nil),
       documents: double, application_type: application_type,
       capital: (double has_premium_bonds: 'yes', partner_has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', partner_will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
       savings: [double], investments: [double], national_savings_certificates: [double], properties: [double]
@@ -211,6 +211,8 @@ describe Summary::HtmlPresenter do
             IncomeDetails
             Employments
             PartnerEmploymentDetails
+            SelfAssessmentTaxBill
+            WorkBenefits
             IncomePaymentsDetails
             IncomeBenefitsDetails
             Dependants

--- a/spec/presenters/summary/sections/self_assessment_tax_bill_spec.rb
+++ b/spec/presenters/summary/sections/self_assessment_tax_bill_spec.rb
@@ -7,33 +7,24 @@ describe Summary::Sections::SelfAssessmentTaxBill do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      outgoings: outgoings,
-      outgoings_payments: outgoings_payments_double
+      income: income
     )
   end
 
-  let(:outgoings_payments_double) { double('outgoings_payments_collection', detect: outgoings_payment) }
-
-  let(:outgoings) do
+  let(:income) do
     instance_double(
-      Outgoings,
-      applicant_self_assessment_tax_bill:,
+      Income,
+      to_param: '12345',
+      applicant_self_assessment_tax_bill: applicant_self_assessment_tax_bill,
+      applicant_self_assessment_tax_bill_amount: 100_00,
+      applicant_self_assessment_tax_bill_frequency: 'week'
     )
   end
 
-  let(:outgoings_payment) do
-    instance_double(
-      OutgoingsPayment,
-      payment_type: 'self_assessment_tax_bill',
-      amount: 234_000,
-      frequency: 'yearly'
-    )
-  end
-
-  let(:applicant_self_assessment_tax_bill) { nil }
+  let(:applicant_self_assessment_tax_bill) { 'yes' }
 
   describe '#show?' do
-    context 'when there is an outgoings' do
+    context 'when there is an self_assessment_tax_bill question' do
       context 'when applicant_self_assessment_tax_bill is set to `yes`' do
         let(:applicant_self_assessment_tax_bill) { 'yes' }
 
@@ -42,8 +33,16 @@ describe Summary::Sections::SelfAssessmentTaxBill do
         end
       end
 
+      context 'when applicant_self_assessment_tax_bill is set to `no`' do
+        let(:applicant_self_assessment_tax_bill) { 'no' }
+
+        it 'shows this section' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
       context 'when applicant_self_assessment_tax_bill is set to nil' do
-        let(:outgoings_payment) { nil }
+        let(:applicant_self_assessment_tax_bill) { nil }
 
         it 'does not show this section' do
           expect(subject.show?).to be(false)
@@ -51,9 +50,8 @@ describe Summary::Sections::SelfAssessmentTaxBill do
       end
     end
 
-    context 'when there is no outgoings' do
-      let(:outgoings) { nil }
-      let(:outgoings_payments_double) { [] }
+    context 'when there is no income' do
+      let(:income) { nil }
 
       it 'does not show this section' do
         expect(subject.show?).to be(false)
@@ -76,7 +74,9 @@ describe Summary::Sections::SelfAssessmentTaxBill do
         expect(answers[1]).to be_an_instance_of(Summary::Components::PaymentAnswer)
         expect(answers[1].question).to eq(:self_assessment_tax_bill_payment)
         expect(answers[1].change_path).to match('applications/12345/steps/income/client/self_assessment_client')
-        expect(answers[1].value).to eq(outgoings_payment)
+        expect(answers[1].value).to be_an_instance_of(
+          Summary::Sections::SelfAssessmentTaxBill::SelfAssessmentTaxBillPayment
+        )
       end
     end
 

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
       manage_other_details: 'Another way that they manage',
       partner_employment_status:  ['not_working'],
       applicant_other_work_benefit_received: nil,
+      applicant_self_assessment_tax_bill: 'yes',
+      applicant_self_assessment_tax_bill_amount_before_type_cast: 100_00,
+      applicant_self_assessment_tax_bill_frequency: 'week',
     )
   end
 
@@ -110,6 +113,9 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
         partner_employment_type: ['not_working'],
         has_no_income_payments: nil,
         has_no_income_benefits: nil,
+        applicant_self_assessment_tax_bill: 'yes',
+        applicant_self_assessment_tax_bill_amount: 100_00,
+        applicant_self_assessment_tax_bill_frequency: 'week',
         applicant_other_work_benefit_received: nil,
         income_payments: [{
           payment_type: 'other',

--- a/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe SubmissionSerializer::Sections::OutgoingsDetails do
       pays_council_tax: 'yes',
       has_no_other_outgoings: nil,
       how_manage: 'A description of how they manage',
-      outgoings_payments: outgoings_payments,
-      applicant_self_assessment_tax_bill: nil
+      outgoings_payments: outgoings_payments
     )
   end
 
@@ -66,8 +65,7 @@ RSpec.describe SubmissionSerializer::Sections::OutgoingsDetails do
           outgoings_more_than_income: 'yes',
           how_manage: 'A description of how they manage',
           pays_council_tax: 'yes',
-          has_no_other_outgoings: nil,
-          applicant_self_assessment_tax_bill: nil
+          has_no_other_outgoings: nil
       }.as_json
     end
 

--- a/spec/services/adapters/structs/income_details_spec.rb
+++ b/spec/services/adapters/structs/income_details_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Adapters::Structs::IncomeDetails do
 
   describe '#employments' do
     it 'returns a employments collection' do
-      # TODO: Need to update schema fixtures to improve the coverage
-      # expect(subject.employments).to all(be_an(Employment))
+      expect(subject.employments).to all(be_an(Employment))
     end
   end
 

--- a/spec/services/adapters/structs/income_details_spec.rb
+++ b/spec/services/adapters/structs/income_details_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Adapters::Structs::IncomeDetails do
   end
 
   describe '#serializable_hash' do
+    # rubocop:disable RSpec/ExampleLength
     it 'returns a serializable hash, including relationships' do
       expect(subject.serializable_hash).to match(
         a_hash_including(
@@ -28,12 +29,15 @@ RSpec.describe Adapters::Structs::IncomeDetails do
           'manage_other_details' => 'Another way they manage',
           'client_has_dependants' => 'yes',
           'has_no_income_benefits' => 'no',
-          'has_no_income_payments' => 'no'
+          'has_no_income_payments' => 'no',
+          'applicant_other_work_benefit_received' => 'no',
+          'applicant_self_assessment_tax_bill' => 'yes',
+          'applicant_self_assessment_tax_bill_amount' => 555_00,
+          'applicant_self_assessment_tax_bill_frequency' => 'fortnight'
         )
       )
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'contains all required attributes' do
       expect(subject.serializable_hash.keys).to match_array(
         %w[
@@ -52,6 +56,10 @@ RSpec.describe Adapters::Structs::IncomeDetails do
           has_no_income_benefits
           has_no_income_payments
           partner_employment_status
+          applicant_other_work_benefit_received
+          applicant_self_assessment_tax_bill
+          applicant_self_assessment_tax_bill_amount
+          applicant_self_assessment_tax_bill_frequency
         ]
       )
     end

--- a/spec/value_objects/outgoings_payment_type_spec.rb
+++ b/spec/value_objects/outgoings_payment_type_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe OutgoingsPaymentType do
           childcare
           maintenance
           legal_aid_contribution
-          self_assessment_tax_bill
         ]
       )
     end


### PR DESCRIPTION
## Description of change

- Remove s**elf assessment tax bill** from an outgoings payment.
- Add **self assessment tax bill** attributes to income

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-875

## Notes for reviewer
> [!NOTE]  
> Here is a confluence [doc](https://dsdmoj.atlassian.net/wiki/spaces/CRIMAP/pages/4940759132/Self+Assessment+tax+bill) to support this change

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
**Page: Check your enswers**
<img width="685" alt="Screenshot 2024-06-13 at 14 24 58" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/a582f634-3a83-42f0-a6af-9fa4bda9d15c">


**Page: Review the application** 
<img width="680" alt="Screenshot 2024-06-13 at 14 25 58" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/9465c159-3241-4959-8a74-7984ff00540b">




## How to manually test the feature

Start employment journey
http://localhost:3000/applications/:id/steps/income/what_is_clients_employment_status
