### PR TITLE
Add non-means check to include partner method

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -43,6 +43,7 @@ module TypeOfMeansAssessment # rubocop:disable Metrics/ModuleLength
   end
 
   def include_partner_in_means_assessment?
+    return false if non_means_tested?
     return false unless partner.present? || partner_detail.present?
     return true if partner_involvement_in_case == PartnerInvolvementType::NONE.to_s
     return false unless partner_involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s

--- a/spec/forms/steps/capital/other_investment_type_form_spec.rb
+++ b/spec/forms/steps/capital/other_investment_type_form_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe Steps::Capital::OtherInvestmentTypeForm do
   subject(:form) { described_class.new(crime_application:) }
 
-  let(:crime_application) { instance_double(CrimeApplication, investments:, partner_detail:, partner:) }
+  let(:crime_application) {
+    instance_double(CrimeApplication, investments: investments, partner_detail: partner_detail, partner: partner,
+  non_means_tested?: false)
+  }
   let(:investments) { double }
   let(:investment_type) { InvestmentType.values.sample.to_s }
   let(:new_investment) { instance_double(Investment) }

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -13,7 +13,15 @@ RSpec.describe TypeOfMeansAssessment do
   end
 
   let(:crime_application) do
-    instance_double(CrimeApplication, applicant:, partner:, kase:, income:, partner_detail:)
+    instance_double(
+      CrimeApplication,
+      applicant: applicant,
+      partner: partner,
+      kase: kase,
+      income: income,
+      partner_detail: partner_detail,
+      non_means_tested?: false
+    )
   end
 
   let(:applicant) { instance_double(Applicant, has_benefit_evidence:) }

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -19,7 +19,8 @@ describe Summary::HtmlPresenter do
       documents: double, application_type: application_type,
       capital: (double has_premium_bonds: 'yes', partner_has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', partner_will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
       savings: [double], investments: [double], national_savings_certificates: [double], properties: [double],
-      is_means_tested: is_means_tested
+      is_means_tested: is_means_tested,
+      non_means_tested?: false
     )
   end
   # rubocop:enable Layout/LineLength

--- a/spec/presenters/summary/sections/dwp_details_spec.rb
+++ b/spec/presenters/summary/sections/dwp_details_spec.rb
@@ -10,7 +10,8 @@ describe Summary::Sections::DWPDetails do
       client_has_partner: 'no',
       partner_detail: nil,
       partner: nil,
-      applicant: applicant
+      applicant: applicant,
+      non_means_tested?: false
     )
   end
 

--- a/spec/presenters/summary/sections/other_outgoings_details_spec.rb
+++ b/spec/presenters/summary/sections/other_outgoings_details_spec.rb
@@ -10,6 +10,7 @@ describe Summary::Sections::OtherOutgoingsDetails do
       outgoings: outgoings,
       partner: partner,
       partner_detail: partner_detail,
+      non_means_tested?: false
     )
   end
 

--- a/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
@@ -9,7 +9,8 @@ describe Summary::Sections::PartnerIncomeBenefitsDetails do
       to_param: '12345',
       income: income,
       partner: instance_double(Partner),
-      partner_detail: instance_double(PartnerDetail, involvement_in_case: 'none')
+      partner_detail: instance_double(PartnerDetail, involvement_in_case: 'none'),
+      non_means_tested?: false
     )
   end
 

--- a/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
@@ -10,7 +10,8 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
       income: income,
       applicant: applicant,
       partner_detail: instance_double(PartnerDetail, involvement_in_case:),
-      partner: partner
+      partner: partner,
+      non_means_tested?: false
     )
   end
 

--- a/spec/presenters/summary/sections/passporting_benefit_check_partner_spec.rb
+++ b/spec/presenters/summary/sections/passporting_benefit_check_partner_spec.rb
@@ -11,7 +11,8 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
       applicant: applicant,
       partner_detail: instance_double(PartnerDetail, involvement_in_case:),
       partner: partner,
-      is_means_tested: is_means_tested
+      is_means_tested: is_means_tested,
+      non_means_tested?: false
     )
   end
 

--- a/spec/serializers/submission_serializer/sections/capital_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/capital_details_spec.rb
@@ -3,7 +3,17 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
   subject(:serializer) { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double CrimeApplication, capital:, income:, partner_detail:, partner: }
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      capital: capital,
+      income: income,
+      partner_detail: partner_detail,
+      partner: partner,
+      non_means_tested?: false
+    )
+  end
+
   let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
   let(:partner) { instance_double(Partner) }
   let(:involvement_in_case) { 'none' }

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
       income: income,
       partner_detail: partner_detail,
       partner: partner,
-      employments: [applicant_employment, partner_employment]
+      employments: [applicant_employment, partner_employment],
+      non_means_tested?: false
     )
   end
 

--- a/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe SubmissionSerializer::Sections::OutgoingsDetails do
   subject(:serializer) { described_class.new(crime_application) }
 
-  let(:crime_application) { instance_double(CrimeApplication, outgoings:, partner_detail:, partner:) }
+  let(:crime_application) {
+    instance_double(CrimeApplication, outgoings: outgoings, partner_detail: partner_detail, partner: partner,
+  non_means_tested?: false)
+  }
   let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
   let(:partner) { instance_double(Partner) }
   let(:involvement_in_case) { 'none' }

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Decisions::CapitalDecisionTree do
       income: income,
       capital: capital,
       partner_detail: partner_detail,
-      partner: nil
+      partner: nil,
+      non_means_tested?: false
     )
   end
 

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 RSpec.describe Decisions::DWPDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
-  let(:crime_application) { instance_double(CrimeApplication, partner:, partner_detail:) }
+  let(:crime_application) {
+    instance_double(CrimeApplication, partner: partner, partner_detail: partner_detail,
+  non_means_tested?: false)
+  }
   let(:applicant) { double(Applicant, benefit_check_result:) }
   let(:benefit_check_result) { false }
   let(:benefit_check_recipient) { applicant }

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Decisions::IncomeDecisionTree do
       partner_detail: partner_detail,
       partner: partner,
       applicant: applicant,
-      appeal_no_changes?: false
+      appeal_no_changes?: false,
+      non_means_tested?: false
     )
   end
 

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       outgoings: outgoings,
       kase: kase,
       partner_detail: partner_detail,
-      partner: partner
+      partner: partner,
+      non_means_tested?: false
     )
   end
 

--- a/spec/services/decisions/submission_decision_tree_spec.rb
+++ b/spec/services/decisions/submission_decision_tree_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Decisions::SubmissionDecisionTree do
       applicant: applicant,
       case: kase,
       partner_detail: nil,
-      partner: nil
+      partner: nil,
+      non_means_tested?: false
     )
   end
 

--- a/spec/services/dwp/benefit_check_status_service_spec.rb
+++ b/spec/services/dwp/benefit_check_status_service_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe DWP::BenefitCheckStatusService do
       to_param: '12345',
       applicant: applicant,
       partner: partner,
-      partner_detail: partner_detail
+      partner_detail: partner_detail,
+      non_means_tested?: false
     )
   end
 

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Passporting::MeansPassporter do
       resubmission?: resubmission?,
       is_means_tested: is_means_tested,
       partner_detail: nil,
-      partner: nil
+      partner: nil,
+      non_means_tested?: false
     )
   }
 

--- a/spec/validators/capital_assessment/answers_validator_spec.rb
+++ b/spec/validators/capital_assessment/answers_validator_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record:, crime_application:) }
 
   let(:record) { instance_double(Capital, crime_application:, errors:) }
-  let(:crime_application) { instance_double(CrimeApplication, income:, partner_detail:, partner:) }
+  let(:crime_application) {
+    instance_double(CrimeApplication, income: income, partner_detail: partner_detail, partner: partner,
+  non_means_tested?: false)
+  }
   let(:income) { instance_double(Income) }
   let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
   let(:partner) { nil }

--- a/spec/validators/outgoings_assessment/answers_validator_spec.rb
+++ b/spec/validators/outgoings_assessment/answers_validator_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record:, crime_application:) }
 
   let(:record) { instance_double(Outgoings, crime_application:, errors:) }
-  let(:crime_application) { instance_double(CrimeApplication, partner: nil) }
-
+  let(:crime_application) { instance_double(CrimeApplication, partner: nil, non_means_tested?: false) }
   let(:errors) { [] }
   let(:requires_full_means_assessment?) { true }
   let(:involvement_in_case?) { nil }


### PR DESCRIPTION
## Description of change
Don't show irrelevant partner declaration section of declarations page if non-means tested even if there is a partner object present (this will not be submitted, and is no longer relevant once type of application is changed to non means)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1207
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

1. Create an application
2. Is means tested == yes
3. Has partner yes - no involvement in case
4. Return to Is means tested page and change to no
5. Continue through all pages to declaration page
6. Declaration page does not show radios and copy for Partner 