### PR TITLE
Remove has partner feature flag

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -18,10 +18,8 @@ class CrimeApplicationsController < DashboardController
     initialize_crime_application do |crime_application|
       if FeatureFlags.non_means_tested.enabled?
         redirect_to edit_steps_client_is_means_tested_path(crime_application)
-      elsif FeatureFlags.partner_journey.enabled?
-        redirect_to edit_crime_application_path(crime_application)
       else
-        redirect_to edit_steps_client_has_partner_path(crime_application)
+        redirect_to edit_crime_application_path(crime_application)
       end
     end
   end

--- a/app/presenters/summary/sections/other_outgoings_details.rb
+++ b/app/presenters/summary/sections/other_outgoings_details.rb
@@ -16,7 +16,7 @@ module Summary
           ),
         ]
 
-        if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+        if include_partner_in_means_assessment?
           answers.push(
             Components::ValueAnswer.new(
               :partner_income_tax_rate_above_threshold, outgoings.partner_income_tax_rate_above_threshold,

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -2,9 +2,7 @@ module Summary
   module Sections
     class PartnerDetails < Sections::BaseSection
       def show?
-        return false unless FeatureFlags.partner_journey.enabled?
-
-        partner&.first_name.present? && client.present? && super
+        client.present? && partner&.first_name.present? && super
       end
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/presenters/summary/sections/partner_income_benefits_details.rb
+++ b/app/presenters/summary/sections/partner_income_benefits_details.rb
@@ -6,7 +6,6 @@ module Summary
       include TypeOfMeansAssessment
 
       def show?
-        return false unless FeatureFlags.partner_journey.enabled?
         return false if income.blank?
         return false unless include_partner_in_means_assessment?
 

--- a/app/presenters/summary/sections/partner_income_payments_details.rb
+++ b/app/presenters/summary/sections/partner_income_payments_details.rb
@@ -6,7 +6,6 @@ module Summary
       include TypeOfMeansAssessment
 
       def show?
-        return false unless FeatureFlags.partner_journey.enabled?
         return false if income.blank?
         return false unless include_partner_in_means_assessment?
 

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -78,8 +78,7 @@ module Datastore
     end
 
     def partner
-      return nil unless FeatureFlags.partner_journey.enabled?
-      return nil unless parent.partner && parent.applicant.has_partner == 'yes'
+      return nil unless parent.applicant.has_partner == 'yes' && parent.partner
 
       attributes_to_ignore = PartnerDetail.fields + %w[benefit_check_status is_included_in_means_assessment]
       attributes = parent.partner.serializable_hash.except!(*attributes_to_ignore)
@@ -88,8 +87,6 @@ module Datastore
 
     # NOTE: Actual partner_detail fields are mixed between the Applicant and Partner Structs
     def partner_detail
-      return nil unless FeatureFlags.partner_journey.enabled?
-
       fields_from_applicant = %w[has_partner relationship_to_partner relationship_status separation_date]
       from_applicant = parent.applicant.serializable_hash.slice(*fields_from_applicant)
 

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -103,7 +103,7 @@ module Decisions
     end
 
     def after_client_trust_fund
-      if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      if include_partner_in_means_assessment?
         edit(:partner_trust_fund)
       else
         after_trust_fund
@@ -169,7 +169,7 @@ module Decisions
     end
 
     def after_premium_bonds
-      if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      if include_partner_in_means_assessment?
         edit(:partner_premium_bonds)
       else
         edit(:has_national_savings_certificates)

--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -75,8 +75,7 @@ module Decisions
     end
 
     def partner_benefit_type_required?
-      form_object.benefit_type.none? &&
-        FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      form_object.benefit_type.none? && include_partner_in_means_assessment?
     end
 
     def after_has_benefit_evidence

--- a/app/services/decisions/income_decision_tree.rb
+++ b/app/services/decisions/income_decision_tree.rb
@@ -286,7 +286,7 @@ module Decisions
     end
 
     def determine_showing_no_income_page
-      if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      if include_partner_in_means_assessment?
         edit(:partner_employment_status)
       elsif crime_application.income&.all_income_over_zero?
         edit(:answers)

--- a/app/services/decisions/outgoings_decision_tree.rb
+++ b/app/services/decisions/outgoings_decision_tree.rb
@@ -37,7 +37,7 @@ module Decisions
     end
 
     def after_income_tax_rate
-      if FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      if include_partner_in_means_assessment?
         edit(:partner_income_tax_rate)
       else
         edit(:outgoings_more_than_income)

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -64,7 +64,7 @@ module CapitalAssessment
     end
 
     def partner_premium_bonds_complete?
-      return true unless FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      return true unless include_partner_in_means_assessment?
       return true if record.partner_has_premium_bonds == 'no'
       return false unless record.partner_has_premium_bonds == 'yes'
 
@@ -101,7 +101,7 @@ module CapitalAssessment
     end
 
     def partner_trust_fund_complete?
-      return true unless FeatureFlags.partner_journey.enabled? && include_partner_in_means_assessment?
+      return true unless include_partner_in_means_assessment?
       return true if record.partner_will_benefit_from_trust_fund == 'no'
       return false unless record.partner_will_benefit_from_trust_fund == 'yes'
 

--- a/app/validators/client_details/answers_validator.rb
+++ b/app/validators/client_details/answers_validator.rb
@@ -61,14 +61,12 @@ module ClientDetails
     end
 
     def client_has_partner_complete?
-      return true unless FeatureFlags.partner_journey.enabled?
       return true if appeal_no_changes? || applicant.under18?
 
       record.client_has_partner.present?
     end
 
     def relationship_status_complete?
-      return true unless FeatureFlags.partner_journey.enabled?
       return true if appeal_no_changes? || applicant.under18?
       return true if record.client_has_partner == 'yes'
 

--- a/app/validators/income_assessment/answers_validator.rb
+++ b/app/validators/income_assessment/answers_validator.rb
@@ -52,7 +52,6 @@ module IncomeAssessment
     end
 
     def partner_income_payments_complete?
-      return true unless FeatureFlags.partner_journey.enabled?
       return true if crime_application.income.partner_has_no_income_payments.to_s == 'yes'
       return true unless include_partner_in_means_assessment?
 
@@ -66,7 +65,6 @@ module IncomeAssessment
     end
 
     def partner_income_benefits_complete?
-      return true unless FeatureFlags.partner_journey.enabled?
       return true if crime_application.income.partner_has_no_income_benefits.to_s == 'yes'
       return true unless include_partner_in_means_assessment?
 

--- a/app/validators/outgoings_assessment/answers_validator.rb
+++ b/app/validators/outgoings_assessment/answers_validator.rb
@@ -76,7 +76,6 @@ module OutgoingsAssessment
     end
 
     def partner_income_tax_rate_complete?
-      return true unless FeatureFlags.partner_journey.enabled?
       return true unless include_partner_in_means_assessment?
 
       record.partner_income_tax_rate_above_threshold.present?

--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -30,7 +30,6 @@ class SectionsCompletenessValidator
   delegate :client_details_complete?, :passporting_benefit_complete?, to: :crime_application
 
   def partner_detail_complete?
-    return true unless FeatureFlags.partner_journey.enabled?
     return true if appeal_no_changes? || applicant&.under18?
     return false unless partner_detail
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,16 +118,14 @@ Rails.application.routes.draw do
         edit_step :relationship_status
       end
 
-      if FeatureFlags.partner_journey.enabled?
-        namespace :partner do
-          edit_step :client_relationship_to_partner, alias: :relationship
-          edit_step :partner_details, alias: :details
-          edit_step :partner_nino, alias: :nino
-          edit_step :partner_involved_in_case, alias: :involvement
-          edit_step :partner_conflict_of_interest, alias: :conflict
-          edit_step :do_client_and_partner_live_same_address, alias: :same_address
-          edit_step :enter_partner_address, alias: :address
-        end
+      namespace :partner do
+        edit_step :client_relationship_to_partner, alias: :relationship
+        edit_step :partner_details, alias: :details
+        edit_step :partner_nino, alias: :nino
+        edit_step :partner_involved_in_case, alias: :involvement
+        edit_step :partner_conflict_of_interest, alias: :conflict
+        edit_step :do_client_and_partner_live_same_address, alias: :same_address
+        edit_step :enter_partner_address, alias: :address
       end
 
       namespace :dwp do
@@ -217,12 +215,8 @@ Rails.application.routes.draw do
         edit_step :which_payments_client, alias: :income_payments
         edit_step :which_benefits_client, alias: :income_benefits
         edit_step :check_your_answers_income, alias: :answers
-
-        if FeatureFlags.partner_journey.enabled?
-          edit_step :which_payments_partner, alias: :income_payments_partner
-          edit_step :which_benefits_partner, alias: :income_benefits_partner
-        end
-
+        edit_step :which_payments_partner, alias: :income_payments_partner
+        edit_step :which_benefits_partner, alias: :income_benefits_partner
         edit_step :what_is_the_partners_employment_status, alias: :partner_employment_status
       end
 
@@ -230,9 +224,7 @@ Rails.application.routes.draw do
         edit_step :housing_payments_where_lives, alias: :housing_payment_type
         edit_step :pay_council_tax, alias: :council_tax
         edit_step :client_paid_income_tax_rate, alias: :income_tax_rate
-        if FeatureFlags.partner_journey.enabled?
-          edit_step :partner_paid_income_tax_rate, alias: :partner_income_tax_rate
-        end
+        edit_step :partner_paid_income_tax_rate, alias: :partner_income_tax_rate
         edit_step :are_outgoings_more_than_income, alias: :outgoings_more_than_income
         edit_step :which_payments, alias: :outgoings_payments
         edit_step :mortgage_payments, alias: :mortgage
@@ -268,10 +260,8 @@ Rails.application.routes.draw do
 
         edit_step :client_any_premium_bonds, alias: :premium_bonds
         edit_step :client_benefit_from_trust_fund, alias: :trust_fund
-        if FeatureFlags.partner_journey.enabled?
-          edit_step :partner_any_premium_bonds, alias: :partner_premium_bonds
-          edit_step :partner_benefit_from_trust_fund, alias: :partner_trust_fund
-        end
+        edit_step :partner_any_premium_bonds, alias: :partner_premium_bonds
+        edit_step :partner_benefit_from_trust_fund, alias: :partner_trust_fund
         edit_step :income_savings_assets_under_restraint_freezing_order, alias: :frozen_income_savings_assets_capital
 
         edit_step :check_your_answers_capital, alias: :answers

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,10 +23,6 @@ feature_flags:
     local: false
     staging: false
     production: false
-  partner_journey:
-    local: true
-    staging: true
-    production: true
   employment_journey:
     local: true
     staging: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -199,10 +199,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_18_144807) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_title"
-    t.string "has_no_deductions"
     t.bigint "amount"
     t.string "frequency"
     t.jsonb "metadata", default: {}, null: false
+    t.string "has_no_deductions"
     t.index ["crime_application_id"], name: "index_employments_on_crime_application_id"
   end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -32,21 +32,6 @@ RSpec.describe 'Dashboard', :authorized do
         }
       end
 
-      context 'when the `partner journey` feature flag is enabled' do
-        before do
-          allow(FeatureFlags).to receive(:partner_journey) {
-            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
-          }
-        end
-
-        it 'creates a new `crime_application` record and redirects to the does client have partner screen' do
-          expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
-
-          expect(response).to have_http_status(:redirect)
-          expect(response).to redirect_to(/does_client_have_partner/)
-        end
-      end
-
       it 'creates a new `crime_application` record and redirects to the task list' do
         expect { post crime_applications_path }.to change(CrimeApplication, :count).by(1)
 

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -1064,12 +1064,6 @@ RSpec.describe Decisions::IncomeDecisionTree do
     context 'when the partner is included in means assessment' do
       let(:partner_detail) { double(PartnerDetail, involvement_in_case: 'none') }
 
-      before do
-        allow(FeatureFlags).to receive(:partner_journey) {
-          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-        }
-      end
-
       it { is_expected.to have_destination(:partner_employment_status, :edit, id: crime_application) }
     end
 


### PR DESCRIPTION
## Description of change
Remove has partner feature flag

Because the partner question moved in flow it makes the routing if partner on vs off conditionals really tricky to maintain - especially once combined with non-means.
## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
