### PR TITLE
CRIMAPP-1180 - Retrieve before_or_after_tax value as string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.22'
+    ref: '58cf09d922ac0eeb64084201184955fda58c82ca'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '58cf09d922ac0eeb64084201184955fda58c82ca'
+    ref: '4655c9b8283dd75ac9362d0df159d25502359d56'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 58cf09d922ac0eeb64084201184955fda58c82ca
-  ref: 58cf09d922ac0eeb64084201184955fda58c82ca
+  revision: 4655c9b8283dd75ac9362d0df159d25502359d56
+  ref: 4655c9b8283dd75ac9362d0df159d25502359d56
   specs:
     laa-criminal-legal-aid-schemas (1.1.23)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 755664244cb7920bc4481ace3d8dae22574c4d7b
-  tag: v1.1.22
+  revision: 58cf09d922ac0eeb64084201184955fda58c82ca
+  ref: 58cf09d922ac0eeb64084201184955fda58c82ca
   specs:
-    laa-criminal-legal-aid-schemas (1.1.22)
+    laa-criminal-legal-aid-schemas (1.1.23)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
@@ -143,13 +143,13 @@ GEM
     dotenv-rails (3.1.2)
       dotenv (= 3.1.2)
       railties (>= 6.1)
-    dry-configurable (1.1.0)
+    dry-configurable (1.2.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
-    dry-inflector (1.0.0)
+    dry-inflector (1.1.0)
     dry-initializer (3.1.1)
     dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)

--- a/app/presenters/summary/components/payment_answer.rb
+++ b/app/presenters/summary/components/payment_answer.rb
@@ -31,7 +31,7 @@ module Summary
       end
 
       def tax_status
-        val = value.respond_to?(:metadata) && value.metadata.to_h.dig('before_or_after_tax', 'value')
+        val = value.respond_to?(:metadata) && value.metadata.to_h['before_or_after_tax']
         t("summary.#{val}") if val
       end
     end

--- a/app/views/steps/income/client/employment_details/edit.html.erb
+++ b/app/views/steps/income/client/employment_details/edit.html.erb
@@ -7,7 +7,6 @@
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-    <% @form_object.before_or_after_tax = @form_object.record.before_or_after_tax['value'] if @form_object.record.before_or_after_tax %>
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :job_title, autocomplete: 'off', width: 'one-third' %>
       <%= f.govuk_number_field :amount, autocomplete: 'off', inputmode: 'numeric', width: 'one-third', prefix_text: '£' %>

--- a/app/views/steps/income/partner/employment_details/edit.html.erb
+++ b/app/views/steps/income/partner/employment_details/edit.html.erb
@@ -7,7 +7,6 @@
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-    <% @form_object.before_or_after_tax = @form_object.record.before_or_after_tax['value'] if @form_object.record.before_or_after_tax %>
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :job_title, autocomplete: 'off', width: 'one-third' %>
       <%= f.govuk_number_field :amount, autocomplete: 'off', inputmode: 'numeric', width: 'one-third', prefix_text: '£' %>

--- a/spec/forms/steps/income/client/employment_details_form_spec.rb
+++ b/spec/forms/steps/income/client/employment_details_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Steps::Income::Client::EmploymentDetailsForm do
       job_title: job_title,
       amount: 100,
       frequency: PaymentFrequencyType::MONTHLY.to_s,
-      before_or_after_tax: BeforeOrAfterTax::AFTER.to_s
+      before_or_after_tax: BeforeOrAfterTax::AFTER
     }
   end
 

--- a/spec/forms/steps/income/partner/employment_details_form_spec.rb
+++ b/spec/forms/steps/income/partner/employment_details_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Steps::Income::Partner::EmploymentDetailsForm do
       job_title: job_title,
       amount: 100,
       frequency: PaymentFrequencyType::MONTHLY.to_s,
-      before_or_after_tax: BeforeOrAfterTax::AFTER.to_s
+      before_or_after_tax: BeforeOrAfterTax::AFTER
     }
   end
 

--- a/spec/models/employment_spec.rb
+++ b/spec/models/employment_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Employment, type: :model do
 
   let(:metadata) do
     {
-      before_or_after_tax: { value: 'before_tax' }
+      before_or_after_tax: 'before_tax'
     }.as_json
   end
 

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -68,7 +68,7 @@ describe Summary::HtmlPresenter do
               'amount' => 25_000,
               'frequency' => 'annual',
               'ownership_type' => 'applicant',
-              'metadata' => { 'before_or_after_tax' => { 'value' => 'before_tax' } },
+              'metadata' => { 'before_or_after_tax' => 'before_tax' },
               'deductions' => [
                 {
                   'deduction_type' => 'income_tax',
@@ -102,7 +102,7 @@ describe Summary::HtmlPresenter do
               'amount' => 12_000,
               'frequency' => 'annual',
               'ownership_type' => 'applicant',
-              'metadata' => { 'before_or_after_tax' => { 'value' => 'after_tax' } },
+              'metadata' => { 'before_or_after_tax' => 'after_tax' },
               'deductions' => []
             }
           ],

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
                     amount_before_type_cast: 25_000,
                     frequency: 'annual',
                     ownership_type: 'applicant',
-                    metadata: { before_or_after_tax: { 'value' => 'before_tax' } }.as_json,
+                    metadata: { before_or_after_tax: 'before_tax' }.as_json,
                     deductions: deductions_double,
                     complete?: true,
                     annualized_amount: Money.new(1500))
@@ -242,7 +242,7 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
                     amount_before_type_cast: 35_000,
                     frequency: 'annual',
                     ownership_type: 'partner',
-                    metadata: { before_or_after_tax: { 'value' => 'after_tax' } }.as_json,
+                    metadata: { before_or_after_tax: 'after_tax' }.as_json,
                     deductions: deductions_double,
                     complete?: true,
                     annualized_amount: Money.new(2500))
@@ -359,7 +359,7 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
             amount: 25_000,
             frequency: 'annual',
             ownership_type: 'applicant',
-            metadata: { before_or_after_tax: { 'value' => 'before_tax' } },
+            metadata: { before_or_after_tax: 'before_tax' },
             deductions: [
               {
                 deduction_type: 'income_tax',
@@ -395,7 +395,7 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
             amount: 35_000,
             frequency: 'annual',
             ownership_type: 'partner',
-            metadata: { before_or_after_tax: { 'value' => 'after_tax' } },
+            metadata: { before_or_after_tax: 'after_tax' },
             deductions: [
               {
                 deduction_type: 'income_tax',


### PR DESCRIPTION
## Description of change

Fix specs to use correct 'metadata' values
Update Schema https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/179 to accept correct metadata value

INCORRECT TEST DATA
```
means_details > income_details > income_payments[] > {"metadata"=>{"before_or_after_tax"=> { "value" => "after_tax"}}}
means_details > income_details > employments[] > {"metadata"=>{"before_or_after_tax"=>{"value"=>"after_tax"}}}
```
CORRECT TEST DATA

```
means_details > income_details > income_payments[] > {"metadata"=>{"before_or_after_tax"=>"after_tax"}}
means_details > income_details > employments[] > {"metadata"=>{"before_or_after_tax"=>"after_tax"}}
```

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1180

## Notes for reviewer
> [!NOTE]  
> To update schema version after schema approval https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/179


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
