### PR TITLE
[CHORE] Remove postinstall script from

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,5 @@
     "@ministryofjustice/frontend": "2.1.3",
     "dropzone": "^6.0.0-beta.2",
     "govuk-frontend": "5.4.0"
-  },
-  "scripts": {
-    "postinstall": "bin/importmap pin govuk-frontend@5.0.0 dropzone@6.0.0-beta.2"
   }
 }


### PR DESCRIPTION
## Description of change
Removes yarn post-install to prevent importmap being changed and then breaking everything

## Link to relevant ticket
For future posterity: https://dsdmoj.atlassian.net/browse/CRIMAPP-1052

## Notes for reviewer
Please do the following locally:

```
yarn install
rails assets:clobber
rails dartsass:build
```

