### PR TITLE
CRIMAPP-991 partner income evidence rules

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,5 +1,11 @@
 class Applicant < Person
   has_many(
+    :income_payments,
+    -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
+    through: :crime_application
+  )
+
+  has_many(
     :income_benefits,
     -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
     through: :crime_application

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,5 +1,11 @@
 class Partner < Person
   has_many(
+    :income_payments,
+    -> { where(ownership_type: OwnershipType::PARTNER.to_s) },
+    through: :crime_application
+  )
+
+  has_many(
     :income_benefits,
     -> { where(ownership_type: OwnershipType::PARTNER.to_s) },
     through: :crime_application

--- a/app/services/evidence/rules/20240426020839_pension_income.rb
+++ b/app/services/evidence/rules/20240426020839_pension_income.rb
@@ -4,25 +4,28 @@ module Evidence
       include Evidence::RuleDsl
 
       # Note value in pounds, db pence/amounts are stored in pennies
+      # Note this is per month
       THRESHOLD = 1000.00
 
       key :income_private_pension_5
       group :income
 
-      client do |crime_application|
-        income = [
-          crime_application.income_payments.private_pension,
-        ]
-
-        total = income.compact.sum { |x| x.prorated_monthly.to_f }
-
-        total > THRESHOLD
+      client do |_crime_application, applicant|
+        PensionEvidenceRequired.for(applicant)
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        false
+      partner do |_crime_application, partner|
+        PensionEvidenceRequired.for(partner)
       end
+    end
+  end
+
+  class PensionEvidenceRequired
+    def self.for(person)
+      pension = person.income_payments.private_pension
+      return false unless pension
+
+      pension.prorated_monthly.to_f > Rules::PrivatePensionIncome::THRESHOLD
     end
   end
 end

--- a/app/services/evidence/rules/20240426022536_maintenance_income.rb
+++ b/app/services/evidence/rules/20240426022536_maintenance_income.rb
@@ -9,20 +9,22 @@ module Evidence
       key :income_maintenance_6
       group :income
 
-      client do |crime_application|
-        income = [
-          crime_application.income_payments.maintenance,
-        ]
-
-        total = income.compact.sum { |x| x.prorated_monthly.to_f }
-
-        total > THRESHOLD
+      client do |_crime_application, applicant|
+        MaintenanceEvidenceRequired.for(applicant)
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        false
+      partner do |_crime_application, partner|
+        MaintenanceEvidenceRequired.for(partner)
       end
+    end
+  end
+
+  class MaintenanceEvidenceRequired
+    def self.for(person)
+      maintenance = person.income_payments.maintenance
+      return false unless maintenance
+
+      maintenance.prorated_monthly.to_f > Rules::MaintenanceIncome::THRESHOLD
     end
   end
 end

--- a/app/services/evidence/rules/20240426024826_interest_and_investments.rb
+++ b/app/services/evidence/rules/20240426024826_interest_and_investments.rb
@@ -6,13 +6,12 @@ module Evidence
       key :income_investments_7
       group :income
 
-      client do |crime_application|
-        crime_application.income_payments.interest_investment.present?
+      client do |_crime_application, applicant|
+        applicant.income_payments.interest_investment.present?
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        false
+      partner do |_crime_application, partner|
+        partner.income_payments.interest_investment.present?
       end
     end
   end

--- a/app/services/evidence/rules/20240426030038_rental_income.rb
+++ b/app/services/evidence/rules/20240426030038_rental_income.rb
@@ -6,13 +6,12 @@ module Evidence
       key :income_rent_8
       group :income
 
-      client do |crime_application|
-        crime_application.income_payments.rent.present?
+      client do |_crime_application, applicant|
+        applicant.income_payments.rent.present?
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        false
+      partner do |_crime_application, partner|
+        partner.income_payments.rent.present?
       end
     end
   end

--- a/app/services/evidence/rules/20240426030754_any_other_income.rb
+++ b/app/services/evidence/rules/20240426030754_any_other_income.rb
@@ -6,16 +6,16 @@ module Evidence
       key :income_other_9
       group :income
 
-      client do |crime_application|
-        other_income = crime_application.income_payments.other
+      client do |_crime_application, applicant|
+        other_income = applicant.income_payments.other
 
         other_income.present? && other_income.details.present?
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        # Predicate must return true or false
-        false
+      partner do |_crime_application, partner|
+        other_income = partner.income_payments.other
+
+        other_income.present? && other_income.details.present?
       end
     end
   end

--- a/config/locales/en/evidence.yml
+++ b/config/locales/en/evidence.yml
@@ -77,7 +77,7 @@ en:
         partner: bank statements showing interest from their savings or investments
       RentalIncome:
         client: bank statements showing the rental income
-        partner:
+        partner: bank statements showing the rental income
       AnyOtherIncome:
         client: bank statements showing the income from other sources
         partner: bank statements showing the income from other sources

--- a/spec/services/evidence/rules/20240426020839_pension_income_spec.rb
+++ b/spec/services/evidence/rules/20240426020839_pension_income_spec.rb
@@ -5,13 +5,38 @@ RSpec.describe Evidence::Rules::PrivatePensionIncome do
 
   let(:crime_application) do
     CrimeApplication.create!(
-      income:,
-      income_payments:
+      income: income,
+      income_payments: income_payments,
+      applicant: Applicant.new,
+      partner: Partner.new
     )
   end
 
+  let(:partner_pension) do
+    IncomePayment.new(
+      payment_type: IncomePaymentType::PRIVATE_PENSION,
+      frequency: PaymentFrequencyType::MONTHLY,
+      amount: 1000.01,
+      ownership_type: OwnershipType::PARTNER
+    )
+  end
+
+  let(:client_pension) do
+    IncomePayment.new(
+      payment_type: IncomePaymentType::PRIVATE_PENSION,
+      frequency: PaymentFrequencyType::FOUR_WEEKLY,
+      amount: 923.10
+    )
+  end
+
+  let(:income_payments) { [client_pension, partner_pension] }
+
+  let(:include_partner?) { true }
   let(:income) { Income.new }
-  let(:income_payments) { [] }
+
+  before do
+    allow(MeansStatus).to receive(:include_partner?) { include_partner? }
+  end
 
   it { expect(described_class.key).to eq :income_private_pension_5 }
   it { expect(described_class.group).to eq :income }
@@ -28,50 +53,46 @@ RSpec.describe Evidence::Rules::PrivatePensionIncome do
     subject { described_class.new(crime_application).client_predicate }
 
     context 'when threshold met' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::PRIVATE_PENSION,
-            frequency: PaymentFrequencyType::FOUR_WEEKLY,
-            amount: 923.10,
-          ),
-        ]
-      end
-
       it { is_expected.to be true }
     end
 
     context 'when threshold not met' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::PRIVATE_PENSION,
-            frequency: PaymentFrequencyType::ANNUALLY,
-            amount: 12_000,
-          ),
-        ]
+      before do
+        client_pension.frequency = PaymentFrequencyType::ANNUALLY
+        client_pension.amount = 1_200_000
       end
 
       it { is_expected.to be false }
     end
 
     context 'when there are no private pension payments' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::RENT,
-            frequency: PaymentFrequencyType::FORTNIGHTLY,
-            amount: 500.00,
-          ),
-        ]
-      end
+      let(:income_payments) { [partner_pension] }
 
       it { is_expected.to be false }
     end
   end
 
   describe '.partner' do
-    it { expect(subject.partner_predicate).to be false }
+    subject { described_class.new(crime_application).partner_predicate }
+
+    context 'when threshold met' do
+      it { is_expected.to be true }
+    end
+
+    context 'when threshold not met' do
+      before do
+        partner_pension.frequency = PaymentFrequencyType::MONTHLY
+        partner_pension.amount = 100_000
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when they have no private pension payments' do
+      let(:income_payments) { [client_pension] }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe '.other' do
@@ -79,16 +100,6 @@ RSpec.describe Evidence::Rules::PrivatePensionIncome do
   end
 
   describe '#to_h' do
-    let(:income_payments) do
-      [
-        IncomePayment.new(
-          payment_type: IncomePaymentType::PRIVATE_PENSION,
-          frequency: PaymentFrequencyType::MONTHLY,
-          amount: 1000.01,
-        ),
-      ]
-    end
-
     let(:expected_hash) do
       {
         id: 'PrivatePensionIncome',
@@ -101,8 +112,8 @@ RSpec.describe Evidence::Rules::PrivatePensionIncome do
             prompt: ['either bank statements or their pension statement'],
           },
           partner: {
-            result: false,
-            prompt: [],
+            result: true,
+            prompt: ['either bank statements or their pension statement'],
           },
           other: {
             result: false,

--- a/spec/services/evidence/rules/20240426022536_maintenance_income_spec.rb
+++ b/spec/services/evidence/rules/20240426022536_maintenance_income_spec.rb
@@ -11,8 +11,24 @@ RSpec.describe Evidence::Rules::MaintenanceIncome do
       partner: Partner.new
     )
   end
+  let(:income_payments) do
+    [
+      IncomePayment.new(
+        payment_type: IncomePaymentType::MAINTENANCE,
+        frequency: PaymentFrequencyType::WEEKLY,
+        amount: 115.39,
+        ownership_type: OwnershipType::APPLICANT
+      ),
+      IncomePayment.new(
+        payment_type: IncomePaymentType::MAINTENANCE,
+        frequency: PaymentFrequencyType::MONTHLY,
+        amount: 510.00,
+        ownership_type: OwnershipType::PARTNER
+      )
+    ]
+  end
+
   let(:income) { Income.new }
-  let(:income_payments) { [] }
 
   before do
     allow(MeansStatus).to receive(:include_partner?).and_return(true)
@@ -33,16 +49,6 @@ RSpec.describe Evidence::Rules::MaintenanceIncome do
     subject { described_class.new(crime_application).client_predicate }
 
     context 'when threshold met' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::MAINTENANCE,
-            frequency: PaymentFrequencyType::WEEKLY,
-            amount: 115.39,
-          ),
-        ]
-      end
-
       it { is_expected.to be true }
     end
 
@@ -76,7 +82,7 @@ RSpec.describe Evidence::Rules::MaintenanceIncome do
   end
 
   describe '.partner' do
-    it { expect(subject.partner_predicate).to be false }
+    it { expect(subject.partner_predicate).to be true }
   end
 
   describe '.other' do
@@ -84,16 +90,6 @@ RSpec.describe Evidence::Rules::MaintenanceIncome do
   end
 
   describe '#to_h' do
-    let(:income_payments) do
-      [
-        IncomePayment.new(
-          payment_type: IncomePaymentType::MAINTENANCE,
-          frequency: PaymentFrequencyType::MONTHLY,
-          amount: 500.01,
-        ),
-      ]
-    end
-
     # rubocop:disable Layout/LineLength
     let(:expected_hash) do
       {
@@ -107,8 +103,8 @@ RSpec.describe Evidence::Rules::MaintenanceIncome do
             prompt: ['bank statements showing the maintenance payments, or the court order or Child Maintence Service agreement'],
           },
           partner: {
-            result: false,
-            prompt: [],
+            result: true,
+            prompt: ['bank statements showing the maintenance payments, or the court order or Child Maintence Service agreement'],
           },
           other: {
             result: false,

--- a/spec/services/evidence/rules/20240426022536_maintenance_income_spec.rb
+++ b/spec/services/evidence/rules/20240426022536_maintenance_income_spec.rb
@@ -5,13 +5,18 @@ RSpec.describe Evidence::Rules::MaintenanceIncome do
 
   let(:crime_application) do
     CrimeApplication.create!(
-      income:,
-      income_payments:
+      income: income,
+      income_payments: income_payments,
+      applicant: Applicant.new,
+      partner: Partner.new
     )
   end
-
   let(:income) { Income.new }
   let(:income_payments) { [] }
+
+  before do
+    allow(MeansStatus).to receive(:include_partner?).and_return(true)
+  end
 
   it { expect(described_class.key).to eq :income_maintenance_6 }
   it { expect(described_class.group).to eq :income }

--- a/spec/services/evidence/rules/20240426024826_interest_and_investments_spec.rb
+++ b/spec/services/evidence/rules/20240426024826_interest_and_investments_spec.rb
@@ -5,13 +5,36 @@ RSpec.describe Evidence::Rules::InterestAndInvestments do
 
   let(:crime_application) do
     CrimeApplication.create!(
-      income:,
-      income_payments:
+      income: income,
+      income_payments: income_payments,
+      applicant: Applicant.new,
+      partner: Partner.new
+    )
+  end
+
+  let(:partner_investments) do
+    IncomePayment.new(
+      payment_type: IncomePaymentType::INTEREST_INVESTMENT,
+      frequency: PaymentFrequencyType::MONTHLY,
+      amount: 20.00,
+      ownership_type: OwnershipType::PARTNER
+    )
+  end
+
+  let(:client_investments) do
+    IncomePayment.new(
+      payment_type: IncomePaymentType::INTEREST_INVESTMENT,
+      frequency: PaymentFrequencyType::WEEKLY,
+      amount: 2.00
     )
   end
 
   let(:income) { Income.new }
-  let(:income_payments) { [] }
+  let(:income_payments) { [client_investments, partner_investments] }
+
+  before do
+    allow(MeansStatus).to receive(:include_partner?).and_return(true)
+  end
 
   it { expect(described_class.key).to eq :income_investments_7 }
   it { expect(described_class.group).to eq :income }
@@ -22,29 +45,25 @@ RSpec.describe Evidence::Rules::InterestAndInvestments do
     subject { described_class.new(crime_application).client_predicate }
 
     context 'with interest or income from savings or investments payments' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::INTEREST_INVESTMENT,
-            frequency: PaymentFrequencyType::WEEKLY,
-            amount: 20.00,
-          ),
-        ]
-      end
-
       it { is_expected.to be true }
     end
 
     context 'without any interest or income from savings payments' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::RENT,
-            frequency: PaymentFrequencyType::FORTNIGHTLY,
-            amount: 500.00,
-          ),
-        ]
-      end
+      let(:income_payments) { [partner_investments] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.partner' do
+    subject { described_class.new(crime_application).partner_predicate }
+
+    context 'with interest or income from savings or investments payments' do
+      it { is_expected.to be true }
+    end
+
+    context 'without any interest or income from savings payments' do
+      let(:income_payments) { [client_investments] }
 
       it { is_expected.to be false }
     end
@@ -55,16 +74,6 @@ RSpec.describe Evidence::Rules::InterestAndInvestments do
   end
 
   describe '#to_h' do
-    let(:income_payments) do
-      [
-        IncomePayment.new(
-          payment_type: IncomePaymentType::INTEREST_INVESTMENT,
-          frequency: PaymentFrequencyType::MONTHLY,
-          amount: 500.01,
-        ),
-      ]
-    end
-
     let(:expected_hash) do
       {
         id: 'InterestAndInvestments',
@@ -77,8 +86,8 @@ RSpec.describe Evidence::Rules::InterestAndInvestments do
             prompt: ['bank statements showing interest from their savings or investments'],
           },
           partner: {
-            result: false,
-            prompt: [],
+            result: true,
+            prompt: ['bank statements showing interest from their savings or investments'],
           },
           other: {
             result: false,

--- a/spec/services/evidence/rules/20240426030038_rental_income_spec.rb
+++ b/spec/services/evidence/rules/20240426030038_rental_income_spec.rb
@@ -5,13 +5,36 @@ RSpec.describe Evidence::Rules::RentalIncome do
 
   let(:crime_application) do
     CrimeApplication.create!(
-      income:,
-      income_payments:
+      income: income,
+      income_payments: income_payments,
+      applicant: Applicant.new,
+      partner: Partner.new
+    )
+  end
+
+  let(:partner_rent) do
+    IncomePayment.new(
+      payment_type: IncomePaymentType::RENT,
+      frequency: PaymentFrequencyType::MONTHLY,
+      amount: 2000.00,
+      ownership_type: OwnershipType::PARTNER
+    )
+  end
+
+  let(:client_rent) do
+    IncomePayment.new(
+      payment_type: IncomePaymentType::RENT,
+      frequency: PaymentFrequencyType::MONTHLY,
+      amount: 2000.00
     )
   end
 
   let(:income) { Income.new }
-  let(:income_payments) { [] }
+  let(:income_payments) { [client_rent, partner_rent] }
+
+  before do
+    allow(MeansStatus).to receive(:include_partner?).and_return(true)
+  end
 
   it { expect(described_class.key).to eq :income_rent_8 }
   it { expect(described_class.group).to eq :income }
@@ -22,36 +45,28 @@ RSpec.describe Evidence::Rules::RentalIncome do
     subject { described_class.new(crime_application).client_predicate }
 
     context 'with rental income' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::RENT,
-            frequency: PaymentFrequencyType::MONTHLY,
-            amount: 2000.00,
-          ),
-        ]
-      end
-
       it { is_expected.to be true }
     end
 
     context 'without rental income' do
-      let(:income_payments) do
-        [
-          IncomePayment.new(
-            payment_type: IncomePaymentType::STUDENT_LOAN_GRANT,
-            frequency: PaymentFrequencyType::FORTNIGHTLY,
-            amount: 500.00,
-          ),
-        ]
-      end
+      let(:income_payments) { [partner_rent] }
 
       it { is_expected.to be false }
     end
   end
 
   describe '.partner' do
-    it { expect(subject.partner_predicate).to be false }
+    subject { described_class.new(crime_application).partner_predicate }
+
+    context 'with rental income' do
+      it { is_expected.to be true }
+    end
+
+    context 'without rental income' do
+      let(:income_payments) { [client_rent] }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe '.other' do
@@ -59,16 +74,6 @@ RSpec.describe Evidence::Rules::RentalIncome do
   end
 
   describe '#to_h' do
-    let(:income_payments) do
-      [
-        IncomePayment.new(
-          payment_type: IncomePaymentType::RENT,
-          frequency: PaymentFrequencyType::ANNUALLY,
-          amount: 20_000.00,
-        ),
-      ]
-    end
-
     let(:expected_hash) do
       {
         id: 'RentalIncome',
@@ -81,8 +86,8 @@ RSpec.describe Evidence::Rules::RentalIncome do
             prompt: ['bank statements showing the rental income'],
           },
           partner: {
-            result: false,
-            prompt: [],
+            result: true,
+            prompt: ['bank statements showing the rental income'],
           },
           other: {
             result: false,


### PR DESCRIPTION
## Description of change

Add partner evidence checks for income payments
- pension
- maintenance
- investments
- other
- rent

## Link to relevant ticket

[CRIMAPP-991](https://dsdmoj.atlassian.net/browse/CRIMAPP-991)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-991]: https://dsdmoj.atlassian.net/browse/CRIMAPP-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ