### PR TITLE
CRIMAPP-1158 do not show/send other work benefits if no longer needed

### DIFF
--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -51,6 +51,14 @@ class Income < ApplicationRecord
     super if partner_employed? && known_to_be_full_means? && MeansStatus.include_partner?(crime_application)
   end
 
+  def applicant_other_work_benefit_received
+    super if client_employed? && known_to_be_full_means?
+  end
+
+  def partner_other_work_benefit_received
+    super if partner_employed? && known_to_be_full_means? && MeansStatus.include_partner?(crime_application)
+  end
+
   def complete?
     valid?(:submission)
   end

--- a/spec/forms/steps/income/client/other_work_benefits_form_spec.rb
+++ b/spec/forms/steps/income/client/other_work_benefits_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
 
   let(:crime_application) { CrimeApplication.new applicant: }
   let(:applicant) { Applicant.new }
-  let(:income) { Income.new(crime_application:) }
+  let(:income) { Income.new(crime_application: crime_application, employment_status: ['employed']) }
   let(:income_payment) {
     IncomePayment.new(crime_application: crime_application,
                       payment_type: IncomePaymentType::WORK_BENEFITS.to_s)
@@ -21,6 +21,10 @@ RSpec.describe Steps::Income::Client::OtherWorkBenefitsForm do
 
   let(:applicant_other_work_benefit_received) { nil }
   let(:amount) { nil }
+
+  before do
+    allow(MeansStatus).to receive_messages(full_means_required?: true)
+  end
 
   describe '#build' do
     subject(:form) { described_class.build(crime_application) }

--- a/spec/forms/steps/income/partner/other_work_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/other_work_benefits_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
 
   let(:partner) { Partner.new }
 
-  let(:income) { Income.new(crime_application:) }
+  let(:income) { Income.new(crime_application: crime_application, partner_employment_status: ['employed']) }
   let(:partner_income_payment) {
     IncomePayment.new(crime_application: crime_application,
                       payment_type: IncomePaymentType::WORK_BENEFITS.to_s,
@@ -32,6 +32,7 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
   let(:amount) { nil }
 
   before do
+    allow(MeansStatus).to receive_messages(full_means_required?: true, include_partner?: true)
     allow(partner).to receive(:income_payments).and_return(double(work_benefits: partner_income_payment))
   end
 

--- a/spec/models/income_spec.rb
+++ b/spec/models/income_spec.rb
@@ -194,6 +194,88 @@ RSpec.describe Income, type: :model do
     end
   end
 
+  describe '#applicant_other_work_benefit_received' do
+    subject(:applicant_other_work_benefit_received) { income.applicant_other_work_benefit_received }
+
+    before do
+      income.applicant_other_work_benefit_received = 'yes'
+    end
+
+    context 'when not known if full means are necessary' do
+      before do
+        allow(MeansStatus).to receive(:full_means_required?).and_raise(
+          Errors::CannotYetDetermineFullMeans
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when full means required and client is employed' do
+      before do
+        income.employment_status = ['employed']
+        allow(MeansStatus).to receive(:full_means_required?).and_return(true)
+      end
+
+      it { is_expected.to eq 'yes' }
+    end
+
+    context 'when full means required and client is not employed' do
+      before do
+        income.employment_status = ['not_working']
+        allow(MeansStatus).to receive(:full_means_required?).and_return(true)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#partner_other_work_benefit_received' do
+    subject(:partner_other_work_benefit_received) { income.partner_other_work_benefit_received }
+
+    before do
+      allow(MeansStatus).to receive(:include_partner?).and_return(true)
+      income.partner_other_work_benefit_received = 'yes'
+    end
+
+    context 'when not known if full means are necessary' do
+      before do
+        allow(MeansStatus).to receive(:full_means_required?).and_raise(
+          Errors::CannotYetDetermineFullMeans
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when full means required and partner is employed' do
+      before do
+        income.partner_employment_status = ['employed']
+        allow(MeansStatus).to receive(:full_means_required?).and_return(true)
+      end
+
+      it { is_expected.to eq 'yes' }
+    end
+
+    context 'when full means required and partner is employed and no longer mean assessed' do
+      before do
+        income.partner_employment_status = ['employed']
+        allow(MeansStatus).to receive_messages(full_means_required?: true, include_partner?: false)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when full means required and client is not employed' do
+      before do
+        income.partner_employment_status = ['not_working']
+        allow(MeansStatus).to receive(:full_means_required?).and_return(true)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#client_employment_income' do
     subject(:client_employment_income) { income.client_employment_income }
 

--- a/spec/services/evidence/rules/20240426014955_benefits_in_kind_spec.rb
+++ b/spec/services/evidence/rules/20240426014955_benefits_in_kind_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Evidence::Rules::BenefitsInKind do
   let(:include_partner?) { true }
 
   before do
-    allow(MeansStatus).to receive(:include_partner?).and_return(include_partner?)
+    allow(MeansStatus).to receive_messages(include_partner?: include_partner?, full_means_required?: true)
   end
 
   it { expect(described_class.key).to eq :income_noncash_benefit_4 }
@@ -22,22 +22,28 @@ RSpec.describe Evidence::Rules::BenefitsInKind do
   describe '.client' do
     subject { described_class.new(crime_application).client_predicate }
 
-    context 'when applicant receives non cash benefit' do
-      let(:income) { Income.new(applicant_other_work_benefit_received: 'yes') }
+    context 'when client employed' do
+      before do
+        income.employment_status = ['employed']
+      end
 
-      it { is_expected.to be true }
-    end
+      context 'when applicant receives non cash benefit' do
+        let(:income) { Income.new(applicant_other_work_benefit_received: 'yes') }
 
-    context 'when applicant does not receive non cash benefit' do
-      let(:income) { Income.new(applicant_other_work_benefit_received: 'no') }
+        it { is_expected.to be true }
+      end
 
-      it { is_expected.to be false }
-    end
+      context 'when applicant does not receive non cash benefit' do
+        let(:income) { Income.new(applicant_other_work_benefit_received: 'no') }
 
-    context 'question was not asked' do
-      let(:income) { Income.new(applicant_other_work_benefit_received: nil) }
+        it { is_expected.to be false }
+      end
 
-      it { is_expected.to be false }
+      context 'question was not asked' do
+        let(:income) { Income.new(applicant_other_work_benefit_received: nil) }
+
+        it { is_expected.to be false }
+      end
     end
 
     context 'income is not present' do
@@ -50,28 +56,34 @@ RSpec.describe Evidence::Rules::BenefitsInKind do
   describe '.partner' do
     subject { described_class.new(crime_application).partner_predicate }
 
-    context 'when partner receives non cash benefit' do
-      let(:income) { Income.new(partner_other_work_benefit_received: 'yes') }
+    context 'when partner employed' do
+      before do
+        income.partner_employment_status = ['employed']
+      end
 
-      it { is_expected.to be true }
-    end
+      context 'when partner receives non cash benefit' do
+        let(:income) { Income.new(partner_other_work_benefit_received: 'yes') }
 
-    context 'when partner does not receive non cash benefit' do
-      let(:income) { Income.new(partner_other_work_benefit_received: 'no') }
+        it { is_expected.to be true }
+      end
 
-      it { is_expected.to be false }
-    end
+      context 'when partner does not receive non cash benefit' do
+        let(:income) { Income.new(partner_other_work_benefit_received: 'no') }
 
-    context 'when question was not asked' do
-      let(:income) { Income.new(partner_other_work_benefit_received: nil) }
+        it { is_expected.to be false }
+      end
 
-      it { is_expected.to be false }
-    end
+      context 'when question was not asked' do
+        let(:income) { Income.new(partner_other_work_benefit_received: nil) }
 
-    context 'when there is no partner' do
-      let(:include_partner?) { false }
+        it { is_expected.to be false }
+      end
 
-      it { is_expected.to be false }
+      context 'when there is no partner' do
+        let(:include_partner?) { false }
+
+        it { is_expected.to be false }
+      end
     end
 
     context 'income is not present' do
@@ -90,6 +102,8 @@ RSpec.describe Evidence::Rules::BenefitsInKind do
       Income.new(
         applicant_other_work_benefit_received: 'yes',
         partner_other_work_benefit_received: 'yes',
+        employment_status: ['employed'],
+        partner_employment_status: ['employed']
       )
     end
 


### PR DESCRIPTION
## Description of change

Do not show other employed benefit answer when not required.

## Link to relevant ticket
[CRIMAPP-1158](https://dsdmoj.atlassian.net/browse/CRIMAPP-1158)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1158]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ