### PR TITLE
Do not create business on save and come back later

### DIFF
--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -9,6 +9,8 @@ class Business < ApplicationRecord
   attribute :salary, :amount_and_frequency
   attribute :total_income_share_sales, :amount_and_frequency
 
+  validates :business_type, inclusion: { in: BusinessType.values.map(&:to_s) }
+
   OPTIONAL_ADDRESS_ATTRIBUTES = %w[address_line_two].freeze
   REQUIRED_ADDRESS_ATTRIBUTES = Address::ADDRESS_ATTRIBUTES.map(&:to_s).reject { |a| a.in? OPTIONAL_ADDRESS_ATTRIBUTES }
 

--- a/spec/models/business_spec.rb
+++ b/spec/models/business_spec.rb
@@ -18,6 +18,45 @@ RSpec.describe Business, type: :model do
     end
   end
 
+  describe '#valid?' do
+    let(:valid_attributes) do
+      {
+        crime_application: CrimeApplication.new,
+        business_type: BusinessType::SELF_EMPLOYED.to_s
+      }
+    end
+
+    context 'when business_type' do
+      subject(:business_is_valid) { business.valid? }
+
+      let(:attributes) { valid_attributes.merge(business_type:) }
+
+      context 'is null' do
+        let(:business_type) { '' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'is empty string' do
+        let(:business_type) { nil }
+
+        it { is_expected.to be false }
+      end
+
+      context 'is something else' do
+        let(:business_type) { 'NotBusinessType' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'is a BusinessType' do
+        let(:business_type) { BusinessType.values.sample.to_s }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
   describe '#owner' do
     subject(:owner) { business.owner }
 


### PR DESCRIPTION
## Description of change

Save and come back later uses FormObject#save! which relies on Model, not FormObject, exceptions to prevent saving. Add mode validation to prevent business being created without a business type.

## Link to relevant ticket

[CRIMAPP-1199](https://dsdmoj.atlassian.net/browse/CRIMAPP-1199)

## Notes for reviewer

Bad data will need to be removed from staging after this is deployed.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1199]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ