### PR TITLE
CRIMAPP-1184 add King's Lynn Magistrates' court to court list

### DIFF
--- a/config/data/courts.csv
+++ b/config/data/courts.csv
@@ -107,6 +107,7 @@ B,Isle of Wight Magistrates' Court
 C,Isleworth Crown Court
 B,Kidderminster Magistrates' Court
 C,King's Lynn Crown Court
+B,King's Lynn Magistrates' Court
 C,Kingston upon Thames Crown Court
 C,Kingston-upon-Hull Crown Court
 C,Lancaster Crown Court

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Court, type: :model do
     subject(:all) { described_class.all }
 
     it 'returns all courts' do
-      expect(all.size).to eq(249)
+      expect(all.size).to eq(250)
     end
 
     it 'returns required courts as expected' do
-      digest_of_expected_court_names = '2783b31a61666a79b810dc8ef95c61d1'
+      digest_of_expected_court_names = '28f3f063e2397d7b9226c8b9334d85b4'
 
       expect(Digest::MD5.hexdigest(all.map(&:name).join)).to eq digest_of_expected_court_names
     end


### PR DESCRIPTION
## Description of change

Add King's Lynn Magistrates' court to court list

## Link to relevant ticket

[CRIMAPP-1184](https://dsdmoj.atlassian.net/browse/CRIMAPP-1184)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1119" alt="Screenshot 2024-07-11 at 10 12 22" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/832595ae-4a6d-4f9e-b2dc-dec78c1cfec7">

<img width="1310" alt="Screenshot 2024-07-11 at 10 12 13" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/15728561/12848961-6386-48d4-8239-ef7d3147064c">


## How to manually test the feature


[CRIMAPP-1184]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ