### PR TITLE
[CRIMAPP-1132] Do not rehydrate partner details if there is no partner

### DIFF
--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -85,6 +85,7 @@ module Datastore
     end
 
     # NOTE: Actual partner_detail fields are mixed between the Applicant and Partner Structs
+    # rubocop:disable Metrics/AbcSize
     def partner_detail
       return nil unless FeatureFlags.partner_journey.enabled?
       return nil unless parent.partner && parent.applicant.has_partner == 'yes'
@@ -97,6 +98,7 @@ module Datastore
 
       PartnerDetail.new({}.merge(from_applicant).merge(from_partner))
     end
+    # rubocop:enable Metrics/AbcSize
 
     def ioj
       if parent.ioj.present?

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -87,6 +87,7 @@ module Datastore
     # NOTE: Actual partner_detail fields are mixed between the Applicant and Partner Structs
     def partner_detail
       return nil unless FeatureFlags.partner_journey.enabled?
+      return nil unless parent.partner && parent.applicant.has_partner == 'yes'
 
       fields_from_applicant = %w[has_partner relationship_to_partner relationship_status separation_date]
       fields_from_partner = %w[involvement_in_case conflict_of_interest has_same_address_as_client]


### PR DESCRIPTION
## Description of change
Fixes bug when rehydrating an app with no partner
[Link to sentry error alert](https://ministryofjustice.sentry.io/issues/5548400275/?environment=staging&project=4507142444023808&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0) 

## Link to relevant ticket
[CRIMAPP-1132](https://dsdmoj.atlassian.net/browse/CRIMAPP-1132)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1593" alt="Screenshot 2024-07-02 at 09 48 04" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/178fbf4c-0587-4adb-aa3d-fb6477769ef5">


## How to manually test the feature

Return a historical application that does not have a partner 
Verify that you are able to rehydrate with no errors and the data is as expected

[CRIMAPP-1132]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ