### PR TITLE
Only display partner 40% tax if there is an included partner

### DIFF
--- a/app/presenters/summary/sections/other_outgoings_details.rb
+++ b/app/presenters/summary/sections/other_outgoings_details.rb
@@ -1,21 +1,31 @@
 module Summary
   module Sections
     class OtherOutgoingsDetails < Sections::BaseSection
+      include TypeOfMeansAssessment
+
       def show?
         outgoings.present? && super
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
-        [
+        answers = [
           Components::ValueAnswer.new(
             :income_tax_rate_above_threshold, outgoings.income_tax_rate_above_threshold,
             change_path: edit_steps_outgoings_income_tax_rate_path
           ),
-          Components::ValueAnswer.new(
-            :partner_income_tax_rate_above_threshold, outgoings.partner_income_tax_rate_above_threshold,
-            change_path: edit_steps_outgoings_partner_income_tax_rate_path
-          ),
+        ]
+
+        if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+          answers.push(
+            Components::ValueAnswer.new(
+              :partner_income_tax_rate_above_threshold, outgoings.partner_income_tax_rate_above_threshold,
+              change_path: edit_steps_outgoings_partner_income_tax_rate_path
+            )
+          )
+        end
+
+        answers.push(
           Components::ValueAnswer.new(
             :outgoings_more_than_income, outgoings.outgoings_more_than_income,
             change_path: edit_steps_outgoings_outgoings_more_than_income_path
@@ -24,9 +34,11 @@ module Summary
             :how_manage, outgoings.how_manage,
             change_path: edit_steps_outgoings_outgoings_more_than_income_path
           ),
-        ].select(&:show?)
+        )
+
+        answers.select(&:show?)
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
     end
   end
 end

--- a/spec/presenters/summary/sections/other_outgoings_details_spec.rb
+++ b/spec/presenters/summary/sections/other_outgoings_details_spec.rb
@@ -8,6 +8,8 @@ describe Summary::Sections::OtherOutgoingsDetails do
       CrimeApplication,
       to_param: '12345',
       outgoings: outgoings,
+      partner: partner,
+      partner_detail: partner_detail,
     )
   end
 
@@ -20,6 +22,9 @@ describe Summary::Sections::OtherOutgoingsDetails do
       how_manage: 'An example of how they manage'
     )
   end
+
+  let(:partner) { nil }
+  let(:partner_detail) { nil }
 
   describe '#name' do
     it { expect(subject.name).to eq(:other_outgoings_details) }
@@ -46,27 +51,56 @@ describe Summary::Sections::OtherOutgoingsDetails do
 
     context 'when there are outgoings details' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(3)
         expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answers[0].question).to eq(:income_tax_rate_above_threshold)
         expect(answers[0].change_path)
           .to match('applications/12345/steps/outgoings/client_paid_income_tax_rate')
-        expect(answers[1].value).to eq('no')
+        expect(answers[0].value).to eq('no')
         expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[1].question).to eq(:partner_income_tax_rate_above_threshold)
+        expect(answers[1].question).to eq(:outgoings_more_than_income)
         expect(answers[1].change_path)
-          .to match('applications/12345/steps/outgoings/partner_paid_income_tax_rate')
-        expect(answers[1].value).to eq('no')
-        expect(answers[2]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[2].question).to eq(:outgoings_more_than_income)
+          .to match('applications/12345/steps/outgoings/are_outgoings_more_than_income')
+        expect(answers[1].value).to eq('yes')
+        expect(answers[2]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answers[2].question).to eq(:how_manage)
         expect(answers[2].change_path)
           .to match('applications/12345/steps/outgoings/are_outgoings_more_than_income')
-        expect(answers[2].value).to eq('yes')
-        expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-        expect(answers[3].question).to eq(:how_manage)
-        expect(answers[3].change_path)
-          .to match('applications/12345/steps/outgoings/are_outgoings_more_than_income')
-        expect(answers[3].value).to eq('An example of how they manage')
+        expect(answers[2].value).to eq('An example of how they manage')
+      end
+
+      context 'when there are partner outgoings details' do
+        let(:partner) { instance_double(Partner) }
+        let(:partner_detail) do
+          instance_double(
+            PartnerDetail,
+            involvement_in_case: 'none',
+          )
+        end
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(4)
+          expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+          expect(answers[0].question).to eq(:income_tax_rate_above_threshold)
+          expect(answers[0].change_path)
+            .to match('applications/12345/steps/outgoings/client_paid_income_tax_rate')
+          expect(answers[0].value).to eq('no')
+          expect(answers[1]).to be_an_instance_of(Summary::Components::ValueAnswer)
+          expect(answers[1].question).to eq(:partner_income_tax_rate_above_threshold)
+          expect(answers[1].change_path)
+            .to match('applications/12345/steps/outgoings/partner_paid_income_tax_rate')
+          expect(answers[1].value).to eq('no')
+          expect(answers[2]).to be_an_instance_of(Summary::Components::ValueAnswer)
+          expect(answers[2].question).to eq(:outgoings_more_than_income)
+          expect(answers[2].change_path)
+            .to match('applications/12345/steps/outgoings/are_outgoings_more_than_income')
+          expect(answers[2].value).to eq('yes')
+          expect(answers[3]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+          expect(answers[3].question).to eq(:how_manage)
+          expect(answers[3].change_path)
+            .to match('applications/12345/steps/outgoings/are_outgoings_more_than_income')
+          expect(answers[3].value).to eq('An example of how they manage')
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
When feature flags are set to production values, outgoings answer playback view cause issues with viewing and submitting an application.


Only display partner 40% tax if there is an included partner

## How to manually test the feature
Set feature flags to prod values (particularly partner journey)
Restart Apply server
Submit an application (try some varieties)