### PR TITLE
[CRIMAPP-1081] [CRIMAPP-1074] Fix appeal no changes and u18 validation

### DIFF
--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -4,7 +4,7 @@ module Summary
       def show?
         return false unless FeatureFlags.partner_journey.enabled?
 
-        partner.present? && client.present? && super
+        partner&.first_name.present? && client.present? && super
       end
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/serializers/submission_serializer/sections/client_details.rb
+++ b/app/serializers/submission_serializer/sections/client_details.rb
@@ -7,9 +7,17 @@ module SubmissionSerializer
 
           json.client_details do
             json.applicant Definitions::Applicant.generate(crime_application)
-            json.partner Definitions::Partner.generate(crime_application) if partner
+            json.partner partner_json
           end
         end
+      end
+
+      private
+
+      def partner_json
+        return unless crime_application.partner
+
+        Definitions::Partner.generate(crime_application)
       end
     end
   end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -31,6 +31,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
 
   def means_valid?
     return true if Passporting::MeansPassporter.new(record).call
+    return true if appeal_no_changes?
 
     evidence_present? || means_record_present? || client_remanded_in_custody?
   end

--- a/app/validators/partner_details/answers_validator.rb
+++ b/app/validators/partner_details/answers_validator.rb
@@ -16,9 +16,9 @@ module PartnerDetails
     def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       return unless applicable?
 
-      errors.add(:relationship_to_partner, :incomplete) unless record.relationship_to_partner.present?
+      errors.add(:relationship_to_partner, :incomplete) if record.relationship_to_partner.blank?
       errors.add(:details, :blank) unless partner_details_complete?
-      errors.add(:involvement_in_case, :incomplete) unless record.involvement_in_case.present?
+      errors.add(:involvement_in_case, :incomplete) if record.involvement_in_case.blank?
       errors.add(:nino, :incomplete) unless nino?
       errors.add(:conflict_of_interest, :incomplete) unless conflict_of_interest?
       errors.add(:has_same_address_as_client, :incomplete) unless same_address?

--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -31,8 +31,10 @@ class SectionsCompletenessValidator
 
   def partner_detail_complete?
     return true unless FeatureFlags.partner_journey.enabled?
+    return true if appeal_no_changes? || applicant&.under18?
+    return false unless partner_detail
 
-    partner_detail&.complete?
+    partner_detail.complete?
   end
 
   def income_assessment_complete?

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -10,7 +10,8 @@ describe Summary::HtmlPresenter do
   # rubocop:disable Layout/LineLength
   let(:database_application) do
     instance_double(
-      CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'), partner: (double Partner), partner_detail: double(PartnerDetail, involvement_in_case: 'none'),
+      CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'),
+      partner: double(first_name: 'Test first name'), partner_detail: double(PartnerDetail, involvement_in_case: 'none'),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
       income: (double partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s], applicant_other_work_benefit_received: nil, applicant_self_assessment_tax_bill: 'no',
                       has_no_income_payments: nil, has_no_income_benefits: nil, partner_has_no_income_payments: nil, partner_has_no_income_benefits: nil),

--- a/spec/serializers/submission_serializer/sections/client_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/client_details_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
           relationship_to_partner: relationship_to_partner,
           relationship_status: relationship_status,
           separation_date: nil,
-        }
+        },
+        partner: nil,
       }
     }
   end

--- a/spec/validators/client_details/answers_validator_spec.rb
+++ b/spec/validators/client_details/answers_validator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ClientDetails::AnswersValidator, type: :model do
   let(:appeal_no_changes?) { false }
   let(:under18?) { false }
   let(:case_type) { nil }
-  let(:client_has_partner) { 'no' }
+  let(:client_has_partner) { nil }
   let(:partner_detail) { nil }
 
   before do
@@ -34,6 +34,7 @@ RSpec.describe ClientDetails::AnswersValidator, type: :model do
         expect(errors).to receive(:add).with(:residence_type, :blank)
         expect(errors).to receive(:add).with(:has_nino, :blank)
         expect(errors).to receive(:add).with(:client_has_partner, :blank)
+        expect(errors).to receive(:add).with(:relationship_status, :blank)
         expect(errors).to receive(:add).with(:base, :incomplete_records)
 
         subject.validate
@@ -42,10 +43,9 @@ RSpec.describe ClientDetails::AnswersValidator, type: :model do
       context 'when application is appeal to crown court no changes' do
         let(:appeal_no_changes?) { true }
 
-        it 'does not add any errors' do
+        it 'adds any errors for details and case type' do
           expect(errors).to receive(:add).with(:details, :blank)
           expect(errors).to receive(:add).with(:case_type, :blank)
-          expect(errors).to receive(:add).with(:client_has_partner, :blank)
           expect(errors).to receive(:add).with(:base, :incomplete_records)
 
           subject.validate
@@ -55,7 +55,7 @@ RSpec.describe ClientDetails::AnswersValidator, type: :model do
       context 'when applicant is under 18' do
         let(:under18?) { true }
 
-        it 'does not add any errors' do
+        it 'adds any errors for details, case type and residence type' do
           expect(errors).to receive(:add).with(:details, :blank)
           expect(errors).to receive(:add).with(:case_type, :blank)
           expect(errors).to receive(:add).with(:residence_type, :blank)

--- a/spec/validators/partner_details/answers_validator_spec.rb
+++ b/spec/validators/partner_details/answers_validator_spec.rb
@@ -65,24 +65,6 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
       end
     end
 
-    context 'without a partner' do
-      subject(:complete?) { validator.complete? }
-
-      let(:client_has_partner) { 'no' }
-
-      context 'with a relationship status' do
-        before { partner_detail.relationship_status = 'divorced' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'without a relationship status' do
-        before { partner_detail.relationship_status = nil }
-
-        it { is_expected.to be false }
-      end
-    end
-
     # NOTE: Relies on top level partner_detail to be valid
     context 'with a partner' do
       subject(:complete?) { validator.complete? }
@@ -156,7 +138,8 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
       it 'adds errors' do
         subject.validate
 
-        expect(subject.errors.of_kind?('partner_details', :incomplete)).to be(true)
+        expect(subject.errors.of_kind?('involvement_in_case', :incomplete)).to be(true)
+        expect(subject.errors.of_kind?('base', :incomplete_records)).to be(true)
       end
     end
   end

--- a/spec/validators/sections_completeness_validator_spec.rb
+++ b/spec/validators/sections_completeness_validator_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
             passporting_benefit_complete?: true,
             kase: double(complete?: true),
             partner_detail: double(complete?: true),
+            appeal_no_changes?: false,
+            applicant: double(under18?: false),
           }
         end
 
@@ -59,6 +61,8 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
           kase: double(complete?: true),
           income: double(complete?: true),
           partner_detail: double(complete?: true),
+          appeal_no_changes?: false,
+          applicant: double(under18?: false),
         }
       end
 
@@ -84,6 +88,8 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
             outgoings: double(complete?: true),
             capital: double(complete?: true),
             partner_detail: double(complete?: true),
+            appeal_no_changes?: false,
+            applicant: double(under18?: false),
           }
         end
 
@@ -102,6 +108,8 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
             outgoings: double(complete?: false),
             capital: double(complete?: false),
             partner_detail: double(complete?: false),
+            appeal_no_changes?: false,
+            applicant: double(under18?: false),
           }
         end
 
@@ -128,8 +136,13 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
             outgoings: nil,
             capital: nil,
             partner_detail: nil,
+            appeal_no_changes?: appeal_no_changes,
+            applicant: double(under18?: under18),
           }
         end
+
+        let(:under18) { false }
+        let(:appeal_no_changes) { false }
 
         it 'adds errors to all sections and base' do
           expect(errors).to receive(:add).with(:income_assessment, :incomplete)
@@ -139,6 +152,26 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
           expect(errors).to receive(:add).with(:base, :incomplete_records)
 
           subject.validate
+        end
+
+        context 'when applicant is under 18' do
+          let(:under18) { true }
+
+          it 'does not add an error for the partner details section' do
+            expect(errors).not_to receive(:add).with(:partner_details, :incomplete)
+
+            subject.validate
+          end
+        end
+
+        context 'when application is appeal no changes' do
+          let(:appeal_no_changes) { true }
+
+          it 'does not add an error for the partner details section' do
+            expect(errors).not_to receive(:add).with(:partner_details, :incomplete)
+
+            subject.validate
+          end
         end
       end
     end


### PR DESCRIPTION
## Description of change
Fixes bug where you could not submit appeal no changes and under 18 applications due to failing section validation checks on the review your application page 

Also fixes bug where appeal no changes apps where being prevented from being submitted due to means checks in the application fulfilment validator. As appeal no changes apps do not go through means assessment, this check is bypassed

## Link to relevant ticket
[CRIMAPP-1081](https://dsdmoj.atlassian.net/browse/CRIMAPP-1081)
[CRIMAPP-1074](https://dsdmoj.atlassian.net/browse/CRIMAPP-1074)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Fill in a appeal no changes and u18 application and verify you are able to go past the review page and submit 


[CRIMAPP-1081]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1074]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ