### PR TITLE
CRIMAPP-1138 initialize payments from dstore as ActiveRecord

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -25,7 +25,6 @@ class CrimeApplication < ApplicationRecord
   accepts_nested_attributes_for :income_payments, allow_destroy: true
 
   has_many(:income_benefits,
-           ->(object) { where(ownership_type: object.ownership_types) },
            inverse_of: :crime_application,
            dependent: :destroy)
   accepts_nested_attributes_for :income_benefits, allow_destroy: true

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -3,7 +3,6 @@ class Income < ApplicationRecord
   include EmployedIncome
 
   belongs_to :crime_application
-  has_many :income_benefits, through: :crime_application
   has_many :dependants, through: :crime_application
   has_many :businesses, through: :crime_application
 
@@ -36,6 +35,12 @@ class Income < ApplicationRecord
     end
 
     @income_payments = scope
+  end
+
+  def income_benefits
+    @income_benefits ||= crime_application.income_benefits.where(
+      ownership_type: ownership_types
+    )
   end
 
   def complete?

--- a/app/presenters/summary/sections/income_benefits_details.rb
+++ b/app/presenters/summary/sections/income_benefits_details.rb
@@ -12,7 +12,7 @@ module Summary
       private
 
       def payments
-        @payments ||= crime_application.income_benefits.select { |i| i.ownership_type == OwnershipType::APPLICANT.to_s }
+        @payments ||= income.income_benefits.select { |i| i.ownership_type == OwnershipType::APPLICANT.to_s }
       end
 
       def no_payments?

--- a/app/presenters/summary/sections/income_payments_details.rb
+++ b/app/presenters/summary/sections/income_payments_details.rb
@@ -12,7 +12,7 @@ module Summary
       private
 
       def payments
-        @payments ||= crime_application.income_payments.select { |i| i.ownership_type == OwnershipType::APPLICANT.to_s }
+        @payments ||= income.income_payments.select { |i| i.ownership_type == OwnershipType::APPLICANT.to_s }
       end
 
       def no_payments?

--- a/app/presenters/summary/sections/partner_income_benefits_details.rb
+++ b/app/presenters/summary/sections/partner_income_benefits_details.rb
@@ -16,7 +16,7 @@ module Summary
       private
 
       def payments
-        @payments ||= crime_application.income_benefits.select { |i| i.ownership_type == OwnershipType::PARTNER.to_s }
+        @payments ||= income.income_benefits.select { |i| i.ownership_type == OwnershipType::PARTNER.to_s }
       end
 
       def no_payments?

--- a/app/presenters/summary/sections/partner_income_payments_details.rb
+++ b/app/presenters/summary/sections/partner_income_payments_details.rb
@@ -16,7 +16,7 @@ module Summary
       private
 
       def payments
-        @payments ||= crime_application.income_payments.select { |i| i.ownership_type == OwnershipType::PARTNER.to_s }
+        @payments ||= income.income_payments.select { |i| i.ownership_type == OwnershipType::PARTNER.to_s }
       end
 
       def no_payments?

--- a/app/services/adapters/structs/crime_application.rb
+++ b/app/services/adapters/structs/crime_application.rb
@@ -52,22 +52,6 @@ module Adapters
         Structs::IncomeDetails.new(means_details.income_details)
       end
 
-      def income_payments
-        return [] unless means_details&.income_details&.income_payments
-
-        means_details.income_details.income_payments.map do |struct|
-          IncomePayment.new(struct.attributes)
-        end
-      end
-
-      def income_benefits
-        return [] unless means_details&.income_details&.income_benefits
-
-        means_details.income_details.income_benefits.map do |struct|
-          IncomeBenefit.new(struct.attributes)
-        end
-      end
-
       def outgoings
         return nil unless means_details
 

--- a/app/services/adapters/structs/income_details.rb
+++ b/app/services/adapters/structs/income_details.rb
@@ -12,6 +12,18 @@ module Adapters
         Money.new(super)
       end
 
+      def income_payments
+        return [] unless __getobj__
+
+        @income_payments ||= super.map { |struct| IncomePayment.new(**struct) }
+      end
+
+      def income_benefits
+        return [] unless __getobj__
+
+        @income_benefits ||= super.map { |struct| IncomeBenefit.new(**struct) }
+      end
+
       def partner_self_assessment_tax_bill_amount
         Money.new(super)
       end
@@ -33,35 +45,6 @@ module Adapters
         end
       end
 
-      def client_employment_income
-        income_payments.find do |payment|
-          payment.payment_type == IncomePaymentType::EMPLOYMENT.to_s &&
-            payment.ownership_type == OwnershipType::APPLICANT.to_s
-        end
-      end
-
-      def partner_employment_income
-        income_payments.find do |payment|
-          payment.payment_type == IncomePaymentType::EMPLOYMENT.to_s &&
-            payment.ownership_type == OwnershipType::PARTNER.to_s
-        end
-      end
-
-      def client_work_benefits
-        income_payments.find do |payment|
-          payment.payment_type == IncomePaymentType::WORK_BENEFITS.to_s &&
-            payment.ownership_type == OwnershipType::APPLICANT.to_s
-        end
-      end
-
-      def partner_work_benefits
-        income_payments.find do |payment|
-          payment.payment_type == IncomePaymentType::WORK_BENEFITS.to_s &&
-            payment.ownership_type == OwnershipType::PARTNER.to_s
-        end
-      end
-
-      # TODO: remove businesses exclusion once businesses added
       def serializable_hash(options = {})
         super(
           options.merge(

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -28,9 +28,9 @@ module Datastore
         outgoings_payments: outgoings_payments,
         documents: parent.documents,
         additional_information: parent.additional_information,
-        income_payments: income_payments,
-        income_benefits: income_benefits,
-        employments: employments,
+        income_payments: parent.income.income_payments,
+        income_benefits: parent.income.income_benefits,
+        employments: parent.income.employments,
         capital: capital,
         savings: capital ? parent.capital.savings : [],
         investments: capital ? parent.capital.investments : [],
@@ -121,28 +121,12 @@ module Datastore
       end || []
     end
 
-    def income_payments
-      parent.means_details&.income_details&.income_payments&.map do |struct|
-        IncomePayment.new(**struct)
-      end || []
-    end
-
-    def income_benefits
-      parent.means_details&.income_details&.income_benefits&.map do |struct|
-        IncomeBenefit.new(**struct)
-      end || []
-    end
-
     def income
       return if parent.income.blank?
 
       Income.new(
         parent.income.serializable_hash
       )
-    end
-
-    def employments
-      parent.income.employments
     end
 
     def outgoings

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -14,9 +14,7 @@ describe Summary::HtmlPresenter do
       partner: double(first_name: 'Test first name'), partner_detail: double(PartnerDetail, involvement_in_case: 'none'),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
       income: income,
-      income_payments: [instance_double(IncomePayment, ownership_type: 'applicant', payment_type: 'maintenance'), instance_double(IncomePayment, ownership_type: 'partner', payment_type: 'maintenance')],
       outgoings_payments: [instance_double(OutgoingsPayment, payment_type: 'childcare')],
-      income_benefits: [instance_double(IncomeBenefit, ownership_type: 'applicant', payment_type: 'incapacity'), instance_double(IncomeBenefit, ownership_type: 'partner', payment_type: 'jsa')],
       outgoings: (double has_no_other_outgoings: nil),
       documents: double, application_type: application_type,
       capital: (double has_premium_bonds: 'yes', partner_has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', partner_will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
@@ -28,6 +26,10 @@ describe Summary::HtmlPresenter do
   let(:income) do
     instance_double(
       Income,
+      income_payments: [instance_double(IncomePayment, ownership_type: 'applicant', payment_type: 'maintenance'),
+                        instance_double(IncomePayment, ownership_type: 'partner', payment_type: 'maintenance')],
+      income_benefits: [instance_double(IncomeBenefit, ownership_type: 'applicant', payment_type: 'incapacity'),
+                        instance_double(IncomeBenefit, ownership_type: 'partner', payment_type: 'jsa')],
       partner_employment_status: [EmploymentStatus::NOT_WORKING.to_s],
       client_employment_income: nil,
       partner_employment_income: nil,

--- a/spec/presenters/summary/sections/income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/income_benefits_details_spec.rb
@@ -7,8 +7,7 @@ describe Summary::Sections::IncomeBenefitsDetails do # rubocop:disable RSpec/Mul
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      income: income,
-      income_benefits: income_benefits,
+      income: income
     )
   end
 
@@ -16,7 +15,8 @@ describe Summary::Sections::IncomeBenefitsDetails do # rubocop:disable RSpec/Mul
     instance_double(
       Income,
       income_above_threshold: 'yes',
-      has_no_income_benefits: has_no_income_benefits
+      has_no_income_benefits: has_no_income_benefits,
+      income_benefits: income_benefits,
     )
   end
 

--- a/spec/presenters/summary/sections/income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/income_payments_details_spec.rb
@@ -9,13 +9,13 @@ describe Summary::Sections::IncomePaymentsDetails do
       CrimeApplication,
       to_param: '12345',
       income: income,
-      income_payments: income_payments,
     )
   end
 
   let(:income) do
     instance_double(
       Income,
+      income_payments: income_payments,
       income_above_threshold: 'yes',
       has_no_income_payments: has_no_income_payments
     )

--- a/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
@@ -9,15 +9,15 @@ describe Summary::Sections::PartnerIncomeBenefitsDetails do
       to_param: '12345',
       income: income,
       partner: instance_double(Partner),
-      partner_detail: instance_double(PartnerDetail, involvement_in_case: 'none'),
-      income_benefits: income_benefits
+      partner_detail: instance_double(PartnerDetail, involvement_in_case: 'none')
     )
   end
 
   let(:income) do
     instance_double(
       Income,
-      partner_has_no_income_benefits:
+      partner_has_no_income_benefits:,
+      income_benefits:
     )
   end
 

--- a/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
@@ -8,7 +8,6 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
       CrimeApplication,
       to_param: '12345',
       income: income,
-      income_payments: income_payments,
       applicant: applicant,
       partner_detail: instance_double(PartnerDetail, involvement_in_case:),
       partner: partner
@@ -21,7 +20,8 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
   let(:income) do
     instance_double(
       Income,
-      partner_has_no_income_payments:
+      partner_has_no_income_payments:,
+      income_payments:,
     )
   end
 


### PR DESCRIPTION
## Description of change

Fix issue where datastore amounts were presented as pounds in pence.
Ensure all datastore payments are loaded as ActiveRecord objects rather than structs for IncomePayment or IncomeBenefits rather than struct.
Refactor to makes sure all income payments / benefits are accessed via Income in summary views.

## Link to relevant ticket

[CRIMAPP-1138](https://dsdmoj.atlassian.net/browse/CRIMAPP-1138)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1037" alt="Screenshot 2024-07-03 at 11 49 23" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/9cc8168e-54c1-4b64-9f12-ad0603ef83a2">

### After changes:

<img width="998" alt="Screenshot 2024-07-03 at 11 49 07" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/a7918c43-091f-4293-b65e-dc4c44d09a9c">


## How to manually test the feature


[CRIMAPP-1138]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ