### PR TITLE
CRIMAPP-1077, CRIMAPP-1033

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,9 +152,12 @@ Naming/PredicateName:
     - has_charges_complete?
     - has_benefit_evidence_complete?
     - has_frozen_assets?
+    - has_no_frozen_assets?
     - has_national_savings_certificates_selected
     - has_benefit_evidence_selected
     - has_frozen_income_or_assets_selected
+    - has_savings?
+    - has_property?
 
 # TODO: adjust these values towards the rubocop defaults
 RSpec/MultipleMemoizedHelpers:

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -13,4 +13,5 @@ module Errors
   class DateOfBirthPending < StandardError; end
   class EmploymentNotFound < NotFound; end
   class SubjectNotFound < NotFound; end
+  class CannotYetDetermineFullMeans < NotFound; end
 end

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -3,7 +3,7 @@ module CapitalAssessment
     include TypeOfMeansAssessment
 
     def applicable?
-      requires_full_means_assessment?
+      extent_of_means_assessment_determined? && requires_full_means_assessment?
     end
 
     def complete?

--- a/app/validators/income_assessment/answers_validator.rb
+++ b/app/validators/income_assessment/answers_validator.rb
@@ -14,10 +14,13 @@ module IncomeAssessment
     def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       return unless applicable?
 
-      EmploymentDetails::AnswersValidator.new(record).validate
-
       errors.add(:income_before_tax, :incomplete) unless income_before_tax_complete?
       errors.add(:frozen_income_savings_assets, :incomplete) unless frozen_income_savings_assets_complete?
+
+      return errors.add(:base, :incomplete_records) unless extent_of_means_assessment_determined?
+
+      EmploymentDetails::AnswersValidator.new(record).validate
+
       errors.add(:income_payments, :incomplete) unless income_payments_complete?
       errors.add(:income_benefits, :incomplete) unless income_benefits_complete?
       errors.add(:partner_income_payments, :incomplete) unless partner_income_payments_complete?

--- a/app/validators/outgoings_assessment/answers_validator.rb
+++ b/app/validators/outgoings_assessment/answers_validator.rb
@@ -3,7 +3,7 @@ module OutgoingsAssessment
     include TypeOfMeansAssessment
 
     def applicable?
-      requires_full_means_assessment?
+      extent_of_means_assessment_determined? && requires_full_means_assessment?
     end
 
     def complete?

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Decisions::IncomeDecisionTree do
       partner_employments: partner_employments_double,
       kase: kase,
       partner_detail: partner_detail,
-      partner: nil
+      partner: nil,
+      appeal_no_changes?: false
     )
   end
 
@@ -459,9 +460,15 @@ RSpec.describe Decisions::IncomeDecisionTree do
   context 'when the step is `income_before_tax`' do
     let(:form_object) { double('FormObject') }
     let(:step_name) { :income_before_tax }
+    let(:case_type) { 'committal' }
 
     before do
-      allow(income).to receive_messages(income_above_threshold:)
+      allow(income).to receive_messages(
+        income_above_threshold: income_above_threshold,
+        has_frozen_income_or_assets: nil,
+        client_owns_property: nil,
+        has_savings: nil
+      )
     end
 
     context 'when income is above the threshold' do
@@ -501,7 +508,12 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:step_name) { :frozen_income_savings_assets }
 
     before do
-      allow(income).to receive_messages(has_frozen_income_or_assets:)
+      allow(income).to receive_messages(
+        income_above_threshold: 'no',
+        has_frozen_income_or_assets: has_frozen_income_or_assets,
+        client_owns_property: nil,
+        has_savings: nil
+      )
     end
 
     context 'when they do not have frozen income or assets' do
@@ -584,7 +596,12 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:step_name) { :client_owns_property }
 
     before do
-      allow(income).to receive_messages(client_owns_property:)
+      allow(income).to receive_messages(
+        income_above_threshold: 'no',
+        has_frozen_income_or_assets: 'no',
+        client_owns_property: client_owns_property,
+        has_savings: nil,
+      )
     end
 
     context 'when they do not have property' do


### PR DESCRIPTION
## Description of change

Skip questions when extent of means assessment determined.
Do not require full means assessment when committal for sentencing.

## Link to relevant ticket

[CRIMAPP-1077](https://dsdmoj.atlassian.net/browse/CRIMAPP-1077)
[CRIMAPP-1033](https://dsdmoj.atlassian.net/browse/CRIMAPP-1033)

## Notes for reviewer

The initial phase of the income assessment has four steps: income_before_tax, frozen_income_savings_assets, client_owns_property, and has_savings. These steps primary purpose is to find out if a full means assessment is necessary. This refactor changes the decision tree to make the role of the steps more obvious. After each step, the decision tree checks if the need for a full means assessment is definitively determined. If the determination is still unclear, the process proceeds to the next step in the sequence.

It also fixes a bug where committal cases were not skipping full means assessment.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1077]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1033]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ