### PR TITLE
CRIMAPP-1062 fix manage_with_no_income routing for employed journey

### DIFF
--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -24,6 +24,10 @@ class Income < ApplicationRecord
   end
 
   def all_income_total
-    income_payments.sum { |p| p.amount.to_i } + income_benefits.sum { |p| p.amount.to_i }
+    income_payments.sum { |p| p.amount.to_i } + income_benefits.sum { |p| p.amount.to_i } + employments_total
+  end
+
+  def employments_total
+    crime_application.employments&.sum { |e| e.amount.to_i }
   end
 end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -268,10 +268,10 @@ module Decisions
     def determine_showing_no_income_page
       if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
         edit(:partner_employment_status)
-      elsif income_payments.empty? && income_benefits.empty?
-        edit(:manage_without_income)
-      else
+      elsif crime_application.income&.all_income_over_zero?
         edit(:answers)
+      else
+        edit(:manage_without_income)
       end
     end
 

--- a/spec/models/income_spec.rb
+++ b/spec/models/income_spec.rb
@@ -88,7 +88,24 @@ RSpec.describe Income, type: :model do
       end
     end
 
+    context 'when there is employment income' do
+      before do
+        crime_application = CrimeApplication.new(income:)
+        crime_application.employments = [
+          Employment.new(amount: 12_000)
+        ]
+      end
+
+      it { is_expected.to be true }
+
+      it 'calculates the correct total' do
+        expect(income.all_income_total).to eq 12_000
+      end
+    end
+
     context 'when there are no income payments or benefits' do
+      before { CrimeApplication.new(income:) }
+
       it { is_expected.to be false }
 
       it 'calculates the correct total' do

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
       it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
     end
 
-    context 'when there are no income payments or benefits' do
+    context 'when there are no income payments, income benefits or employment income' do
       before { allow(income).to receive(:all_income_over_zero?).and_return(false) }
 
       it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
@@ -726,20 +726,18 @@ RSpec.describe Decisions::IncomeDecisionTree do
     context 'when does not require full means assessment' do
       let(:requires_full_means_assessment) { false }
 
-      before do
-        allow(crime_application).to receive_messages(income_payments:, income_benefits:)
-      end
-
-      context 'when there are no payments' do
-        let(:income_payments) { [] }
-        let(:income_benefits) { [] }
+      context 'when income is zero' do
+        before do
+          allow(income).to receive(:all_income_over_zero?).and_return false
+        end
 
         it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
       end
 
-      context 'when there are payments or benefits' do
-        let(:income_payments) { [{ amount: 1234 }] }
-        let(:income_benefits) { [] }
+      context 'when income is above zero' do
+        before do
+          allow(income).to receive(:all_income_over_zero?).and_return true
+        end
 
         it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
       end
@@ -757,7 +755,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
 
       context 'when there are no payments' do
         before do
-          allow(crime_application).to receive_messages(income_payments: [], income_benefits: [])
+          allow(income).to receive(:all_income_over_zero?).and_return false
         end
 
         it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
@@ -765,20 +763,8 @@ RSpec.describe Decisions::IncomeDecisionTree do
 
       context 'when there are payments' do
         before do
-          allow(crime_application).to receive_messages(income_payments: [{ amount: 1234 }], income_benefits: [])
-
-          allow(income).to receive_messages(
-            income_above_threshold:,
-            has_frozen_income_or_assets:,
-            client_owns_property:,
-            has_savings:
-          )
+          allow(income).to receive(:all_income_over_zero?).and_return true
         end
-
-        let(:income_above_threshold) { YesNoAnswer::NO.to_s }
-        let(:has_frozen_income_or_assets) { YesNoAnswer::NO.to_s }
-        let(:client_owns_property) { YesNoAnswer::NO.to_s }
-        let(:has_savings) { YesNoAnswer::NO.to_s }
 
         it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
       end
@@ -866,30 +852,18 @@ RSpec.describe Decisions::IncomeDecisionTree do
       it { is_expected.to have_destination(:partner_employment_status, :edit, id: crime_application) }
     end
 
-    context 'when there are no payments' do
+    context 'when income is zero' do
       before do
-        allow(crime_application).to receive_messages(income_payments: [], income_benefits: [])
+        allow(income).to receive(:all_income_over_zero?).and_return false
       end
 
       it { is_expected.to have_destination(:manage_without_income, :edit, id: crime_application) }
     end
 
-    context 'when there are payments' do
+    context 'when income is above zero' do
       before do
-        allow(crime_application).to receive_messages(income_payments: [{ amount: 1234 }], income_benefits: [])
-
-        allow(income).to receive_messages(
-          income_above_threshold:,
-          has_frozen_income_or_assets:,
-          client_owns_property:,
-          has_savings:
-        )
+        allow(income).to receive(:all_income_over_zero?).and_return true
       end
-
-      let(:income_above_threshold) { YesNoAnswer::NO.to_s }
-      let(:has_frozen_income_or_assets) { YesNoAnswer::NO.to_s }
-      let(:client_owns_property) { YesNoAnswer::NO.to_s }
-      let(:has_savings) { YesNoAnswer::NO.to_s }
 
       it { is_expected.to have_destination(:answers, :edit, id: crime_application) }
     end


### PR DESCRIPTION
## Description of change

The logic for displaying 'How does your client (and their partner) manage with no income?' page did not take employment income into account, meaning that the page would incorrectly display when the client has employment income. This PR fixes that, and should work for both client and partner employment income. 

## Link to relevant ticket

[CRIMAPP-1062](https://dsdmoj.atlassian.net/browse/CRIMAPP-1062)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

1. Process a summary only case
2. Select No to partner
3. Select YES to employed
4. Select yes to > £12475
5. Answer 'Employed and self employed' to go down the jobs loop, and enter an amount > £12475 per year before tax to the wages question
6. Continue with the Income section questions
7. The ‘How does your client manage with no income?’ should not appear - you should get to the Income CYA page without having seen this question. 


[CRIMAPP-1062]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ