### PR TITLE
CRIMAPP-1136 Fix employed loop incomplete job routing

### DIFF
--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -241,7 +241,7 @@ module Decisions
 
     def employment_start
       if requires_full_means_assessment?
-        if income.client_employments.empty?
+        if income.client_employments.empty? || incomplete_client_employments.present?
           redirect_to_employer_details(client_employment)
         else
           edit('/steps/income/client/employments_summary')
@@ -253,7 +253,7 @@ module Decisions
 
     def partner_employment_start
       if requires_full_means_assessment?
-        if income.partner_employments.empty?
+        if income.partner_employments.empty? || incomplete_partner_employments.present?
           redirect_to_partner_employer_details(partner_employment)
         else
           edit('/steps/income/partner/employments_summary')


### PR DESCRIPTION
## Description of change

When starting the employment loop:
If there are no existing jobs, route to the 'employer details' page.
If there is an incomplete job, route to the 'employer details' page for this job.
If there are existing jobs but all are complete, route to the shopping basket.

## Link to relevant ticket

[CRIMAPP-1136](https://dsdmoj.atlassian.net/browse/CRIMAPP-1136)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1136]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ