### PR TITLE
CRIMAPP-1095 Create employed maat schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.21'
+    tag: 'v1.1.22'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3de29a75a0507192f3b350cfe98faad14da7146c
-  tag: v1.1.21
+  revision: 755664244cb7920bc4481ace3d8dae22574c4d7b
+  tag: v1.1.22
   specs:
-    laa-criminal-legal-aid-schemas (1.1.21)
+    laa-criminal-legal-aid-schemas (1.1.22)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/lib/employment_income_payments_calculator.rb
+++ b/app/lib/employment_income_payments_calculator.rb
@@ -1,0 +1,34 @@
+class EmploymentIncomePaymentsCalculator
+  class << self
+    def annualized_payments(crime_application)
+      grouped_employments(crime_application.employments).map do |ownership_type, employments_array|
+        {
+          amount: annual_income(employments_array),
+          income_tax: annual_deduction(employments_array, :income_tax),
+          national_insurance: annual_deduction(employments_array, :national_insurance),
+          frequency: PaymentFrequencyType::ANNUALLY.to_s,
+          ownership_type: ownership_type
+        }
+      end
+    end
+
+    private
+
+    def grouped_employments(employments)
+      employments.select(&:complete?).group_by(&:ownership_type)
+    end
+
+    def annual_income(employments)
+      employments.sum { |e| e.annualized_amount.value }
+    end
+
+    def annual_deduction(employments, deduction_type)
+      deductions = employments.map do |employment|
+        employment.deductions.complete.select do |deduction|
+          deduction.deduction_type == deduction_type.to_s
+        end
+      end.flatten
+      deductions.sum { |d| d.annualized_amount.value }
+    end
+  end
+end

--- a/app/lib/employment_income_payments_calculator.rb
+++ b/app/lib/employment_income_payments_calculator.rb
@@ -1,25 +1,51 @@
 class EmploymentIncomePaymentsCalculator
   class << self
-    def annualized_payments(crime_application)
-      grouped_employments(crime_application.employments).map do |ownership_type, employments_array|
-        {
-          amount: annual_income(employments_array),
-          income_tax: annual_deduction(employments_array, :income_tax),
-          national_insurance: annual_deduction(employments_array, :national_insurance),
-          frequency: PaymentFrequencyType::ANNUALLY.to_s,
-          ownership_type: ownership_type
-        }
+    def annualized_payments(crime_application) # rubocop:disable Metrics/MethodLength
+      if single_employment_income?(crime_application.income)
+        # singe employment for client and partner
+        grouped_income_payments(crime_application.income_payments).map do |ownership_type, income_payments_array|
+          {
+            amount: annual_income(income_payments_array),
+            income_tax: 0,
+            national_insurance: 0,
+            frequency: PaymentFrequencyType::ANNUALLY.to_s,
+            ownership_type: ownership_type
+          }
+        end
+      else
+        # employments loop for client and partner
+        grouped_employments(crime_application.employments).map do |ownership_type, employments_array|
+          {
+            amount: annual_income(employments_array),
+            income_tax: annual_deduction(employments_array, :income_tax),
+            national_insurance: annual_deduction(employments_array, :national_insurance),
+            frequency: PaymentFrequencyType::ANNUALLY.to_s,
+            ownership_type: ownership_type
+          }
+        end
       end
     end
 
     private
 
+    def single_employment_income?(income)
+      income.employment_status.include?(EmploymentStatus::EMPLOYED.to_s) &&
+        income.income_above_threshold == YesNoAnswer::NO.to_s &&
+        income.has_frozen_income_or_assets == YesNoAnswer::NO.to_s &&
+        income.client_owns_property == YesNoAnswer::NO.to_s &&
+        income.has_savings == YesNoAnswer::NO.to_s
+    end
+
     def grouped_employments(employments)
       employments.select(&:complete?).group_by(&:ownership_type)
     end
 
-    def annual_income(employments)
-      employments.sum { |e| e.annualized_amount.value }
+    def grouped_income_payments(income_payments)
+      income_payments.select { |ip| ip.payment_type == IncomePaymentType::EMPLOYMENT.to_s }.group_by(&:ownership_type)
+    end
+
+    def annual_income(payments)
+      payments.sum { |e| e.annualized_amount.value }
     end
 
     def annual_deduction(employments, deduction_type)

--- a/app/models/concerns/annualized_amount_calculator.rb
+++ b/app/models/concerns/annualized_amount_calculator.rb
@@ -16,8 +16,6 @@ module AnnualizedAmountCalculator
         (amount.value * 12)
       when PaymentFrequencyType::ANNUALLY.to_s
         amount.value
-      else
-        raise 'Unsupported frequency'
       end
 
     Money.new(prorated_value)

--- a/app/models/concerns/annualized_amount_calculator.rb
+++ b/app/models/concerns/annualized_amount_calculator.rb
@@ -5,7 +5,7 @@ module AnnualizedAmountCalculator
     return amount if amount.nil? || amount.zero?
 
     prorated_value =
-      case frequency
+      case frequency.to_s
       when PaymentFrequencyType::WEEKLY.to_s
         (amount.value * 52)
       when PaymentFrequencyType::FORTNIGHTLY.to_s

--- a/app/models/concerns/annualized_amount_calculator.rb
+++ b/app/models/concerns/annualized_amount_calculator.rb
@@ -1,0 +1,25 @@
+module AnnualizedAmountCalculator
+  extend ActiveSupport::Concern
+
+  def annualized_amount # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+    return amount if amount.nil? || amount.zero?
+
+    prorated_value =
+      case frequency
+      when PaymentFrequencyType::WEEKLY.to_s
+        (amount.value * 52)
+      when PaymentFrequencyType::FORTNIGHTLY.to_s
+        (amount.value * 26)
+      when PaymentFrequencyType::FOUR_WEEKLY.to_s
+        (amount.value * 13)
+      when PaymentFrequencyType::MONTHLY.to_s
+        (amount.value * 12)
+      when PaymentFrequencyType::ANNUALLY.to_s
+        amount.value
+      else
+        raise 'Unsupported frequency'
+      end
+
+    Money.new(prorated_value)
+  end
+end

--- a/app/models/deduction.rb
+++ b/app/models/deduction.rb
@@ -1,4 +1,6 @@
 class Deduction < ApplicationRecord
+  include AnnualizedAmountCalculator
+
   # Ordering using deduction_type maintains the deduction order income_tax, national_insurance and other
   default_scope { order(deduction_type: :asc) }
 

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,4 +1,6 @@
 class Employment < ApplicationRecord
+  include AnnualizedAmountCalculator
+
   belongs_to :crime_application
 
   # Using UUIDs as the record IDs. We can't trust sequential ordering by ID

--- a/app/models/income_payment.rb
+++ b/app/models/income_payment.rb
@@ -1,4 +1,6 @@
 class IncomePayment < Payment
+  include AnnualizedAmountCalculator
+
   store_accessor :metadata,
                  [:before_or_after_tax]
 

--- a/app/serializers/submission_serializer/sections/income_details.rb
+++ b/app/serializers/submission_serializer/sections/income_details.rb
@@ -35,6 +35,16 @@ module SubmissionSerializer
             json.partner_self_assessment_tax_bill_amount income.partner_self_assessment_tax_bill_amount_before_type_cast
             json.partner_self_assessment_tax_bill_frequency income.partner_self_assessment_tax_bill_frequency
           end
+
+          # Attribute required  CAA (crime application adaptor)
+          annualized_employment_payments = EmploymentIncomePaymentsCalculator.annualized_payments(crime_application)
+          json.employment_income_payments annualized_employment_payments do |attachment|
+            json.amount attachment[:amount]
+            json.income_tax attachment[:income_tax]
+            json.national_insurance attachment[:national_insurance]
+            json.frequency attachment[:frequency]
+            json.ownership_type attachment[:ownership_type]
+          end
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength

--- a/app/services/adapters/structs/income_details.rb
+++ b/app/services/adapters/structs/income_details.rb
@@ -42,7 +42,7 @@ module Adapters
             except: [
               :employment_type, :partner_employment_type,
               :dependants, :income_payments, :income_benefits,
-              :employments, :businesses
+              :employments, :businesses, :employment_income_payments
             ]
           )
         )

--- a/spec/lib/employment_income_payments_calculator_spec.rb
+++ b/spec/lib/employment_income_payments_calculator_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+describe EmploymentIncomePaymentsCalculator do
+  subject { described_class.annualized_payments(crime_application) }
+
+  let(:crime_application) { CrimeApplication.new }
+
+  describe '#annualized_payments' do
+    before do
+      allow_any_instance_of(Employment).to receive(:complete?).and_return(true)
+      allow_any_instance_of(Deduction).to receive(:complete?).and_return(true)
+    end
+
+    context 'when client and partner has no employments' do
+      it 'has the right value' do
+        expect(subject.count).to eq(0)
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when client has employments' do
+      before do
+        create_employments('applicant')
+      end
+
+      it 'has the right value' do
+        expect(subject.count).to eq(1)
+        expect(subject).to contain_exactly({
+                                             amount: 196_000,
+                                             frequency: 'annual',
+                                             income_tax: 63_700,
+                                             national_insurance: 2400,
+                                             ownership_type: 'applicant'
+                                           })
+      end
+    end
+
+    context 'when partner has employments' do
+      before do
+        create_employments('partner')
+      end
+
+      it 'has the right value' do
+        expect(subject.count).to eq(1)
+        expect(subject).to contain_exactly({
+                                             amount: 196_000,
+                                             frequency: 'annual',
+                                             income_tax: 63_700,
+                                             national_insurance: 2400,
+                                             ownership_type: 'partner'
+                                           })
+      end
+    end
+
+    context 'when client and partner has employments' do
+      before do
+        create_employments('applicant')
+        create_employments('partner')
+      end
+
+      it 'has the right value' do
+        expect(subject.count).to eq(2)
+        expect(subject).to contain_exactly({
+                                             amount: 196_000,
+                                             frequency: 'annual',
+                                             income_tax: 63_700,
+                                             national_insurance: 2400,
+                                             ownership_type: 'applicant'
+                                           }, {
+                                             amount: 196_000,
+                                             frequency: 'annual',
+                                             income_tax: 63_700,
+                                             national_insurance: 2400,
+                                             ownership_type: 'partner'
+                                           })
+      end
+    end
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def create_employments(ownership_type)
+    employments = [
+      Employment.new(amount: 1000,
+                     frequency: PaymentFrequencyType::WEEKLY.to_s,
+                     deductions: [
+                       Deduction.new(
+                         deduction_type: DeductionType::INCOME_TAX.to_s,
+                         amount: 500,
+                         frequency: PaymentFrequencyType::WEEKLY.to_s
+                       ) # Deduction annually: 26000
+                     ],
+                     ownership_type: ownership_type), # Employment annually: 52000
+      Employment.new(amount: 2000,
+                     frequency: PaymentFrequencyType::FORTNIGHTLY.to_s,
+                     deductions: [],
+                     ownership_type: ownership_type), # Employment annually: 52000
+      Employment.new(amount: 3000,
+                     frequency: PaymentFrequencyType::FOUR_WEEKLY.to_s,
+                     deductions: [
+                       Deduction.new(
+                         deduction_type: DeductionType::INCOME_TAX.to_s,
+                         amount: 500,
+                         frequency: PaymentFrequencyType::FOUR_WEEKLY.to_s
+                       ), # Deduction annually: 6500
+                       Deduction.new(
+                         deduction_type: DeductionType::NATIONAL_INSURANCE.to_s,
+                         amount: 200,
+                         frequency: PaymentFrequencyType::MONTHLY.to_s
+                       ) # Deduction annually: 2400
+                     ],
+                     ownership_type: ownership_type), # Employment annually: 39000
+      Employment.new(amount: 4000,
+                     frequency: PaymentFrequencyType::MONTHLY.to_s,
+                     deductions: [
+                       Deduction.new(
+                         deduction_type: DeductionType::INCOME_TAX.to_s,
+                         amount: 600,
+                         frequency: PaymentFrequencyType::WEEKLY.to_s
+                       ), # Deduction annually: 31200
+                       Deduction.new(
+                         deduction_type: DeductionType::OTHER.to_s,
+                         amount: 700,
+                         frequency: PaymentFrequencyType::WEEKLY.to_s
+                       ) # Deduction annually: 36400
+                     ],
+                     ownership_type: ownership_type), # Employment annually: 48000
+      Employment.new(amount: 5000,
+                     frequency: PaymentFrequencyType::ANNUALLY.to_s,
+                     deductions: [
+                       Deduction.new(
+                         deduction_type: DeductionType::OTHER.to_s,
+                         amount: 800,
+                         frequency: PaymentFrequencyType::ANNUALLY.to_s
+                       ) # Deduction annually: 800
+                     ],
+                     ownership_type: ownership_type), # Employment annually: 5000
+    ]
+    crime_application.employments << employments
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+end

--- a/spec/lib/employment_income_payments_calculator_spec.rb
+++ b/spec/lib/employment_income_payments_calculator_spec.rb
@@ -3,76 +3,95 @@ require 'rails_helper'
 describe EmploymentIncomePaymentsCalculator do
   subject { described_class.annualized_payments(crime_application) }
 
-  let(:crime_application) { CrimeApplication.new }
+  let(:crime_application) { CrimeApplication.new(income: income, income_payments: [income_payment1, income_payment2]) }
+  let(:income) { Income.new(employment_status: ['employed']) }
+
+  let(:income_payment1) {
+    IncomePayment.new(amount: 100, frequency: 'week', ownership_type: 'applicant', payment_type: 'employment')
+  }
+  let(:income_payment2) {
+    IncomePayment.new(amount: 100, frequency: 'week', ownership_type: 'applicant', payment_type: 'employment')
+  }
 
   describe '#annualized_payments' do
-    before do
-      allow_any_instance_of(Employment).to receive(:complete?).and_return(true)
-      allow_any_instance_of(Deduction).to receive(:complete?).and_return(true)
-    end
-
-    context 'when client and partner has no employments' do
-      it 'has the right value' do
-        expect(subject.count).to eq(0)
-        expect(subject).to be_empty
+    context 'when single employment for client and partner' do
+      context 'when client and partner has no employment' do
+        it 'has the right value' do
+          expect(subject.count).to eq(0)
+          expect(subject).to be_empty
+        end
       end
     end
 
-    context 'when client has employments' do
+    context 'when multiple employments for client and partner' do
       before do
-        create_employments('applicant')
+        allow_any_instance_of(Employment).to receive(:complete?).and_return(true)
+        allow_any_instance_of(Deduction).to receive(:complete?).and_return(true)
       end
 
-      it 'has the right value' do
-        expect(subject.count).to eq(1)
-        expect(subject).to contain_exactly({
-                                             amount: 196_000,
-                                             frequency: 'annual',
-                                             income_tax: 63_700,
-                                             national_insurance: 2400,
-                                             ownership_type: 'applicant'
-                                           })
-      end
-    end
-
-    context 'when partner has employments' do
-      before do
-        create_employments('partner')
+      context 'when client and partner has no employments' do
+        it 'has the right value' do
+          expect(subject.count).to eq(0)
+          expect(subject).to be_empty
+        end
       end
 
-      it 'has the right value' do
-        expect(subject.count).to eq(1)
-        expect(subject).to contain_exactly({
-                                             amount: 196_000,
-                                             frequency: 'annual',
-                                             income_tax: 63_700,
-                                             national_insurance: 2400,
-                                             ownership_type: 'partner'
-                                           })
-      end
-    end
+      context 'when client has employments' do
+        before do
+          create_employments('applicant')
+        end
 
-    context 'when client and partner has employments' do
-      before do
-        create_employments('applicant')
-        create_employments('partner')
+        it 'has the right value' do
+          expect(subject.count).to eq(1)
+          expect(subject).to contain_exactly({
+                                               amount: 196_000,
+                                               frequency: 'annual',
+                                               income_tax: 63_700,
+                                               national_insurance: 2400,
+                                               ownership_type: 'applicant'
+                                             })
+        end
       end
 
-      it 'has the right value' do
-        expect(subject.count).to eq(2)
-        expect(subject).to contain_exactly({
-                                             amount: 196_000,
-                                             frequency: 'annual',
-                                             income_tax: 63_700,
-                                             national_insurance: 2400,
-                                             ownership_type: 'applicant'
-                                           }, {
-                                             amount: 196_000,
-                                             frequency: 'annual',
-                                             income_tax: 63_700,
-                                             national_insurance: 2400,
-                                             ownership_type: 'partner'
-                                           })
+      context 'when partner has employments' do
+        before do
+          create_employments('partner')
+        end
+
+        it 'has the right value' do
+          expect(subject.count).to eq(1)
+          expect(subject).to contain_exactly({
+                                               amount: 196_000,
+                                               frequency: 'annual',
+                                               income_tax: 63_700,
+                                               national_insurance: 2400,
+                                               ownership_type: 'partner'
+                                             })
+        end
+      end
+
+      context 'when client and partner has employments' do
+        before do
+          create_employments('applicant')
+          create_employments('partner')
+        end
+
+        it 'has the right value' do
+          expect(subject.count).to eq(2)
+          expect(subject).to contain_exactly({
+                                               amount: 196_000,
+                                               frequency: 'annual',
+                                               income_tax: 63_700,
+                                               national_insurance: 2400,
+                                               ownership_type: 'applicant'
+                                             }, {
+                                               amount: 196_000,
+                                               frequency: 'annual',
+                                               income_tax: 63_700,
+                                               national_insurance: 2400,
+                                               ownership_type: 'partner'
+                                             })
+        end
       end
     end
   end

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -99,19 +99,22 @@ partner_detail: partner_detail, partner: partner
         Deduction, deduction_type: 'income_tax',
                       amount_before_type_cast: 1000,
                       frequency: 'week',
-                      details: nil, annualized_amount: Money.new(100)
+                      details: nil,
+                      annualized_amount: Money.new(100)
       ),
       instance_double(
         Deduction, deduction_type: 'national_insurance',
                       amount_before_type_cast: 2000,
                       frequency: 'fortnight',
-                      details: nil, annualized_amount: Money.new(200)
+                      details: nil,
+                      annualized_amount: Money.new(200)
       ),
       instance_double(
         Deduction, deduction_type: 'other',
                       amount_before_type_cast: 3000,
                       frequency: 'annual',
-                      details: 'deduction details', annualized_amount: Money.new(300)
+                      details: 'deduction details',
+                      annualized_amount: Money.new(300)
       )
     ]
   end
@@ -131,7 +134,8 @@ partner_detail: partner_detail, partner: partner
                     ownership_type: 'applicant',
                     metadata: { before_or_after_tax: { 'value' => 'before_tax' } }.as_json,
                     deductions: deductions_double,
-                    complete?: true, annualized_amount: Money.new(1500))
+                    complete?: true,
+                    annualized_amount: Money.new(1500))
   end
 
   let(:partner_employment) do
@@ -149,7 +153,8 @@ partner_detail: partner_detail, partner: partner
                     ownership_type: 'partner',
                     metadata: { before_or_after_tax: { 'value' => 'after_tax' } }.as_json,
                     deductions: deductions_double,
-                    complete?: true, annualized_amount: Money.new(2500))
+                    complete?: true,
+                    annualized_amount: Money.new(2500))
   end
 
   describe '#generate' do # rubocop:disable RSpec/MultipleMemoizedHelpers

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -99,19 +99,19 @@ partner_detail: partner_detail, partner: partner
         Deduction, deduction_type: 'income_tax',
                       amount_before_type_cast: 1000,
                       frequency: 'week',
-                      details: nil
+                      details: nil, annualized_amount: Money.new(100)
       ),
       instance_double(
         Deduction, deduction_type: 'national_insurance',
                       amount_before_type_cast: 2000,
                       frequency: 'fortnight',
-                      details: nil
+                      details: nil, annualized_amount: Money.new(200)
       ),
       instance_double(
         Deduction, deduction_type: 'other',
                       amount_before_type_cast: 3000,
                       frequency: 'annual',
-                      details: 'deduction details'
+                      details: 'deduction details', annualized_amount: Money.new(300)
       )
     ]
   end
@@ -130,7 +130,8 @@ partner_detail: partner_detail, partner: partner
                     frequency: 'annual',
                     ownership_type: 'applicant',
                     metadata: { before_or_after_tax: { 'value' => 'before_tax' } }.as_json,
-                    deductions: deductions_double)
+                    deductions: deductions_double,
+                    complete?: true, annualized_amount: Money.new(1500))
   end
 
   let(:partner_employment) do
@@ -147,7 +148,8 @@ partner_detail: partner_detail, partner: partner
                     frequency: 'annual',
                     ownership_type: 'partner',
                     metadata: { before_or_after_tax: { 'value' => 'after_tax' } }.as_json,
-                    deductions: deductions_double)
+                    deductions: deductions_double,
+                    complete?: true, annualized_amount: Money.new(2500))
   end
 
   describe '#generate' do # rubocop:disable RSpec/MultipleMemoizedHelpers
@@ -284,7 +286,22 @@ partner_detail: partner_detail, partner: partner
             ]
           }
         ],
-        employment_income_payments: [],
+        employment_income_payments: [
+          {
+            amount: 1500,
+            frequency: 'annual',
+            income_tax: 100,
+            national_insurance: 200,
+            ownership_type: 'applicant'
+          },
+          {
+            amount: 2500,
+            frequency: 'annual',
+            income_tax: 100,
+            national_insurance: 200,
+            ownership_type: 'partner'
+          }
+        ],
       }.as_json
     end
 

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -283,7 +283,8 @@ partner_detail: partner_detail, partner: partner
               }
             ]
           }
-        ]
+        ],
+        employment_income_payments: [],
       }.as_json
     end
 


### PR DESCRIPTION
## Description of change
Annualise employment income and deductions for income
- below £12,475 (single employment)
- above £12,475 (employments loop)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1095

## Notes for reviewer
> [!IMPORTANT]  
> We are not annualising 'other' deductions(deduction_type=='other') as MAAT doesn't need this information

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Rails Console

```
crime_application = CrimeApplication.find(:id)

SubmissionSerializer::Application.new( crime_application).generate.as_json["means_details"]["income_details"]
```

You should see 'employment_income_payments' array attribute in payload
