### PR TITLE
[CRIMAPP-1079] Display client only income payments/benefits

### DIFF
--- a/app/forms/steps/income/income_benefit_fieldset_form.rb
+++ b/app/forms/steps/income/income_benefit_fieldset_form.rb
@@ -31,7 +31,7 @@ module Steps
       end
 
       def delete
-        crime_application.income_benefits.find_by(payment_type:)&.delete
+        crime_application.income_benefits.for_client.find_by(payment_type:)&.delete
       end
 
       private

--- a/app/forms/steps/income/income_benefits_form.rb
+++ b/app/forms/steps/income/income_benefits_form.rb
@@ -31,7 +31,7 @@ module Steps
         define_method :"#{type}=" do |attrs|
           @new_payments ||= {}
           record = IncomeBenefitFieldsetForm.build(
-            IncomeBenefit.new(payment_type: type.to_s, **attrs),
+            IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s, **attrs),
             crime_application:
           )
 
@@ -56,7 +56,7 @@ module Steps
         return @types if @types
         return ['none'] if income.has_no_income_benefits == 'yes'
 
-        income.income_benefits.pluck(:payment_type)
+        income.income_benefits.for_client.pluck(:payment_type)
       end
 
       def has_no_income_benefits
@@ -69,13 +69,13 @@ module Steps
       def find_or_create_income_benefit(type) # rubocop:disable Metrics/AbcSize
         if types.include?(type.to_s) && @new_payments&.key?(type.value.to_s)
           attrs = @new_payments[type.value.to_s].attributes
-          return IncomeBenefit.new(payment_type: type.to_s, **attrs)
+          return IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s, **attrs)
         end
 
-        income_benefit = crime_application.income_benefits.find_by(payment_type: type.value.to_s)
+        income_benefit = crime_application.income_benefits.for_client.find_by(payment_type: type.value.to_s)
         return income_benefit if income_benefit
 
-        IncomeBenefit.new(payment_type: type.to_s)
+        IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s,)
       end
 
       # Individual income_benefits_fieldset_forms are in charge of saving themselves

--- a/app/forms/steps/income/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/income_payment_fieldset_form.rb
@@ -39,7 +39,7 @@ module Steps
       end
 
       def delete
-        crime_application.income_payments.find_by(payment_type:)&.delete
+        crime_application.income_payments.for_client.find_by(payment_type:)&.delete
       end
 
       private

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -31,7 +31,7 @@ module Steps
         define_method :"#{type}=" do |attrs|
           @new_payments ||= {}
           record = IncomePaymentFieldsetForm.build(
-            IncomePayment.new(payment_type: type.to_s, **attrs),
+            IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s, **attrs),
             crime_application:
           )
 
@@ -56,7 +56,7 @@ module Steps
         return @types if @types
         return ['none'] if income.has_no_income_payments == 'yes'
 
-        income.income_payments.pluck(:payment_type)
+        income.income_payments.for_client.pluck(:payment_type)
       end
 
       def has_no_income_payments
@@ -69,13 +69,13 @@ module Steps
       def find_or_create_income_payment(type) # rubocop:disable Metrics/AbcSize
         if types.include?(type.to_s) && @new_payments&.key?(type.value.to_s)
           attrs = @new_payments[type.value.to_s].attributes
-          return IncomePayment.new(payment_type: type.to_s, **attrs)
+          return IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s, **attrs)
         end
 
-        income_payment = crime_application.income_payments.find_by(payment_type: type.value.to_s)
+        income_payment = crime_application.income_payments.for_client.find_by(payment_type: type.value.to_s)
         return income_payment if income_payment
 
-        IncomePayment.new(payment_type: type.to_s)
+        IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s)
       end
 
       # Individual income_payments_fieldset_forms are in charge of saving themselves

--- a/app/presenters/summary/components/property.rb
+++ b/app/presenters/summary/components/property.rb
@@ -25,6 +25,11 @@ module Summary
       def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         attributes = [
           Components::FreeTextAnswer.new(
+            :house_type,
+            house_type, i18n_opts: i18n_opts,
+            show: residential?
+          ),
+          Components::FreeTextAnswer.new(
             :bedrooms,
             property.bedrooms.to_s,
             show: residential?
@@ -123,6 +128,14 @@ module Summary
 
       def asset
         PROPERTY_TYPE_MAPPING[property.property_type][:display_name]
+      end
+
+      def house_type
+        if property.house_type == ::Property::OTHER_HOUSE_TYPE
+          property.other_house_type
+        else
+          I18n.t(property.house_type, scope: [:summary, :sections, :property, :house_type])
+        end
       end
 
       def relationship(owner)

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -740,6 +740,9 @@ en:
       # END national_savings_certificates
 
       # BEGIN property, address and owners
+      house_type:
+        question: Type of property
+        absence_answer: *absence_none
       bedrooms:
         question: Bedrooms
         absence_answer: *absence_none

--- a/spec/forms/steps/income/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/income_benefits_form_spec.rb
@@ -20,7 +20,18 @@ RSpec.describe Steps::Income::IncomeBenefitsForm do
       payment_type: 'jsa',
       crime_application: crime_application,
       amount: '123',
-      frequency: 'four_weeks'
+      frequency: 'four_weeks',
+      ownership_type: 'applicant'
+    )
+  end
+
+  let(:payment_with_incorrect_ownership) do
+    IncomeBenefit.create!(
+      payment_type: 'child',
+      crime_application: crime_application,
+      amount: '200',
+      frequency: 'month',
+      ownership_type: 'partner'
     )
   end
 
@@ -29,6 +40,13 @@ RSpec.describe Steps::Income::IncomeBenefitsForm do
   end
 
   it_behaves_like 'a payment form', described_class, :has_no_income_benefits
+
+  context 'when record with incorrect ownership exists' do
+    it 'does not include the payment type' do
+      payment_with_incorrect_ownership
+      expect(subject.types).not_to include(payment_with_incorrect_ownership.payment_type)
+    end
+  end
 
   describe '#save' do
     context 'with form submission' do

--- a/spec/forms/steps/income/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/income_payments_form_spec.rb
@@ -20,7 +20,18 @@ RSpec.describe Steps::Income::IncomePaymentsForm do
       payment_type: 'rent',
       crime_application: crime_application,
       amount: '123',
-      frequency: 'four_weeks'
+      frequency: 'four_weeks',
+      ownership_type: 'applicant'
+    )
+  end
+
+  let(:payment_with_incorrect_ownership) do
+    IncomePayment.create!(
+      payment_type: 'maintenance',
+      crime_application: crime_application,
+      amount: '500',
+      frequency: 'monthly',
+      ownership_type: 'partner'
     )
   end
 
@@ -29,6 +40,13 @@ RSpec.describe Steps::Income::IncomePaymentsForm do
   end
 
   it_behaves_like 'a payment form', described_class, :has_no_income_payments
+
+  context 'when record with incorrect ownership exists' do
+    it 'does not include the payment type' do
+      payment_with_incorrect_ownership
+      expect(subject.types).not_to include(payment_with_incorrect_ownership.payment_type)
+    end
+  end
 
   describe '#save' do
     context 'with form submission' do

--- a/spec/forms/steps/income/partner/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_benefits_form_spec.rb
@@ -25,11 +25,28 @@ RSpec.describe Steps::Income::Partner::IncomeBenefitsForm do
     )
   end
 
+  let(:payment_with_incorrect_ownership) do
+    IncomeBenefit.create!(
+      payment_type: 'child',
+      crime_application: crime_application,
+      amount: '200',
+      frequency: 'month',
+      ownership_type: 'applicant'
+    )
+  end
+
   let(:payments) do
     subject.crime_application.income_benefits
   end
 
   it_behaves_like 'a payment form', described_class, :partner_has_no_income_benefits
+
+  context 'when record with incorrect ownership exists' do
+    it 'does not include the payment type' do
+      payment_with_incorrect_ownership
+      expect(subject.types).not_to include(payment_with_incorrect_ownership.payment_type)
+    end
+  end
 
   describe '#save' do
     context 'with form submission' do

--- a/spec/forms/steps/income/partner/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_payments_form_spec.rb
@@ -25,11 +25,28 @@ RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
     )
   end
 
+  let(:payment_with_incorrect_ownership) do
+    IncomePayment.create!(
+      payment_type: 'maintenance',
+      crime_application: crime_application,
+      amount: '500',
+      ownership_type: 'applicant',
+      frequency: 'monthly'
+    )
+  end
+
   let(:payments) do
     subject.crime_application.income_payments
   end
 
   it_behaves_like 'a payment form', described_class, :partner_has_no_income_payments
+
+  context 'when record with incorrect ownership exists' do
+    it 'does not include the payment type' do
+      payment_with_incorrect_ownership
+      expect(subject.types).not_to include(payment_with_incorrect_ownership.payment_type)
+    end
+  end
 
   describe '#save' do
     context 'with form submission' do


### PR DESCRIPTION
## Description of change
The income payments and benefits pages for the client were displaying partner payments/benefits as well as the clients. This PR fixes the bug and adds specs

## Link to relevant ticket
[CRIMAPP-1079](https://dsdmoj.atlassian.net/browse/CRIMAPP-1079)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

1. Start an application with a partner and get to the income means assessment section.
2. Go through the screens and enter payment and benefit information for the client and partner 
3. Once you added payment and benefit information for the partner, go back and ensure you cannot see the partner's payment and benefit information on the client payment and benefit forms 

[CRIMAPP-1079]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ