### PR TITLE
[CRIMAPP-1195] Recalculate means passport value for resubmitted applications

### DIFF
--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -3,11 +3,9 @@ module Passporting
     include TypeOfMeansAssessment
 
     def call
-      return passported? if resubmission?
-
       means_passport = []
       means_passport << MeansPassportType::ON_NOT_MEANS_TESTED if app_not_means_tested?
-      means_passport << MeansPassportType::ON_AGE_UNDER18      if applicant_under18?
+      means_passport << MeansPassportType::ON_AGE_UNDER18      if age_passported?
       means_passport << MeansPassportType::ON_BENEFIT_CHECK    if benefit_check_passed?
 
       crime_application.update(means_passport:)

--- a/spec/services/passporting/means_passporter_spec.rb
+++ b/spec/services/passporting/means_passporter_spec.rb
@@ -33,17 +33,6 @@ RSpec.describe Passporting::MeansPassporter do
   end
 
   describe '#call' do
-    context 'for a resubmitted application' do
-      let(:resubmission?) { true }
-
-      it 'uses the existing values' do
-        expect(crime_application).not_to receive(:update)
-        expect(subject).to receive(:passported?)
-
-        subject.call
-      end
-    end
-
     context 'means passporting on non-means tested' do
       let(:is_means_tested) { 'no' }
 


### PR DESCRIPTION
## Description of change
Refactors the means passporter to always calculate an apps passport status regardless of whether the app is resubmitted (with the exception of under 18 applications which need to retain the previous status). This is to prevent inaccuracies in presenting the passporting status when an application is resubmitted and the means passport value has not been updated on resubmission

## Link to relevant ticket
[CRIMAPP-1195](https://dsdmoj.atlassian.net/browse/CRIMAPP-1195)

## Notes for reviewer
The only means passport value that needs to be retained on resubmission is the under 18 status. I did take a look at the benefit check passport but that is recalculated ([see pr](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/838)) 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Requires [datastore](https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/291) and [review](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/649) pr's to test locally 


[CRIMAPP-1195]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ