### PR TITLE
CRIMAPP-1121 hide partner heading on income

### DIFF
--- a/app/views/steps/income/answers/edit.html.erb
+++ b/app/views/steps/income/answers/edit.html.erb
@@ -19,10 +19,10 @@
 
     <%= render @presenter.income_sections %>
 
-    <% if current_crime_application.client_has_partner == YesNoAnswer::YES.to_s %>
-    <h1 class="govuk-heading-l"><%= t('.subheading.partner') %></h1>
+    <% if MeansStatus.include_partner?(current_crime_application) %>
+      <h1 class="govuk-heading-l"><%= t('.subheading.partner') %></h1>
 
-    <%= render @presenter.partner_income_sections %>
+      <%= render @presenter.partner_income_sections %>
     <% end %>
 
     <%= render @presenter.other_income_sections %>


### PR DESCRIPTION
## Description of change

Hide partner heading from income CYA if contrary interest.

## Link to relevant ticket
[CRIMAPP-1121](https://dsdmoj.atlassian.net/browse/CRIMAPP-1121)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1121]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ