### PR TITLE
[CRIMAPP-1035] Reset partner dwp attributes if nino changed

### DIFF
--- a/app/forms/steps/partner/nino_form.rb
+++ b/app/forms/steps/partner/nino_form.rb
@@ -21,11 +21,34 @@ module Steps
       private
 
       def persist!
-        if has_nino.no?
-          partner.update(attributes.except('nino'))
-        else
-          partner.update(attributes)
-        end
+        return true unless changed?
+
+        partner.update(attributes.merge(attributes_to_reset))
+      end
+
+      def changed?
+        !partner.has_nino.eql?(has_nino.to_s) || nino_changed?
+      end
+
+      def nino_changed?
+        return false if partner.nino.nil? || nino == ''
+
+        partner.nino != nino
+      end
+
+      def attributes_to_reset
+        nino_attr = partner_has_nino? ? nino : nil
+
+        {
+          'benefit_type' => nil,
+          'last_jsa_appointment_date' => nil,
+          'benefit_check_result' => nil,
+          'will_enter_nino' => nil,
+          'has_benefit_evidence' => nil,
+          'confirm_details' => nil,
+          'confirm_dwp_result' => nil,
+          'nino' => nino_attr
+        }
       end
 
       def partner_has_nino?

--- a/spec/forms/steps/partner/nino_form_spec.rb
+++ b/spec/forms/steps/partner/nino_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Steps::Partner::NinoForm do
     )
   end
 
-  let(:partner) { instance_double(Partner, has_nino:, nino:) }
+  let(:partner) { Partner.new }
   let(:has_nino) { nil }
   let(:nino) { nil }
 
@@ -76,9 +76,17 @@ RSpec.describe Steps::Partner::NinoForm do
       let(:nino) { 'JA293483A' }
 
       it 'saves the record' do
-        expect(partner).to receive(:update).with(
-          { 'has_nino' => YesNoAnswer::YES, 'nino' => 'JA293483A' }
-        ).and_return(true)
+        expect(partner).to receive(:update).with({
+                                                   'has_nino' => YesNoAnswer::YES,
+                                                   'nino' => 'JA293483A',
+                                                   'benefit_type' => nil,
+                                                   'last_jsa_appointment_date' => nil,
+                                                   'benefit_check_result' => nil,
+                                                   'will_enter_nino' => nil,
+                                                   'has_benefit_evidence' => nil,
+                                                   'confirm_details' => nil,
+                                                   'confirm_dwp_result' => nil,
+                                                 }).and_return(true)
 
         expect(subject.save).to be(true)
       end
@@ -89,11 +97,37 @@ RSpec.describe Steps::Partner::NinoForm do
       let(:nino) { 'NotRequired' }
 
       it 'saves the record' do
-        expect(partner).to receive(:update).with(
-          { 'has_nino' => YesNoAnswer::NO }
-        ).and_return(true)
+        expect(partner).to receive(:update).with({
+                                                   'has_nino' => YesNoAnswer::NO,
+                                                   'nino' => nil,
+                                                   'benefit_type' => nil,
+                                                   'last_jsa_appointment_date' => nil,
+                                                   'benefit_check_result' => nil,
+                                                   'will_enter_nino' => nil,
+                                                   'has_benefit_evidence' => nil,
+                                                   'confirm_details' => nil,
+                                                   'confirm_dwp_result' => nil,
+                                                 }).and_return(true)
 
         expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when has nino is unchanged' do
+      before do
+        allow(partner).to receive_messages(has_nino: previous_has_nino, nino: previous_nino)
+      end
+
+      context 'when has nino is the same as in the persisted record' do
+        let(:previous_has_nino) { YesNoAnswer::YES.to_s }
+        let(:previous_nino) { 'AB123456C' }
+        let(:has_nino) { YesNoAnswer::YES }
+        let(:nino) { 'AB123456C' }
+
+        it 'does not save the record but returns true' do
+          expect(partner).not_to receive(:update)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -514,6 +514,7 @@ RSpec.describe TypeOfMeansAssessment do
     end
 
     context 'defaults to applicant' do
+      let(:partner) { instance_double(Partner) }
       let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'none') }
       let(:applicant_benefit_type) { 'none' }
       let(:partner_benefit_type) { 'none' }


### PR DESCRIPTION
## Description of change
Resets partner dwp attributes if partner nino details are updated

## Link to relevant ticket

[CRIMAPP-1035](https://dsdmoj.atlassian.net/browse/CRIMAPP-1035)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1035]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ