### PR TITLE
CRIMAPP-1123 global scope includes un-owned assets

### DIFF
--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -1,4 +1,6 @@
 class Capital < ApplicationRecord
+  include MeansOwnershipScope
+
   belongs_to :crime_application
   attribute :premium_bonds_total_value, :pence
   attribute :partner_premium_bonds_total_value, :pence
@@ -23,17 +25,6 @@ class Capital < ApplicationRecord
   def complete?
     valid?(:submission)
   end
-
-  # :nocov:
-  # TOOD add coverage before release
-  def ownership_types
-    if MeansStatus.include_partner?(crime_application)
-      OwnershipType.values.map(&:to_s)
-    else
-      [OwnershipType::APPLICANT.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s]
-    end
-  end
-  # :nocov:
 
   private
 

--- a/app/models/concerns/means_ownership_scope.rb
+++ b/app/models/concerns/means_ownership_scope.rb
@@ -1,0 +1,17 @@
+module MeansOwnershipScope
+  extend ActiveSupport::Concern
+
+  #
+  # Used in scopes and associations such as savings, properties, etc to
+  # exclude things owned by the partner when there is a contrary interest.
+  #
+  def ownership_types
+    app = is_a?(CrimeApplication) ? self : crime_application
+
+    if MeansStatus.include_partner?(app)
+      OwnershipType.values.map(&:to_s) << nil
+    else
+      [OwnershipType::APPLICANT.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s, nil]
+    end
+  end
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,6 +1,7 @@
-class CrimeApplication < ApplicationRecord # rubocop:disable Metrics/ClassLength
+class CrimeApplication < ApplicationRecord
   include TypeOfApplication
   include Passportable
+  include MeansOwnershipScope
 
   attr_readonly :application_type
   attribute :date_stamp, :datetime
@@ -128,14 +129,5 @@ class CrimeApplication < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def passporting_benefit_complete?
     valid?(:passporting_benefit)
-  end
-
-  # Used in scopes and associations such as savings, properties, etc
-  def ownership_types
-    if MeansStatus.include_partner?(self)
-      OwnershipType.values.map(&:to_s)
-    else
-      [OwnershipType::APPLICANT.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s]
-    end
   end
 end

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -1,4 +1,6 @@
 class Income < ApplicationRecord
+  include MeansOwnershipScope
+
   belongs_to :crime_application
   has_many :income_payments, through: :crime_application
   has_many :income_benefits, through: :crime_application
@@ -30,13 +32,5 @@ class Income < ApplicationRecord
 
   def employments_total
     crime_application.employments&.sum { |e| e.amount.to_i }
-  end
-
-  def ownership_types
-    if MeansStatus.include_partner?(crime_application)
-      [OwnershipType::APPLICANT.to_s, OwnershipType::PARTNER.to_s]
-    else
-      [OwnershipType::APPLICANT.to_s]
-    end
   end
 end

--- a/app/models/outgoings.rb
+++ b/app/models/outgoings.rb
@@ -1,4 +1,6 @@
 class Outgoings < ApplicationRecord
+  include MeansOwnershipScope
+
   belongs_to :crime_application
   has_many :outgoings_payments, through: :crime_application
 
@@ -18,13 +20,5 @@ class Outgoings < ApplicationRecord
 
   def answers_validator
     @answers_validator ||= OutgoingsAssessment::AnswersValidator.new(record: self)
-  end
-
-  def ownership_types
-    if MeansStatus.include_partner?(crime_application)
-      [OwnershipType::APPLICANT.to_s, OwnershipType::PARTNER.to_s]
-    else
-      [OwnershipType::APPLICANT.to_s]
-    end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -46,7 +46,7 @@ class Person < ApplicationRecord
   # :nocov:
   # TOOD add coverage before release
   def ownership_types
-    OwnershipType.values.map(&:to_s)
+    OwnershipType.values.map(&:to_s) << nil
   end
   # :nocov:
 end

--- a/spec/models/capital_spec.rb
+++ b/spec/models/capital_spec.rb
@@ -48,4 +48,6 @@ RSpec.describe Capital, type: :model do
       end
     end
   end
+
+  it_behaves_like 'it has a means ownership scope'
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -70,4 +70,6 @@ RSpec.describe CrimeApplication, type: :model do
       expect(subject.passporting_benefit_complete?).to be false
     end
   end
+
+  it_behaves_like 'it has a means ownership scope'
 end

--- a/spec/models/income_spec.rb
+++ b/spec/models/income_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Income, type: :model do
   subject(:income) { described_class.new }
 
+  it_behaves_like 'it has a means ownership scope'
+
   describe 'validations' do
     let(:answers_validator) { double('answers_validator') }
 

--- a/spec/models/outgoings_spec.rb
+++ b/spec/models/outgoings_spec.rb
@@ -35,4 +35,6 @@ RSpec.describe Outgoings, type: :model do
       end
     end
   end
+
+  it_behaves_like 'it has a means ownership scope'
 end

--- a/spec/support/shared_examples/a_means_ownership_scope.rb
+++ b/spec/support/shared_examples/a_means_ownership_scope.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples 'it has a means ownership scope' do
+  describe '#ownership_types' do
+    subject(:ownership_types) { described_class.new.ownership_types }
+
+    context 'when partner included in means' do
+      before do
+        allow(MeansStatus).to receive(:include_partner?).and_return(true)
+      end
+
+      it { is_expected.to eq %w[applicant applicant_and_partner partner] << nil }
+    end
+
+    context 'when partner exlcuded from means assesment' do
+      before do
+        allow(MeansStatus).to receive(:include_partner?).and_return(false)
+      end
+
+      it { is_expected.to eq %w[applicant applicant_and_partner] << nil }
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Assets are not owned initially. This pr adds unowned assets to the global scope to fix regression in asset type pages.

## Link to relevant ticket
[CRIMAPP-1123](https://dsdmoj.atlassian.net/browse/CRIMAPP-1123)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1123]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ