### PR TITLE
CRIMAPP-1111 Only show needed capital answers.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Naming/VariableNumber:
 Rails/FilePath:
   Enabled: false
 
+Naming/PredicateName:
+  Enabled: false
+
 # Rspec cops
 ############
 
@@ -132,32 +135,6 @@ Style/HashEachMethods:
 Style/BlockDelimiters:
   Exclude:
     - 'spec/**/*'
-
-Naming/PredicateName:
-  AllowedMethods:
-    - has_nino
-    - has_codefendants
-    - has_one_association
-    - has_no_income_payments
-    - has_no_income_benefits
-    - has_no_other_outgoings
-    - has_no_properties
-    - has_no_savings
-    - has_no_investments
-    - has_no_national_savings_certificates
-    - has_national_savings_certificates_complete?
-    - has_nino_complete?
-    - has_passporting_benefit?
-    - has_codefendants_complete?
-    - has_charges_complete?
-    - has_benefit_evidence_complete?
-    - has_frozen_assets?
-    - has_no_frozen_assets?
-    - has_national_savings_certificates_selected
-    - has_benefit_evidence_selected
-    - has_frozen_income_or_assets_selected
-    - has_savings?
-    - has_property?
 
 # TODO: adjust these values towards the rubocop defaults
 RSpec/MultipleMemoizedHelpers:

--- a/app/forms/steps/income/client/deductions_form.rb
+++ b/app/forms/steps/income/client/deductions_form.rb
@@ -58,7 +58,6 @@ module Steps
           employment.deductions.pluck(:deduction_type)
         end
 
-        # rubocop:disable Naming/PredicateName
         def has_no_deductions
           'yes' if types.include?('none')
         end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -11,15 +11,6 @@ class Applicant < Person
     through: :crime_application
   )
 
-  # :nocov:
-  # TOOD add coverage before release
-  has_many(
-    :outgoings_payments,
-    -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
-    through: :crime_application
-  )
-  # :nocov:
-
   has_many(
     :national_savings_certificates,
     -> { where(ownership_type: OwnershipType::APPLICANT.to_s) },
@@ -51,7 +42,7 @@ class Applicant < Person
   # Utility methods for testing/output
   delegate :partner_detail, to: :crime_application
 
-  def has_partner # rubocop:disable Naming/PredicateName
+  def has_partner
     partner_detail&.has_partner
   end
 
@@ -61,10 +52,6 @@ class Applicant < Person
 
   def separation_date
     partner_detail&.separation_date
-  end
-
-  def ownership_types
-    [OwnershipType::APPLICANT.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s]
   end
 
   def ownership_type

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -2,17 +2,13 @@ class Capital < ApplicationRecord
   include MeansOwnershipScope
 
   belongs_to :crime_application
+
   attribute :premium_bonds_total_value, :pence
   attribute :partner_premium_bonds_total_value, :pence
   attribute :trust_fund_amount_held, :pence
   attribute :trust_fund_yearly_dividend, :pence
   attribute :partner_trust_fund_amount_held, :pence
   attribute :partner_trust_fund_yearly_dividend, :pence
-
-  has_many :savings, through: :crime_application
-  has_many :investments, through: :crime_application
-  has_many :national_savings_certificates, through: :crime_application
-  has_many :properties, through: :crime_application
 
   validate on: :submission do
     answers_validator.validate
@@ -27,6 +23,54 @@ class Capital < ApplicationRecord
     valid?(:submission)
   end
 
+  def savings
+    return [] unless requires_full_capital?
+
+    crime_application.savings.where(ownership_type: ownership_types)
+  end
+
+  def properties
+    return [] unless requires_full_capital?
+
+    crime_application.properties
+  end
+
+  def investments
+    return [] unless requires_full_capital?
+
+    crime_application.investments.where(ownership_type: ownership_types)
+  end
+
+  def national_savings_certificates
+    return [] unless requires_full_capital?
+
+    crime_application.national_savings_certificates.where(ownership_type: ownership_types)
+  end
+
+  def has_national_savings_certificates
+    super if requires_full_capital?
+  end
+
+  def has_no_properties
+    super if requires_full_capital?
+  end
+
+  def has_no_savings
+    super if requires_full_capital?
+  end
+
+  def has_no_investments
+    super if requires_full_capital?
+  end
+
+  def has_premium_bonds
+    super if requires_full_capital?
+  end
+
+  def partner_has_premium_bonds
+    super if requires_full_capital?
+  end
+
   private
 
   def confirmation_validator
@@ -35,5 +79,9 @@ class Capital < ApplicationRecord
 
   def answers_validator
     @answers_validator ||= CapitalAssessment::AnswersValidator.new(record: self)
+  end
+
+  def requires_full_capital?
+    @requires_full_capital ||= MeansStatus.full_capital_required?(crime_application)
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -46,17 +46,17 @@ class CrimeApplication < ApplicationRecord
            dependent: :destroy)
 
   has_many(:savings,
-           ->(object) { where(ownership_type: object.ownership_types).order(created_at: :asc) },
+           -> { order(created_at: :asc) },
            inverse_of: :crime_application,
            dependent: :destroy)
 
   has_many(:investments,
-           ->(object) { where(ownership_type: object.ownership_types).order(created_at: :asc) },
+           -> { order(created_at: :asc) },
            inverse_of: :crime_application,
            dependent: :destroy)
 
   has_many(:national_savings_certificates,
-           ->(object) { where(ownership_type: object.ownership_types).order(created_at: :asc) },
+           -> { order(created_at: :asc) },
            inverse_of: :crime_application,
            dependent: :destroy)
 

--- a/app/models/means_status.rb
+++ b/app/models/means_status.rb
@@ -13,6 +13,10 @@ class MeansStatus
     def full_means_required?(crime_application)
       new(crime_application).requires_full_means_assessment?
     end
+
+    def full_capital_required?(crime_application)
+      new(crime_application).requires_full_capital?
+    end
   end
 
   private

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -39,10 +39,6 @@ class Partner < Person
     'partner'
   end
 
-  def ownership_types
-    [OwnershipType::PARTNER.to_s, OwnershipType::APPLICANT_AND_PARTNER.to_s]
-  end
-
   def ownership_type
     OwnershipType::PARTNER
   end

--- a/app/presenters/summary/components/business.rb
+++ b/app/presenters/summary/components/business.rb
@@ -1,6 +1,8 @@
 module Summary
   module Components
     class Business < BaseRecord
+      GROUP_BY = :business_type
+
       alias business record
 
       private

--- a/app/presenters/summary/components/grouped_list.rb
+++ b/app/presenters/summary/components/grouped_list.rb
@@ -1,7 +1,7 @@
 module Summary
   module Components
     class GroupedList < ViewComponent::Base
-      def initialize(items:, group_by:, item_component:, show_actions: true, show_record_actions: false)
+      def initialize(items:, item_component:, group_by: nil, show_actions: true, show_record_actions: false)
         @items = items
         @group_by = group_by
         @item_component = item_component
@@ -11,10 +11,14 @@ module Summary
         super
       end
 
-      attr_reader :items, :group_by, :item_component, :show_actions, :show_record_actions
+      attr_reader :items, :item_component, :show_actions, :show_record_actions
 
       def groups
         items.group_by(&group_by.to_sym).map(&:last)
+      end
+
+      def group_by
+        @group_by ||= item_component::GROUP_BY
       end
     end
   end

--- a/app/presenters/summary/components/investment.rb
+++ b/app/presenters/summary/components/investment.rb
@@ -1,6 +1,7 @@
 module Summary
   module Components
     class Investment < BaseRecord
+      GROUP_BY = :investment_type
       alias investment record
 
       private

--- a/app/presenters/summary/components/national_savings_certificate.rb
+++ b/app/presenters/summary/components/national_savings_certificate.rb
@@ -1,6 +1,8 @@
 module Summary
   module Components
     class NationalSavingsCertificate < BaseRecord
+      GROUP_BY = :id
+
       alias national_savings_certificate record
 
       private

--- a/app/presenters/summary/components/property.rb
+++ b/app/presenters/summary/components/property.rb
@@ -1,6 +1,8 @@
 module Summary
   module Components
     class Property < BaseRecord # rubocop:disable Metrics/ClassLength
+      GROUP_BY = :property_type
+
       include TypeOfMeansAssessment
 
       alias property record

--- a/app/presenters/summary/components/saving.rb
+++ b/app/presenters/summary/components/saving.rb
@@ -1,6 +1,8 @@
 module Summary
   module Components
     class Saving < BaseRecord
+      GROUP_BY = :saving_type
+
       include TypeOfMeansAssessment
 
       alias saving record

--- a/app/presenters/summary/sections/base_capital_records_section.rb
+++ b/app/presenters/summary/sections/base_capital_records_section.rb
@@ -1,0 +1,50 @@
+module Summary
+  module Sections
+    class BaseCapitalRecordsSection < Sections::BaseSection
+      def show?
+        return false if capital.blank?
+
+        records.present? || has_records_answer.present?
+      end
+
+      def answers
+        return list_component if records.present?
+
+        [has_no_records_component]
+      end
+
+      def list?
+        records.present?
+      end
+
+      private
+
+      def list_component
+        Summary::Components::GroupedList.new(
+          items: records,
+          item_component: item_component_class,
+          show_actions: editable?,
+          show_record_actions: headless?
+        )
+      end
+
+      # :nocov: #
+      def item_component_class
+        raise 'must be implemented in subclasses'
+      end
+
+      def has_no_records_component
+        raise 'must be implemented in subclasses'
+      end
+
+      def records
+        raise 'must be implemented in subclasses'
+      end
+
+      def has_records_answer
+        raise 'must be implemented in subclasses'
+      end
+      # :nocov: #
+    end
+  end
+end

--- a/app/presenters/summary/sections/businesses.rb
+++ b/app/presenters/summary/sections/businesses.rb
@@ -10,7 +10,6 @@ module Summary
       def answers
         Summary::Components::GroupedList.new(
           items: businesses,
-          group_by: :business_type,
           item_component: Summary::Components::Business,
           show_actions: editable?,
           show_record_actions: headless?

--- a/app/presenters/summary/sections/investments.rb
+++ b/app/presenters/summary/sections/investments.rb
@@ -1,51 +1,32 @@
 module Summary
   module Sections
-    class Investments < Sections::BaseSection
-      def show?
-        shown_investments?
-      end
-
-      # rubocop:disable Metrics/MethodLength
-      def answers
-        if no_investments?
-          [
-            Components::ValueAnswer.new(
-              :has_investments, 'none',
-              change_path: edit_steps_capital_investment_type_path
-            )
-          ]
-        else
-          Summary::Components::GroupedList.new(
-            items: investments,
-            group_by: :investment_type,
-            item_component: Summary::Components::Investment,
-            show_actions: editable?,
-            show_record_actions: headless?
-          )
-        end
-      end
-      # rubocop:enable Metrics/MethodLength
-
-      def list?
-        return false if investments.empty?
-
-        true
-      end
-
+    class Investments < BaseCapitalRecordsSection
       private
 
-      def investments
-        @investments ||= crime_application.investments
+      def has_no_records_component
+        Components::ValueAnswer.new(
+          :has_investments, has_records_answer,
+          change_path: edit_steps_capital_investment_type_path
+        )
       end
 
-      def shown_investments?
-        capital.present? && (no_investments? || investments.present?)
+      def item_component_class
+        Summary::Components::Investment
       end
 
-      def no_investments?
-        return false if capital.has_no_investments.nil?
+      def records
+        @records ||= capital.investments
+      end
 
-        YesNoAnswer.new(capital.has_no_investments).yes?
+      def has_records_answer
+        case capital.has_no_investments
+        when 'yes'
+          YesNoAnswer::NO
+        when 'no'
+          YesNoAnswer::YES
+        else
+          capital.has_no_investments
+        end
       end
     end
   end

--- a/app/presenters/summary/sections/national_savings_certificates.rb
+++ b/app/presenters/summary/sections/national_savings_certificates.rb
@@ -1,45 +1,27 @@
 module Summary
   module Sections
-    class NationalSavingsCertificates < Sections::BaseSection
-      def show?
-        shown_question?
-      end
-
-      def answers
-        if no_certificates?
-          [
-            Components::ValueAnswer.new(
-              :has_national_savings_certificate, 'no',
-              change_path: edit_steps_capital_has_national_savings_certificates_path
-            )
-          ]
-        else
-          Summary::Components::NationalSavingsCertificate.with_collection(
-            national_savings_certificates, show_actions: editable?, show_record_actions: headless?
-          )
-        end
-      end
-
-      def list?
-        return false if national_savings_certificates.empty?
-
-        true
-      end
-
+    class NationalSavingsCertificates < BaseCapitalRecordsSection
       private
 
-      def national_savings_certificates
-        @national_savings_certificates ||= crime_application.national_savings_certificates
+      def has_no_records_component
+        Components::ValueAnswer.new(
+          :has_national_savings_certificate, has_records_answer,
+          change_path: edit_steps_capital_has_national_savings_certificates_path
+        )
       end
 
-      def shown_question?
-        capital.present? && (no_certificates? || national_savings_certificates.present?)
+      def list_component
+        Summary::Components::NationalSavingsCertificate.with_collection(
+          records, show_actions: editable?, show_record_actions: headless?
+        )
       end
 
-      def no_certificates?
-        return false if capital.has_national_savings_certificates.nil?
+      def records
+        @records ||= capital.national_savings_certificates
+      end
 
-        YesNoAnswer.new(capital.has_national_savings_certificates).no?
+      def has_records_answer
+        capital.has_national_savings_certificates
       end
     end
   end

--- a/app/presenters/summary/sections/premium_bonds.rb
+++ b/app/presenters/summary/sections/premium_bonds.rb
@@ -1,6 +1,6 @@
 module Summary
   module Sections
-    # rubocop:disable Naming/PredicateName, Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     class PremiumBonds < Sections::BaseSection
       def show?
         shown_premium_bonds? && super

--- a/app/presenters/summary/sections/properties.rb
+++ b/app/presenters/summary/sections/properties.rb
@@ -1,51 +1,32 @@
 module Summary
   module Sections
-    class Properties < Sections::BaseSection
-      def show?
-        shown_question?
-      end
-
-      # rubocop:disable Metrics/MethodLength
-      def answers
-        if no_properties?
-          [
-            Components::ValueAnswer.new(
-              :has_assets, 'none',
-              change_path: edit_steps_capital_property_type_path
-            )
-          ]
-        else
-          Summary::Components::GroupedList.new(
-            items: properties,
-            group_by: :property_type,
-            item_component: Summary::Components::Property,
-            show_actions: editable?,
-            show_record_actions: headless?
-          )
-        end
-      end
-      # rubocop:enable Metrics/MethodLength
-
-      def list?
-        return false if properties.empty?
-
-        true
-      end
-
+    class Properties < BaseCapitalRecordsSection
       private
 
-      def properties
-        @properties ||= crime_application.properties
+      def has_no_records_component
+        Components::ValueAnswer.new(
+          :has_assets, has_records_answer,
+          change_path: edit_steps_capital_property_type_path
+        )
       end
 
-      def shown_question?
-        capital.present? && (no_properties? || properties.present?)
+      def item_component_class
+        Summary::Components::Property
       end
 
-      def no_properties?
-        return false if capital.has_no_properties.nil?
+      def records
+        @records ||= capital.properties
+      end
 
-        YesNoAnswer.new(capital.has_no_properties).yes?
+      def has_records_answer
+        case capital.has_no_properties
+        when 'yes'
+          YesNoAnswer::NO
+        when 'no'
+          YesNoAnswer::YES
+        else
+          capital.has_no_properties
+        end
       end
     end
   end

--- a/app/presenters/summary/sections/savings.rb
+++ b/app/presenters/summary/sections/savings.rb
@@ -1,49 +1,32 @@
 module Summary
   module Sections
-    class Savings < Sections::BaseSection
-      def show?
-        shown_savings?
-      end
-
-      def answers
-        return savings_list_component unless no_savings?
-
-        [
-          Components::ValueAnswer.new(
-            :has_capital_savings, 'none',
-            change_path: edit_steps_capital_saving_type_path
-          )
-        ]
-      end
-
-      def list?
-        !no_savings?
-      end
-
+    class Savings < BaseCapitalRecordsSection
       private
 
-      def savings_list_component
-        Summary::Components::GroupedList.new(
-          items: savings,
-          group_by: :saving_type,
-          item_component: Summary::Components::Saving,
-          show_actions: editable?,
-          show_record_actions: headless?
+      def has_no_records_component
+        Components::ValueAnswer.new(
+          :has_capital_savings, has_records_answer,
+          change_path: edit_steps_capital_saving_type_path
         )
       end
 
-      def savings
-        @savings ||= crime_application.savings
+      def item_component_class
+        Summary::Components::Saving
       end
 
-      def shown_savings?
-        capital.present? && (no_savings? || savings.present?)
+      def records
+        @records ||= capital.savings
       end
 
-      def no_savings?
-        return false if capital.has_no_savings.nil?
-
-        YesNoAnswer.new(capital.has_no_savings).yes?
+      def has_records_answer
+        case capital.has_no_savings
+        when 'yes'
+          YesNoAnswer::NO
+        when 'no'
+          YesNoAnswer::YES
+        else
+          capital.has_no_savings
+        end
       end
     end
   end

--- a/app/services/adapters/structs/capital_details.rb
+++ b/app/services/adapters/structs/capital_details.rb
@@ -1,30 +1,6 @@
 module Adapters
   module Structs
     class CapitalDetails < BaseStructAdapter
-      def trust_fund_amount_held
-        cast_to_pounds(super)
-      end
-
-      def trust_fund_yearly_dividend
-        cast_to_pounds(super)
-      end
-
-      def partner_trust_fund_amount_held
-        cast_to_pounds(super)
-      end
-
-      def partner_trust_fund_yearly_dividend
-        cast_to_pounds(super)
-      end
-
-      def premium_bonds_total_value
-        cast_to_pounds(super)
-      end
-
-      def partner_premium_bonds_total_value
-        cast_to_pounds(super)
-      end
-
       def savings
         return [] unless __getobj__
 
@@ -59,11 +35,6 @@ module Adapters
       def serializable_hash(options = {})
         except = %i[savings investments national_savings_certificates properties]
         super(options.merge(except:))
-      end
-
-      # TODO: figure out why casting from pence is not happening automatically
-      def cast_to_pounds(value)
-        Money.new(value)
       end
     end
   end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -701,9 +701,8 @@ en:
         question: Sort code or branch name
         absence_answer: ''
       has_capital_savings:
-        question: Savings %{subject} has
-        answers:
-          'none': *absence_none
+        question: Any savings?
+        answers: *YESNO
       # END saving
 
       # START premium_bonds
@@ -740,9 +739,8 @@ en:
         answers: *OWNERSHIP_TYPE
         absence_answer: ''
       has_investments:
-        question: Investments?
-        answers:
-          'none': *absence_none
+        question: Any investments?
+        answers: *YESNO
       # END investments
 
       # START national_savings_certificates
@@ -813,8 +811,7 @@ en:
         absence_answer: *absence_none
       has_assets:
         question: Assets %{subject} owns
-        answers:
-          'none': *absence_none
+        answers: *YESNO
       # END property, address and owners
 
       # START trust_fund

--- a/spec/forms/steps/capital/answers_form_spec.rb
+++ b/spec/forms/steps/capital/answers_form_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe Steps::Capital::AnswersForm do
     context 'when `has_no_other_assets` is `yes` but answers are incomplete' do
       let(:attributes) { { has_no_other_assets: YesNoAnswer::YES.to_s } }
 
-      before { capital.properties.build }
-
       it 'updates capital record' do
         expect(capital).not_to receive(:update)
         expect(subject.save).to be(false)

--- a/spec/models/capital_spec.rb
+++ b/spec/models/capital_spec.rb
@@ -49,5 +49,203 @@ RSpec.describe Capital, type: :model do
     end
   end
 
+  describe '#investments' do
+    subject(:capital_investments) { capital.investments }
+
+    let(:capital) { described_class.new(has_no_investments:) }
+    let(:crime_application) { CrimeApplication.new(capital:, investments:) }
+    let(:has_no_investments) { nil }
+
+    let(:investments) do
+      [
+        Investment.new(ownership_type: 'applicant', investment_type: 'bond'),
+        Investment.new(ownership_type: 'partner', investment_type: 'pep')
+      ]
+    end
+
+    before do
+      crime_application.save!
+      allow(MeansStatus).to receive_messages(
+        include_partner?: include_partner, full_capital_required?: full_capital_required
+      )
+    end
+
+    context 'when full capital required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq investments }
+    end
+
+    context 'when partner is excluded from means' do
+      let(:include_partner) { false }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq [investments.first] }
+    end
+
+    context 'when full capital is not required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { false }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#properties' do
+    subject(:capital_properties) { capital.properties }
+
+    let(:capital) { described_class.new }
+    let(:crime_application) { CrimeApplication.new(capital:, properties:) }
+    let(:properties) { [Property.new(property_type: 'land')] }
+
+    before do
+      crime_application.save!
+      allow(MeansStatus).to receive_messages(
+        full_capital_required?: full_capital_required
+      )
+    end
+
+    context 'when full capital required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq properties }
+    end
+
+    context 'when full capital is not required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { false }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#national_savings_certificates' do
+    subject(:capital_national_savings_certificates) { capital.national_savings_certificates }
+
+    let(:capital) { described_class.new }
+    let(:crime_application) { CrimeApplication.new(capital:, national_savings_certificates:) }
+
+    let(:national_savings_certificates) do
+      [
+        NationalSavingsCertificate.new(ownership_type: 'applicant'),
+        NationalSavingsCertificate.new(ownership_type: 'partner')
+      ]
+    end
+
+    before do
+      crime_application.save!
+      allow(MeansStatus).to receive_messages(
+        include_partner?: include_partner, full_capital_required?: full_capital_required
+      )
+    end
+
+    context 'when full capital required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq national_savings_certificates }
+    end
+
+    context 'when partner is excluded from means' do
+      let(:include_partner) { false }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq [national_savings_certificates.first] }
+    end
+
+    context 'when full capital is not required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { false }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#savings' do
+    subject(:capital_savings) { capital.savings }
+
+    let(:capital) { described_class.new(has_no_savings:) }
+    let(:crime_application) { CrimeApplication.new(capital:, savings:) }
+    let(:has_no_savings) { nil }
+
+    let(:savings) do
+      [
+        Saving.new(ownership_type: 'applicant', saving_type: 'bank'),
+        Saving.new(ownership_type: 'partner', saving_type: 'cash_isa')
+      ]
+    end
+
+    before do
+      crime_application.save!
+      allow(MeansStatus).to receive_messages(
+        include_partner?: include_partner, full_capital_required?: full_capital_required
+      )
+    end
+
+    context 'when full capital required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq savings }
+    end
+
+    context 'when partner is excluded from means' do
+      let(:include_partner) { false }
+      let(:full_capital_required) { true }
+
+      it { is_expected.to eq [savings.first] }
+    end
+
+    context 'when full capital is not required' do
+      let(:include_partner) { true }
+      let(:full_capital_required) { false }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe 'has asset answers' do
+    subject(:has_asset_answers) { capital.values_at(*attribute_names) }
+
+    let(:attribute_names) do
+      %i[
+        has_national_savings_certificates
+        has_no_properties
+        has_no_savings
+        has_no_investments
+        has_premium_bonds
+        partner_has_premium_bonds
+      ]
+    end
+
+    before do
+      attribute_names.each do |attr|
+        capital.public_send(:"#{attr}=", 'yes')
+      end
+    end
+
+    context 'full capital is required' do
+      before do
+        allow(MeansStatus).to receive(:full_capital_required?).and_return(true)
+      end
+
+      it 'returns the stored answers' do
+        expect(has_asset_answers.uniq).to eq ['yes']
+      end
+    end
+
+    context 'full capital is no longer required' do
+      before do
+        allow(MeansStatus).to receive(:full_capital_required?).and_return(false)
+      end
+
+      it 'returns the stored answers' do
+        expect(has_asset_answers.uniq).to eq [nil]
+      end
+    end
+  end
+
   it_behaves_like 'it has a means ownership scope'
 end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -17,13 +17,30 @@ describe Summary::HtmlPresenter do
       outgoings_payments: [instance_double(OutgoingsPayment, payment_type: 'childcare')],
       outgoings: (double has_no_other_outgoings: nil),
       documents: double, application_type: application_type,
-      capital: (double has_premium_bonds: 'yes', partner_has_premium_bonds: 'yes', will_benefit_from_trust_fund: 'yes', partner_will_benefit_from_trust_fund: 'yes', has_no_properties: nil, has_no_savings: nil, has_no_investments: nil, has_national_savings_certificates: 'yes'),
+      capital: capital,
       savings: [double], investments: [double], national_savings_certificates: [double], properties: [double],
       is_means_tested: is_means_tested,
       non_means_tested?: false
     )
   end
   # rubocop:enable Layout/LineLength
+
+  let(:capital) do
+    instance_double(
+      Capital,
+      has_premium_bonds: 'yes',
+      partner_has_premium_bonds: 'yes',
+      will_benefit_from_trust_fund: 'yes',
+      partner_will_benefit_from_trust_fund: 'yes',
+      has_no_properties: nil, has_no_savings: nil,
+      has_no_investments: nil,
+      has_national_savings_certificates: 'yes',
+      savings: [double],
+      investments: [double],
+      national_savings_certificates: [double],
+      properties: [double]
+    )
+  end
 
   let(:income) do
     instance_double(

--- a/spec/presenters/summary/sections/investments_spec.rb
+++ b/spec/presenters/summary/sections/investments_spec.rb
@@ -1,102 +1,10 @@
 require 'rails_helper'
 
 describe Summary::Sections::Investments do
-  subject { described_class.new(crime_application) }
-
-  let(:crime_application) {
-    instance_double(CrimeApplication,
-                    investments: records,
-                    in_progress?: true,
-                    capital: double(Capital, has_no_investments:),
-                    to_param: 12_345)
-  }
-  let(:records) { [Investment.new] }
-  let(:has_no_investments) { nil }
-
-  describe '#list?' do
-    it { expect(subject.list?).to be true }
-  end
-
-  describe '#show?' do
-    context 'when there are investments' do
-      it 'shows this section' do
-        expect(subject.show?).to be true
-      end
-    end
-
-    context 'when there are no investments' do
-      let(:records) { [] }
-
-      context 'when the full capital journey was shown' do
-        let(:has_no_investments) { 'yes' }
-
-        it 'shows this section' do
-          expect(subject.show?).to be true
-        end
-      end
-
-      context 'when the full capital journey was not shown' do
-        it 'does not show this section' do
-          expect(subject.show?).to be false
-        end
-      end
-    end
-  end
-
-  describe '#answers' do
-    context 'when there are investments' do
-      let(:component) { instance_double(Summary::Components::GroupedList) }
-
-      before do
-        allow(Summary::Components::GroupedList).to receive(:new) { component }
-      end
-
-      it 'returns the grouped list component with actions' do
-        expect(subject.answers).to be component
-
-        expect(Summary::Components::GroupedList).to have_received(:new).with(
-          items: records,
-          group_by: :investment_type,
-          item_component: Summary::Components::Investment,
-          show_actions: true,
-          show_record_actions: false
-        )
-      end
-
-      context 'not in progress' do
-        before do
-          allow(crime_application).to receive(:in_progress?).and_return(false)
-        end
-
-        it 'returns the grouped list component without actions' do
-          expect(subject.answers).to be component
-
-          expect(Summary::Components::GroupedList).to have_received(:new).with(
-            items: records,
-            group_by: :investment_type,
-            item_component: Summary::Components::Investment,
-            show_actions: false,
-            show_record_actions: false
-          )
-        end
-      end
-    end
-
-    context 'when there are no investments' do
-      let(:records) { [] }
-      let(:answers) { subject.answers }
-      let(:has_no_investments) { 'yes' }
-
-      context 'when full capital journey was required' do
-        it 'has the correct rows' do
-          expect(answers.count).to eq(1)
-
-          expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
-          expect(answers[0].question).to eq(:has_investments)
-          expect(answers[0].change_path).to match('applications/12345/steps/capital/which_investments')
-          expect(answers[0].value).to eq('none')
-        end
-      end
-    end
+  it_behaves_like 'a capital records section' do
+    let(:capital) { instance_double(Capital, has_no_investments: has_no_answer, investments: records,) }
+    let(:record) { Investment.new }
+    let(:expected_question_text) { 'Any investments?' }
+    let(:expected_change_path) { 'applications/12345/steps/capital/which_investments' }
   end
 end

--- a/spec/presenters/summary/sections/national_savings_certificates_spec.rb
+++ b/spec/presenters/summary/sections/national_savings_certificates_spec.rb
@@ -6,10 +6,17 @@ describe Summary::Sections::NationalSavingsCertificates do
   let(:crime_application) do
     instance_double(
       CrimeApplication,
-      national_savings_certificates: records,
+      capital: capital,
       in_progress?: true,
-      capital: double(Capital, has_national_savings_certificates:),
       to_param: 12_345
+    )
+  end
+
+  let(:capital) do
+    instance_double(
+      Capital,
+      has_national_savings_certificates: has_national_savings_certificates,
+      national_savings_certificates: records
     )
   end
 

--- a/spec/presenters/summary/sections/properties_spec.rb
+++ b/spec/presenters/summary/sections/properties_spec.rb
@@ -1,105 +1,17 @@
 require 'rails_helper'
 
 describe Summary::Sections::Properties do
-  subject { described_class.new(crime_application) }
-
-  let(:crime_application) do
-    instance_double(
-      CrimeApplication,
-      properties: records,
-      in_progress?: true,
-      capital: double(Capital, has_no_properties:),
-      to_param: 12_345
-    )
-  end
-
-  let(:records) { [Property.new] }
-  let(:has_no_properties) { nil }
-
-  describe '#list?' do
-    it { expect(subject.list?).to be true }
-  end
-
-  describe '#show?' do
-    context 'when there are properties' do
-      it 'shows this section' do
-        expect(subject.show?).to be true
-      end
+  it_behaves_like 'a capital records section' do
+    let(:capital) do
+      instance_double(
+        Capital,
+        has_no_properties: has_no_answer,
+        properties: records
+      )
     end
 
-    context 'when there are no properties' do
-      let(:records) { [] }
-
-      context 'when the full capital journey was shown' do
-        let(:has_no_properties) { 'yes' }
-
-        it 'shows this section' do
-          expect(subject.show?).to be true
-        end
-      end
-
-      context 'when the full capital journey was not shown' do
-        it 'does not show this section' do
-          expect(subject.show?).to be false
-        end
-      end
-    end
-  end
-
-  describe '#answers' do
-    context 'when there are properties' do
-      let(:component) { instance_double(Summary::Components::GroupedList) }
-
-      before do
-        allow(Summary::Components::GroupedList).to receive(:new) { component }
-      end
-
-      it 'returns the grouped list component with actions' do
-        expect(subject.answers).to be component
-
-        expect(Summary::Components::GroupedList).to have_received(:new).with(
-          items: records,
-          group_by: :property_type,
-          item_component: Summary::Components::Property,
-          show_actions: true,
-          show_record_actions: false
-        )
-      end
-
-      context 'not in progress' do
-        before do
-          allow(crime_application).to receive(:in_progress?).and_return(false)
-        end
-
-        it 'returns the grouped list component without actions' do
-          expect(subject.answers).to be component
-
-          expect(Summary::Components::GroupedList).to have_received(:new).with(
-            items: records,
-            group_by: :property_type,
-            item_component: Summary::Components::Property,
-            show_actions: false,
-            show_record_actions: false
-          )
-        end
-      end
-    end
-
-    context 'when there are no properties' do
-      let(:records) { [] }
-      let(:answers) { subject.answers }
-      let(:has_no_properties) { 'yes' }
-
-      context 'when full capital journey was required' do
-        it 'has the correct rows' do
-          expect(answers.count).to eq(1)
-
-          expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
-          expect(answers[0].question).to eq(:has_assets)
-          expect(answers[0].change_path).to match('applications/12345/steps/capital/which_assets_owned')
-          expect(answers[0].value).to eq('none')
-        end
-      end
-    end
+    let(:record) { Property.new }
+    let(:expected_question_text) { 'Assets client owns' }
+    let(:expected_change_path) { 'applications/12345/steps/capital/which_assets_owned' }
   end
 end

--- a/spec/presenters/summary/sections/savings_spec.rb
+++ b/spec/presenters/summary/sections/savings_spec.rb
@@ -1,99 +1,13 @@
 require 'rails_helper'
 
 describe Summary::Sections::Savings do
-  subject { described_class.new(crime_application) }
-
-  let(:crime_application) {
-    instance_double(CrimeApplication, savings: records, in_progress?: true, capital: double(Capital, has_no_savings:),
-   to_param: 12_345)
-  }
-  let(:records) { [Saving.new] }
-  let(:has_no_savings) { nil }
-
-  describe '#list?' do
-    it { expect(subject.list?).to be true }
-  end
-
-  describe '#show?' do
-    context 'when there are savings' do
-      it 'shows this section' do
-        expect(subject.show?).to be true
-      end
+  it_behaves_like 'a capital records section' do
+    let(:capital) do
+      instance_double(Capital, has_no_savings: has_no_answer, savings: records)
     end
 
-    context 'when there are no savings' do
-      let(:records) { [] }
-
-      context 'when the full capital journey was shown' do
-        let(:has_no_savings) { 'yes' }
-
-        it 'shows this section' do
-          expect(subject.show?).to be true
-        end
-      end
-
-      context 'when the full capital journey was not shown' do
-        it 'does not show this section' do
-          expect(subject.show?).to be false
-        end
-      end
-    end
-  end
-
-  describe '#answers' do
-    context 'when there are savings' do
-      let(:component) { instance_double(Summary::Components::GroupedList) }
-
-      before do
-        allow(Summary::Components::GroupedList).to receive(:new) { component }
-      end
-
-      it 'returns the grouped list component with actions' do
-        expect(subject.answers).to be component
-
-        expect(Summary::Components::GroupedList).to have_received(:new).with(
-          items: records,
-          group_by: :saving_type,
-          item_component: Summary::Components::Saving,
-          show_actions: true,
-          show_record_actions: false
-        )
-      end
-
-      context 'not in progress' do
-        before do
-          allow(crime_application).to receive(:in_progress?).and_return(false)
-        end
-
-        it 'returns the grouped list component without actions' do
-          expect(subject.answers).to be component
-
-          expect(Summary::Components::GroupedList).to have_received(:new).with(
-            items: records,
-            group_by: :saving_type,
-            item_component: Summary::Components::Saving,
-            show_actions: false,
-            show_record_actions: false
-          )
-        end
-      end
-    end
-
-    context 'when there are no savings' do
-      let(:records) { [] }
-      let(:answers) { subject.answers }
-      let(:has_no_savings) { 'yes' }
-
-      context 'when full capital journey was required' do
-        it 'has the correct rows' do
-          expect(answers.count).to eq(1)
-
-          expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
-          expect(answers[0].question).to eq(:has_capital_savings)
-          expect(answers[0].change_path).to match('applications/12345/steps/capital/which_savings')
-          expect(answers[0].value).to eq('none')
-        end
-      end
-    end
+    let(:record) { Saving.new }
+    let(:expected_question_text) { 'Any savings?' }
+    let(:expected_change_path) { 'applications/12345/steps/capital/which_savings' }
   end
 end

--- a/spec/requests/investments_summary_spec.rb
+++ b/spec/requests/investments_summary_spec.rb
@@ -1,16 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Investments summary page', :authorized do
-  before :all do
+  before do
+    allow(MeansStatus).to receive(:full_capital_required?).and_return('true')
+
     app = CrimeApplication.create(capital: Capital.new)
     app.investments.create!(investment_type: InvestmentType::BOND,
                             description: 'About the Bond',
                             value: 10_001,
                             ownership_type: OwnershipType::APPLICANT)
-  end
-
-  after :all do
-    CrimeApplication.destroy_all
   end
 
   describe 'list of added investments in summary page' do

--- a/spec/requests/national_savings_certificates_summary_spec.rb
+++ b/spec/requests/national_savings_certificates_summary_spec.rb
@@ -1,18 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'NationalSavingsCertificates summary page', :authorized do
-  before :all do
-    app = CrimeApplication.create(capital: Capital.new)
+  before do
+    allow(MeansStatus).to receive(:full_capital_required?).and_return('true')
+
+    app = CrimeApplication.create(capital: Capital.new(has_national_savings_certificates: 'yes'))
     app.national_savings_certificates.create!(
       holder_number: 'A!',
       certificate_number: 'B2',
       value: 10_001,
       ownership_type: OwnershipType::APPLICANT
     )
-  end
-
-  after :all do
-    CrimeApplication.destroy_all
   end
 
   describe 'list of added certificates on summary page' do

--- a/spec/requests/savings_summary_spec.rb
+++ b/spec/requests/savings_summary_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Savings summary page', :authorized do
-  before :all do
+  before do
+    allow(MeansStatus).to receive(:full_capital_required?).and_return('true')
+
     app = CrimeApplication.create(capital: Capital.new)
     app.savings.create!(saving_type: SavingType::BANK,
                         provider_name: 'Bank of Test',
@@ -11,10 +13,6 @@ RSpec.describe 'Savings summary page', :authorized do
                         account_balance: '100.01',
                         is_overdrawn: YesNoAnswer.values.sample,
                         are_wages_paid_into_account: YesNoAnswer.values.sample)
-  end
-
-  after :all do
-    CrimeApplication.destroy_all
   end
 
   describe 'list of added savings in summary page' do

--- a/spec/services/adapters/structs/capital_details_spec.rb
+++ b/spec/services/adapters/structs/capital_details_spec.rb
@@ -5,24 +5,6 @@ RSpec.describe Adapters::Structs::CapitalDetails do
 
   let(:application_struct) { build_struct_application }
 
-  describe '#trust_fund_yearly_dividend' do
-    it 'returns a money object' do
-      expect(subject.trust_fund_yearly_dividend).to be_an_instance_of(Money)
-    end
-  end
-
-  describe '#trust_fund_amount_held' do
-    it 'returns a money object' do
-      expect(subject.trust_fund_amount_held).to be_an_instance_of(Money)
-    end
-  end
-
-  describe '#premium_bonds_total_value' do
-    it 'returns a money object' do
-      expect(subject.premium_bonds_total_value).to be_an_instance_of(Money)
-    end
-  end
-
   describe '#savings' do
     it 'returns a savings collection' do
       expect(subject.savings).to all(be_an(Saving))

--- a/spec/services/evidence/rules/20240426094427_premium_bonds_spec.rb
+++ b/spec/services/evidence/rules/20240426094427_premium_bonds_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe Evidence::Rules::PremiumBonds do
   let(:capital) { Capital.new }
 
   before do
-    allow(MeansStatus).to receive(:include_partner?).with(crime_application)
-                                                    .and_return(true)
+    allow(MeansStatus).to receive_messages(
+      include_partner?: true,
+      full_capital_required?: true
+    )
   end
 
   it { expect(described_class.key).to eq :capital_premium_bonds_21 }

--- a/spec/support/shared_examples/a_capital_records_section.rb
+++ b/spec/support/shared_examples/a_capital_records_section.rb
@@ -1,0 +1,119 @@
+RSpec.shared_examples 'a capital records section' do |_options|
+  subject(:presenter) { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      to_param: 12_345,
+      capital: capital, in_progress?: true
+    )
+  end
+
+  let(:records) { [record] }
+
+  describe '#list?' do
+    subject(:list?) { presenter.list? }
+
+    let(:has_no_answer) { nil }
+
+    context 'when there are records' do
+      it { is_expected.to be true }
+    end
+
+    context 'when there are no records' do
+      let(:records) { [] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#show?' do
+    subject(:show?) { presenter.show? }
+
+    context 'when there are records' do
+      let(:has_no_answer) { nil }
+      let(:records) { [record] }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when there are no records' do
+      let(:records) { [] }
+
+      context 'when the has no question answer is yes' do
+        let(:has_no_answer) { 'yes' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the has no question answer is no' do
+        let(:has_no_answer) { 'no' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the has no question has not been answered answered' do
+        let(:has_no_answer) { nil }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:item_component) { Summary::Components.const_get(record.class.name) }
+    let(:has_no_answer) { nil }
+
+    context 'when there are records' do
+      let(:component) { instance_double(Summary::Components::GroupedList) }
+
+      before do
+        allow(Summary::Components::GroupedList).to receive(:new) { component }
+      end
+
+      it 'returns the grouped list component with actions' do
+        expect(subject.answers).to be component
+
+        expect(Summary::Components::GroupedList).to have_received(:new).with(
+          items: records,
+          item_component: item_component,
+          show_actions: true,
+          show_record_actions: false
+        )
+      end
+
+      context 'not in progress' do
+        before do
+          allow(crime_application).to receive(:in_progress?).and_return(false)
+        end
+
+        it 'returns the grouped list component without actions' do
+          expect(subject.answers).to be component
+
+          expect(Summary::Components::GroupedList).to have_received(:new).with(
+            items: records,
+            item_component: item_component,
+            show_actions: false,
+            show_record_actions: false
+          )
+        end
+      end
+    end
+
+    context 'when there are no records' do
+      let(:records) { [] }
+      let(:answers) { subject.answers }
+      let(:has_no_answer) { 'yes' }
+
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[0].question_text).to eq expected_question_text
+        expect(answers[0].answer_text).to eq 'No'
+        expect(answers[0].change_path).to match expected_change_path
+        expect(answers[0].value).to eq(YesNoAnswer::NO)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Only show Capital asset answers when full capital required.

## Link to relevant ticket

[CRIMAPP-1111](https://dsdmoj.atlassian.net/browse/CRIMAPP-1111)

## Notes for reviewer

This follows a similar pattern to Income, where the Capital model is responsible for knowing when to include/omit answers.

There is a similar issue for evidence prompt which is part of a separate ticket: [CRIMAPP-1215](https://dsdmoj.atlassian.net/browse/CRIMAPP-1215)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1111]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRIMAPP-1215]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ