### PR TITLE
[CRIMAPP-1032] Retain client relationship status value

### DIFF
--- a/app/forms/steps/client/has_partner_form.rb
+++ b/app/forms/steps/client/has_partner_form.rb
@@ -11,9 +11,15 @@ module Steps
 
       private
 
+      def changed?
+        !crime_application.client_has_partner.eql?(client_has_partner.to_s)
+      end
+
       # TODO: When FeatureFlag.partner_journey is removed,
       # move this form into /partner and Partner module
       def persist!
+        return true unless changed?
+
         ::CrimeApplication.transaction do
           reset!
 

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Steps::Client::HasPartnerForm do
 
   let(:crime_application) do
     CrimeApplication.new(
-      client_has_partner:,
       partner_detail:,
       partner:,
       income:,
@@ -126,6 +125,22 @@ RSpec.describe Steps::Client::HasPartnerForm do
 
         expect(subject.save).to be(true)
         expect(crime_application.payments.for_client.size).to eq 1
+      end
+    end
+
+    context 'when has client_has_partner is unchanged' do
+      before do
+        allow(crime_application).to receive_messages(client_has_partner: previous_client_has_partner)
+      end
+
+      context 'when has nino is the same as in the persisted record' do
+        let(:previous_client_has_partner) { YesNoAnswer::YES.to_s }
+        let(:client_has_partner) { YesNoAnswer::YES }
+
+        it 'does not save the record but returns true' do
+          expect(crime_application).not_to receive(:update!)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
The client relationship status attribute was being reset every time the has partner form was saved
A guard clause was added to the persist method to check whether the has partner value had been updated before performing any updates

## Link to relevant ticket
[CRIMAPP-1032](https://dsdmoj.atlassian.net/browse/CRIMAPP-1032)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1032]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ