### PR TITLE
Amend display logic for partner income payments and benefits sections

### DIFF
--- a/app/presenters/summary/sections/partner_income_benefits_details.rb
+++ b/app/presenters/summary/sections/partner_income_benefits_details.rb
@@ -7,8 +7,9 @@ module Summary
 
       def show?
         return false unless FeatureFlags.partner_journey.enabled?
+        return false if income.blank?
 
-        include_partner_in_means_assessment?
+        income.partner_has_no_income_benefits == 'yes' || super
       end
 
       private

--- a/app/presenters/summary/sections/partner_income_payments_details.rb
+++ b/app/presenters/summary/sections/partner_income_payments_details.rb
@@ -7,8 +7,9 @@ module Summary
 
       def show?
         return false unless FeatureFlags.partner_journey.enabled?
+        return false if income.blank?
 
-        include_partner_in_means_assessment?
+        income.partner_has_no_income_payments == 'yes' || super
       end
 
       private

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -12,7 +12,8 @@ describe Summary::HtmlPresenter do
     instance_double(
       CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'), partner: (double Partner), partner_detail: double(PartnerDetail, involvement_in_case: 'none'),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
-      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, applicant_self_assessment_tax_bill: 'no', has_no_income_payments: nil, has_no_income_benefits: nil),
+      income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, applicant_self_assessment_tax_bill: 'no',
+                      has_no_income_payments: nil, has_no_income_benefits: nil, partner_has_no_income_payments: nil, partner_has_no_income_benefits: nil),
       income_payments: [instance_double(IncomePayment, ownership_type: 'applicant', payment_type: 'maintenance'), instance_double(IncomePayment, ownership_type: 'partner', payment_type: 'maintenance')],
       outgoings_payments: [instance_double(OutgoingsPayment, payment_type: 'childcare')],
       income_benefits: [instance_double(IncomeBenefit, ownership_type: 'applicant', payment_type: 'incapacity'), instance_double(IncomeBenefit, ownership_type: 'partner', payment_type: 'jsa')],
@@ -130,6 +131,8 @@ describe Summary::HtmlPresenter do
                              'is_home_address' => 'yes',
                              'has_other_owners' => 'no',
                              'address' => nil, 'property_owners' => [] }],
+          'partner_has_no_income_payments' => 'yes',
+          'partner_has_no_income_benefits' => 'yes',
           'has_premium_bonds' => 'yes',
           'premium_bonds_total_value' => 1234,
           'premium_bonds_holder_number' => '1234A',

--- a/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe Summary::Sections::PartnerIncomeBenefitsDetails do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      income: income,
+      income_benefits: income_benefits
+    )
+  end
+
+  let(:income) do
+    instance_double(
+      Income,
+      partner_has_no_income_benefits:
+    )
+  end
+
+  let(:income_benefits) { [] }
+  let(:partner_has_no_income_benefits) { nil }
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:partner_income_benefits_details) }
+  end
+
+  describe '#show?' do
+    context 'when there is no income data' do
+      let(:income) { nil }
+
+      it 'shows this section' do
+        expect(subject.show?).to be false
+      end
+    end
+
+    context 'when there are no income benefits' do
+      context 'when the question was shown' do
+        let(:partner_has_no_income_benefits) { 'yes' }
+
+        it 'shows this section' do
+          expect(subject.show?).to be true
+        end
+      end
+
+      context 'when the question was not shown' do
+        it 'does not show this section' do
+          expect(subject.show?).to be false
+        end
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    context 'when no benefits are reported' do
+      let(:partner_has_no_income_benefits) { 'yes' }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:which_benefits_partner)
+        expect(answers[0].change_path).to match('applications/12345/steps/income/which_benefits_partner')
+        expect(answers[0].value).to eq('none')
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe Summary::Sections::PartnerIncomePaymentsDetails do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: '12345',
+      income: income,
+      income_payments: income_payments
+    )
+  end
+
+  let(:income) do
+    instance_double(
+      Income,
+      partner_has_no_income_payments:
+    )
+  end
+
+  let(:income_payments) { [] }
+  let(:partner_has_no_income_payments) { nil }
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:partner_income_payments_details) }
+  end
+
+  describe '#show?' do
+    context 'when there is no income data' do
+      let(:income) { nil }
+
+      it 'shows this section' do
+        expect(subject.show?).to be false
+      end
+    end
+
+    context 'when there are no income payments' do
+      context 'when the question was shown' do
+        let(:partner_has_no_income_payments) { 'yes' }
+
+        it 'shows this section' do
+          expect(subject.show?).to be true
+        end
+      end
+
+      context 'when the question was not shown' do
+        it 'does not show this section' do
+          expect(subject.show?).to be false
+        end
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:answers) { subject.answers }
+
+    context 'when no payments are reported' do
+      let(:partner_has_no_income_payments) { 'yes' }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question).to eq(:which_payments_partner)
+        expect(answers[0].change_path).to match('applications/12345/steps/income/which_payments_partner')
+        expect(answers[0].value).to eq('none')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Fixes a bug where the partner income payment and benefits sections were displaying when the question hadn't been asked 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1104" alt="Screenshot 2024-06-18 at 09 24 20" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/83fe41ca-7da8-4295-a0b5-878746dc6104">

### After changes:

## How to manually test the feature
