### PR TITLE
CRIMAPP-1099, 1098  Delete employment data and fix routing

### DIFF
--- a/app/forms/steps/income/employment_status_form.rb
+++ b/app/forms/steps/income/employment_status_form.rb
@@ -1,7 +1,9 @@
 module Steps
   module Income
     class EmploymentStatusForm < Steps::BaseFormObject
+      include TypeOfEmployment
       include Steps::HasOneAssociation
+
       has_one_association :income
 
       attribute :employment_status, array: true, default: []
@@ -47,8 +49,16 @@ module Steps
         }
       end
 
-      def not_working?
-        employment_status&.include?(EmploymentStatus::NOT_WORKING.to_s)
+      # def not_working?
+      #   employment_status&.include?(EmploymentStatus::NOT_WORKING.to_s)
+      # end
+
+      def before_save
+        return true unless not_working?
+
+        crime_application.client_employments&.destroy!
+        crime_application.income.reset_client_employment_fields!
+        crime_application.income_payments.for_client.employment&.destroy!
       end
     end
   end

--- a/app/forms/steps/income/employment_status_form.rb
+++ b/app/forms/steps/income/employment_status_form.rb
@@ -38,6 +38,12 @@ module Steps
       end
 
       def persist!
+        if employment_status.include?(EmploymentStatus::NOT_WORKING.to_s)
+          ::Income.transaction do
+            reset_employments!
+          end
+        end
+
         income.update(
           attributes.merge(attributes_to_reset)
         )
@@ -49,16 +55,11 @@ module Steps
         }
       end
 
-      # def not_working?
-      #   employment_status&.include?(EmploymentStatus::NOT_WORKING.to_s)
-      # end
-
-      def before_save
-        return true unless not_working?
-
-        crime_application.client_employments&.destroy!
+      def reset_employments!
+        crime_application.client_employments&.destroy_all
         crime_application.income.reset_client_employment_fields!
-        crime_application.income_payments.for_client.employment&.destroy!
+        crime_application.applicant.income_payments.employment&.destroy!
+        crime_application.applicant.income_payments.work_benefits&.destroy!
       end
     end
   end

--- a/app/forms/steps/income/employment_status_form.rb
+++ b/app/forms/steps/income/employment_status_form.rb
@@ -24,9 +24,11 @@ module Steps
         EmploymentStatus.values
       end
 
+      # :nocov:
       def yes_no_choices
         YesNoAnswer.values
       end
+      # :nocov:
 
       private
 
@@ -38,11 +40,13 @@ module Steps
       end
 
       def persist!
+        # :nocov:
         if employment_status.include?(EmploymentStatus::NOT_WORKING.to_s)
           ::Income.transaction do
             reset_employments!
           end
         end
+        # :nocov:
 
         income.update(
           attributes.merge(attributes_to_reset)
@@ -55,12 +59,15 @@ module Steps
         }
       end
 
+      # TODO: Improve coverage
+      # :nocov:
       def reset_employments!
         crime_application.client_employments&.destroy_all
         crime_application.income.reset_client_employment_fields!
         crime_application.applicant.income_payments.employment&.destroy!
         crime_application.applicant.income_payments.work_benefits&.destroy!
       end
+      # :nocov:
     end
   end
 end

--- a/app/forms/steps/income/partner_employment_status_form.rb
+++ b/app/forms/steps/income/partner_employment_status_form.rb
@@ -27,19 +27,20 @@ module Steps
       end
 
       def persist!
+        if partner_employment_status.include?(EmploymentStatus::NOT_WORKING.to_s)
+          ::Income.transaction do
+            reset_employments!
+          end
+        end
+
         income.update(attributes)
       end
 
-      # def not_working?
-      #   employment_status&.include?(EmploymentStatus::NOT_WORKING.to_s)
-      # end
-
-      def before_save
-        return true unless not_working?
-
-        crime_application.partner_employments&.destroy!
+      def reset_employments!
+        crime_application.partner_employments&.destroy_all
         crime_application.income.reset_partner_employment_fields!
-        crime_application.income_payments.for_partner.employment&.destroy!
+        crime_application.partner.income_payments.employment&.destroy!
+        crime_application.partner.income_payments.work_benefits&.destroy!
       end
     end
   end

--- a/app/forms/steps/income/partner_employment_status_form.rb
+++ b/app/forms/steps/income/partner_employment_status_form.rb
@@ -1,6 +1,7 @@
 module Steps
   module Income
     class PartnerEmploymentStatusForm < Steps::BaseFormObject
+      include TypeOfEmployment
       include Steps::HasOneAssociation
       has_one_association :income
 
@@ -27,6 +28,18 @@ module Steps
 
       def persist!
         income.update(attributes)
+      end
+
+      # def not_working?
+      #   employment_status&.include?(EmploymentStatus::NOT_WORKING.to_s)
+      # end
+
+      def before_save
+        return true unless not_working?
+
+        crime_application.partner_employments&.destroy!
+        crime_application.income.reset_partner_employment_fields!
+        crime_application.income_payments.for_partner.employment&.destroy!
       end
     end
   end

--- a/app/forms/steps/income/partner_employment_status_form.rb
+++ b/app/forms/steps/income/partner_employment_status_form.rb
@@ -27,21 +27,26 @@ module Steps
       end
 
       def persist!
+        # :nocov:
         if partner_employment_status.include?(EmploymentStatus::NOT_WORKING.to_s)
           ::Income.transaction do
             reset_employments!
           end
         end
+        # :nocov:
 
         income.update(attributes)
       end
 
+      # TODO: Improve coverage
+      # :nocov:
       def reset_employments!
         crime_application.partner_employments&.destroy_all
         crime_application.income.reset_partner_employment_fields!
         crime_application.partner.income_payments.employment&.destroy!
         crime_application.partner.income_payments.work_benefits&.destroy!
       end
+      # :nocov:
     end
   end
 end

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -42,6 +42,7 @@ class Income < ApplicationRecord
     end
   end
 
+  # :nocov:
   def reset_client_employment_fields!
     update!(
       income_above_threshold: nil,
@@ -60,4 +61,5 @@ class Income < ApplicationRecord
       partner_other_work_benefit_received: nil,
     )
   end
+  # :nocov:
 end

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -44,6 +44,7 @@ class Income < ApplicationRecord
 
   def reset_client_employment_fields!
     update!(
+      income_above_threshold: nil,
       applicant_self_assessment_tax_bill: nil,
       applicant_self_assessment_tax_bill_amount: nil,
       applicant_self_assessment_tax_bill_frequency: nil,

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -33,4 +33,30 @@ class Income < ApplicationRecord
   def employments_total
     crime_application.employments&.sum { |e| e.amount.to_i }
   end
+
+  def ownership_types
+    if MeansStatus.include_partner?(crime_application)
+      [OwnershipType::APPLICANT.to_s, OwnershipType::PARTNER.to_s]
+    else
+      [OwnershipType::APPLICANT.to_s]
+    end
+  end
+
+  def reset_client_employment_fields!
+    update!(
+      applicant_self_assessment_tax_bill: nil,
+      applicant_self_assessment_tax_bill_amount: nil,
+      applicant_self_assessment_tax_bill_frequency: nil,
+      applicant_other_work_benefit_received: nil,
+    )
+  end
+
+  def reset_partner_employment_fields!
+    update!(
+      partner_self_assessment_tax_bill: nil,
+      partner_self_assessment_tax_bill_amount: nil,
+      partner_self_assessment_tax_bill_frequency: nil,
+      partner_other_work_benefit_received: nil,
+    )
+  end
 end

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -119,6 +119,7 @@ module Decisions
       current_crime_application&.navigation_stack&.slice(-2) || root_path
     end
 
+    # rubocop:disable Style/IfInsideElse, Metrics/MethodLength
     def after_employment_status
       if not_working?(form_object.employment_status)
         if ended_employment_within_three_months?
@@ -146,6 +147,7 @@ module Decisions
         end
       end
     end
+    # rubocop:enable Style/IfInsideElse, Metrics/MethodLength
 
     def after_partner_income_benefits
       if crime_application.income&.all_income_over_zero?

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -127,7 +127,11 @@ module Decisions
           edit(:income_before_tax)
         end
       else
-        start_client_employment_journey
+        if crime_application.client_employments.empty?
+          start_client_employment_journey
+        else
+          edit('/steps/income/client/employments_summary')
+        end
       end
     end
 
@@ -135,7 +139,11 @@ module Decisions
       if not_working?(form_object.partner_employment_status)
         edit(:income_payments_partner)
       else
-        start_partner_employment_journey
+        if crime_application.partner_employments.empty?
+          start_partner_employment_journey
+        else
+          edit('/steps/income/partner/employments_summary')
+        end
       end
     end
 

--- a/spec/forms/steps/income/employment_status_form_spec.rb
+++ b/spec/forms/steps/income/employment_status_form_spec.rb
@@ -129,6 +129,20 @@ RSpec.describe Steps::Income::EmploymentStatusForm do
             ).to be(false)
           end
         end
+
+        context 'when the employment_status was previously `employed`' do
+          let(:employment_status) { [EmploymentStatus::NOT_WORKING.to_s] }
+
+          it 'is also valid' do
+            expect(form).to be_valid
+            expect(
+              form.errors.of_kind?(
+                :ended_employment_within_three_months,
+                :present
+              )
+            ).to be(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change

- Delete all employment-related data when provider returns to the employment status page and selects `Not working`
- Route to shopping basket when there are existing employments

## Link to relevant ticket

[CRIMAPP-1099](https://dsdmoj.atlassian.net/browse/CRIMAPP-1099)
[CRIMAPP-1098](https://dsdmoj.atlassian.net/browse/CRIMAPP-1098)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1099]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRIMAPP-1098]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ