### PR TITLE
[CRIMAPP-992] Add partner content to review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.14'
+    tag: 'v1.1.15'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 4dc64cdded4f21b042d561f6208b5b907f4d3c91
-  tag: v1.1.14
+  revision: ce1b54f373b302f6cb84dce421c2ac0b4d21fed0
+  tag: v1.1.15
   specs:
-    laa-criminal-legal-aid-schemas (1.1.14)
+    laa-criminal-legal-aid-schemas (1.1.15)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/serializers/submission_serializer/definitions/partner.rb
+++ b/app/serializers/submission_serializer/definitions/partner.rb
@@ -30,18 +30,17 @@ module SubmissionSerializer
           json.conflict_of_interest partner_detail.conflict_of_interest
           json.has_same_address_as_client partner_detail.has_same_address_as_client
 
-          json.is_included_in_means_assessment is_included_in_means_assessment
+          json.is_included_in_means_assessment partner_in_means_assessment?
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-      # TODO: how to include TypeOfMeansAssessment in this file??
-      def is_included_in_means_assessment
-        return false unless partner.present? || partner_detail.present?
-        return true if partner_involvement_in_case == PartnerInvolvementType::NONE.to_s
-        return false unless partner_involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
+      def partner_in_means_assessment?
+        return false if partner_detail.blank?
+        return true if partner_detail.involvement_in_case == PartnerInvolvementType::NONE.to_s
+        return false unless partner_detail.involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
 
-        partner_conflict_of_interest == 'no'
+        partner_detail.conflict_of_interest == 'no'
       end
     end
   end

--- a/app/serializers/submission_serializer/definitions/partner.rb
+++ b/app/serializers/submission_serializer/definitions/partner.rb
@@ -30,18 +30,10 @@ module SubmissionSerializer
           json.conflict_of_interest partner_detail.conflict_of_interest
           json.has_same_address_as_client partner_detail.has_same_address_as_client
 
-          json.is_included_in_means_assessment partner_in_means_assessment?
+          json.is_included_in_means_assessment MeansStatus.new(self).include_partner_in_means_assessment?
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-
-      def partner_in_means_assessment?
-        return false if partner_detail.blank?
-        return true if partner_detail.involvement_in_case == PartnerInvolvementType::NONE.to_s
-        return false unless partner_detail.involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
-
-        partner_detail.conflict_of_interest == 'no'
-      end
     end
   end
 end

--- a/app/serializers/submission_serializer/definitions/partner.rb
+++ b/app/serializers/submission_serializer/definitions/partner.rb
@@ -29,9 +29,20 @@ module SubmissionSerializer
           json.involvement_in_case partner_detail.involvement_in_case
           json.conflict_of_interest partner_detail.conflict_of_interest
           json.has_same_address_as_client partner_detail.has_same_address_as_client
+
+          json.is_included_in_means_assessment is_included_in_means_assessment
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      # TODO: how to include TypeOfMeansAssessment in this file??
+      def is_included_in_means_assessment
+        return false unless partner.present? || partner_detail.present?
+        return true if partner_involvement_in_case == PartnerInvolvementType::NONE.to_s
+        return false unless partner_involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
+
+        partner_conflict_of_interest == 'no'
+      end
     end
   end
 end

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -80,7 +80,7 @@ module Datastore
       return nil unless FeatureFlags.partner_journey.enabled?
       return nil unless parent.partner && parent.applicant.has_partner == 'yes'
 
-      attributes_to_ignore = PartnerDetail.fields + %w[benefit_check_status]
+      attributes_to_ignore = PartnerDetail.fields + %w[benefit_check_status is_included_in_means_assessment]
       attributes = parent.partner.serializable_hash.except!(*attributes_to_ignore)
       Partner.new(attributes)
     end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -793,7 +793,7 @@ en:
 
       # START trust_fund
       will_benefit_from_trust_fund:
-        question: Stands to benefit from a trust fund?
+        question: Trust fund
         answers: *YESNO
       trust_fund_amount_held:
         question: Amount in fund

--- a/spec/serializers/submission_serializer/sections/client_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/client_details_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
           has_benefit_evidence: nil,
           confirm_details: nil,
           confirm_dwp_result: nil,
+          is_included_in_means_assessment: false
         }
 
         applicant_without_partner.deep_merge(client_details: { partner: partner_attributes })


### PR DESCRIPTION
## Description of change 
Introduces attribute `is_included_in_means_assessment` to the partner to facilitate display of the correct content subject in review depending on whether the partner was part of the means assessment 

## Link to relevant ticket
[CRIMAPP-992](https://dsdmoj.atlassian.net/browse/CRIMAPP-992)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-992]: https://dsdmoj.atlassian.net/browse/CRIMAPP-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ