### PR TITLE
CRIMAPP-1223 captial details uses Money for amounts

### DIFF
--- a/app/services/adapters/structs/capital_details.rb
+++ b/app/services/adapters/structs/capital_details.rb
@@ -1,6 +1,30 @@
 module Adapters
   module Structs
     class CapitalDetails < BaseStructAdapter
+      def trust_fund_amount_held
+        Money.new(super)
+      end
+
+      def trust_fund_yearly_dividend
+        Money.new(super)
+      end
+
+      def partner_trust_fund_amount_held
+        Money.new(super)
+      end
+
+      def partner_trust_fund_yearly_dividend
+        Money.new(super)
+      end
+
+      def premium_bonds_total_value
+        Money.new(super)
+      end
+
+      def partner_premium_bonds_total_value
+        Money.new(super)
+      end
+
       def savings
         return [] unless __getobj__
 

--- a/spec/services/adapters/structs/capital_details_spec.rb
+++ b/spec/services/adapters/structs/capital_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Adapters::Structs::CapitalDetails do
-  subject { application_struct.capital }
+  subject(:adapter) { application_struct.capital }
 
   let(:application_struct) { build_struct_application }
 
@@ -27,6 +27,48 @@ RSpec.describe Adapters::Structs::CapitalDetails do
     it 'returns a properties collection' do
       expect(subject.properties).to all(be_an(Property))
     end
+  end
+
+  describe '#trust_fund_amount_held' do
+    subject(:trust_fund_amount_held) { adapter.trust_fund_amount_held }
+
+    it { is_expected.to be_a Money }
+    it { is_expected.to eq 100_000 }
+  end
+
+  describe '#trust_fund_yearly_dividend' do
+    subject(:trust_fund_yearly_dividend) { adapter.trust_fund_yearly_dividend }
+
+    it { is_expected.to be_a Money }
+    it { is_expected.to eq 200_000 }
+  end
+
+  describe '#premium_bonds_total_value' do
+    subject(:premium_bonds_total_value) { adapter.premium_bonds_total_value }
+
+    it { is_expected.to be_a Money }
+    it { is_expected.to eq 100_000 }
+  end
+
+  describe '#partner_premium_bonds_total_value' do
+    subject(:partner_premium_bonds_total_value) { adapter.partner_premium_bonds_total_value }
+
+    it { is_expected.to be_a Money }
+    it { expect(subject.value).to be_nil }
+  end
+
+  describe '#partner_trust_fund_yearly_dividend' do
+    subject(:partner_trust_fund_yearly_dividend) { adapter.partner_trust_fund_yearly_dividend }
+
+    it { is_expected.to be_a Money }
+    it { expect(subject.value).to be_nil }
+  end
+
+  describe '#partner_trust_fund_amount_held' do
+    subject(:partner_trust_fund_amount_held) { adapter.partner_trust_fund_amount_held }
+
+    it { is_expected.to be_a Money }
+    it { expect(subject.value).to be_nil }
   end
 
   describe '#serializable_hash' do


### PR DESCRIPTION
## Description of change

Capital details adapter converts amounts to Money.

## Link to relevant ticket
[CRIMAPP-1222](https://dsdmoj.atlassian.net/browse/CRIMAPP-1222)
[CRIMAPP-1223](https://dsdmoj.atlassian.net/browse/CRIMAPP-1223)

## Notes for reviewer

Code to cast these values was removed in error. This pr adds that code back and adds specs to prevent that happening again.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1222]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1223]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ