### PR TITLE
CRIMAPP-1124 Serialize 'has_no_other_assets' for all applications with any capital details

### DIFF
--- a/app/serializers/submission_serializer/sections/capital_details.rb
+++ b/app/serializers/submission_serializer/sections/capital_details.rb
@@ -26,12 +26,12 @@ module SubmissionSerializer
             )
             json.has_no_properties capital.has_no_properties
             json.properties Definitions::Property.generate(capital.properties)
-            json.has_no_other_assets capital.has_no_other_assets
           end
 
           json.will_benefit_from_trust_fund capital.will_benefit_from_trust_fund
           json.trust_fund_amount_held capital.trust_fund_amount_held_before_type_cast
           json.trust_fund_yearly_dividend capital.trust_fund_yearly_dividend_before_type_cast
+          json.has_no_other_assets capital.has_no_other_assets
 
           if include_partner_in_means_assessment?
             json.partner_will_benefit_from_trust_fund capital.partner_will_benefit_from_trust_fund

--- a/spec/serializers/submission_serializer/sections/capital_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/capital_details_spec.rb
@@ -85,13 +85,14 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
 
       let(:json_output) do
         {
-          will_benefit_from_trust_fund: 'yes',
-          trust_fund_amount_held: 1000,
-          trust_fund_yearly_dividend: 2000,
-          partner_will_benefit_from_trust_fund: 'yes',
-          partner_trust_fund_amount_held: 2000,
-          partner_trust_fund_yearly_dividend: 200,
-          has_frozen_income_or_assets: 'yes'
+          :will_benefit_from_trust_fund => 'yes',
+          :trust_fund_amount_held => 1000,
+          :trust_fund_yearly_dividend => 2000,
+          :partner_will_benefit_from_trust_fund => 'yes',
+          :partner_trust_fund_amount_held => 2000,
+          :partner_trust_fund_yearly_dividend => 200,
+          :has_frozen_income_or_assets => 'yes',
+          'has_no_other_assets' => 'yes'
         }.as_json
       end
 
@@ -104,12 +105,13 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
 
         let(:json_output) do
           {
-            will_benefit_from_trust_fund: 'yes',
-            trust_fund_amount_held: 1000,
-            trust_fund_yearly_dividend: 2000,
-            partner_will_benefit_from_trust_fund: 'yes',
-            partner_trust_fund_amount_held: 2000,
-            partner_trust_fund_yearly_dividend: 200
+            :will_benefit_from_trust_fund => 'yes',
+            :trust_fund_amount_held => 1000,
+            :trust_fund_yearly_dividend => 2000,
+            :partner_will_benefit_from_trust_fund => 'yes',
+            :partner_trust_fund_amount_held => 2000,
+            :partner_trust_fund_yearly_dividend => 200,
+            'has_no_other_assets' => 'yes'
           }.as_json
         end
 


### PR DESCRIPTION


## Description of change
Serialize 'has_no_other_assets' for all applications with any capital details

This question is asked and is required as soon as any capital question is asked (I think!) so needs to be serialized to be stored in ds and shown in review - and therefore make it back to Apply in rehydration if rejected, validator then passes, and no error shown
