### PR TITLE
CRIMAPP-991 partner trust fund evidence

### DIFF
--- a/app/services/evidence/rules/20240426032048_trust_fund.rb
+++ b/app/services/evidence/rules/20240426032048_trust_fund.rb
@@ -18,9 +18,16 @@ module Evidence
         end
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        false
+      partner do |crime_application|
+        if crime_application.capital
+          dividend = crime_application.capital.partner_trust_fund_yearly_dividend
+
+          crime_application.capital.partner_will_benefit_from_trust_fund == 'yes' &&
+            dividend.present? &&
+            dividend.value.positive?
+        else
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change

Require evidence of partner's trust fund.

## Link to relevant ticket

[CRIMAPP-991](https://dsdmoj.atlassian.net/browse/CRIMAPP-991)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-991]: https://dsdmoj.atlassian.net/browse/CRIMAPP-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ