### PR TITLE
[CRIMAPP-1086] Display correct subject for outgoings payments heading

### DIFF
--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -30,6 +30,7 @@ module Summary
           name,
           scope: 'summary.sections',
           subject: I18n.t("summary.dictionary.subjects.#{subject_type}"),
+          ownership: I18n.t("summary.dictionary.ownership.#{subject_type}"),
           count: subject_type.to_s == SubjectType::APPLICANT_AND_PARTNER.to_s ? 2 : 1
         )
       end

--- a/app/presenters/summary/sections/outgoings_payments_details.rb
+++ b/app/presenters/summary/sections/outgoings_payments_details.rb
@@ -1,6 +1,8 @@
 module Summary
   module Sections
     class OutgoingsPaymentsDetails < Sections::PaymentDetails
+      include TypeOfMeansAssessment
+
       def show?
         return false if outgoings.blank?
 
@@ -37,6 +39,12 @@ module Summary
 
       def payment_types
         %w[childcare maintenance legal_aid_contribution]
+      end
+
+      def subject_type
+        return unless include_partner_in_means_assessment?
+
+        SubjectType.new(:applicant_and_partner)
       end
     end
   end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -78,8 +78,8 @@ en:
         other: "Other sources of income: client and partner"
       housing_payments: Housing Payments
       outgoings_payments_details:
-        one: Payments your %{subject} makes
-        other: Payments your %{subject} make
+        one: Payments %{ownership} makes
+        other: Payments %{ownership} make
       other_outgoings_details: Other outgoings
       supporting_evidence: Supporting evidence
       more_information: Further information


### PR DESCRIPTION
## Description of change
Fixes subject display for outgoings payments section heading

## Link to relevant ticket
[CRIMAPP-1086](https://dsdmoj.atlassian.net/browse/CRIMAPP-1086)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1074" alt="Screenshot 2024-06-20 at 09 42 00" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/36955de9-55b7-4d11-961d-cca7bad0a2e4">
<img width="1074" alt="Screenshot 2024-06-20 at 09 42 09" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/2ab92a09-5b4e-4c69-ae2a-4e655c708376">

## How to manually test the feature


[CRIMAPP-1086]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ