### PR TITLE
CRIMAPP-1110: Update CYA page  after changing income information

### DIFF
--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -75,6 +75,12 @@ class Income < ApplicationRecord
     super if known_to_be_full_means?
   end
 
+  def manage_without_income
+    return if all_income_over_zero?
+
+    super
+  end
+
   def complete?
     valid?(:submission)
   end

--- a/app/presenters/summary/sections/other_income_details.rb
+++ b/app/presenters/summary/sections/other_income_details.rb
@@ -4,7 +4,7 @@ module Summary
       include TypeOfMeansAssessment
 
       def show?
-        income.present? && super
+        income.present? && income.manage_without_income.present? && super
       end
 
       def answers

--- a/spec/controllers/steps/income/manage_without_income_controller_spec.rb
+++ b/spec/controllers/steps/income/manage_without_income_controller_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Income::ManageWithoutIncomeController, type: :controller do
+  before do
+    allow_any_instance_of(Applicant).to receive(:under18?).and_return(false)
+  end
+
   it_behaves_like 'a generic step controller', Steps::Income::ManageWithoutIncomeForm, Decisions::IncomeDecisionTree
 end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -66,9 +66,11 @@ describe Summary::HtmlPresenter do
       has_no_income_benefits: nil,
       partner_has_no_income_payments: nil,
       partner_has_no_income_benefits: nil,
-      manage_without_income: nil
+      manage_without_income: manage_without_income
     )
   end
+
+  let(:manage_without_income) { nil }
 
   let(:is_means_tested) { 'yes' }
 
@@ -270,7 +272,6 @@ describe Summary::HtmlPresenter do
             IncomeBenefitsDetails
             PartnerIncomePaymentsDetails
             PartnerIncomeBenefitsDetails
-            OtherIncomeDetails
             HousingPayments
             OutgoingsPaymentsDetails
             OtherOutgoingsDetails
@@ -509,7 +510,17 @@ describe Summary::HtmlPresenter do
     context 'when an initial application' do
       let(:application_type) { 'initial' }
 
-      it { is_expected.to match_array(expected_sections) }
+      context 'when `manage_without_income` is present' do
+        let(:manage_without_income) { ManageWithoutIncomeType::LIVING_ON_STREETS.to_s }
+
+        it { is_expected.to match_array(expected_sections) }
+      end
+
+      context 'when `manage_without_income` is not present' do
+        let(:manage_without_income) { nil }
+
+        it { is_expected.not_to match_array(expected_sections) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change

Show 'OtherIncomeDetails' section if sum of the following payments  is 0

- income_payments
- income_benefits
- employments_total

## Link to relevant ticket
[CRIMAPP-1110](https://dsdmoj.atlassian.net/browse/CRIMAPP-1110)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1110]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ