### PR TITLE
Make sure crime_application is set on council_tax form

### DIFF
--- a/app/forms/steps/outgoings/council_tax_form.rb
+++ b/app/forms/steps/outgoings/council_tax_form.rb
@@ -18,7 +18,7 @@ module Steps
       def self.build(crime_application)
         payment = crime_application.outgoings_payments.council_tax
 
-        new.tap do |form|
+        new(crime_application:).tap do |form|
           form.attributes = payment.slice(:amount) if payment
           form.pays_council_tax = crime_application.outgoings&.pays_council_tax
         end

--- a/spec/forms/steps/outgoings/council_tax_form_spec.rb
+++ b/spec/forms/steps/outgoings/council_tax_form_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Steps::Outgoings::CouncilTaxForm do
   describe '#build' do
     subject(:form) { described_class.build(crime_application) }
 
+    it 'sets the crime_application' do
+      expect(subject.crime_application).not_to be_nil
+    end
+
     context 'when no council_tax payment exists' do
       it 'creates empty form if model does not exist' do
         expect(subject.amount).to be_nil


### PR DESCRIPTION
## Description of change

Fix missing parter next on council tax form.

## Link to relevant ticket

[CRIMAPP-1038](https://dsdmoj.atlassian.net/browse/CRIMAPP-1038)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="822" alt="Screenshot 2024-06-14 at 13 09 41" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/be013324-ad8e-4848-a031-f370e5f571ab">


### After changes:

<img width="613" alt="Screenshot 2024-06-14 at 13 09 32" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/fb6c5125-ab30-43e9-b1e7-fe1e319ca6ed">


## How to manually test the feature


[CRIMAPP-1038]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ