### PR TITLE
[CRIMAPP-1075, 1083, 1090] CYA and translation bugs

### DIFF
--- a/app/forms/steps/capital/answers_form.rb
+++ b/app/forms/steps/capital/answers_form.rb
@@ -1,6 +1,9 @@
 module Steps
   module Capital
     class AnswersForm < Steps::BaseFormObject
+      include TypeOfMeansAssessment
+      include ApplicantAndPartner
+
       include Steps::HasOneAssociation
       has_one_association :capital
 

--- a/app/presenters/summary/components/property.rb
+++ b/app/presenters/summary/components/property.rb
@@ -25,11 +25,6 @@ module Summary
       def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         attributes = [
           Components::FreeTextAnswer.new(
-            :house_type,
-            house_type, i18n_opts: i18n_opts,
-            show: residential?
-          ),
-          Components::FreeTextAnswer.new(
             :bedrooms,
             property.bedrooms.to_s,
             show: residential?
@@ -128,14 +123,6 @@ module Summary
 
       def asset
         PROPERTY_TYPE_MAPPING[property.property_type][:display_name]
-      end
-
-      def house_type
-        if property.house_type == ::Property::OTHER_HOUSE_TYPE
-          property.other_house_type
-        else
-          I18n.t(property.house_type, scope: [:summary, :sections, :property, :house_type])
-        end
       end
 
       def relationship(owner)

--- a/app/presenters/summary/components/saving.rb
+++ b/app/presenters/summary/components/saving.rb
@@ -8,7 +8,7 @@ module Summary
       private
 
       def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-        [
+        answers = [
           Components::FreeTextAnswer.new(
             :provider_name, saving.provider_name, show: true
           ),
@@ -28,16 +28,21 @@ module Summary
             :are_wages_paid_into_account,
             saving.are_wages_paid_into_account,
             show: true
-          ),
-          Components::ValueAnswer.new(
+          )
+        ]
+
+        if include_partner_in_means_assessment?
+          answers << Components::ValueAnswer.new(
             :are_partners_wages_paid_into_account,
             saving.are_partners_wages_paid_into_account,
-            show: include_partner_in_means_assessment?
-          ),
-          Components::ValueAnswer.new(
-            :saving_ownership_type, saving.ownership_type, show: true
           )
-        ].select(&:show?)
+        end
+
+        answers << Components::ValueAnswer.new(
+          :saving_ownership_type, saving.ownership_type, show: true
+        )
+
+        answers.select(&:show?)
       end
 
       def name

--- a/app/views/steps/capital/answers/edit.html.erb
+++ b/app/views/steps/capital/answers/edit.html.erb
@@ -21,7 +21,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_check_boxes_fieldset :has_no_other_assets, multiple: false do %>
-        <%= f.govuk_check_box :has_no_other_assets, YesNoAnswer::YES, multiple: false, link_errors: true %>
+        <%= f.govuk_check_box :has_no_other_assets, YesNoAnswer::YES, label: { text: label_t('yes') }, multiple: false, link_errors: true %>
       <% end %>
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -954,7 +954,7 @@ en:
             base:
               incomplete_records: You need to complete all questions before you can submit the application
             has_no_other_assets:
-              blank: Confirm your client has no other assets or capital
+              blank: Confirm whether there are any other assets or capital
         steps/submission/more_information_form:
           attributes:
             additional_information:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1013,5 +1013,6 @@ en:
       steps_capital_frozen_income_savings_assets_form:
         has_frozen_income_or_assets_options: *YESNO
       steps_capital_answers_form:
-        has_no_other_assets_options:
-          'yes': My client confirms they have no other assets or capital
+        'yes':
+          one: Tick to confirm %{subject} does not have any other assets or capital
+          other: Tick to confirm %{subject} do not have any other assets or capital

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -740,9 +740,6 @@ en:
       # END national_savings_certificates
 
       # BEGIN property, address and owners
-      house_type:
-        question: Type of property
-        absence_answer: *absence_none
       bedrooms:
         question: Bedrooms
         absence_answer: *absence_none
@@ -810,12 +807,6 @@ en:
       partner_trust_fund_yearly_dividend:
         question: Yearly dividend
       # END partner_trust_fund
-
-      has_no_other_assets:
-        question: Client has no other assets or capital
-        absence_answer: *absence_none
-        answers:
-          'yes': Confirmed
 
       employment:
         employer_name:

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -88,10 +88,6 @@ RSpec.describe Summary::Components::Property, type: :component do
   describe 'answers' do
     it 'renders as summary list' do # rubocop:disable RSpec/ExampleLength
       expect(page).to have_summary_row(
-        'Type of property',
-        'other_house_type'
-      )
-      expect(page).to have_summary_row(
         'Bedrooms',
         '3',
       )
@@ -221,11 +217,7 @@ RSpec.describe Summary::Components::Property, type: :component do
         }
       end
 
-      it 'renders as summary list with the correct absence_answer' do # rubocop:disable RSpec/ExampleLength
-        expect(page).to have_summary_row(
-          'Type of property',
-          'None'
-        )
+      it 'renders as summary list with the correct absence_answer' do
         expect(page).to have_summary_row(
           'Bedrooms',
           'None',


### PR DESCRIPTION
## Description of change
Fixes the following bugs: 
- The capital CYA declaration did not have dynamic text 
- A translation issue with property house types
- The answer for whether the partners wages or benefits are paid into the account for a saving was not displaying on the review page 

## Link to relevant ticket
[CRIMAPP-1075](https://dsdmoj.atlassian.net/browse/CRIMAPP-1075)
[CRIMAPP-1083](https://dsdmoj.atlassian.net/browse/CRIMAPP-1083)
[CRIMAPP-1090](https://dsdmoj.atlassian.net/browse/CRIMAPP-1090)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1061" alt="Screenshot 2024-06-20 at 17 09 37" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/c1e55038-4167-42cd-9fee-7d697c43d41c">

<img width="1051" alt="Screenshot 2024-06-20 at 17 32 08" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/19772da6-cd52-4384-83cd-658f111b1e12">
<img width="1061" alt="Screenshot 2024-06-20 at 17 19 47" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/f63115f1-0575-4b62-b08b-a5c70e5b6781">

<img width="1061" alt="Screenshot 2024-06-20 at 17 30 59" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/ca1b6a38-e103-4691-815b-8845845f8017">


## How to manually test the feature
Test the scenarios in the linked tickets 

[CRIMAPP-1075]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1083]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1090]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ