### PR TITLE
[CRIMAPP-1201] Fix section display of other work benefits

### DIFF
--- a/app/presenters/summary/sections/partner_work_benefits.rb
+++ b/app/presenters/summary/sections/partner_work_benefits.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class PartnerWorkBenefits < Sections::BaseSection
       def show?
-        income.present? && work_benefits.present?
+        income.present? && income.partner_other_work_benefit_received.present?
       end
 
       def answers # rubocop:disable Metrics/MethodLength

--- a/app/presenters/summary/sections/work_benefits.rb
+++ b/app/presenters/summary/sections/work_benefits.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class WorkBenefits < Sections::BaseSection
       def show?
-        income.present? && work_benefits.present?
+        income.present? && income.applicant_other_work_benefit_received.present?
       end
 
       def answers # rubocop:disable Metrics/MethodLength

--- a/spec/presenters/summary/sections/partner_work_benefits_spec.rb
+++ b/spec/presenters/summary/sections/partner_work_benefits_spec.rb
@@ -40,7 +40,16 @@ describe Summary::Sections::PartnerWorkBenefits do
         end
       end
 
-      context 'when partner_other_work_benefit_received is set to nil' do
+      context 'when partner_other_work_benefit_received is set to `no`' do
+        let(:partner_other_work_benefit_received) { 'no' }
+        let(:income_payment) { nil }
+
+        it 'shows this section' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'when partner_other_work_benefit question was not asked' do
         let(:income_payment) { nil }
 
         it 'does not show this section' do

--- a/spec/presenters/summary/sections/work_benefits_spec.rb
+++ b/spec/presenters/summary/sections/work_benefits_spec.rb
@@ -40,7 +40,16 @@ describe Summary::Sections::WorkBenefits do
         end
       end
 
-      context 'when applicant_other_work_benefit_received is set to nil' do
+      context 'when applicant_other_work_benefit_received is set to `no`' do
+        let(:applicant_other_work_benefit_received) { 'no' }
+        let(:income_payment) { nil }
+
+        it 'shows this section' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'when applicant_other_work_benefit question was not asked' do
         let(:income_payment) { nil }
 
         it 'does not show this section' do


### PR DESCRIPTION
## Description of change
Bug where ‘Other work benefits’ section was not displaying on Apply - CYA and final review screen.
This was when the answer 'no' was selected as the logic was presenting the section if a work benefit payment was present but there is no work benefit payment when the answer selected is no 

## Link to relevant ticket
[CRIMAPP-1201](https://dsdmoj.atlassian.net/browse/CRIMAPP-1201)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1078" alt="Screenshot 2024-07-11 at 16 47 07" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/51047911/1f17e0e0-4b45-4977-9633-2f6fc2cc77e3">

## How to manually test the feature


[CRIMAPP-1201]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ