### PR TITLE
Fix has partner CTAs and back button

### DIFF
--- a/app/views/steps/client/has_partner/edit.html.erb
+++ b/app/views/steps/client/has_partner/edit.html.erb
@@ -20,7 +20,7 @@
           <p><%= t('.partner_definitions.exclusion') %></p>
         <% end %>
 
-        <%= f.continue_button(secondary: false) %>
+        <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/client/has_partner/edit.html.erb
+++ b/app/views/steps/client/has_partner/edit.html.erb
@@ -1,9 +1,5 @@
 <% title t('.page_title') %>
-<% if FeatureFlags.non_means_tested.enabled? %>
-  <% step_header %>
-<% else %>
-  <% step_header(path: crime_applications_path) %>
-<% end %>
+<% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Description of change
Fix has partner CTAs and back button

## Screenshots of changes (if applicable)

### Before changes:
<img width="1304" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/331b666c-9a4d-4b7f-8343-2da7a7173b02">

### After changes:
<img width="949" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/45827968/4de98991-7d0d-4e34-9e75-c954fcdb4382">

## How to manually test the feature
Get to has_partner page
See Save and continue, AND save and come back later buttons
Click the back link in top left, go back to Applicant NINO