### PR TITLE
[CRIMAPP-1022] Add evidence prompts for employed journey

### DIFF
--- a/app/services/evidence/rules/20240425220057_salaried_employee.rb
+++ b/app/services/evidence/rules/20240425220057_salaried_employee.rb
@@ -16,9 +16,14 @@ module Evidence
         end
       end
 
-      # TODO: Awaiting partner implementation
-      partner do |_crime_application|
-        false
+      partner do |crime_application|
+        if MeansStatus.include_partner?(crime_application) && crime_application.income
+          [EmploymentStatus::EMPLOYED.to_s].intersect?(
+            Array.wrap(crime_application.income.partner_employment_status)
+          )
+        else
+          false
+        end
       end
     end
   end

--- a/app/services/evidence/rules/20240426002316_self_assessed.rb
+++ b/app/services/evidence/rules/20240426002316_self_assessed.rb
@@ -7,13 +7,11 @@ module Evidence
       group :income
 
       client do |crime_application|
-        if crime_application.outgoings
-          (crime_application.outgoings.income_tax_rate_above_threshold == 'yes') || false
-        else
-          false
-        end
+        crime_application.outgoings&.income_tax_rate_above_threshold == 'yes' ||
+          crime_application.income&.applicant_self_assessment_tax_bill == 'yes'
       end
 
+      # TODO: awaiting partner_self_assessment_tax_bill
       partner do |crime_application|
         if MeansStatus.include_partner?(crime_application) && crime_application.outgoings
           (crime_application.outgoings.partner_income_tax_rate_above_threshold == 'yes') || false

--- a/app/services/evidence/rules/20240426014955_benefits_in_kind.rb
+++ b/app/services/evidence/rules/20240426014955_benefits_in_kind.rb
@@ -8,7 +8,7 @@ module Evidence
 
       client do |crime_application|
         if crime_application.income
-          (crime_application.income.applicant_other_work_benefit_received == 'yes') || false
+          crime_application.income.applicant_other_work_benefit_received == 'yes'
         else
           false
         end

--- a/app/services/evidence/rules/20240426014955_benefits_in_kind.rb
+++ b/app/services/evidence/rules/20240426014955_benefits_in_kind.rb
@@ -6,9 +6,12 @@ module Evidence
       key :income_noncash_benefit_4
       group :income
 
-      # TODO: Awaiting client implementation
-      client do |_crime_application|
-        false
+      client do |crime_application|
+        if crime_application.income
+          (crime_application.income.applicant_other_work_benefit_received == 'yes') || false
+        else
+          false
+        end
       end
 
       # TODO: Awaiting partner implementation

--- a/spec/services/evidence/rules/20240426002316_self_assessed_spec.rb
+++ b/spec/services/evidence/rules/20240426002316_self_assessed_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Evidence::Rules::SelfAssessed do
   let(:crime_application) do
     CrimeApplication.create!(
       outgoings:,
+      income:,
     )
   end
 
   let(:outgoings) { Outgoings.new }
+  let(:income) { Income.new }
   let(:include_partner?) { true }
 
   before do
@@ -32,6 +34,18 @@ RSpec.describe Evidence::Rules::SelfAssessed do
 
     context 'when not high tax earner' do
       let(:outgoings) { Outgoings.new(income_tax_rate_above_threshold: 'no') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when applicant has paid a self assessment tax bill' do
+      let(:income) { Income.new(applicant_self_assessment_tax_bill: 'yes') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when applicant has not paid a self assessment tax bill' do
+      let(:income) { Income.new(applicant_self_assessment_tax_bill: 'no') }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
## Description of change
Adds the evidence prompts for rules 0a, 2 and 4 (see spreadsheet below)
This is with the exception of the partner triggers for rules 2 and 4 which is awaiting implementation

## Link to relevant ticket
[CRIMAPP-1022](https://dsdmoj.atlassian.net/browse/CRIMAPP-1022)
[Evidence spreadsheet](https://docs.google.com/spreadsheets/d/1hFVZXo87BhnZ4xUrWubnXjOR0kodN694azBi2y2XstM/edit#gid=764299190)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="836" alt="Screenshot 2024-06-19 at 12 18 59" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/126f13bc-8803-49dc-beb2-c794f5e738ea">


## How to manually test the feature


[CRIMAPP-1022]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ