### PR TITLE
Add partner declaration to declaration page

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -88,6 +88,8 @@ class CrimeApplication < ApplicationRecord
   alias_attribute :reference, :usn
 
   store_accessor :provider_details,
+                 :legal_rep_has_partner_declaration,
+                 :legal_rep_no_partner_declaration_reason,
                  :provider_email,
                  :legal_rep_first_name,
                  :legal_rep_last_name,

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,6 +4,8 @@ class Provider < ApplicationRecord
 
   store_accessor :settings,
                  :selected_office_code,
+                 :legal_rep_has_partner_declaration,
+                 :legal_rep_no_partner_declaration_reason,
                  :legal_rep_first_name,
                  :legal_rep_last_name,
                  :legal_rep_telephone

--- a/app/serializers/submission_serializer/sections/provider_details.rb
+++ b/app/serializers/submission_serializer/sections/provider_details.rb
@@ -1,16 +1,30 @@
 module SubmissionSerializer
   module Sections
     class ProviderDetails < Sections::BaseSection
-      def to_builder
+      def to_builder # rubocop:disable Metrics/AbcSize
         Jbuilder.new do |json|
           json.provider_details do
             json.office_code crime_application.office_code
             json.provider_email crime_application.provider_email
+            json.legal_rep_has_partner_declaration rep_has_partner_declaration
+            json.legal_rep_no_partner_declaration_reason rep_no_declaration_reason
             json.legal_rep_first_name crime_application.legal_rep_first_name
             json.legal_rep_last_name crime_application.legal_rep_last_name
             json.legal_rep_telephone crime_application.legal_rep_telephone
           end
         end
+      end
+
+      private
+
+      def rep_has_partner_declaration
+        return unless crime_application.legal_rep_has_partner_declaration
+
+        crime_application.legal_rep_has_partner_declaration['value']
+      end
+
+      def rep_no_declaration_reason
+        crime_application.legal_rep_no_partner_declaration_reason
       end
     end
   end

--- a/app/views/steps/submission/declaration/_initial.html.erb
+++ b/app/views/steps/submission/declaration/_initial.html.erb
@@ -1,24 +1,48 @@
 <h1 class="govuk-heading-xl">
-  Enter your details to confirm the following
+  Declarations
 </h1>
 
 <p class="govuk-body">Your client agrees that:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>they’ve instructed your law firm to represent them</li>
-  <li>they’ve read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.laa_privacy_notice_url, target: '_blank', rel: 'noopener' %></li>
-  <li>we can share their information with other government departments like the DWP and HMRC (as stated in our privacy notice)</li>
+  <li>they have instructed your law firm to represent them</li>
+  <li>they have read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.laa_privacy_notice_url, target: '_blank', rel: 'noopener' %></li>
+  <li>we can share their information with other government departments including the Department for Work and Pensions and HM Revenue and Customs</li>
   <li>we can check their details with bank and credit reference agencies</li>
   <li>if they are convicted of any offences, they may have to pay towards legal aid through any income or capital they have</li>
-  <li>the information they’ve given is complete and correct</li>
-  <li>they’ll report any changes to their financial situation immediately</li>
+  <li>the information they have given is complete and correct</li>
+  <li>they will report any changes in financial circumstance <%= 'including those of their partner' if partner_relevant %> immediately</li>
 </ul>
+
+<% if partner_relevant %>
+  <p class="govuk-body">Your client's partner agrees that:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>they have read the <%= link_to 'LAA privacy notice (opens in new tab)', Settings.laa_privacy_notice_url, target: '_blank', rel: 'noopener' %></li>
+    <li>we can share their information with other government departments including the Department for Work and Pensions and HM Revenue and Customs</li>
+    <li>we can check their details with bank and credit reference agencies</li>
+    <li>the information they have given is complete and correct</li>
+  </ul>
+
+    <%= f.govuk_radio_buttons_fieldset(:legal_rep_has_partner_declaration, legend: { size: 's' }) do %>
+      <% form_object.choices.each_with_index do |choice, index| %>
+        <% if choice == YesNoAnswer::NO %>
+          <%= f.govuk_radio_button :legal_rep_has_partner_declaration, choice.value do %>
+            <%= f.govuk_text_area :legal_rep_no_partner_declaration_reason, autocomplete: 'off', width: 'one-third',
+                                   extra_letter_spacing: true %>
+          <% end %>
+        <% else %>
+          <%= f.govuk_radio_button :legal_rep_has_partner_declaration, choice.value, link_errors: index.zero? %>
+        <% end %>
+      <% end %>
+    <% end %>
+<% end %>
 
 <div class="govuk-warning-text govuk-!-margin-bottom-0">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-    If your client gives wrong or incomplete information, does not report changes, or is found to have committed benefit fraud, they may:
+    <span class="govuk-warning-text__assistive govuk-visually-hidden">Warning</span>
+    If they give wrong or incomplete information, do not report changes, or are found to have committed benefit fraud, they may:
     <ul class="govuk-list govuk-list--bullet govuk-!-font-weight-bold">
       <li>be prosecuted</li>
       <li>need to pay a financial penalty</li>
@@ -30,7 +54,7 @@
 <p class="govuk-body">You agree that:</p>
 
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-  <li>you’ve explained to your client why they may have to pay towards legal aid and the consequences of not paying contributions on time or at all</li>
-  <li>you’ve obtained a signed declaration from your client</li>
-  <li>you’ve provided correct and complete information in this application</li>
+  <li>you have explained to your client why they may have to pay towards legal aid and the consequences of not paying contributions on time or at all</li>
+  <li>you have a signed declaration from your client</li>
+  <li>you have provided correct and complete information in this application</li>
 </ul>

--- a/app/views/steps/submission/declaration/edit.en.html.erb
+++ b/app/views/steps/submission/declaration/edit.en.html.erb
@@ -5,12 +5,12 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
 
-    <%= render partial: @form_object.application_type %>
-
     <%= render partial: 'fulfilment_errors',
                locals: { errors: @form_object.fulfilment_errors } if @form_object.fulfilment_errors.any? %>
 
     <%= step_form @form_object do |f| %>
+      <%= render partial: @form_object.application_type,
+                 locals: { f: f, form_object: @form_object, partner_relevant: @form_object.include_partner_in_means_assessment? } %>
       <%= f.govuk_fieldset legend: { text: t('.legal_representative_legend') } do %>
         <%= f.govuk_text_field :legal_rep_first_name, autocomplete: 'off', width: 'three-quarters' %>
         <%= f.govuk_text_field :legal_rep_last_name, autocomplete: 'off', width: 'three-quarters' %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1005,6 +1005,10 @@ en:
               inclusion: Select yes if you need to add any more information to this application
         steps/submission/declaration_form:
           attributes:
+            legal_rep_has_partner_declaration:
+              inclusion: Select yes if you have a signed declaration from your client’s partner
+            legal_rep_no_partner_declaration_reason:
+              blank: Enter the reason you could not get a signed declaration from the partner
             legal_rep_first_name:
               blank: Enter a first name
             legal_rep_last_name:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -249,6 +249,8 @@ en:
         relationship: What their relationship to %{subject}?
       steps_capital_answers_form:
         has_no_other_assets: Confirm the following
+      steps_submission_declaration_form:
+        legal_rep_has_partner_declaration: Do you have a signed declaration from your client’s partner?
 
     hint:
       steps_client_relationship_status_form:
@@ -921,6 +923,8 @@ en:
         additional_information_required_options: *YESNO
         additional_information: Enter details that will help us process this application
       steps_submission_declaration_form:
+        legal_rep_has_partner_declaration_options: *YESNO
+        legal_rep_no_partner_declaration_reason: Explain the reason you could not get a signed declaration from the partner
         legal_rep_first_name: First name
         legal_rep_last_name: Last name
         legal_rep_telephone: Telephone number

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -699,7 +699,7 @@ en:
           heading: Review the application
       declaration:
         edit:
-          page_title: Declaration
+          page_title: Declarations
           legal_representative_legend: Legal representative
         fulfilment_errors:
           heading: You need to complete the following information before the application can be submitted

--- a/spec/serializers/submission_serializer/application_spec.rb
+++ b/spec/serializers/submission_serializer/application_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe SubmissionSerializer::Application do
         provider_details: {
           office_code: nil,
           provider_email: nil,
+          legal_rep_has_partner_declaration: nil,
+          legal_rep_no_partner_declaration_reason: nil,
           legal_rep_first_name: nil,
           legal_rep_last_name: nil,
           legal_rep_telephone: nil

--- a/spec/serializers/submission_serializer/sections/provider_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/provider_details_spec.rb
@@ -8,17 +8,38 @@ RSpec.describe SubmissionSerializer::Sections::ProviderDetails do
       CrimeApplication,
       office_code: 'XYZ',
       provider_email: 'foo@bar.com',
+      legal_rep_has_partner_declaration: rep_has_partner_declaration,
+      legal_rep_no_partner_declaration_reason: rep_no_declaration_reason,
       legal_rep_first_name: 'John',
       legal_rep_last_name: 'Doe',
       legal_rep_telephone: '123456789',
     )
   end
 
+  let(:rep_has_partner_declaration) { nil }
+  let(:rep_no_declaration_reason) { nil }
+
   let(:json_output) do
     {
       provider_details: {
         office_code: 'XYZ',
         provider_email: 'foo@bar.com',
+        legal_rep_has_partner_declaration: nil,
+        legal_rep_no_partner_declaration_reason: nil,
+        legal_rep_first_name: 'John',
+        legal_rep_last_name: 'Doe',
+        legal_rep_telephone: '123456789',
+      }
+    }.as_json
+  end
+
+  let(:json_with_partner_output) do
+    {
+      provider_details: {
+        office_code: 'XYZ',
+        provider_email: 'foo@bar.com',
+        legal_rep_has_partner_declaration: 'no',
+        legal_rep_no_partner_declaration_reason: 'A reason',
         legal_rep_first_name: 'John',
         legal_rep_last_name: 'Doe',
         legal_rep_telephone: '123456789',
@@ -27,6 +48,15 @@ RSpec.describe SubmissionSerializer::Sections::ProviderDetails do
   end
 
   describe '#generate' do
-    it { expect(subject.generate).to eq(json_output) }
+    context 'when there is no partner' do
+      it { expect(subject.generate).to eq(json_output) }
+    end
+
+    context 'when there is a partner' do
+      let(:rep_has_partner_declaration) { { 'value' => 'no' } }
+      let(:rep_no_declaration_reason) { 'A reason' }
+
+      it { expect(subject.generate).to eq(json_with_partner_output) }
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Add partner declaration to declaration page

Shows conditionally if there is a partner


## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1088
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="476" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/5957e13f-ebd4-4fe1-af70-93ac48942c7b">

### After changes:
<img width="314" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/312636b4-4303-4f1e-9663-a9c242f53e39">

## How to manually test the feature
Create an application with a partner (no involvement)
Progress to end of application
See new fields on declaration page
Check errors (no copy in spreadsheet)
Check submits when valid