### PR TITLE
CRIMAPP-1001: Fix partner employment income routing

### DIFF
--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -223,8 +223,38 @@ RSpec.describe Decisions::IncomeDecisionTree do
       context 'feature flag `employment_journey` is enabled' do
         let(:feature_flag_employment_journey_enabled) { true }
 
-        it 'redirects to the `partner/employment_income` page' do
-          expect(subject).to have_destination('/steps/income/partner/employment_income', :edit, id: crime_application)
+        context 'when route_to_partner_employment_income?' do
+          before do
+            allow_any_instance_of(described_class).to receive(:route_to_partner_employment_income?).and_return(true)
+          end
+
+          it 'redirects to the `partner/employment_income` page' do
+            expect(subject).to have_destination('/steps/income/partner/employment_income', :edit, id: crime_application)
+          end
+        end
+
+        context 'when no route_to_partner_employment_income?' do
+          before do
+            allow_any_instance_of(described_class).to receive(:route_to_partner_employment_income?).and_return(false)
+          end
+
+          context 'with partner employments present' do
+            let(:partner_employments_empty?) { true }
+
+            it 'redirects to the `partner/employer_details` page' do
+              expect(subject).to have_destination('/steps/income/partner/employer_details', :edit,
+                                                  id: crime_application)
+            end
+          end
+
+          context 'with partner employments not present' do
+            let(:partner_employments_empty?) { false }
+
+            it 'redirects to the `partner/employments_summary` page' do
+              expect(subject).to have_destination('/steps/income/partner/employments_summary', :edit,
+                                                  id: crime_application)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## Description of change

Fix partner employment income routing as per 👇 logic.

<img width="1494" alt="Screenshot 2024-06-28 at 14 32 54" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/195928/d9212d9c-34f4-4f7f-bb36-107e27d0a00d">

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1001

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

http://localhost:3000/applications/:id/steps/income/what_is_the_partners_employment_status