### PR TITLE
[EXPERIMENTAL] Change RDS AWS CA Cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,12 @@ RUN chown -R appuser:appgroup log tmp
 # Download RDS certificates bundle -- needed for SSL verification
 # We set the path to the bundle in the ENV, and use it in `/config/database.yml`
 #
-ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+# OLD:
+# ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
+# ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+# NEW:
+ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/global-bundle.pem
+ADD https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem $RDS_COMBINED_CA_BUNDLE
 RUN chmod +r $RDS_COMBINED_CA_BUNDLE
 
 ARG APP_BUILD_DATE


### PR DESCRIPTION
## Description of change
Uses modern CA certs for RDS via AWS website

## Link to relevant ticket
https://mojdt.slack.com/archives/CH6D099DF/p1718625451095069

## Notes for reviewer
Unsure if this works - requires Dockerfile rebuild
