### PR TITLE
CRIMAPP-991 outoings evidence includes 'and partner' in heading 

### DIFF
--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -1,6 +1,9 @@
 module Steps
   module Evidence
     class UploadForm < Steps::BaseFormObject
+      include TypeOfMeansAssessment
+      include ApplicantAndPartner
+
       delegate :documents, to: :crime_application
 
       def prompt

--- a/config/locales/en/evidence.yml
+++ b/config/locales/en/evidence.yml
@@ -3,7 +3,7 @@ en:
     persona:
       client:
         income: Evidence of your client's income
-        outgoings: Evidence of your client's outgoings
+        outgoings: "Evidence of %{subject}'s outgoings"
         capital: Evidence of your client's capital
         none: Other evidence of your client's income, outgoings or capital
       partner:


### PR DESCRIPTION
## Description of change

Update outgoings evidence for partner.

## Link to relevant ticket

## Notes for reviewer

Because in outgoings partner and applicant are combined in the question, here we update the heading for the client outgoings prompt to include "and the partner" if partner is included in means assessment. The is only one evidence trigger.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
![Uploading Screenshot 2024-06-14 at 15.04.29.png…]()



## How to manually test the feature
