### PR TITLE
Evidence upload task list behaviour amends

### DIFF
--- a/app/presenters/tasks/evidence_upload.rb
+++ b/app/presenters/tasks/evidence_upload.rb
@@ -5,11 +5,15 @@ module Tasks
     end
 
     def can_start?
-      true
+      crime_application.applicant.present?
     end
 
     def in_progress?
-      true
+      crime_application.documents.any?
+    end
+
+    def completed?
+      false
     end
 
     private

--- a/spec/presenters/tasks/evidence_upload_spec.rb
+++ b/spec/presenters/tasks/evidence_upload_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Tasks::EvidenceUpload do
       CrimeApplication,
       to_param: '12345',
       applicant: applicant,
+      documents: documents
     )
   end
 
   let(:applicant) { instance_double Applicant }
+  let(:documents) { [] }
 
   describe '#path' do
     it { expect(subject.path).to eq('/applications/12345/steps/evidence/upload') }
@@ -23,27 +25,27 @@ RSpec.describe Tasks::EvidenceUpload do
 
   describe '#can_start?' do
     it { expect(subject.can_start?).to be(true) }
+
+    context 'when applicant is not present' do
+      let(:applicant) { nil }
+
+      it { expect(subject.can_start?).to be(false) }
+    end
   end
 
   describe '#in_progress?' do
-    it { expect(subject.in_progress?).to be(true) }
+    context 'when documents are not present' do
+      it { expect(subject.in_progress?).to be(false) }
+    end
+
+    context 'when documents are present' do
+      let(:documents) { ['doc'] }
+
+      it { expect(subject.in_progress?).to be(true) }
+    end
   end
 
   describe '#completed?' do
-    before do
-      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:complete?).and_return(evidence_complete)
-    end
-
-    context 'when evidence validation is true' do
-      let(:evidence_complete) { true }
-
-      it { expect(subject.completed?).to be(true) }
-    end
-
-    context 'when evidence validation is false' do
-      let(:evidence_complete) { false }
-
-      it { expect(subject.completed?).to be(false) }
-    end
+    it { expect(subject.completed?).to be(false) }
   end
 end

--- a/spec/validators/supporting_evidence/answers_validator_spec.rb
+++ b/spec/validators/supporting_evidence/answers_validator_spec.rb
@@ -117,4 +117,24 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
       end
     end
   end
+
+  describe '#complete?' do
+    context 'when errors are present' do
+      before do
+        allow(validator).to receive(:validate).and_return(false)
+      end
+
+      it { expect(subject.complete?).to be(false) }
+    end
+
+    context 'when errors is empty' do
+      let(:errors) { double(:errors, empty?: true) }
+
+      before do
+        allow(validator).to receive(:validate).and_return(true)
+      end
+
+      it { expect(subject.complete?).to be(true) }
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

Fixes behaviour with the evidence upload task list following work to validate evidence upload 
Previously the evidence upload task will display as complete immediately as there are no evidence prompts yet 
However, we don't really know if an application's evidence is complete, only whether they have uploaded at least one piece of evidence. It may also give unrealistic view to providers that they don't have to upload any more evidence. So it was decided it is best to keep the status as in progress rather than ever setting the task to complete

The evidence form, review application page and declaration page will ensure apps are only submitted if they have fulfilled the validation criteria 

Implemented behaviour:

- Evidence upload status will = not started if there is no evidence uploaded
- Evidence upload status will = in progress if at least one piece of evidence has been uploaded 
- Evidence upload status will never be set to completed as we do not know if evidence is complete (so arguably more accurate)

There was also a bug when a user clicks the evidence upload link immediately after starting an application as there is no applicant yet and the evidence prompts are expecting a person to be available to assess whether evidence is required. So the evidence upload section cannot be started if an applicant is not present 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
**Currently evidence upload section is always displayed as completed**
<img width="893" alt="Screenshot 2024-07-16 at 13 14 29" src="https://github.com/user-attachments/assets/0ca2849f-6a3d-4dbb-96e4-6d0227204f57">

### After changes:

**When there is no evidence uploaded**
<img width="893" alt="Screenshot 2024-07-16 at 13 12 39" src="https://github.com/user-attachments/assets/2b3b893f-1b07-4e2c-906b-1fea56b66214">

**When there is evidence uploaded**
<img width="893" alt="Screenshot 2024-07-16 at 13 12 56" src="https://github.com/user-attachments/assets/bc96dd9c-fc62-43be-b1e0-eefe31491747">



## How to manually test the feature
