### PR TITLE
[CRIMAPP-1170] Block submission of app if evidence upload required

### DIFF
--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -4,13 +4,23 @@ module Steps
       include TypeOfMeansAssessment
       include ApplicantAndPartner
 
-      delegate :documents, to: :crime_application
+      delegate :documents, :evidence_prompts, to: :crime_application
+
+      validate do
+        validator.validate
+      end
 
       def prompt
         @prompt ||= ::Evidence::Prompt.new(crime_application).run!(ignore_exempt: false)
       end
 
       private
+
+      def validator
+        @validator ||= ::SupportingEvidence::AnswersValidator.new(
+          record: self, crime_application: crime_application
+        )
+      end
 
       # :nocov:
       def persist!

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -101,8 +101,7 @@ class CrimeApplication < ApplicationRecord
   validates_with PseFulfilmentValidator, on: :submission, if: :post_submission_evidence?
 
   validate on: :client_details do
-    ::ClientDetails::AnswersValidator.new(record: self, crime_application: self)
-                                     .validate
+    ::ClientDetails::AnswersValidator.new(record: self, crime_application: self).validate
   end
 
   validate on: :passporting_benefit do

--- a/app/presenters/tasks/evidence_upload.rb
+++ b/app/presenters/tasks/evidence_upload.rb
@@ -4,26 +4,20 @@ module Tasks
       edit_steps_evidence_upload_path
     end
 
-    def not_applicable?
-      false
-    end
-
     def can_start?
       true
     end
 
     def in_progress?
-      documents.any?
-    end
-
-    def completed?
-      documents.stored.any?
+      true
     end
 
     private
 
-    def documents
-      @documents ||= crime_application.documents
+    def validator
+      @validator ||= ::SupportingEvidence::AnswersValidator.new(
+        record: crime_application, crime_application: crime_application
+      )
     end
   end
 end

--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -20,6 +20,8 @@ class SectionsCompletenessValidator
       errors.add(:capital_assessment, :incomplete) unless capital_assessment_complete?
 
       errors.add(:partner_details, :incomplete) unless partner_detail_complete?
+
+      errors.add(:documents, :incomplete) unless evidence_validator.evidence_complete?
     else
       errors.add(:client_details, :incomplete)
     end
@@ -55,5 +57,9 @@ class SectionsCompletenessValidator
     return false unless capital
 
     capital.complete?
+  end
+
+  def evidence_validator
+    ::SupportingEvidence::AnswersValidator.new(record:, crime_application:)
   end
 end

--- a/app/validators/supporting_evidence/answers_validator.rb
+++ b/app/validators/supporting_evidence/answers_validator.rb
@@ -1,0 +1,74 @@
+module SupportingEvidence
+  class AnswersValidator < BaseAnswerValidator
+    include TypeOfMeansAssessment
+
+    attr_reader :record
+    alias crime_application record
+
+    def complete?
+      validate
+      errors.empty?
+    end
+
+    def applicable?
+      true
+    end
+
+    def validate
+      errors.add(:documents, :blank) unless evidence_complete?
+    end
+
+    def evidence_complete?
+      return true if exempt?
+
+      evidence_present?
+    end
+
+    # TODO: add branch for CIFC applications
+    def exempt?
+      return true unless evidence_required?
+      return true if indictable_or_in_crown_court?
+
+      nino_is_only_evidence_prompt && has_passporting_benefit? && client_remanded_in_custody?
+    end
+
+    def client_remanded_in_custody?
+      return true unless kase
+
+      kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
+    end
+
+    def indictable_or_in_crown_court?
+      return true unless kase
+
+      [CaseType::INDICTABLE.to_s, CaseType::ALREADY_IN_CROWN_COURT.to_s]
+        .include?(kase&.case_type)
+    end
+
+    def evidence_required?
+      evidence_prompt_results.uniq.any?
+    end
+
+    def evidence_prompt_count
+      evidence_prompt_results.count(true)
+    end
+
+    def nino_is_only_evidence_prompt
+      nino_evidence_required? && (evidence_prompt_count == 1)
+    end
+
+    # rubocop:disable Layout/LineLength
+    def nino_evidence_required?
+      record.evidence_prompts.first { |result| result['key'] == :national_insurance_32 }['run'].slice('client', 'partner', 'other').values.pluck('result').flatten.uniq.any?
+    end
+
+    def evidence_prompt_results
+      record.evidence_prompts.map { |result| result['run'].slice('client', 'partner', 'other') }.map { |e| e.values.pluck('result') }.flatten
+    end
+    # rubocop:enable Layout/LineLength
+
+    def evidence_present?
+      record.documents.stored.any?
+    end
+  end
+end

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -4,6 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="upload-page">
     <%= render partial: 'shared/flash_banner' %>
+    <%= govuk_error_summary(@form_object) %>
 
     <%# Required to display dropzone error messages %>
     <%= render partial: 'steps/evidence/upload/upload_error_summary' %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1229,3 +1229,7 @@ en:
             details:
               blank: Enter details
               invalid: Details not required
+        steps/evidence/upload_form:
+          attributes:
+            documents:
+              blank: You must provide the required evidence

--- a/spec/forms/steps/evidence/upload_form_spec.rb
+++ b/spec/forms/steps/evidence/upload_form_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Steps::Evidence::UploadForm do
     end
 
     before do
-      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(evidence_complete)
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?)
+        .and_return(evidence_complete)
       form.valid?
     end
 

--- a/spec/forms/steps/evidence/upload_form_spec.rb
+++ b/spec/forms/steps/evidence/upload_form_spec.rb
@@ -37,4 +37,27 @@ RSpec.describe Steps::Evidence::UploadForm do
       expect(sentences).to eq ['certificate or statement for each stock, gilt or government bond']
     end
   end
+
+  describe 'validation' do
+    subject(:error_message) do
+      form.errors.full_messages_for(:documents).first
+    end
+
+    before do
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(evidence_complete)
+      form.valid?
+    end
+
+    context 'when the supporting evidence section is not complete' do
+      let(:evidence_complete) { false }
+
+      it { is_expected.to eq 'You must provide the required evidence' }
+    end
+
+    context 'when the supporting evidence section is complete' do
+      let(:evidence_complete) { true }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/presenters/tasks/evidence_upload_spec.rb
+++ b/spec/presenters/tasks/evidence_upload_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Tasks::EvidenceUpload do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      documents: documents,
+      applicant: applicant,
     )
   end
 
-  let(:documents) { [] }
+  let(:applicant) { instance_double Applicant }
 
   describe '#path' do
     it { expect(subject.path).to eq('/applications/12345/steps/evidence/upload') }
@@ -26,30 +26,22 @@ RSpec.describe Tasks::EvidenceUpload do
   end
 
   describe '#in_progress?' do
-    context 'when there are any documents' do
-      let(:documents) { ['doc'] }
-
-      it { expect(subject.in_progress?).to be(true) }
-    end
-
-    context 'when there are no documents yet' do
-      let(:documents) { [] }
-
-      it { expect(subject.in_progress?).to be(false) }
-    end
+    it { expect(subject.in_progress?).to be(true) }
   end
 
   describe '#completed?' do
-    let(:documents) { double(stored: scoped_documents) }
+    before do
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:complete?).and_return(evidence_complete)
+    end
 
-    context 'when there are any stored documents' do
-      let(:scoped_documents) { ['stored_doc'] }
+    context 'when evidence validation is true' do
+      let(:evidence_complete) { true }
 
       it { expect(subject.completed?).to be(true) }
     end
 
-    context 'when there are no stored documents yet' do
-      let(:scoped_documents) { [] }
+    context 'when evidence validation is false' do
+      let(:evidence_complete) { false }
 
       it { expect(subject.completed?).to be(false) }
     end

--- a/spec/validators/sections_completeness_validator_spec.rb
+++ b/spec/validators/sections_completeness_validator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
           }
         end
 
-        it 'adds errors to all sections and base' do
+        it 'adds errors to all sections and base' do # rubocop:disable RSpec/MultipleExpectations
           expect(errors).to receive(:add).with(:benefit_type, :incomplete)
           expect(errors).to receive(:add).with(:case_details, :incomplete)
           expect(errors).to receive(:add).with(:income_assessment, :incomplete)

--- a/spec/validators/sections_completeness_validator_spec.rb
+++ b/spec/validators/sections_completeness_validator_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
           )
         end
 
+        let(:evidence_complete?) { true }
         let(:attributes) do
           {
             client_details_complete?: true,

--- a/spec/validators/sections_completeness_validator_spec.rb
+++ b/spec/validators/sections_completeness_validator_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
 
   let(:record) { instance_double(CrimeApplication, errors: errors, non_means_tested?: false) }
   let(:errors) { double(:errors, empty?: false) }
+  let(:evidence_complete?) { false }
+
+  before do
+    allow_any_instance_of(SupportingEvidence::AnswersValidator)
+      .to receive(:evidence_complete?).and_return(evidence_complete?)
+  end
 
   describe '#validate' do
     before { allow(record).to receive_messages(**attributes) }
@@ -16,6 +22,7 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
 
       context 'when case complete' do
         let(:errors) { [] }
+        let(:evidence_complete?) { true }
 
         let(:attributes) do
           {
@@ -53,6 +60,7 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
       end
 
       let(:errors) { [] }
+      let(:evidence_complete?) { true }
 
       let(:attributes) do
         {
@@ -77,6 +85,7 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
       end
 
       context 'when all sections complete' do
+        let(:evidence_complete?) { true }
         let(:errors) { [] }
 
         let(:attributes) do
@@ -120,6 +129,7 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
           expect(errors).to receive(:add).with(:outgoings_assessment, :incomplete)
           expect(errors).to receive(:add).with(:capital_assessment, :incomplete)
           expect(errors).to receive(:add).with(:partner_details, :incomplete)
+          expect(errors).to receive(:add).with(:documents, :incomplete)
           expect(errors).to receive(:add).with(:base, :incomplete_records)
 
           subject.validate
@@ -127,6 +137,8 @@ RSpec.describe SectionsCompletenessValidator, type: :model do
       end
 
       context 'when income, outgoings, capital and partner details are missing' do
+        let(:evidence_complete?) { true }
+
         let(:attributes) do
           {
             client_details_complete?: true,

--- a/spec/validators/supporting_evidence/answers_validator_spec.rb
+++ b/spec/validators/supporting_evidence/answers_validator_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
+  subject(:validator) { described_class.new(record: record, crime_application: record) }
+
+  let(:record) {
+    instance_double(CrimeApplication, errors:, applicant:, documents:, kase:, evidence_prompts:)
+  }
+  let(:errors) { double(:errors, empty?: false) }
+  let(:applicant) { instance_double(Applicant) }
+  let(:kase) { instance_double(Case, case_type:) }
+  let(:case_type) { nil }
+  let(:documents) { double(stored: stored_documents) }
+  let(:stored_documents) { [] }
+
+  let(:evidence_prompts) do
+    [
+      {
+        'id' => 'ExampleRule1',
+        'key' => prompt_key,
+        'run' => {
+          'client' => { 'result' => result },
+          'partner' => { 'result' => false },
+          'other' => { 'result' => false },
+        }
+      }
+    ]
+  end
+
+  let(:prompt_key) { 'example_rule1' }
+  let(:result) { true }
+
+  before do
+    allow(validator).to receive(:has_passporting_benefit?).and_return(false)
+  end
+
+  describe '#validate' do
+    context 'when validation fails' do
+      it 'adds errors for all failed validations' do
+        expect(errors).to receive(:add).with(:documents, :blank)
+
+        subject.validate
+      end
+    end
+
+    context 'when evidence is present' do
+      let(:stored_documents) { [Document.new] }
+
+      it 'does not add an error' do
+        expect(errors).not_to receive(:add).with(:documents, :blank)
+
+        subject.validate
+      end
+    end
+
+    context 'when case is indictable' do
+      let(:case_type) { CaseType::INDICTABLE.to_s }
+
+      it 'does not add an error' do
+        expect(errors).not_to receive(:add).with(:documents, :blank)
+
+        subject.validate
+      end
+    end
+
+    context 'when case is in crown court' do
+      let(:case_type) { CaseType::ALREADY_IN_CROWN_COURT.to_s }
+
+      it 'does not add an error' do
+        expect(errors).not_to receive(:add).with(:documents, :blank)
+
+        subject.validate
+      end
+    end
+
+    context 'when there are no evidence prompts' do
+      let(:result) { false }
+
+      it 'does not add an error' do
+        expect(errors).not_to receive(:add).with(:documents, :blank)
+
+        subject.validate
+      end
+    end
+
+    context 'the only evidence prompt is for nino evidence' do
+      let(:prompt_key) { :national_insurance_32 }
+
+      context 'when there is a passporting benefit' do
+        before do
+          allow(validator).to receive(:has_passporting_benefit?).and_return(true)
+        end
+
+        context 'when applicant is not remanded in custody' do
+          before do
+            allow(kase).to receive_messages(is_client_remanded: 'no')
+          end
+
+
+          it 'adds errors for all failed validations' do
+            expect(errors).to receive(:add).with(:documents, :blank)
+
+            subject.validate
+          end
+        end
+
+        context 'when client is remanded in custody' do
+          before do
+            allow(kase).to receive_messages(is_client_remanded: 'yes', date_client_remanded: 1.month.ago.to_date)
+          end
+
+          it 'does not add an error' do
+            expect(errors).not_to receive(:add).with(:documents, :blank)
+
+            subject.validate
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/supporting_evidence/answers_validator_spec.rb
+++ b/spec/validators/supporting_evidence/answers_validator_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
             allow(kase).to receive_messages(is_client_remanded: 'no')
           end
 
-
           it 'adds errors for all failed validations' do
             expect(errors).to receive(:add).with(:documents, :blank)
 


### PR DESCRIPTION
## Description of change
Adds validation to the evidence upload page, task list, review you application and declaration pages to prevent the submission of applications without the attachment of required evidence when appropriate (see diagram or ticket for  scenarios) 

## Link to relevant ticket
[CRIMAPP-1170](https://dsdmoj.atlassian.net/browse/CRIMAPP-1170)

## Notes for reviewer
Note this does not handle CIFC yet as the work is in progress
Scenarios can be found here:

![Mandatory Evidence Rules](https://github.com/user-attachments/assets/9a87517e-94b6-495e-b3e1-128ec11eecc3)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1078" alt="Screenshot 2024-07-12 at 16 05 44" src="https://github.com/user-attachments/assets/3837b865-0adb-4685-8cef-04a1936602f7">
<img width="1078" alt="Screenshot 2024-07-12 at 16 05 35" src="https://github.com/user-attachments/assets/27169897-ae6a-4d8b-bbd6-66aaf3093909">
<img width="1078" alt="Screenshot 2024-07-12 at 16 06 10" src="https://github.com/user-attachments/assets/8d95c0ac-1d41-4f66-baf1-dd2b6c53da7e">

## How to manually test the feature
Test the scenario in the diagram above

[CRIMAPP-1170]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ