### PR TITLE
CRIMAP-1161 always show evidence card on submission/review

### DIFF
--- a/app/presenters/summary/sections/supporting_evidence.rb
+++ b/app/presenters/summary/sections/supporting_evidence.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class SupportingEvidence < Sections::BaseSection
       def show?
-        documents.present? && super
+        true
       end
 
       def answers
@@ -16,6 +16,12 @@ module Summary
             )
           end
         ].flatten.compact.select(&:show?)
+      end
+
+      def change_path
+        return unless documents.empty?
+
+        edit_steps_evidence_upload_path
       end
 
       private

--- a/spec/presenters/summary/sections/supporting_evidence_spec.rb
+++ b/spec/presenters/summary/sections/supporting_evidence_spec.rb
@@ -21,6 +21,24 @@ describe Summary::Sections::SupportingEvidence do
     )]
   end
 
+  describe '#show' do
+    let(:documents) { [] }
+
+    it { expect(subject.show?).to be true }
+  end
+
+  describe '#change_path' do
+    context 'when there are documents' do
+      it { expect(subject.change_path).to be_nil }
+    end
+
+    context 'when there are no documents' do
+      let(:documents) { [] }
+
+      it { expect(subject.change_path).to eq '/applications/12345/steps/evidence/upload' }
+    end
+  end
+
   describe '#name' do
     it { expect(subject.name).to eq(:supporting_evidence) }
   end


### PR DESCRIPTION
## Description of change

Always show evidence card on submission/review

## Link to relevant ticket

[CRIMAPP-1161](https://dsdmoj.atlassian.net/browse/CRIMAPP-1161)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1034" alt="Screenshot 2024-07-11 at 16 49 54" src="https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/assets/34935/b9305daa-305b-4a93-baa1-0c99bc1e2a6c">


## How to manually test the feature


[CRIMAPP-1161]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ