### PR TITLE
CRIMAPP-1187 fix submission when means extent unknown

### DIFF
--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -44,6 +44,7 @@ class SectionsCompletenessValidator
   end
 
   def outgoings_assessment_complete?
+    return false unless extent_of_means_assessment_determined?
     return true unless requires_full_means_assessment?
     return false unless outgoings
 
@@ -51,6 +52,7 @@ class SectionsCompletenessValidator
   end
 
   def capital_assessment_complete?
+    return false unless extent_of_means_assessment_determined?
     return true unless requires_full_means_assessment?
     return false unless capital
 

--- a/spec/validators/sections_completeness_validator_spec.rb
+++ b/spec/validators/sections_completeness_validator_spec.rb
@@ -126,6 +126,37 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
         end
       end
 
+      context 'when extent of means assessment is not yet known' do
+        before do
+          allow(subject).to receive(:requires_means_assessment?).and_return(true)
+          allow(subject).to receive(:requires_full_means_assessment?).and_raise(
+            Errors::CannotYetDetermineFullMeans
+          )
+        end
+
+        let(:attributes) do
+          {
+            client_details_complete?: true,
+            passporting_benefit_complete?: true,
+            kase: double(complete?: true),
+            income: double(complete?: true),
+            outgoings: double(complete?: true),
+            capital: double(complete?: true),
+            partner_detail: double(complete?: true),
+            appeal_no_changes?: false,
+            applicant: double(under18?: false),
+          }
+        end
+
+        it 'adds errors to outgoings, capital, base' do
+          expect(errors).to receive(:add).with(:outgoings_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:capital_assessment, :incomplete)
+          expect(errors).to receive(:add).with(:base, :incomplete_records)
+
+          subject.validate
+        end
+      end
+
       context 'when income, outgoings, capital and partner details are missing' do
         let(:attributes) do
           {


### PR DESCRIPTION
## Description of change

Section completeness validator gracefully handles when extent of means is not yet known.

## Link to relevant ticket

[CRIMAPP-858](https://dsdmoj.atlassian.net/browse/CRIMAPP-858)

[LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-1N](https://ministryofjustice.sentry.io/issues/5559295887/)


## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-858]: https://dsdmoj.atlassian.net/browse/CRIMAPP-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ