### PR TITLE
[CRIMAPP-1126] remove partner address, and destroy partner assets when changed to conflict

### DIFF
--- a/app/serializers/submission_serializer/definitions/partner.rb
+++ b/app/serializers/submission_serializer/definitions/partner.rb
@@ -12,7 +12,6 @@ module SubmissionSerializer
           json.last_name partner.last_name
           json.other_names partner.other_names
           json.date_of_birth partner.date_of_birth
-          json.home_address Definitions::Address.generate(partner.home_address)
 
           json.has_nino partner.has_nino
           json.nino partner.nino
@@ -28,7 +27,11 @@ module SubmissionSerializer
 
           json.involvement_in_case partner_detail.involvement_in_case
           json.conflict_of_interest partner_detail.conflict_of_interest
-          json.has_same_address_as_client partner_detail.has_same_address_as_client
+
+          if MeansStatus.include_partner?(self)
+            json.has_same_address_as_client partner_detail.has_same_address_as_client
+            json.home_address Definitions::Address.generate(partner.home_address)
+          end
 
           json.is_included_in_means_assessment MeansStatus.include_partner?(self)
         end

--- a/app/services/datastore/application_submission.rb
+++ b/app/services/datastore/application_submission.rb
@@ -22,7 +22,7 @@ module Datastore
             payload: application_payload
           ).call
 
-          crime_application.destroy!
+          PostSubmissionApplicationPurger.call(crime_application)
         end
 
         true

--- a/app/services/post_submission_application_purger.rb
+++ b/app/services/post_submission_application_purger.rb
@@ -1,5 +1,4 @@
 class PostSubmissionApplicationPurger < ApplicationPurger
-
   class << self
     def call(crime_application)
       new(crime_application).call
@@ -7,7 +6,7 @@ class PostSubmissionApplicationPurger < ApplicationPurger
   end
 
   def initialize(crime_application)
-    @crime_application = crime_application
+    super(crime_application, nil)
   end
   private_class_method :new
 

--- a/app/services/post_submission_application_purger.rb
+++ b/app/services/post_submission_application_purger.rb
@@ -1,0 +1,20 @@
+class PostSubmissionApplicationPurger < ApplicationPurger
+
+  class << self
+    def call(crime_application)
+      new(crime_application).call
+    end
+  end
+
+  def initialize(crime_application)
+    @crime_application = crime_application
+  end
+  private_class_method :new
+
+  def call
+    ActiveRecord::Base.transaction do
+      delete_orphan_partner_assets!
+      crime_application.destroy!
+    end
+  end
+end

--- a/app/validators/partner_details/answers_validator.rb
+++ b/app/validators/partner_details/answers_validator.rb
@@ -21,8 +21,11 @@ module PartnerDetails
       errors.add(:involvement_in_case, :incomplete) if record.involvement_in_case.blank?
       errors.add(:nino, :incomplete) unless nino?
       errors.add(:conflict_of_interest, :incomplete) unless conflict_of_interest?
-      errors.add(:has_same_address_as_client, :incomplete) unless same_address?
-      errors.add(:home_address, :incomplete) unless address?
+
+      if include_partner_in_means_assessment?
+        errors.add(:has_same_address_as_client, :incomplete) unless same_address?
+        errors.add(:home_address, :incomplete) unless address?
+      end
 
       errors.add(:base, :incomplete_records) if errors.present?
     end
@@ -42,11 +45,13 @@ module PartnerDetails
     end
 
     def address?
+      return true unless include_partner_in_means_assessment?
+
       record.has_same_address_as_client == 'no' ? crime_application.partner&.home_address.present? : true
     end
 
     def same_address?
-      return true unless record.involvement_in_case == 'none' || record.conflict_of_interest == 'no'
+      return true unless include_partner_in_means_assessment?
 
       record.has_same_address_as_client.present?
     end

--- a/spec/services/post_submission_application_purger_spec.rb
+++ b/spec/services/post_submission_application_purger_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe PostSubmissionApplicationPurger do
+  let(:crime_application) { instance_double(CrimeApplication, partner: nil) }
+
+  before do
+    allow(crime_application).to receive(:destroy!)
+  end
+
+  describe '.call' do
+    context 'when it has orphan partner assets' do
+      let(:documents) { [] }
+      let(:partner_savings) { double(:partner_savings) }
+
+      before do
+        allow(crime_application).to receive(:partner).and_return(Partner.new)
+        allow(MeansStatus).to receive(:include_partner?).and_return(false)
+        allow(Saving).to receive(:where).with(
+          crime_application: crime_application,
+          ownership_type: 'partner'
+        ).and_return(partner_savings)
+      end
+
+      it 'deletes the orhpan assets' do
+        expect(partner_savings).to receive(:delete_all)
+        expect(crime_application).to receive(:destroy!)
+        described_class.call(crime_application)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Hide partner address questions if changes to partner with contrary interest.
Use application purger on submission to ensure orphaned partner assets are removed.

## Link to relevant ticket
[CRIMAPP-1124](https://dsdmoj.atlassian.net/browse/CRIMAPP-1124)
[CRIMAPP-1126](https://dsdmoj.atlassian.net/browse/CRIMAPP-1126)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1124]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1126]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ