### PR TITLE
Exclude employment type from income payments validator

### DIFF
--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -56,7 +56,7 @@ module Steps
         return @types if @types
         return ['none'] if income.has_no_income_payments == 'yes'
 
-        crime_application.applicant.income_payments.pluck(:payment_type)
+        crime_application.applicant.income_payments.pluck(:payment_type) & PAYMENT_TYPES_ORDER
       end
 
       def has_no_income_payments

--- a/app/forms/steps/income/partner/income_payments_form.rb
+++ b/app/forms/steps/income/partner/income_payments_form.rb
@@ -57,7 +57,7 @@ module Steps
           return @types if @types
           return ['none'] if income.partner_has_no_income_payments == 'yes'
 
-          crime_application.partner.income_payments.pluck(:payment_type)
+          crime_application.partner.income_payments.pluck(:payment_type) & PAYMENT_TYPES_ORDER
         end
 
         def partner_has_no_income_payments


### PR DESCRIPTION
## Description of change

Fix for an error in production which I couldn't reproduce but has something to do with the Income Payments Validator trying to validate an employment payment type. This validator only runs on the Income Payments form so I think there is no need to validate the employment payment in any case. 

This fix skips the employment type. 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
