### PR TITLE
Add guard clauses for partner journey

### DIFF
--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -2,6 +2,8 @@ module Summary
   module Sections
     class PartnerDetails < Sections::BaseSection
       def show?
+        return false unless FeatureFlags.partner_journey.enabled?
+
         partner.present? && client.present? && super
       end
 

--- a/app/validators/client_details/answers_validator.rb
+++ b/app/validators/client_details/answers_validator.rb
@@ -59,6 +59,7 @@ module ClientDetails
     end
 
     def relationship_status_complete?
+      return true unless FeatureFlags.partner_journey.enabled?
       return true if applicant.under18?
       return true if record.client_has_partner == 'no' && record.partner_detail&.relationship_status.present?
       return true if record.client_has_partner == 'yes'

--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -19,7 +19,7 @@ class SectionsCompletenessValidator
       errors.add(:outgoings_assessment, :incomplete) unless outgoings_assessment_complete?
       errors.add(:capital_assessment, :incomplete) unless capital_assessment_complete?
 
-      errors.add(:partner_details, :incomplete) unless partner_detail&.complete?
+      errors.add(:partner_details, :incomplete) unless partner_detail_complete?
     else
       errors.add(:client_details, :incomplete)
     end
@@ -28,6 +28,12 @@ class SectionsCompletenessValidator
   end
 
   delegate :client_details_complete?, :passporting_benefit_complete?, to: :crime_application
+
+  def partner_detail_complete?
+    return true unless FeatureFlags.partner_journey.enabled?
+
+    partner_detail&.complete?
+  end
 
   def income_assessment_complete?
     return true unless requires_means_assessment?


### PR DESCRIPTION
## Description of change
When feature flags are set to production values, certain elements of partner journey (answer playback views, and validators in particular) cause issues with viewing and submitting an application.

Add guard clauses to check partner journey is enabled to ensure we do not cause a regression should we deploy to prod

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1051

## How to manually test the feature
Set feature flags to prod values (particularly partner journey)
Restart Apply server
Submit an application (try some varieties)
