### PR TITLE
Add generic court options

### DIFF
--- a/config/data/courts.csv
+++ b/config/data/courts.csv
@@ -49,6 +49,7 @@ B,Cardiff Magistrates' Court
 C,Carlisle Crown Court
 B,Carlisle Magistrates' Court
 C,Central Criminal Court
+A,Chancery Division
 C,Chelmsford Crown Court
 B,Chelmsford Magistrates' Court
 B,Cheltenham Magistrates' Court
@@ -60,7 +61,9 @@ B,Chorley Magistrates' Court
 B,Cirencester Magistrates' Court
 B,City of London Magistrates' Court
 B,Colchester Magistrates' Court
+A,County Court
 C,Court of Appeal
+A,Court of Protection
 C,Coventry Crown Court
 B,Coventry Magistrates' Court
 B,Crawley Magistrates' Court
@@ -79,6 +82,7 @@ B,Ealing Magistrates' Court
 B,Eastbourne Magistrates' Court
 C,Exeter Crown Court
 B,Exeter Magistrates' Court
+A,Family Court
 B,Folkestone Magistrates' Court
 B,Gateshead Magistrates' Court
 C,Gloucester Crown Court
@@ -95,6 +99,7 @@ B,Haverfordwest Magistrates' Court
 B,Hendon Magistrates' Court
 C,Hereford Crown Court
 B,Herefordshire Magistrates' Court
+A,High Court
 B,Highbury Corner Magistrates' Court
 B,Horsham Magistrates' Court
 B,Huddersfield Magistrates' Court

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Court, type: :model do
     subject(:all) { described_class.all }
 
     it 'returns all courts' do
-      expect(all.size).to eq(250)
+      expect(all.size).to eq(255)
     end
 
     it 'returns required courts as expected' do
-      digest_of_expected_court_names = '28f3f063e2397d7b9226c8b9334d85b4'
+      digest_of_expected_court_names = '0391053914b3ca1265d08ed1330191e1'
 
       expect(Digest::MD5.hexdigest(all.map(&:name).join)).to eq digest_of_expected_court_names
     end


### PR DESCRIPTION
## Description of change
Add to court list:
Chancery Division
County Court
Court of Protection
Family Court
High Court
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1197
## Notes for reviewer

Cods are listed as A - as a placeholder for now.

I believe at least 'County Court' 'Family Court' - are catchalls for 'x County Court' or 'y Family Court' where x and y are names of locations. So these I would expect wouldn't really have proper codes given they are not actual names of courts


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
