### PR TITLE
CRIMAPP-1115 capital CYA hides partner info

### DIFF
--- a/app/presenters/summary/sections/partner_employment_details.rb
+++ b/app/presenters/summary/sections/partner_employment_details.rb
@@ -2,7 +2,9 @@ module Summary
   module Sections
     class PartnerEmploymentDetails < Sections::BaseSection
       def show?
-        income.present? && income.partner_employment_status.present? && super
+        income.present? &&
+          MeansStatus.include_partner?(crime_application) &&
+          income.partner_employment_status.present? && super
       end
 
       def answers

--- a/app/presenters/summary/sections/partner_premium_bonds.rb
+++ b/app/presenters/summary/sections/partner_premium_bonds.rb
@@ -31,7 +31,9 @@ module Summary
       private
 
       def show_partner_premium_bonds?
-        capital.present? && capital.partner_has_premium_bonds.present?
+        capital.present? &&
+          MeansStatus.include_partner?(crime_application) &&
+          capital.partner_has_premium_bonds.present?
       end
 
       def partner_have_premium_bonds?

--- a/app/presenters/summary/sections/partner_self_assessment_tax_bill.rb
+++ b/app/presenters/summary/sections/partner_self_assessment_tax_bill.rb
@@ -4,7 +4,9 @@ module Summary
       SelfAssessmentTaxBillPayment = Struct.new(:amount, :frequency)
 
       def show?
-        income.present? && income.partner_self_assessment_tax_bill.present?
+        income.present? &&
+          MeansStatus.include_partner?(crime_application) &&
+          income.partner_self_assessment_tax_bill.present?
       end
 
       def answers # rubocop:disable Metrics/MethodLength

--- a/app/presenters/summary/sections/partner_trust_fund.rb
+++ b/app/presenters/summary/sections/partner_trust_fund.rb
@@ -3,7 +3,9 @@ module Summary
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     class PartnerTrustFund < Sections::BaseSection
       def show?
-        capital.present? && capital.partner_will_benefit_from_trust_fund.present?
+        capital.present? &&
+          MeansStatus.include_partner?(crime_application) &&
+          capital.partner_will_benefit_from_trust_fund.present?
       end
 
       def answers

--- a/spec/presenters/summary/sections/partner_premium_bonds_spec.rb
+++ b/spec/presenters/summary/sections/partner_premium_bonds_spec.rb
@@ -14,6 +14,10 @@ describe Summary::Sections::PartnerPremiumBonds do
     )
   end
 
+  before do
+    allow(MeansStatus).to receive(:include_partner?).and_return(true)
+  end
+
   describe '#name' do
     it { expect(subject.name).to eq(:partner_premium_bonds) }
   end

--- a/spec/presenters/summary/sections/partner_trust_fund_spec.rb
+++ b/spec/presenters/summary/sections/partner_trust_fund_spec.rb
@@ -14,6 +14,10 @@ describe Summary::Sections::PartnerTrustFund do
     )
   end
 
+  before do
+    allow(MeansStatus).to receive(:include_partner?).and_return(true)
+  end
+
   describe '#name' do
     it { expect(subject.name).to eq(:partner_trust_fund) }
   end


### PR DESCRIPTION
## Description of change

Capital CYA uses database not json and as such was showing partner details when contrary interest. This PR fixes that.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1115?focusedCommentId=475167

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
