### PR TITLE
CRIMAPP-976 Business Type page for Client and Partner

### DIFF
--- a/app/controllers/steps/income/business_type_controller.rb
+++ b/app/controllers/steps/income/business_type_controller.rb
@@ -1,0 +1,52 @@
+module Steps
+  module Income
+    class BusinessTypeController < Steps::IncomeStepController
+      before_action :set_subject
+      before_action :require_no_businesss, except: [:update]
+
+      def edit
+        @form_object = BusinessTypeForm.new(
+          record: current_crime_application.businesses.new(
+            ownership_type: @subject.ownership_type
+          ),
+          crime_application: current_crime_application,
+          subject: @subject
+        )
+      end
+
+      def update
+        update_and_advance(BusinessTypeForm, as: :business_type, subject: @subject)
+      end
+
+      private
+
+      # TODO: extract subject setting etc to concern as pattern evolves.
+      #
+      def set_subject
+        case params[:subject]
+        when /client/
+          @subject = current_crime_application.applicant
+        when /partner/
+          raise Errors::SubjectNotFound unless MeansStatus.include_partner?(current_crime_application)
+
+          @subject = current_crime_application.partner
+        else
+          raise Errors::SubjectNotFound
+        end
+      end
+
+      def require_no_businesss
+        return true if @subject.businesses.empty?
+
+        redirect_to edit_steps_income_businesses_summary_path(
+          subject: params[:subject],
+          id: current_crime_application
+        )
+      end
+
+      def decision_tree_class
+        Decisions::SelfEmployedIncomeDecisionTree
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/business_type_form.rb
+++ b/app/forms/steps/income/business_type_form.rb
@@ -1,0 +1,26 @@
+module Steps
+  module Income
+    class BusinessTypeForm < Steps::BaseFormObject
+      attribute :business_type, :value_object, source: BusinessType
+
+      validates :business_type, inclusion: { in: BusinessType.values }
+      validates :ownership_type, inclusion: { in: OwnershipType.exclusive }
+
+      attr_accessor :subject
+
+      def choices
+        BusinessType.values
+      end
+
+      private
+
+      def ownership_type
+        subject.ownership_type
+      end
+
+      def persist!
+        Business.create!(crime_application:, business_type:, ownership_type:)
+      end
+    end
+  end
+end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -12,4 +12,5 @@ module Errors
   class DocumentUnavailable < NotFound; end
   class DateOfBirthPending < StandardError; end
   class EmploymentNotFound < NotFound; end
+  class SubjectNotFound < NotFound; end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -29,6 +29,12 @@ class Applicant < Person
     through: :crime_application
   )
 
+  has_many(
+    :businesses,
+    -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
+    through: :crime_application
+  )
+
   # Utility methods for testing/output
   delegate :partner_detail, to: :crime_application
 
@@ -42,5 +48,9 @@ class Applicant < Person
 
   def separation_date
     partner_detail&.separation_date
+  end
+
+  def ownership_type
+    OwnershipType::APPLICANT
   end
 end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -1,0 +1,3 @@
+class Business < ApplicationRecord
+  belongs_to :crime_application
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -63,6 +63,11 @@ class CrimeApplication < ApplicationRecord
            inverse_of: :crime_application,
            dependent: :destroy)
 
+  has_many(:businesses,
+           -> { order(created_at: :asc) },
+           inverse_of: :crime_application,
+           dependent: :destroy)
+
   enum status: ApplicationStatus.enum_values
 
   scope :with_applicant, -> { joins(:people).includes(:applicant).merge(Applicant.with_name) }

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -28,4 +28,14 @@ class Partner < Person
     -> { where(ownership_type: OwnershipType::PARTNER.to_s) },
     through: :crime_application
   )
+
+  has_many(
+    :businesses,
+    -> { where(ownership_type: OwnershipType::PARTNER.to_s) },
+    through: :crime_application
+  )
+
+  def ownership_type
+    OwnershipType::PARTNER
+  end
 end

--- a/app/services/decisions/self_employed_income_decision_tree.rb
+++ b/app/services/decisions/self_employed_income_decision_tree.rb
@@ -1,0 +1,7 @@
+module Decisions
+  class SelfEmployedIncomeDecisionTree < BaseDecisionTree
+    # :nocov:
+    def destination; end
+    # :nocov:
+  end
+end

--- a/app/value_objects/business_type.rb
+++ b/app/value_objects/business_type.rb
@@ -1,0 +1,7 @@
+class BusinessType < ValueObject
+  VALUES = [
+    SELF_EMPLOYED = new(:self_employed),
+    PARTNERSHIP = new(:partnership),
+    DIRECTOR_OR_SHAREHOLDER = new(:director_or_shareholder),
+  ].freeze
+end

--- a/app/views/steps/income/business_type/edit.html.erb
+++ b/app/views/steps/income/business_type/edit.html.erb
@@ -1,0 +1,21 @@
+<% title legend_t(:business_type) %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/flash_banner' %>
+    <%= govuk_error_summary(@form_object) %>
+    <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons(
+            :business_type,
+            @form_object.choices,
+            :value,
+            legend: { size: 'xl' }
+          ) %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -617,6 +617,10 @@ en:
               inclusion: Select how they manage with no income
             manage_other_details:
               blank: Enter details on how they manage with no income
+        steps/income/business_type_form:
+          attributes:
+            business_type:
+              inclusion: Select a business type
         steps/outgoings/housing_payment_type_form:
           attributes:
             housing_payment_type:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -169,6 +169,8 @@ en:
         manage_without_income:
           one: How does %{subject} manage with no income?
           other: How do %{subject} manage with no income?
+      steps_income_business_type_form:
+        business_type: What is the business type?
       steps_outgoings_housing_payment_type_form:
         housing_payment_type: Which of these payments does %{subject} make where they usually live?
       steps_outgoings_mortgage_form:
@@ -353,6 +355,8 @@ en:
         types_options:
           jsa: This includes New Style JSA.
           other: Disregarded benefits include Housing Benefit and Personal Independence Payment (PIP).
+      steps_income_business_type_form:
+        business_type: You can add more later.
       steps_outgoings_board_and_lodging_form:
         food_amount: Enter '0' if none.
       steps_submission_declaration_form:
@@ -720,6 +724,12 @@ en:
         manage_other_details:
           one: Tell us how %{subject} manages with no income
           other: Tell us how %{subject} manage with no income
+      steps_income_business_type_form:
+        business_type_options:
+          self_employed: Self-employed business 
+          partnership: Business partnership 
+          director_or_shareholder: Company director or shareholder
+
 
       # BEGIN: Partner Income
       steps_income_partner_income_payments_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,12 @@ Rails.application.routes.draw do
           edit_step :add_employments, alias: :employments_summary
           edit_step :other_work_benefits_client, alias: :other_work_benefits
         end
+
+        scope '/:subject/', constraints: -> (_) { FeatureFlags.self_employed_journey.enabled? } do
+          edit_step :business_type
+          edit_step :businesses_summary
+        end
+
         show_step :employed_exit
         show_step :self_employed_exit
         edit_step :did_client_lose_job_being_in_custody, alias: :lost_job_in_custody

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  self_employed_journey:
+    local: true
+    staging: false
+    production: false
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/db/migrate/20240617115219_create_businesses.rb
+++ b/db/migrate/20240617115219_create_businesses.rb
@@ -1,0 +1,11 @@
+class CreateBusinesses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :businesses, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: false
+      t.string :business_type, null: false
+      t.string :ownership_type, null: false, default: "applicant"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_13_005740) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_17_115219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -32,6 +32,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_13_005740) do
     t.string "lookup_id"
     t.index ["person_id"], name: "index_addresses_on_person_id"
     t.index ["type", "person_id"], name: "index_addresses_on_type_and_person_id", unique: true
+  end
+
+  create_table "businesses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id", null: false
+    t.string "business_type", null: false
+    t.string "ownership_type", default: "applicant", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crime_application_id"], name: "index_businesses_on_crime_application_id"
   end
 
   create_table "capitals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -176,10 +185,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_13_005740) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_title"
-    t.string "has_no_deductions"
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
+    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 
@@ -395,6 +404,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_13_005740) do
   end
 
   add_foreign_key "addresses", "people"
+  add_foreign_key "businesses", "crime_applications"
   add_foreign_key "capitals", "crime_applications"
   add_foreign_key "cases", "crime_applications"
   add_foreign_key "charges", "cases"

--- a/spec/controllers/steps/income/business_type_controller_spec.rb
+++ b/spec/controllers/steps/income/business_type_controller_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::BusinessTypeController, type: :controller do
+  let(:existing_case) do
+    CrimeApplication.create!(
+      partner: Partner.new,
+      applicant: Applicant.new,
+      businesses: businesses
+    )
+  end
+
+  let(:businesses) do
+    [Business.new(business_type: 'partnership', ownership_type: existing_ownership)]
+  end
+
+  let(:subject_param) { 'client' }
+  let(:existing_ownership) { 'applicant' }
+  let(:include_partner?) { true }
+
+  before do
+    allow(MeansStatus).to receive(:include_partner?) { include_partner? }
+  end
+
+  describe '#edit' do
+    context 'when application is not found' do
+      it 'redirects to the application not found error page' do
+        get :edit, params: { id: '12345', subject: 'partner' }
+        expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'when application is found' do
+      before do
+        get :edit, params: { id: existing_case, subject: subject_param }
+      end
+
+      context 'when subject is neither partner or client' do
+        let(:subject_param) { 'co-defendant' }
+
+        context 'when partner is included in means assessment' do
+          it 'redirects to not found' do
+            expect(response).to redirect_to(not_found_errors_path)
+          end
+        end
+      end
+
+      context 'when subject is partner' do
+        let(:subject_param) { 'partner' }
+
+        it 'succeeds' do
+          expect(response).to be_successful
+        end
+
+        context 'when partner is not included in means assessment' do
+          let(:include_partner?) { false }
+
+          it 'redirects to not found' do
+            expect(response).to redirect_to(not_found_errors_path)
+          end
+        end
+
+        context 'when partner already has a business' do
+          let(:existing_ownership) { 'partner' }
+
+          it 'redirects to partner business summary page' do
+            expect(response).to redirect_to(
+              edit_steps_income_businesses_summary_path(
+                id: existing_case.id, subject: 'partner'
+              )
+            )
+          end
+        end
+      end
+
+      context 'when subject is client' do
+        let(:subject_param) { 'client' }
+        let(:existing_ownership) { 'partner' }
+
+        it 'succeeds' do
+          expect(response).to be_successful
+        end
+
+        context 'when client already has a business' do
+          let(:existing_ownership) { 'applicant' }
+
+          it 'redirects to partner business summary page' do
+            expect(response).to redirect_to(
+              edit_steps_income_businesses_summary_path(
+                id: existing_case.id, subject: 'client'
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:expected_params) do
+      { id: existing_case, subject: subject_param, steps_income_business_type_form: {} }
+    end
+
+    context 'when an application in progress is found' do
+      let(:form_object) do
+        instance_double(Steps::Income::BusinessTypeForm, attributes: { business_type: 'partnership' })
+      end
+
+      before do
+        allow(Steps::Income::BusinessTypeForm).to receive(:new).and_return(form_object)
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          expect(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) {
+          instance_double(Decisions::SelfEmployedIncomeDecisionTree, destination: '/expected_destination')
+        }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(Decisions::SelfEmployedIncomeDecisionTree).to receive(:new)
+            .and_return(decision_tree)
+
+          put :update, params: expected_params
+
+          expect(response).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          expect(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the question page again' do
+          put :update, params: expected_params
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/income/business_type_form_spec.rb
+++ b/spec/forms/steps/income/business_type_form_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::BusinessTypeForm do
+  subject(:form) { described_class.new(crime_application: crime_application, record: record, subject: form_subject) }
+
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:record) { instance_double(Business) }
+  let(:form_subject) { applicant }
+  let(:applicant) { Applicant.new }
+
+  describe '#choices' do
+    subject(:choices) { form.choices }
+
+    it { is_expected.to eq(BusinessType.values) }
+  end
+
+  describe '#validations' do
+    it { is_expected.to validate_is_a(:business_type, BusinessType) }
+  end
+
+  describe 'save' do
+    let(:business_type) { BusinessType.values.sample }
+
+    before do
+      allow(Business).to receive(:create!).and_return(true)
+
+      form.business_type = business_type
+      form.save
+    end
+
+    context 'when the form subject is applicant' do
+      it 'create a new business with the ownership type from the subject' do
+        expect(Business).to have_received(:create!).with(
+          crime_application: crime_application,
+          business_type: business_type,
+          ownership_type: OwnershipType::APPLICANT
+        )
+      end
+    end
+
+    context 'when the form subject is the partner' do
+      let(:form_subject) { Partner.new }
+
+      it 'create a new business with the ownership type from the subject' do
+        expect(Business).to have_received(:create!).with(
+          crime_application: crime_application,
+          business_type: business_type,
+          ownership_type: OwnershipType::PARTNER
+        )
+      end
+    end
+
+    context 'when the form subject does not have an ownership type' do
+      let(:form_subject) { double(:other_subject, ownership_type: nil) }
+
+      it 'create a new business with the ownership type from the subject' do
+        expect(Business).not_to have_received(:create!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds business type for both client and partner.

## Link to relevant ticket

[CRIMAPP-976](https://dsdmoj.atlassian.net/browse/CRIMAPP-976)

## Notes for reviewer

The logic for handling flow when both employed and self employed yet to be determined. Plan to extract subject setting for controllers as pattern evolves.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="706" alt="Screenshot 2024-06-18 at 10 36 52" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/76a02ae7-99a4-4d93-b45e-7daa84b32aba">

<img width="707" alt="Screenshot 2024-06-18 at 10 37 04" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/cc70f7de-da72-4fdc-aa20-c485b6d0f2a7">


## How to manually test the feature


[CRIMAPP-976]: https://dsdmoj.atlassian.net/browse/CRIMAPP-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ