### PR TITLE
CRIMAPP-1115 ignore partner details when involvement in case changes

### DIFF
--- a/app/forms/steps/income/client/employment_income_form.rb
+++ b/app/forms/steps/income/client/employment_income_form.rb
@@ -17,7 +17,7 @@ module Steps
         end
 
         def self.build(crime_application)
-          payment = crime_application.income_payments.for_client.employment
+          payment = crime_application.applicant.income_payments.employment
           form = new
 
           if payment
@@ -46,7 +46,7 @@ module Steps
         end
 
         def reset!
-          crime_application.income_payments.for_client.employment&.destroy
+          crime_application.applicant.income_payments.employment&.destroy
         end
       end
     end

--- a/app/forms/steps/income/client/other_work_benefits_form.rb
+++ b/app/forms/steps/income/client/other_work_benefits_form.rb
@@ -10,7 +10,7 @@ module Steps
         validates :amount, numericality: { greater_than: 0 }, if: -> { receives_other_work_benefit? }
 
         def self.build(crime_application)
-          payment = crime_application.income_payments.for_client.work_benefits
+          payment = crime_application.applicant.income_payments.work_benefits
           income = crime_application.income
           form = new
 
@@ -50,7 +50,7 @@ module Steps
         end
 
         def reset!
-          crime_application.income_payments.for_client.work_benefits&.destroy
+          crime_application.applicant.income_payments.work_benefits&.destroy
         end
       end
     end

--- a/app/forms/steps/income/income_benefit_fieldset_form.rb
+++ b/app/forms/steps/income/income_benefit_fieldset_form.rb
@@ -31,7 +31,7 @@ module Steps
       end
 
       def delete
-        crime_application.income_benefits.for_client.find_by(payment_type:)&.delete
+        crime_application.applicant.income_benefits.find_by(payment_type:)&.delete
       end
 
       private

--- a/app/forms/steps/income/income_benefits_form.rb
+++ b/app/forms/steps/income/income_benefits_form.rb
@@ -56,7 +56,7 @@ module Steps
         return @types if @types
         return ['none'] if income.has_no_income_benefits == 'yes'
 
-        income.income_benefits.for_client.pluck(:payment_type)
+        crime_application.applicant.income_benefits.pluck(:payment_type)
       end
 
       def has_no_income_benefits
@@ -72,7 +72,7 @@ module Steps
           return IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s, **attrs)
         end
 
-        income_benefit = crime_application.income_benefits.for_client.find_by(payment_type: type.value.to_s)
+        income_benefit = crime_application.applicant.income_benefits.find_by(payment_type: type.value.to_s)
         return income_benefit if income_benefit
 
         IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s,)

--- a/app/forms/steps/income/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/income_payment_fieldset_form.rb
@@ -39,7 +39,7 @@ module Steps
       end
 
       def delete
-        crime_application.income_payments.for_client.find_by(payment_type:)&.delete
+        crime_application.applicant.income_payments.find_by(payment_type:)&.delete
       end
 
       private

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -56,7 +56,7 @@ module Steps
         return @types if @types
         return ['none'] if income.has_no_income_payments == 'yes'
 
-        income.income_payments.for_client.pluck(:payment_type)
+        crime_application.applicant.income_payments.pluck(:payment_type)
       end
 
       def has_no_income_payments
@@ -72,7 +72,7 @@ module Steps
           return IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s, **attrs)
         end
 
-        income_payment = crime_application.income_payments.for_client.find_by(payment_type: type.value.to_s)
+        income_payment = crime_application.applicant.income_payments.find_by(payment_type: type.value.to_s)
         return income_payment if income_payment
 
         IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::APPLICANT.to_s)

--- a/app/forms/steps/income/partner/employment_income_form.rb
+++ b/app/forms/steps/income/partner/employment_income_form.rb
@@ -17,7 +17,7 @@ module Steps
         end
 
         def self.build(crime_application)
-          payment = crime_application.income_payments.for_partner.employment
+          payment = crime_application.partner.income_payments.employment
           form = new
 
           if payment
@@ -46,7 +46,7 @@ module Steps
         end
 
         def reset!
-          crime_application.income_payments.for_partner.employment&.destroy
+          crime_application.partner.income_payments.employment&.destroy
         end
       end
     end

--- a/app/forms/steps/income/partner/income_benefit_fieldset_form.rb
+++ b/app/forms/steps/income/partner/income_benefit_fieldset_form.rb
@@ -32,7 +32,7 @@ module Steps
         end
 
         def delete
-          crime_application.income_benefits.for_partner.find_by(payment_type:)&.delete
+          crime_application.partner.income_benefits.find_by(payment_type:)&.delete
         end
 
         private

--- a/app/forms/steps/income/partner/income_benefits_form.rb
+++ b/app/forms/steps/income/partner/income_benefits_form.rb
@@ -57,7 +57,7 @@ module Steps
           return @types if @types
           return ['none'] if income.partner_has_no_income_benefits == 'yes'
 
-          income.income_benefits.for_partner.pluck(:payment_type)
+          crime_application.partner.income_benefits.pluck(:payment_type)
         end
 
         def partner_has_no_income_benefits
@@ -73,7 +73,7 @@ module Steps
             return IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::PARTNER.to_s, **attrs)
           end
 
-          income_benefit = crime_application.income_benefits.for_partner.find_by(payment_type: type.value.to_s)
+          income_benefit = crime_application.partner.income_benefits.find_by(payment_type: type.value.to_s)
           return income_benefit if income_benefit
 
           IncomeBenefit.new(payment_type: type.to_s, ownership_type: OwnershipType::PARTNER.to_s)

--- a/app/forms/steps/income/partner/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/partner/income_payment_fieldset_form.rb
@@ -40,7 +40,7 @@ module Steps
         end
 
         def delete
-          crime_application.income_payments.for_partner.find_by(payment_type:)&.delete
+          crime_application.partner.income_payments.find_by(payment_type:)&.delete
         end
 
         private

--- a/app/forms/steps/income/partner/income_payments_form.rb
+++ b/app/forms/steps/income/partner/income_payments_form.rb
@@ -57,7 +57,7 @@ module Steps
           return @types if @types
           return ['none'] if income.partner_has_no_income_payments == 'yes'
 
-          income.income_payments.for_partner.pluck(:payment_type)
+          crime_application.partner.income_payments.pluck(:payment_type)
         end
 
         def partner_has_no_income_payments
@@ -73,7 +73,7 @@ module Steps
             return IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::PARTNER.to_s, **attrs)
           end
 
-          income_payment = crime_application.income_payments.for_partner.find_by(payment_type: type.value.to_s)
+          income_payment = crime_application.partner.income_payments.find_by(payment_type: type.value.to_s)
           return income_payment if income_payment
 
           IncomePayment.new(payment_type: type.to_s, ownership_type: OwnershipType::PARTNER.to_s)

--- a/app/forms/steps/income/partner/other_work_benefits_form.rb
+++ b/app/forms/steps/income/partner/other_work_benefits_form.rb
@@ -10,7 +10,7 @@ module Steps
         validates :amount, numericality: { greater_than: 0 }, if: -> { receives_other_work_benefit? }
 
         def self.build(crime_application)
-          payment = crime_application.income_payments.for_partner.work_benefits
+          payment = crime_application.partner.income_payments.work_benefits
           income = crime_application.income
           form = new
 
@@ -50,7 +50,7 @@ module Steps
         end
 
         def reset!
-          crime_application.income_payments.for_partner.work_benefits&.destroy
+          crime_application.partner.income_payments.work_benefits&.destroy
         end
       end
     end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -11,6 +11,15 @@ class Applicant < Person
     through: :crime_application
   )
 
+  # :nocov:
+  # TOOD add coverage before release
+  has_many(
+    :outgoings_payments,
+    -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
+    through: :crime_application
+  )
+  # :nocov:
+
   has_many(
     :national_savings_certificates,
     -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
@@ -48,6 +57,13 @@ class Applicant < Person
 
   def separation_date
     partner_detail&.separation_date
+  end
+
+  def ownership_types
+    [
+      OwnershipType::APPLICANT.to_s,
+      OwnershipType::APPLICANT_AND_PARTNER.to_s
+    ]
   end
 
   def ownership_type

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -24,6 +24,17 @@ class Capital < ApplicationRecord
     valid?(:submission)
   end
 
+  # :nocov:
+  # TOOD add coverage before release
+  def ownership_types
+    if MeansStatus.include_partner?(crime_application)
+      OwnershipType.values.map(&:to_s)
+    else
+      [OwnershipType::APPLICANT.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s]
+    end
+  end
+  # :nocov:
+
   private
 
   def confirmation_validator

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -31,4 +31,12 @@ class Income < ApplicationRecord
   def employments_total
     crime_application.employments&.sum { |e| e.amount.to_i }
   end
+
+  def ownership_types
+    if MeansStatus.include_partner?(crime_application)
+      [OwnershipType::APPLICANT.to_s, OwnershipType::PARTNER.to_s]
+    else
+      [OwnershipType::APPLICANT.to_s]
+    end
+  end
 end

--- a/app/models/outgoings.rb
+++ b/app/models/outgoings.rb
@@ -19,4 +19,12 @@ class Outgoings < ApplicationRecord
   def answers_validator
     @answers_validator ||= OutgoingsAssessment::AnswersValidator.new(record: self)
   end
+
+  def ownership_types
+    if MeansStatus.include_partner?(crime_application)
+      [OwnershipType::APPLICANT.to_s, OwnershipType::PARTNER.to_s]
+    else
+      [OwnershipType::APPLICANT.to_s]
+    end
+  end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -35,6 +35,13 @@ class Partner < Person
     through: :crime_application
   )
 
+  # :nocov:
+  # TOOD add coverage before release
+  def ownership_types
+    [OwnershipType::PARTNER.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s]
+  end
+  # :nocov:
+
   def ownership_type
     OwnershipType::PARTNER
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -42,4 +42,11 @@ class Person < ApplicationRecord
 
     datum.in_time_zone('London').to_date - 18.years >= date_of_birth
   end
+
+  # :nocov:
+  # TOOD add coverage before release
+  def ownership_types
+    OwnershipType.values.map(&:to_s)
+  end
+  # :nocov:
 end

--- a/app/presenters/summary/sections/outgoings_payments_details.rb
+++ b/app/presenters/summary/sections/outgoings_payments_details.rb
@@ -42,7 +42,7 @@ module Summary
       end
 
       def subject_type
-        return unless include_partner_in_means_assessment?
+        return super unless include_partner_in_means_assessment?
 
         SubjectType.new(:applicant_and_partner)
       end

--- a/app/presenters/summary/sections/partner_income_benefits_details.rb
+++ b/app/presenters/summary/sections/partner_income_benefits_details.rb
@@ -8,6 +8,7 @@ module Summary
       def show?
         return false unless FeatureFlags.partner_journey.enabled?
         return false if income.blank?
+        return false unless include_partner_in_means_assessment?
 
         income.partner_has_no_income_benefits == 'yes' || super
       end

--- a/app/presenters/summary/sections/partner_income_payments_details.rb
+++ b/app/presenters/summary/sections/partner_income_payments_details.rb
@@ -8,6 +8,7 @@ module Summary
       def show?
         return false unless FeatureFlags.partner_journey.enabled?
         return false if income.blank?
+        return false unless include_partner_in_means_assessment?
 
         income.partner_has_no_income_payments == 'yes' || super
       end

--- a/app/presenters/summary/sections/passporting_benefit_check_partner.rb
+++ b/app/presenters/summary/sections/passporting_benefit_check_partner.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class PassportingBenefitCheckPartner < Sections::PassportingBenefitCheck
       def show?
-        client_has_partner?
+        include_partner_in_means_assessment?
       end
 
       def change_path
@@ -13,10 +13,6 @@ module Summary
 
       def person
         @person ||= crime_application.partner
-      end
-
-      def client_has_partner?
-        crime_application.applicant.has_partner == 'yes'
       end
     end
   end

--- a/app/serializers/submission_serializer/definitions/base_definition.rb
+++ b/app/serializers/submission_serializer/definitions/base_definition.rb
@@ -9,7 +9,7 @@ module SubmissionSerializer
 
       def generate
         if respond_to?(:map)
-          map { |item| self.class.generate(item) }
+          filter_map { |item| self.class.generate(item) }
         elsif present?
           to_builder.attributes!
         end

--- a/app/serializers/submission_serializer/definitions/partner.rb
+++ b/app/serializers/submission_serializer/definitions/partner.rb
@@ -30,7 +30,7 @@ module SubmissionSerializer
           json.conflict_of_interest partner_detail.conflict_of_interest
           json.has_same_address_as_client partner_detail.has_same_address_as_client
 
-          json.is_included_in_means_assessment MeansStatus.new(self).include_partner_in_means_assessment?
+          json.is_included_in_means_assessment MeansStatus.include_partner?(self)
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/serializers/submission_serializer/definitions/saving.rb
+++ b/app/serializers/submission_serializer/definitions/saving.rb
@@ -10,6 +10,7 @@ module SubmissionSerializer
           json.account_balance account_balance_before_type_cast
           json.is_overdrawn is_overdrawn
           json.are_wages_paid_into_account are_wages_paid_into_account
+
           if include_partner_in_means_assessment?
             json.are_partners_wages_paid_into_account are_partners_wages_paid_into_account
           end

--- a/app/serializers/submission_serializer/sections/capital_details.rb
+++ b/app/serializers/submission_serializer/sections/capital_details.rb
@@ -1,7 +1,7 @@
 module SubmissionSerializer
   module Sections
     class CapitalDetails < Sections::BaseSection
-      def to_builder # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def to_builder # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
         Jbuilder.new do |json| # rubocop:disable Metrics/BlockLength
           next unless capital && requires_full_means_assessment?
 
@@ -9,9 +9,13 @@ module SubmissionSerializer
             json.has_premium_bonds capital.has_premium_bonds
             json.premium_bonds_total_value capital.premium_bonds_total_value_before_type_cast
             json.premium_bonds_holder_number capital.premium_bonds_holder_number
-            json.partner_has_premium_bonds capital.partner_has_premium_bonds
-            json.partner_premium_bonds_total_value capital.partner_premium_bonds_total_value_before_type_cast
-            json.partner_premium_bonds_holder_number capital.partner_premium_bonds_holder_number
+
+            if include_partner_in_means_assessment?
+              json.partner_has_premium_bonds capital.partner_has_premium_bonds
+              json.partner_premium_bonds_total_value capital.partner_premium_bonds_total_value_before_type_cast
+              json.partner_premium_bonds_holder_number capital.partner_premium_bonds_holder_number
+            end
+
             json.has_no_savings capital.has_no_savings
             json.savings Definitions::Saving.generate(capital.savings)
             json.has_no_investments capital.has_no_investments
@@ -28,9 +32,12 @@ module SubmissionSerializer
           json.will_benefit_from_trust_fund capital.will_benefit_from_trust_fund
           json.trust_fund_amount_held capital.trust_fund_amount_held_before_type_cast
           json.trust_fund_yearly_dividend capital.trust_fund_yearly_dividend_before_type_cast
-          json.partner_will_benefit_from_trust_fund capital.partner_will_benefit_from_trust_fund
-          json.partner_trust_fund_amount_held capital.partner_trust_fund_amount_held_before_type_cast
-          json.partner_trust_fund_yearly_dividend capital.partner_trust_fund_yearly_dividend_before_type_cast
+
+          if include_partner_in_means_assessment?
+            json.partner_will_benefit_from_trust_fund capital.partner_will_benefit_from_trust_fund
+            json.partner_trust_fund_amount_held capital.partner_trust_fund_amount_held_before_type_cast
+            json.partner_trust_fund_yearly_dividend capital.partner_trust_fund_yearly_dividend_before_type_cast
+          end
 
           unless income.has_frozen_income_or_assets.present? || capital.has_frozen_income_or_assets.blank?
             json.has_frozen_income_or_assets capital.has_frozen_income_or_assets

--- a/app/serializers/submission_serializer/sections/income_details.rb
+++ b/app/serializers/submission_serializer/sections/income_details.rb
@@ -21,17 +21,20 @@ module SubmissionSerializer
           json.income_benefits Definitions::Payment.generate(income.income_benefits)
           json.has_no_income_payments income.has_no_income_payments
           json.has_no_income_benefits income.has_no_income_benefits
-          json.partner_has_no_income_payments income.partner_has_no_income_payments
-          json.partner_has_no_income_benefits income.partner_has_no_income_benefits
-          json.partner_employment_type income.partner_employment_status
           json.applicant_other_work_benefit_received income.applicant_other_work_benefit_received
-          json.partner_other_work_benefit_received income.partner_other_work_benefit_received
           json.applicant_self_assessment_tax_bill income.applicant_self_assessment_tax_bill
           json.applicant_self_assessment_tax_bill_amount income.applicant_self_assessment_tax_bill_amount_before_type_cast # rubocop:disable Layout/LineLength
           json.applicant_self_assessment_tax_bill_frequency income.applicant_self_assessment_tax_bill_frequency
-          json.partner_self_assessment_tax_bill income.partner_self_assessment_tax_bill
-          json.partner_self_assessment_tax_bill_amount income.partner_self_assessment_tax_bill_amount_before_type_cast
-          json.partner_self_assessment_tax_bill_frequency income.partner_self_assessment_tax_bill_frequency
+
+          if include_partner_in_means_assessment?
+            json.partner_has_no_income_payments income.partner_has_no_income_payments
+            json.partner_has_no_income_benefits income.partner_has_no_income_benefits
+            json.partner_employment_type income.partner_employment_status
+            json.partner_other_work_benefit_received income.partner_other_work_benefit_received
+            json.partner_self_assessment_tax_bill income.partner_self_assessment_tax_bill
+            json.partner_self_assessment_tax_bill_amount income.partner_self_assessment_tax_bill_amount_before_type_cast
+            json.partner_self_assessment_tax_bill_frequency income.partner_self_assessment_tax_bill_frequency
+          end
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength

--- a/app/serializers/submission_serializer/sections/outgoings_details.rb
+++ b/app/serializers/submission_serializer/sections/outgoings_details.rb
@@ -1,14 +1,18 @@
 module SubmissionSerializer
   module Sections
     class OutgoingsDetails < Sections::BaseSection
-      def to_builder # rubocop:disable Metrics/AbcSize
+      def to_builder # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         Jbuilder.new do |json|
           next unless outgoings && requires_full_means_assessment?
 
           json.outgoings Definitions::Payment.generate(outgoings.outgoings_payments)
           json.housing_payment_type outgoings.housing_payment_type
           json.income_tax_rate_above_threshold outgoings.income_tax_rate_above_threshold
-          json.partner_income_tax_rate_above_threshold outgoings.partner_income_tax_rate_above_threshold
+
+          if include_partner_in_means_assessment?
+            json.partner_income_tax_rate_above_threshold outgoings.partner_income_tax_rate_above_threshold
+          end
+
           json.outgoings_more_than_income outgoings.outgoings_more_than_income
           json.how_manage outgoings.how_manage
           json.pays_council_tax outgoings.pays_council_tax

--- a/app/validators/income_assessment/answers_validator.rb
+++ b/app/validators/income_assessment/answers_validator.rb
@@ -44,7 +44,7 @@ module IncomeAssessment
     def income_payments_complete?
       return true if record.has_no_income_payments == 'yes'
 
-      record.income_payments.for_client.present? && record.income_payments.for_client.all?(&:complete?)
+      applicant.income_payments.present? && applicant.income_payments.all?(&:complete?)
     end
 
     def partner_income_payments_complete?
@@ -52,13 +52,13 @@ module IncomeAssessment
       return true if crime_application.income.partner_has_no_income_payments.to_s == 'yes'
       return true unless include_partner_in_means_assessment?
 
-      record.income_payments.for_partner.present? && record.income_payments.for_partner.all?(&:complete?)
+      partner.income_payments.present? && partner.income_payments.all?(&:complete?)
     end
 
     def income_benefits_complete?
       return true if record.has_no_income_benefits == 'yes'
 
-      record.income_benefits.for_client.present? && record.income_benefits.for_client.all?(&:complete?)
+      applicant.income_benefits.present? && applicant.income_benefits.all?(&:complete?)
     end
 
     def partner_income_benefits_complete?
@@ -66,7 +66,7 @@ module IncomeAssessment
       return true if crime_application.income.partner_has_no_income_benefits.to_s == 'yes'
       return true unless include_partner_in_means_assessment?
 
-      record.income_benefits.for_partner.present? && record.income_benefits.for_partner.all?(&:complete?)
+      partner.income_benefits.present? && partner.income_benefits.all?(&:complete?)
     end
 
     def dependants_complete?

--- a/app/views/steps/capital/savings_summary/edit.html.erb
+++ b/app/views/steps/capital/savings_summary/edit.html.erb
@@ -9,7 +9,7 @@
     <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
 
     <h1 class="govuk-heading-xl">
-      <%=t '.heading', count: @form_object.savings.size %>
+      <%=t '.heading', count: current_crime_application.savings.size %>
     </h1>
 
     <%= render Summary::Sections::Savings.new(current_crime_application, headless: true) %>

--- a/spec/controllers/steps/capital/has_national_savings_certificates_controller_spec.rb
+++ b/spec/controllers/steps/capital/has_national_savings_certificates_controller_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe Steps::Capital::HasNationalSavingsCertificatesController, type: :
                   Decisions::CapitalDecisionTree do
     context 'when National Saving Certificates present' do
       let(:existing_case) do
-        CrimeApplication.create(national_savings_certificates: [NationalSavingsCertificate.new],
-                                applicant: Applicant.new)
+        CrimeApplication.create(
+          national_savings_certificates: [NationalSavingsCertificate.new(ownership_type: 'applicant')],
+          applicant: Applicant.new,
+        )
       end
 
       describe '#edit' do

--- a/spec/controllers/steps/capital/investment_type_controller_spec.rb
+++ b/spec/controllers/steps/capital/investment_type_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Steps::Capital::InvestmentTypeController, type: :controller do
   it_behaves_like 'a generic step controller', Steps::Capital::InvestmentTypeForm, Decisions::CapitalDecisionTree do
     context 'when investments present' do
       let(:existing_case) do
-        CrimeApplication.create(investments: [Investment.new(investment_type: :bank)], applicant: Applicant.new)
+        CrimeApplication.create(investments: [Investment.new(investment_type: :bank, ownership_type: 'applicant')],
+                                applicant: Applicant.new)
       end
 
       describe '#edit' do

--- a/spec/controllers/steps/capital/investments_controller_spec.rb
+++ b/spec/controllers/steps/capital/investments_controller_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Steps::Capital::InvestmentsController, type: :controller do
 
     context 'when application is found' do
       let(:investment) do
-        Investment.create!(investment_type: InvestmentType::BOND, crime_application: crime_application)
+        Investment.create!(investment_type: InvestmentType::BOND, crime_application: crime_application,
+                           ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -27,7 +28,8 @@ RSpec.describe Steps::Capital::InvestmentsController, type: :controller do
 
     context 'when investment is for another application' do
       let(:investment) do
-        Investment.create!(investment_type: InvestmentType::BOND, crime_application: CrimeApplication.create!)
+        Investment.create!(investment_type: InvestmentType::BOND, crime_application: CrimeApplication.create!,
+                           ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -62,7 +64,8 @@ RSpec.describe Steps::Capital::InvestmentsController, type: :controller do
 
     context 'when investment is for another application' do
       let(:investment) do
-        Investment.create!(investment_type: InvestmentType::BOND, crime_application: CrimeApplication.create!)
+        Investment.create!(investment_type: InvestmentType::BOND, crime_application: CrimeApplication.create!,
+                           ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -74,7 +77,8 @@ RSpec.describe Steps::Capital::InvestmentsController, type: :controller do
 
     context 'when an in progress application and investment is found' do
       let(:investment) do
-        Investment.create!(investment_type: InvestmentType::BOND, crime_application: crime_application)
+        Investment.create!(investment_type: InvestmentType::BOND, crime_application: crime_application,
+                           ownership_type: 'applicant')
       end
 
       before do

--- a/spec/controllers/steps/capital/investments_summary_controller_spec.rb
+++ b/spec/controllers/steps/capital/investments_summary_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Capital::InvestmentsSummaryController, type: :controller d
   end
 
   context 'when investments present' do
-    let(:investments) { [Investment.new(investment_type: 'pep')] }
+    let(:investments) { [Investment.new(investment_type: 'pep', ownership_type: 'applicant')] }
 
     it_behaves_like 'a generic step controller',
                     Steps::Capital::InvestmentsSummaryForm, Decisions::CapitalDecisionTree

--- a/spec/controllers/steps/capital/national_savings_certificates_controller_spec.rb
+++ b/spec/controllers/steps/capital/national_savings_certificates_controller_spec.rb
@@ -4,7 +4,13 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesController, type: :con
   let(:form_class) { Steps::Capital::NationalSavingsCertificatesForm }
   let(:decision_tree_class) { Decisions::CapitalDecisionTree }
 
-  let(:crime_application) { CrimeApplication.create }
+  let(:crime_application) do
+    CrimeApplication.create!(
+      partner: Partner.new,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
 
   describe '#edit' do
     context 'when application is not found' do
@@ -16,7 +22,7 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesController, type: :con
 
     context 'when application is found' do
       let(:national_savings_certificate) do
-        NationalSavingsCertificate.create!(crime_application:)
+        NationalSavingsCertificate.create!(crime_application: crime_application, ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -27,7 +33,7 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesController, type: :con
 
     context 'when National Savings Certificate is for another application' do
       let(:national_savings_certificate) do
-        NationalSavingsCertificate.create!(crime_application: CrimeApplication.create!)
+        NationalSavingsCertificate.create!(crime_application: CrimeApplication.create!, ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -62,7 +68,7 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesController, type: :con
 
     context 'when National Savings Certificate is for another application' do
       let(:national_savings_certificate) do
-        NationalSavingsCertificate.create!(crime_application: CrimeApplication.create!)
+        NationalSavingsCertificate.create!(crime_application: CrimeApplication.create!, ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -74,7 +80,7 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesController, type: :con
 
     context 'when an in progress application and National Savings Certificate is found' do
       let(:national_savings_certificate) do
-        NationalSavingsCertificate.create!(crime_application:)
+        NationalSavingsCertificate.create!(crime_application: crime_application, ownership_type: 'applicant')
       end
 
       before do

--- a/spec/controllers/steps/capital/national_savings_certificates_summary_controller_spec.rb
+++ b/spec/controllers/steps/capital/national_savings_certificates_summary_controller_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesSummaryController, typ
   end
 
   context 'when national savings certificates present' do
-    let(:national_savings_certificates) { [NationalSavingsCertificate.new] }
+    let(:national_savings_certificates) {
+      [NationalSavingsCertificate.new(ownership_type: 'applicant')]
+    }
 
     it_behaves_like 'a generic step controller',
                     Steps::Capital::NationalSavingsCertificatesSummaryForm, Decisions::CapitalDecisionTree

--- a/spec/controllers/steps/capital/saving_type_controller_spec.rb
+++ b/spec/controllers/steps/capital/saving_type_controller_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe Steps::Capital::SavingTypeController, type: :controller do
                   Steps::Capital::SavingTypeForm, Decisions::CapitalDecisionTree do
     context 'when savings present' do
       let(:existing_case) do
-        CrimeApplication.create(savings: [Saving.new(saving_type: :bank)], applicant: Applicant.new)
+        CrimeApplication.create(
+          savings: [Saving.new(saving_type: :bank, ownership_type: 'applicant')],
+          applicant: Applicant.new
+        )
       end
 
       describe '#edit' do

--- a/spec/controllers/steps/capital/savings_controller_spec.rb
+++ b/spec/controllers/steps/capital/savings_controller_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Steps::Capital::SavingsController, type: :controller do
 
     context 'when application is found' do
       let(:saving) do
-        Saving.create!(saving_type: SavingType::BANK, crime_application: crime_application)
+        Saving.create!(saving_type: SavingType::BANK,
+                       crime_application: crime_application, ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -27,7 +28,8 @@ RSpec.describe Steps::Capital::SavingsController, type: :controller do
 
     context 'when saving is for another application' do
       let(:saving) do
-        Saving.create!(saving_type: SavingType::BANK, crime_application: CrimeApplication.create!)
+        Saving.create!(saving_type: SavingType::BANK, crime_application: CrimeApplication.create!,
+                       ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -62,7 +64,8 @@ RSpec.describe Steps::Capital::SavingsController, type: :controller do
 
     context 'when saving is for another application' do
       let(:saving) do
-        Saving.create!(saving_type: SavingType::BANK, crime_application: CrimeApplication.create!)
+        Saving.create!(saving_type: SavingType::BANK, crime_application: CrimeApplication.create!,
+                       ownership_type: 'applicant')
       end
 
       it 'responds with HTTP success' do
@@ -74,7 +77,7 @@ RSpec.describe Steps::Capital::SavingsController, type: :controller do
 
     context 'when an in progress application and saving is found' do
       let(:saving) do
-        Saving.create!(saving_type: SavingType::BANK, crime_application: crime_application)
+        Saving.create!(saving_type: SavingType::BANK, crime_application: crime_application, ownership_type: 'applicant')
       end
 
       before do

--- a/spec/controllers/steps/capital/savings_summary_controller_spec.rb
+++ b/spec/controllers/steps/capital/savings_summary_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Capital::SavingsSummaryController, type: :controller do
   end
 
   context 'when savings present' do
-    let(:savings) { [Saving.new(saving_type: 'bank')] }
+    let(:savings) { [Saving.new(saving_type: 'bank', ownership_type: 'applicant')] }
 
     it_behaves_like 'a generic step controller',
                     Steps::Capital::SavingsSummaryForm, Decisions::CapitalDecisionTree

--- a/spec/forms/steps/income/client/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/client/employment_income_form_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
-  # rubocop:disable RSpec/MessageChain
   subject(:form) { described_class.new(arguments) }
 
   let(:arguments) do
@@ -13,7 +12,15 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
     }
   end
 
-  let(:crime_application) { CrimeApplication.new }
+  let(:crime_application) do
+    CrimeApplication.new(
+      partner: Partner.new,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: applicant
+    )
+  end
+
+  let(:applicant) { Applicant.new }
   let(:income_payment) {
     IncomePayment.new(crime_application: crime_application,
                       payment_type: IncomePaymentType::EMPLOYMENT.to_s)
@@ -22,12 +29,6 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
   let(:amount) { nil }
   let(:before_or_after_tax) { nil }
   let(:frequency) { nil }
-
-  before do
-    allow(crime_application.income_payments).to receive_message_chain(
-      :for_client, :employment
-    ).and_return(income_payment)
-  end
 
   describe '#before_or_after_tax_options' do
     it 'returns the possible options' do
@@ -48,13 +49,12 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
                         payment_type: IncomePaymentType::EMPLOYMENT.to_s,
                         amount: 600,
                         frequency: 'four_weeks',
+                        ownership_type: 'applicant',
                         metadata: { 'before_or_after_tax' => BeforeOrAfterTax::AFTER })
     }
 
     before do
-      allow(crime_application.income_payments).to receive_message_chain(
-        :for_client, :employment
-      ).and_return(existing_employment_income_payment)
+      allow(applicant).to receive(:income_payments).and_return(double(employment: existing_employment_income_payment))
     end
 
     it 'sets the form attributes from the model metadata' do
@@ -130,5 +130,4 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
       end
     end
   end
-  # rubocop:enable RSpec/MessageChain
 end

--- a/spec/forms/steps/income/client/other_work_benefits_form_spec.rb
+++ b/spec/forms/steps/income/client/other_work_benefits_form_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
-  # rubocop:disable RSpec/MessageChain
   subject(:form) { described_class.new(arguments) }
 
   let(:arguments) do
@@ -12,7 +11,8 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
     }
   end
 
-  let(:crime_application) { CrimeApplication.new }
+  let(:crime_application) { CrimeApplication.new applicant: }
+  let(:applicant) { Applicant.new }
   let(:income) { Income.new(crime_application:) }
   let(:income_payment) {
     IncomePayment.new(crime_application: crime_application,
@@ -21,12 +21,6 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
 
   let(:applicant_other_work_benefit_received) { nil }
   let(:amount) { nil }
-
-  before do
-    allow(crime_application.income_payments).to receive_message_chain(
-      :for_client, :work_benefits
-    ).and_return(income_payment)
-  end
 
   describe '#build' do
     subject(:form) { described_class.build(crime_application) }
@@ -39,9 +33,7 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
     }
 
     before do
-      allow(crime_application.income_payments).to receive_message_chain(
-        :for_client, :work_benefits
-      ).and_return(existing_income_payment)
+      allow(applicant).to receive(:income_payments).and_return(double(work_benefits: existing_income_payment))
       income.applicant_other_work_benefit_received = 'yes'
     end
 
@@ -137,5 +129,4 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
       end
     end
   end
-  # rubocop:enable RSpec/MessageChain
 end

--- a/spec/forms/steps/income/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/income_benefits_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Steps::Income::IncomeBenefitsForm do
   subject(:form) { described_class.new(crime_application:) }
 
-  let(:crime_application) { CrimeApplication.new(case: case_record) }
+  let(:crime_application) { CrimeApplication.new(case: case_record, applicant: Applicant.new) }
   let(:case_record) { Case.new }
 
   let(:allowed_types) do

--- a/spec/forms/steps/income/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/income_payments_form_spec.rb
@@ -3,7 +3,17 @@ require 'rails_helper'
 RSpec.describe Steps::Income::IncomePaymentsForm do
   subject(:form) { described_class.new(crime_application:) }
 
-  let(:crime_application) { CrimeApplication.new(case: Case.new, income: Income.new) }
+  let(:crime_application) do
+    CrimeApplication.new(
+      case: Case.new,
+      income: Income.new,
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
 
   let(:allowed_types) do
     %w[maintenance private_pension state_pension interest_investment student_loan_grant

--- a/spec/forms/steps/income/partner/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/partner/employment_income_form_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
-  # rubocop:disable RSpec/MessageChain
   subject(:form) { described_class.new(arguments) }
 
   let(:arguments) do
@@ -13,7 +12,15 @@ RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
     }
   end
 
-  let(:crime_application) { CrimeApplication.new }
+  let(:crime_application) do
+    CrimeApplication.new(
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
   let(:income_payment) {
     IncomePayment.new(crime_application: crime_application,
                       payment_type: IncomePaymentType::EMPLOYMENT.to_s)
@@ -22,12 +29,6 @@ RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
   let(:amount) { nil }
   let(:before_or_after_tax) { nil }
   let(:frequency) { nil }
-
-  before do
-    allow(crime_application.income_payments).to receive_message_chain(
-      :for_partner, :employment
-    ).and_return(income_payment)
-  end
 
   describe '#before_or_after_tax_options' do
     it 'returns the possible options' do
@@ -53,9 +54,7 @@ RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
     }
 
     before do
-      allow(crime_application.income_payments).to receive_message_chain(
-        :for_partner, :employment
-      ).and_return(existing_employment_income_payment)
+      allow(partner).to receive(:income_payments).and_return(double(employment: existing_employment_income_payment))
     end
 
     it 'sets the form attributes from the model metadata' do
@@ -131,5 +130,4 @@ RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
       end
     end
   end
-  # rubocop:enable RSpec/MessageChain
 end

--- a/spec/forms/steps/income/partner/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_benefits_form_spec.rb
@@ -1,9 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Income::Partner::IncomeBenefitsForm do
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   subject(:form) { described_class.new(crime_application:) }
 
-  let(:crime_application) { CrimeApplication.new(case: case_record) }
+  let(:crime_application) do
+    CrimeApplication.new(
+      case: case_record,
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
   let(:case_record) { Case.new }
 
   let(:allowed_types) do
@@ -121,4 +131,5 @@ RSpec.describe Steps::Income::Partner::IncomeBenefitsForm do
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/forms/steps/income/partner/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_payments_form_spec.rb
@@ -3,7 +3,17 @@ require 'rails_helper'
 RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
   subject(:form) { described_class.new(crime_application:) }
 
-  let(:crime_application) { CrimeApplication.new(case: Case.new, income: Income.new) }
+  let(:crime_application) do
+    CrimeApplication.new(
+      case: Case.new,
+      income: Income.new,
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
 
   let(:allowed_types) do
     %w[maintenance private_pension state_pension interest_investment student_loan_grant

--- a/spec/forms/steps/income/partner/other_work_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/other_work_benefits_form_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
-  # rubocop:disable RSpec/MessageChain
   subject(:form) { described_class.new(arguments) }
 
   let(:arguments) do
@@ -12,7 +11,16 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
     }
   end
 
-  let(:crime_application) { CrimeApplication.new }
+  let(:crime_application) do
+    CrimeApplication.new(
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
+
   let(:income) { Income.new(crime_application:) }
   let(:partner_income_payment) {
     IncomePayment.new(crime_application: crime_application,
@@ -24,9 +32,7 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
   let(:amount) { nil }
 
   before do
-    allow(crime_application.income_payments).to receive_message_chain(
-      :for_partner, :work_benefits
-    ).and_return(partner_income_payment)
+    allow(partner).to receive(:income_payments).and_return(double(work_benefits: partner_income_payment))
   end
 
   describe '#build' do
@@ -41,9 +47,7 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
     }
 
     before do
-      allow(crime_application.income_payments).to receive_message_chain(
-        :for_partner, :work_benefits
-      ).and_return(existing_income_payment)
+      allow(partner).to receive(:income_payments).and_return(double(work_benefits: existing_income_payment))
       income.partner_other_work_benefit_received = 'yes'
     end
 
@@ -127,9 +131,7 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
         }
 
         before do
-          allow(crime_application.income_payments).to(
-            receive(:work_benefits).and_return(existing_income_payment)
-          )
+          allow(partner).to receive(:income_payments).and_return(double(work_benefits: existing_income_payment))
         end
 
         it 'resets the attributes before saving' do
@@ -139,5 +141,4 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
       end
     end
   end
-  # rubocop:enable RSpec/MessageChain
 end

--- a/spec/models/income_spec.rb
+++ b/spec/models/income_spec.rb
@@ -40,8 +40,14 @@ RSpec.describe Income, type: :model do
     subject(:all_income_over_zero) { income.all_income_over_zero? }
 
     context 'when there are any income payments or benefits' do
+      let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'none') }
+
       before do
-        crime_application = CrimeApplication.new(income:)
+        partner = Partner.new
+
+        crime_application = CrimeApplication.new(
+          income:, partner_detail:, partner:
+        )
 
         crime_application.income_payments = [
           IncomePayment.new(
@@ -85,6 +91,14 @@ RSpec.describe Income, type: :model do
 
       it 'calculates the correct total' do
         expect(income.all_income_total).to eq 600
+      end
+
+      context 'when partner has contrary interest' do
+        let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'victim') }
+
+        it 'only includes applicant payments' do
+          expect(income.all_income_total).to eq 200
+        end
       end
     end
 

--- a/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
@@ -8,6 +8,8 @@ describe Summary::Sections::PartnerIncomeBenefitsDetails do
       CrimeApplication,
       to_param: '12345',
       income: income,
+      partner: instance_double(Partner),
+      partner_detail: instance_double(PartnerDetail, involvement_in_case: 'none'),
       income_benefits: income_benefits
     )
   end

--- a/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
@@ -8,9 +8,15 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
       CrimeApplication,
       to_param: '12345',
       income: income,
-      income_payments: income_payments
+      income_payments: income_payments,
+      applicant: applicant,
+      partner_detail: instance_double(PartnerDetail, involvement_in_case:),
+      partner: partner
     )
   end
+
+  let(:applicant) { double(Applicant) }
+  let(:partner) { double(Partner) }
 
   let(:income) do
     instance_double(
@@ -19,6 +25,7 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
     )
   end
 
+  let(:involvement_in_case) { 'none' }
   let(:income_payments) { [] }
   let(:partner_has_no_income_payments) { nil }
 

--- a/spec/presenters/summary/sections/passporting_benefit_check_partner_spec.rb
+++ b/spec/presenters/summary/sections/passporting_benefit_check_partner_spec.rb
@@ -8,16 +8,12 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
       CrimeApplication,
       to_param: '12345',
       applicant: applicant,
+      partner_detail: instance_double(PartnerDetail, involvement_in_case:),
       partner: partner
     )
   end
 
-  let(:applicant) do
-    double(
-      Applicant,
-      has_partner:
-    )
-  end
+  let(:applicant) { double(Applicant) }
 
   let(:partner) do
     double(
@@ -34,11 +30,10 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
   let(:benefit_check_status) { nil }
   let(:confirm_details) { nil }
   let(:has_benefit_evidence) { nil }
-  let(:has_partner) { 'yes' }
+  let(:involvement_in_case) { 'none' }
 
   before do
     allow(partner).to receive(:benefit_check_status).and_return(benefit_check_status)
-    allow(applicant).to receive(:has_partner).and_return(has_partner)
   end
 
   describe '#name' do
@@ -53,7 +48,7 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
     end
 
     context 'when the applicant has no partner' do
-      let(:has_partner) { 'no' }
+      let(:involvement_in_case) { 'victim' }
 
       it 'does not show this section' do
         expect(subject.show?).to be(false)

--- a/spec/requests/investments_summary_spec.rb
+++ b/spec/requests/investments_summary_spec.rb
@@ -53,7 +53,10 @@ RSpec.describe 'Investments summary page', :authorized do
     context 'when there are other investments' do
       it 'deletes the investment and redirects back to the summary page' do
         # ensure we have at least an additional investment
-        investment = crime_application.investments.create!(investment_type: InvestmentType::SHARE_ISA)
+        investment = crime_application.investments.create!(
+          investment_type: InvestmentType::SHARE_ISA,
+          ownership_type: 'applicant'
+        )
 
         expect do
           delete steps_capital_investments_path(id: crime_application, investment_id: investment)

--- a/spec/requests/national_savings_certificates_summary_spec.rb
+++ b/spec/requests/national_savings_certificates_summary_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'NationalSavingsCertificates summary page', :authorized do
     context 'when there are other certificates' do
       it 'deletes the certificate and redirects back to the summary page' do
         # ensure we have at least an additional certificate
-        crime_application.national_savings_certificates.create!
+        crime_application.national_savings_certificates.create!(ownership_type: 'applicant')
 
         expect { delete destroy_path }.to change(NationalSavingsCertificate, :count).by(-1)
         expect(response).to have_http_status(:redirect)

--- a/spec/requests/savings_summary_spec.rb
+++ b/spec/requests/savings_summary_spec.rb
@@ -57,7 +57,10 @@ RSpec.describe 'Savings summary page', :authorized do
     context 'when there are other savings' do
       it 'deletes the saving and redirects back to the summary page' do
         # ensure we have at least an additional saving
-        saving = crime_application.savings.create!(saving_type: SavingType::CASH_ISA)
+        saving = crime_application.savings.create!(
+          saving_type: SavingType::CASH_ISA,
+          ownership_type: 'applicant'
+        )
 
         expect do
           delete steps_capital_savings_path(id: crime_application, saving_id: saving)

--- a/spec/serializers/submission_serializer/sections/capital_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/capital_details_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
   subject(:serializer) { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double CrimeApplication, capital:, income: }
+  let(:crime_application) { instance_double CrimeApplication, capital:, income:, partner_detail:, partner: }
+  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:partner) { instance_double(Partner) }
+  let(:involvement_in_case) { 'none' }
 
   let(:capital) do
     instance_double(

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -5,9 +5,13 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
   subject { described_class.new(crime_application) }
 
   let(:crime_application) {
-    instance_double CrimeApplication, income: income, employments: [applicant_employment, partner_employment]
+    instance_double CrimeApplication, income: income, employments: [applicant_employment, partner_employment],
+partner_detail: partner_detail, partner: partner
   }
 
+  let(:partner) { instance_double(Partner) }
+  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:involvement_in_case) { 'none' }
   let(:deductions_double) { double('deductions_collection', complete: deductions) }
 
   let(:income) do

--- a/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Sections::OutgoingsDetails do
   subject(:serializer) { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double CrimeApplication, outgoings: }
+  let(:crime_application) { instance_double(CrimeApplication, outgoings:, partner_detail:, partner:) }
+  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:partner) { instance_double(Partner) }
+  let(:involvement_in_case) { 'none' }
 
   let(:outgoings) do
     instance_double(

--- a/spec/support/shared_examples/payment_shared_examples.rb
+++ b/spec/support/shared_examples/payment_shared_examples.rb
@@ -10,7 +10,16 @@ RSpec.shared_examples 'a payment fieldset form' do |fieldset_class|
     }
   end
 
-  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:crime_application) do
+    CrimeApplication.new(
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
+
   let(:record_id) { '12345' }
 
   describe '#persisted?' do
@@ -107,7 +116,17 @@ RSpec.shared_examples 'a payment form' do |payment_class, has_none_attr|
     }
   end
 
-  let(:crime_application) { CrimeApplication.new(case: case_record, income: income) }
+  let(:crime_application) do
+    CrimeApplication.new(
+      case: case_record,
+      income: income,
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
   let(:record_id) { '12345' }
   let(:case_record) { Case.new }
   let(:income) { Income.new }

--- a/spec/support/shared_examples/step_controller_shared_examples.rb
+++ b/spec/support/shared_examples/step_controller_shared_examples.rb
@@ -40,7 +40,15 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
     # to the shared examples, or to also create the partner associated record.
     #
     context 'when application is found' do
-      let(:existing_case) { CrimeApplication.create(applicant: Applicant.new) } unless method_defined?(:existing_case)
+      unless method_defined?(:existing_case)
+        let(:existing_case) do
+          CrimeApplication.create(
+            applicant: Applicant.new,
+            partner: Partner.new,
+            partner_detail: PartnerDetail.new(involvement_in_case: false)
+          )
+        end
+      end
 
       it 'responds with HTTP success' do
         get :edit, params: { id: existing_case }

--- a/spec/validators/income_assessment/answers_validator_spec.rb
+++ b/spec/validators/income_assessment/answers_validator_spec.rb
@@ -4,9 +4,20 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record:, crime_application:) }
 
   let(:record) { Income.new(crime_application:) }
-  let(:crime_application) { CrimeApplication.new(case: Case.new(case_type: 'summary_only')) }
+
+  let(:crime_application) do
+    CrimeApplication.new(
+      case: Case.new(case_type: 'summary_only'),
+      partner: partner,
+      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      applicant: Applicant.new
+    )
+  end
+
+  let(:partner) { Partner.new }
 
   let(:requires_means_assessment?) { true }
+
   let(:employment_validator) do
     instance_double(EmploymentDetails::AnswersValidator, validate: nil)
   end
@@ -388,7 +399,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
 
       it 'returns false' do
         expect(subject.income_payments.all.size).to be 1
-        expect(subject.income_payments.for_partner.size).to be 0
+        expect(partner.income_payments.size).to be 0
         expect(subject.partner_income_payments_complete?).to be(false)
       end
     end
@@ -401,7 +412,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
       end
 
       it 'returns false' do
-        expect(subject.income_payments.for_partner.size).to be 0
+        expect(partner.income_payments.size).to be 0
         expect(subject.partner_income_payments_complete?).to be(false)
       end
     end
@@ -423,7 +434,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
       end
 
       it 'returns true' do
-        expect(subject.income_payments.for_partner.size).to be 0
+        expect(partner.income_payments.size).to be 0
         expect(subject.partner_income_payments_complete?).to be(true)
       end
     end
@@ -473,7 +484,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
 
       it 'returns false' do
         expect(subject.income_benefits.all.size).to be 1
-        expect(subject.income_benefits.for_partner.size).to be 0
+        expect(partner.income_benefits.size).to be 0
         expect(subject.partner_income_benefits_complete?).to be(false)
       end
     end
@@ -486,7 +497,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
       end
 
       it 'returns false' do
-        expect(subject.income_benefits.for_partner.size).to be 0
+        expect(partner.income_benefits.size).to be 0
         expect(subject.partner_income_benefits_complete?).to be(false)
       end
     end
@@ -508,7 +519,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
       end
 
       it 'returns true' do
-        expect(subject.income_benefits.for_partner.size).to be 0
+        expect(partner.income_benefits.size).to be 0
         expect(subject.partner_income_payments_complete?).to be(true)
       end
     end


### PR DESCRIPTION
## Description of change

Hide and do not submit partner information and assets when a partner’s interest changes from neutral to contrary.

## Link to relevant ticket

[CRIMAPP-1116](https://dsdmoj.atlassian.net/browse/CRIMAPP-1116)
[CRIMAPP-1115](https://dsdmoj.atlassian.net/browse/CRIMAPP-1115)

## Notes for reviewer

Due to lack of time, missing coverage will be added whilst this FIx is being QA'd.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1116]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1115]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ