### PR TITLE
[CRIMAPP-1040] Reset partner dwp details when partner details updated

### DIFF
--- a/app/forms/steps/partner/details_form.rb
+++ b/app/forms/steps/partner/details_form.rb
@@ -18,7 +18,21 @@ module Steps
       def persist!
         return true unless changed?
 
-        partner.update!(attributes)
+        partner.update(attributes.merge(attributes_to_reset))
+      end
+
+      def attributes_to_reset
+        return {} unless changed?(:last_name, :date_of_birth)
+
+        {
+          has_nino: nil,
+          nino: nil,
+          will_enter_nino: nil,
+          has_benefit_evidence: nil,
+          benefit_type: nil,
+          last_jsa_appointment_date: nil,
+          benefit_check_result: nil,
+        }
       end
     end
   end

--- a/app/presenters/summary/components/property.rb
+++ b/app/presenters/summary/components/property.rb
@@ -68,7 +68,7 @@ module Summary
             :percentage_partner_owned,
             property.percentage_partner_owned,
             i18n_opts: i18n_opts,
-            show: include_partner_in_means_assessment?
+            show: property.percentage_partner_owned.present?
           ),
           Components::ValueAnswer.new(
             :is_home_address,

--- a/app/presenters/summary/sections/codefendants.rb
+++ b/app/presenters/summary/sections/codefendants.rb
@@ -6,19 +6,34 @@ module Summary
       end
 
       def answers
+        return codefendants_component unless no_codefendants?
+
+        [
+          Components::ValueAnswer.new(
+            :has_codefendants, kase.has_codefendants,
+            change_path: edit_steps_case_has_codefendants_path
+          )
+        ]
+      end
+
+      def list?
+        !no_codefendants?
+      end
+
+      private
+
+      def codefendants_component
         Components::Codefendant.with_collection(
           codefendants, show_actions: editable?, show_record_actions: headless?
         )
       end
 
-      def list?
-        true
-      end
-
-      private
-
       def codefendants
         @codefendants ||= kase.codefendants
+      end
+
+      def no_codefendants?
+        kase.has_codefendants.to_s == 'no'
       end
     end
   end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -317,7 +317,7 @@ en:
 
       # BEGIN codefendants section
       has_codefendants:
-        question: Co-defendants
+        question: Co-defendants?
         answers:
           <<: *YESNO
       conflict_of_interest:

--- a/spec/forms/steps/partner/details_form_spec.rb
+++ b/spec/forms/steps/partner/details_form_spec.rb
@@ -50,17 +50,60 @@ RSpec.describe Steps::Partner::DetailsForm do
       end
 
       it 'saves the record' do
-        expect(partner_record).to receive(:update!).with(form_attributes.stringify_keys).and_return(true)
+        expect(partner_record).to receive(:update).with(form_attributes.stringify_keys).and_return(true)
 
         partner_record.first_name = 'Ella'
         expect(subject.save).to be(true)
       end
 
       it 'does not update unchanged details' do
-        expect(partner_record).not_to receive(:update!)
-        expect(partner_detail).not_to receive(:update!)
+        expect(partner_record).not_to receive(:update)
+        expect(partner_detail).not_to receive(:update)
 
         expect(subject.save).to be(true)
+      end
+
+      context 'when details linked to DWP passporting have changed' do
+        context 'last_name' do
+          let(:form_attributes) { super().merge(last_name: 'Smith') }
+
+          it_behaves_like 'a has-one-association form',
+                          association_name: :partner,
+                          expected_attributes: {
+                            'first_name' => 'John',
+                            'last_name' => 'Smith',
+                            'other_names' => nil,
+                            'date_of_birth' => 20.years.ago.to_date,
+                            :has_nino => nil,
+                            :nino => nil,
+                            :benefit_type => nil,
+                            :benefit_check_result => nil,
+                            :last_jsa_appointment_date => nil,
+                            :will_enter_nino => nil,
+                            :has_benefit_evidence => nil,
+                          }
+        end
+
+        context 'date_of_birth' do
+          let(:date_of_birth) { 20.years.ago.to_date }
+          let(:form_attributes) { super().merge(date_of_birth:) }
+
+          it_behaves_like 'a has-one-association form',
+                          association_name: :partner,
+                          expected_attributes: {
+                            'first_name' => 'John',
+                            'last_name' => 'Doe',
+                            'other_names' => nil,
+                            'date_of_birth' => 20.years.ago.to_date,
+                            :has_nino => nil,
+                            :nino => nil,
+                            :benefit_type => nil,
+                            :benefit_check_result => nil,
+                            :last_jsa_appointment_date => nil,
+                            :will_enter_nino => nil,
+                            :has_benefit_evidence => nil,
+                          }
+        end
       end
     end
   end

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Summary::Components::Property, type: :component do
                     percentage_owned: 10.567)
   }
   let(:crime_application) { instance_double(CrimeApplication, id: 'APP123') }
-  let(:client_has_partner) { false }
   let(:relationship) { 'friends' }
   let(:property_type) { 'residential' }
 
@@ -47,7 +46,6 @@ RSpec.describe Summary::Components::Property, type: :component do
   let(:has_other_owners) { 'yes' }
 
   before do
-    allow(component).to receive(:include_partner_in_means_assessment?) { client_has_partner }
     render_summary_component(component)
   end
 
@@ -149,21 +147,9 @@ RSpec.describe Summary::Components::Property, type: :component do
     end
 
     describe 'summary list partner percentage' do
-      let(:partner_percent_text) { 'Percentage partner owns' }
-
-      context 'when client has partner' do
-        let(:client_has_partner) { true }
-
+      context 'when partner percentage owned is present' do
         it 'renders as summary list with partner percentage' do
-          expect(page).to have_summary_row(partner_percent_text, '50.00%')
-        end
-      end
-
-      context 'when client has no partner' do
-        let(:client_has_partner) { false }
-
-        it 'renders as summary list without partner percentage' do
-          expect(page).not_to have_content(partner_percent_text)
+          expect(page).to have_summary_row('Percentage partner owns', '50.00%')
         end
       end
     end
@@ -256,6 +242,12 @@ RSpec.describe Summary::Components::Property, type: :component do
           'Other owners',
           '',
         )
+      end
+
+      context 'when partner percentage owned is not present' do
+        it 'renders as summary list without partner percentage' do
+          expect(page).not_to have_content('Percentage partner owns')
+        end
       end
     end
   end

--- a/spec/presenters/summary/sections/codefendants_spec.rb
+++ b/spec/presenters/summary/sections/codefendants_spec.rb
@@ -8,18 +8,20 @@ describe Summary::Sections::Codefendants do
       CrimeApplication,
       in_progress?: true,
       kase: kase,
+      to_param: 12_345
     )
   end
 
   let(:kase) do
     instance_double(
       Case,
-      has_codefendants: 'yes',
+      has_codefendants: has_codefendants,
       codefendants: records,
     )
   end
 
   let(:records) { [Codefendant.new] }
+  let(:has_codefendants) { 'yes' }
 
   describe '#list?' do
     it { expect(subject.list?).to be true }
@@ -42,31 +44,48 @@ describe Summary::Sections::Codefendants do
   end
 
   describe '#answers' do
-    let(:component) { instance_double(Summary::Components::Codefendant) }
+    context 'when there are codefendants' do
+      let(:component) { instance_double(Summary::Components::Codefendant) }
 
-    before do
-      allow(Summary::Components::Codefendant).to receive(:with_collection) { component }
-    end
-
-    it 'returns the component with actions' do
-      expect(subject.answers).to be component
-
-      expect(Summary::Components::Codefendant).to have_received(:with_collection).with(
-        records, show_actions: true, show_record_actions: false
-      )
-    end
-
-    context 'not in progress' do
       before do
-        allow(crime_application).to receive(:in_progress?).and_return(false)
+        allow(Summary::Components::Codefendant).to receive(:with_collection) { component }
       end
 
-      it 'returns the component without actions' do
+      it 'returns the component with actions' do
         expect(subject.answers).to be component
 
         expect(Summary::Components::Codefendant).to have_received(:with_collection).with(
-          records, show_actions: false, show_record_actions: false
+          records, show_actions: true, show_record_actions: false
         )
+      end
+
+      context 'not in progress' do
+        before do
+          allow(crime_application).to receive(:in_progress?).and_return(false)
+        end
+
+        it 'returns the component without actions' do
+          expect(subject.answers).to be component
+
+          expect(Summary::Components::Codefendant).to have_received(:with_collection).with(
+            records, show_actions: false, show_record_actions: false
+          )
+        end
+      end
+    end
+
+    context 'when there are no codefendants' do
+      let(:records) { [] }
+      let(:answers) { subject.answers }
+      let(:has_codefendants) { 'no' }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:has_codefendants)
+        expect(answers[0].change_path).to match('applications/12345/steps/case/has_codefendants')
+        expect(answers[0].value).to eq('no')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Resets partner dwp details when the partner's last name or dob are updated

Also fixes a couple of bugs spotted: 
- Missing co defendants summary section when there are no codefendants 
- Assets partner percentage owned row not displaying

## Link to relevant ticket
[CRIMAPP-1040](https://dsdmoj.atlassian.net/browse/CRIMAPP-1040)
[CRIMAPP-1039](https://dsdmoj.atlassian.net/browse/CRIMAPP-1039)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1040]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1039]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ