### PR TITLE
CRIMAPP-1088 Show declarations on completed applications view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.20'
+    tag: 'v1.1.21'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 48abb067ba41b98d5d829c4f79d8eca8f40cace7
-  tag: v1.1.20
+  revision: 3de29a75a0507192f3b350cfe98faad14da7146c
+  tag: v1.1.21
   specs:
-    laa-criminal-legal-aid-schemas (1.1.20)
+    laa-criminal-legal-aid-schemas (1.1.21)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -50,6 +50,7 @@ module Summary
         other_capital_details
         supporting_evidence
         more_information
+        declarations
         legal_representative_details
       ],
       post_submission_evidence: %i[

--- a/app/presenters/summary/sections/declarations.rb
+++ b/app/presenters/summary/sections/declarations.rb
@@ -7,24 +7,33 @@ module Summary
         true
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
-        [
-          Components::ValueAnswer.new(
-            :legal_rep_has_client_declaration,
-            'yes'
-          ),
-          Components::ValueAnswer.new(
-            :legal_rep_has_partner_declaration,
-            provider_details.legal_rep_has_partner_declaration,
-          ),
-          Components::FreeTextAnswer.new(
-            :legal_rep_no_partner_declaration_reason,
-            provider_details.legal_rep_no_partner_declaration_reason,
-          ),
-        ]
+        answers =
+          [
+            Components::ValueAnswer.new(
+              :legal_rep_has_client_declaration,
+              'yes'
+            )
+          ]
+        if provider_details.legal_rep_has_partner_declaration.present?
+          answers.push(Components::ValueAnswer.new(
+                         :legal_rep_has_partner_declaration,
+                         provider_details.legal_rep_has_partner_declaration,
+                       ))
+        end
+
+        if provider_details.legal_rep_has_partner_declaration == 'no' &&
+           provider_details.legal_rep_no_partner_declaration_reason
+          answers.push(Components::FreeTextAnswer.new(
+                         :legal_rep_no_partner_declaration_reason,
+                         provider_details.legal_rep_no_partner_declaration_reason,
+                       ))
+        end
+
+        answers.flatten.select(&:show?)
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       private
 

--- a/app/presenters/summary/sections/declarations.rb
+++ b/app/presenters/summary/sections/declarations.rb
@@ -1,0 +1,36 @@
+module Summary
+  module Sections
+    class Declarations < Sections::BaseSection
+      def show?
+        return false if crime_application.in_progress?
+
+        true
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def answers
+        [
+          Components::ValueAnswer.new(
+            :legal_rep_has_client_declaration,
+            'yes'
+          ),
+          Components::ValueAnswer.new(
+            :legal_rep_has_partner_declaration,
+            provider_details.legal_rep_has_partner_declaration,
+          ),
+          Components::FreeTextAnswer.new(
+            :legal_rep_no_partner_declaration_reason,
+            provider_details.legal_rep_no_partner_declaration_reason,
+          ),
+        ]
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def provider_details
+        @provider_details ||= crime_application.provider_details
+      end
+    end
+  end
+end

--- a/app/serializers/submission_serializer/sections/provider_details.rb
+++ b/app/serializers/submission_serializer/sections/provider_details.rb
@@ -1,13 +1,15 @@
 module SubmissionSerializer
   module Sections
     class ProviderDetails < Sections::BaseSection
-      def to_builder # rubocop:disable Metrics/AbcSize
+      def to_builder # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         Jbuilder.new do |json|
           json.provider_details do
             json.office_code crime_application.office_code
             json.provider_email crime_application.provider_email
             json.legal_rep_has_partner_declaration rep_has_partner_declaration
-            json.legal_rep_no_partner_declaration_reason rep_no_declaration_reason
+            json.legal_rep_no_partner_declaration_reason(
+              crime_application.legal_rep_no_partner_declaration_reason
+            )
             json.legal_rep_first_name crime_application.legal_rep_first_name
             json.legal_rep_last_name crime_application.legal_rep_last_name
             json.legal_rep_telephone crime_application.legal_rep_telephone
@@ -21,10 +23,6 @@ module SubmissionSerializer
         return unless crime_application.legal_rep_has_partner_declaration
 
         crime_application.legal_rep_has_partner_declaration['value']
-      end
-
-      def rep_no_declaration_reason
-        crime_application.legal_rep_no_partner_declaration_reason
       end
     end
   end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -66,6 +66,7 @@ en:
       first_court_hearing: First court hearing
       justification_for_legal_aid: Justification for legal aid
       passport_justification_for_legal_aid: Justification for legal aid
+      declarations: Declarations
       legal_representative_details: Legal representative
       employment_details: Employment
       income_details: Income
@@ -631,6 +632,19 @@ en:
       how_manage:
         question: How they cover outgoings that are more than income
       # END other outgoings details section
+
+      # BEGIN declarations section
+      legal_rep_has_client_declaration:
+        question: Declaration from client?
+        answers:
+          <<: *YESNO
+      legal_rep_has_partner_declaration:
+        question: Declaration from partner?
+        answers:
+          <<: *YESNO
+      legal_rep_no_partner_declaration_reason:
+        question: Reason for no partner declaration
+      # END declarations section
 
       # BEGIN legal representative details section
       legal_rep_first_name:

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -281,6 +281,7 @@ describe Summary::HtmlPresenter do
             OtherCapitalDetails
             SupportingEvidence
             MoreInformation
+            Declarations
             LegalRepresentativeDetails
           ]
         end


### PR DESCRIPTION
## Description of change
Add declaration details to completed applicaiton view## Link to relevant ticket
## Link to ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1088

## Notes for reviewer
Not rehydrating for now

## Screenshots of changes (if applicable)
<img width="1084" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/651d468d-922d-4ec9-a499-a687205b1b80">

## How to manually test the feature
SCENARIO 1:
Create an application on Apply main
Add a partner
Fill in declaration at the end with 'no' and some reason
Submit
Click view completed application
Check the rows show correctly

SCENARIO 2:
Create an application on Apply main
Add a partner
Fill in declaration at the end with 'yes'
Submit
Click view completed application
Check the rows show correctly

SCENARIO 3:
Create an application on Apply main
DO NOT add a partner
Shouldn't see partner declaration on Apply submission
Submit
Click view completed application
Check the rows show correctly