### PR TITLE
[CRIMAPP-1093] Update start and exit page content

### DIFF
--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -10,9 +10,9 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>the application is non-means tested </li>
       <% if FeatureFlags.employment_journey.enabled? %>
-        <li>your client, and any partner they have, is self-employed</li>
+        <li>your client, and any partner they have, is self-employed, in a business partnership or is a director or shareholder in a private company</li>
       <% else %>
-        <li>your client, and any partner they have, is working or self-employed</li>
+        <li>your client, and any partner they have, is working or self-employed, in a business partnership or is a director or shareholder in a private company</li>
       <% end %>
     </ul>
     <p class="govuk-body">For these types of applications, or to tell us about a change in financial circumstances, <%= link_to 'apply using eForms', Settings.eforms_url %>.</p>

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -9,7 +9,11 @@
     <p class="govuk-body">You cannot use this service if:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the application is non-means tested </li>
-      <li>your client, and any partner they have, is working or self-employed</li>
+      <% if FeatureFlags.employment_journey.enabled? %>
+        <li>your client, and any partner they have, is self-employed</li>
+      <% else %>
+        <li>your client, and any partner they have, is working or self-employed</li>
+      <% end %>
     </ul>
     <p class="govuk-body">For these types of applications, or to tell us about a change in financial circumstances, <%= link_to 'apply using eForms', Settings.eforms_url %>.</p>
 

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -7,11 +7,11 @@
     <ul class="govuk-list govuk-list--bullet app-inverted-text">
       <li>their application is non-means tested</li>
       <% if FeatureFlags.employment_journey.enabled? %>
-        <li>they are self-employed</li>
-        <li>they have a partner who is self-employed</li>
+        <li>they are self-employed, in a business partnership or are a director or shareholder in a private company </li>
+        <li>they have a partner who is self-employed, in a business partnership or is a director or shareholder in a private company </li>
       <% else %>
-        <li>they are working or self-employed</li>
-        <li>they have a partner who is working or self-employed</li>
+        <li>they are working or self-employed, in a business partnership or are a director or shareholder in a private company</li>
+        <li>they have a partner who is working or self-employed, in a business partnership or is a director or shareholder in a private company</li>
       <% end %>
     </ul>
 

--- a/app/views/shared/_eforms_redirect.en.html.erb
+++ b/app/views/shared/_eforms_redirect.en.html.erb
@@ -1,43 +1,25 @@
-<% if FeatureFlags.employment_journey.enabled? %>
-  <div class="govuk-grid-row app-inverted--card app-inverted-text">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l app-inverted-text">You need to apply using eForms</h1>
+<div class="govuk-grid-row app-inverted--card app-inverted-text">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l app-inverted-text">You need to apply using eForms</h1>
 
-      <p class="govuk-body app-inverted-text">This is because one or more of the following applies to your client:</p>
+    <p class="govuk-body app-inverted-text">This is because one or more of the following applies to your client:</p>
 
-      <ul class="govuk-list govuk-list--bullet app-inverted-text">
-        <li>they have a partner</li>
-        <li>they do not get a passporting benefit, based on DWP records</li>
-        <li>they are self-employed, in a business partnership, or a director or shareholder in a private company</li>
-      </ul>
-
-      <div class="govuk-button-group govuk-!-margin-top-6">
-        <%= link_button t('helpers.submit.apply_in_eforms'), Settings.eforms_url,
-                        class: 'app-button--m app-button--inverted' %>
-      </div>
-
-      <%= link_to t('helpers.back_to_applications'), crime_applications_path, class: 'app-link--inverted govuk-!-font-size-19' %>
-    </div>
-  </div>
-<% else %>
-  <div class="govuk-grid-row app-inverted--card app-inverted-text">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l app-inverted-text">You need to apply using eForms</h1>
-
-      <p class="govuk-body app-inverted-text">This is because one or more of the following applies to your client:</p>
-
-      <ul class="govuk-list govuk-list--bullet app-inverted-text">
-        <li>their application is non-means tested</li>
+    <ul class="govuk-list govuk-list--bullet app-inverted-text">
+      <li>their application is non-means tested</li>
+      <% if FeatureFlags.employment_journey.enabled? %>
+        <li>they are self-employed</li>
+        <li>they have a partner who is self-employed</li>
+      <% else %>
         <li>they are working or self-employed</li>
         <li>they have a partner who is working or self-employed</li>
-      </ul>
+      <% end %>
+    </ul>
 
-      <div class="govuk-button-group govuk-!-margin-top-6">
-        <%= link_button t('helpers.submit.apply_in_eforms'), Settings.eforms_url,
-                        class: 'app-button--m app-button--inverted' %>
-      </div>
-
-      <%= link_to t('helpers.back_to_applications'), crime_applications_path, class: 'app-link--inverted govuk-!-font-size-19' %>
+    <div class="govuk-button-group govuk-!-margin-top-6">
+      <%= link_button t('helpers.submit.apply_in_eforms'), Settings.eforms_url,
+                      class: 'app-button--m app-button--inverted' %>
     </div>
+
+    <%= link_to t('helpers.back_to_applications'), crime_applications_path, class: 'app-link--inverted govuk-!-font-size-19' %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
## Description of change
Updates start and exit page content ahead of employed release

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**Start and exit pages when employed functionality is enabled but self employed is not** 

<img width="1110" alt="Screenshot 2024-07-01 at 14 44 04" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/dd301146-4cdb-4bd4-8983-77966ea7f463">
<img width="1110" alt="Screenshot 2024-07-01 at 14 43 52" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/322db183-130c-40a6-aa20-9d6f47a0a220">

**Start and exit pages when both employed and self employed functionality is not enabled** 

<img width="1110" alt="Screenshot 2024-07-01 at 14 42 26" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/15aef0f8-ae9d-4423-86ad-b6574f5fb255">
<img width="1110" alt="Screenshot 2024-07-01 at 14 43 02" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/3ff1df03-397f-4c58-8a71-2ab0438d95a3">

## How to manually test the feature

Set the employed feature flag to true and false and check the correct content appears for the start page and the eforms exit screen (triggered by selecting the employed or self employed option depending on whether employed ff is enabled or not)