### PR TITLE
CRIMAPP-1208 excempt not means tested applications

### DIFF
--- a/app/services/evidence/prompt.rb
+++ b/app/services/evidence/prompt.rb
@@ -54,7 +54,8 @@ module Evidence
 
       [
         under18?,
-        in_custody?
+        in_custody?,
+        not_means_tested?
       ].any?(true)
     end
 
@@ -84,6 +85,14 @@ module Evidence
     end
 
     private
+
+    def not_means_tested?
+      return false unless crime_application.is_means_tested == 'no'
+
+      @exempt_reasons << I18n.t('evidence.exempt.not_means_tested')
+
+      true
+    end
 
     def under18?
       return false unless crime_application.applicant

--- a/config/locales/en/evidence.yml
+++ b/config/locales/en/evidence.yml
@@ -13,6 +13,7 @@ en:
         none: Other evidence of the partner's income, outgoings or capital
       other: Other evidence
     exempt:
+      not_means_tested: it is not subject to the usual means or passported test
       under_18: your client was under 18 when the application was first made
       in_custody: you have told us they are remanded in custody
     rule:

--- a/spec/services/evidence/prompt_spec.rb
+++ b/spec/services/evidence/prompt_spec.rb
@@ -55,11 +55,12 @@ RSpec.describe Evidence::Prompt do
       :evidence_prompts= => nil,
       :evidence_last_run_at => [],
       :evidence_last_run_at= => nil,
+      :is_means_tested => 'yes',
       :save! => true
     )
 
     allow(applicant).to receive_messages(
-      under18?: false
+      under18?: false,
     )
   end
 
@@ -215,6 +216,19 @@ RSpec.describe Evidence::Prompt do
       it 'returns false' do
         expect(prompt.exempt?).to be false
         expect(prompt.exempt_reasons).to be_empty
+      end
+    end
+
+    context 'when the client is not means tested' do
+      before do
+        allow(crime_application).to receive(:is_means_tested).and_return 'no'
+      end
+
+      it 'returns true and sets the reason' do
+        expect(prompt.exempt?).to be true
+        expect(prompt.exempt_reasons).to contain_exactly(
+          'it is not subject to the usual means or passported test'
+        )
       end
     end
 


### PR DESCRIPTION
## Description of change

Exempt Non-means applications from evidence.

## Link to relevant ticket
[CRIMAPP-1208](https://dsdmoj.atlassian.net/browse/CRIMAPP-1208)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="597" alt="Screenshot 2024-07-15 at 17 20 04" src="https://github.com/user-attachments/assets/1ef36d71-d9d3-46eb-8632-6a59df381f7c">


## How to manually test the feature


[CRIMAPP-1208]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ