### PR TITLE
[CRIMAPP-1189] Amend evidence validation logic for court custody cases

### DIFF
--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -7,7 +7,7 @@ module Steps
       delegate :documents, :evidence_prompts, to: :crime_application
 
       validate do
-        validator.validate
+        validator.validate if validator.applicable?
       end
 
       def prompt

--- a/app/presenters/tasks/evidence_upload.rb
+++ b/app/presenters/tasks/evidence_upload.rb
@@ -12,6 +12,10 @@ module Tasks
       crime_application.documents.any?
     end
 
+    def applicable?
+      true
+    end
+
     def completed?
       false
     end

--- a/app/services/evidence/prompt.rb
+++ b/app/services/evidence/prompt.rb
@@ -54,7 +54,6 @@ module Evidence
 
       [
         under18?,
-        in_custody?,
         not_means_tested?
       ].any?(true)
     end
@@ -99,15 +98,6 @@ module Evidence
 
       result = crime_application.applicant&.under18?
       @exempt_reasons << I18n.t('evidence.exempt.under_18') if result
-
-      result
-    end
-
-    def in_custody?
-      return false unless crime_application.kase&.is_client_remanded
-
-      result = crime_application.kase&.is_client_remanded == 'yes'
-      @exempt_reasons << I18n.t('evidence.exempt.in_custody') if result
 
       result
     end

--- a/config/locales/en/evidence.yml
+++ b/config/locales/en/evidence.yml
@@ -15,7 +15,6 @@ en:
     exempt:
       not_means_tested: it is not subject to the usual means or passported test
       under_18: your client was under 18 when the application was first made
-      in_custody: you have told us they are remanded in custody
     rule:
       # Test rules
       ExampleRule1:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -678,7 +678,7 @@ en:
           exempt: Your client's application does not need any supporting evidence because %{reasons}. You may still upload any documents that will help your application.
           optional: No supporting evidence is required based on your current application, but you may upload any documents that will help your application.
           required: 'Based on your answers, use this page to provide:'
-          reject_warning: This application will be rejected if you have not uploaded the relevant evidence unless it is a Crown Court Trial (in which case evidence may follow within 14 days).
+          reject_warning: This application will be rejected if you have not uploaded the relevant evidence unless either the client is in Court Custody and therefore self-certifies, or it is a Crown Court Trial (in which case evidence may follow within 14 days).
           recent_docs: All evidence must be from the last 3 months.
           rename_files: Files often have long, meaningless names by default, but if you rename them to a friendly name it will make it easier for us to assess your case. For example, Client-bank-statement.PDF instead of File23.PDF.
           upload_file_button: Upload file

--- a/spec/forms/steps/evidence/upload_form_spec.rb
+++ b/spec/forms/steps/evidence/upload_form_spec.rb
@@ -43,22 +43,34 @@ RSpec.describe Steps::Evidence::UploadForm do
       form.errors.full_messages_for(:documents).first
     end
 
+    let(:applicable) { false }
+    let(:evidence_complete) { false }
+
     before do
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(applicable)
       allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?)
         .and_return(evidence_complete)
       form.valid?
     end
 
-    context 'when the supporting evidence section is not complete' do
-      let(:evidence_complete) { false }
-
-      it { is_expected.to eq 'You must provide the required evidence' }
+    context 'when validation is not applicable' do
+      context 'validate returns nil' do
+        it { is_expected.to be_nil }
+      end
     end
 
-    context 'when the supporting evidence section is complete' do
-      let(:evidence_complete) { true }
+    context 'when validation is applicable' do
+      let(:applicable) { true }
 
-      it { is_expected.to be_nil }
+      context 'when the supporting evidence section is not complete' do
+        it { is_expected.to eq 'You must provide the required evidence' }
+      end
+
+      context 'when the supporting evidence section is complete' do
+        let(:evidence_complete) { true }
+
+        it { is_expected.to be_nil }
+      end
     end
   end
 end

--- a/spec/presenters/tasks/evidence_upload_spec.rb
+++ b/spec/presenters/tasks/evidence_upload_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Tasks::EvidenceUpload do
     it { expect(subject.path).to eq('/applications/12345/steps/evidence/upload') }
   end
 
-  describe '#not_applicable?' do
-    it { expect(subject.not_applicable?).to be(false) }
+  describe '#applicable?' do
+    it { expect(subject.applicable?).to be(true) }
   end
 
   describe '#can_start?' do

--- a/spec/services/evidence/prompt_spec.rb
+++ b/spec/services/evidence/prompt_spec.rb
@@ -244,17 +244,6 @@ RSpec.describe Evidence::Prompt do
         )
       end
     end
-
-    context 'when the client is in custody' do
-      let(:kase) { instance_double(Case, is_client_remanded: 'yes') }
-
-      it 'returns true and sets the reason' do
-        expect(prompt.exempt?).to be true
-        expect(prompt.exempt_reasons).to contain_exactly(
-          'you have told us they are remanded in custody'
-        )
-      end
-    end
   end
 
   describe '#required?' do

--- a/spec/validators/supporting_evidence/answers_validator_spec.rb
+++ b/spec/validators/supporting_evidence/answers_validator_spec.rb
@@ -4,22 +4,31 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record: record, crime_application: record) }
 
   let(:record) {
-    instance_double(CrimeApplication, errors:, applicant:, documents:, kase:, evidence_prompts:)
+    instance_double(CrimeApplication, errors: errors, applicant: instance_double(Applicant),
+                                              documents: documents, kase: kase, evidence_prompts: evidence_prompts)
   }
   let(:errors) { double(:errors, empty?: false) }
-  let(:applicant) { instance_double(Applicant) }
   let(:kase) { instance_double(Case, case_type:) }
   let(:case_type) { nil }
   let(:documents) { double(stored: stored_documents) }
   let(:stored_documents) { [] }
-
+  let(:has_passporting_benefit?) { false }
   let(:evidence_prompts) do
     [
       {
         'id' => 'ExampleRule1',
-        'key' => prompt_key,
+        'key' => 'example_rule1',
         'run' => {
-          'client' => { 'result' => result },
+          'client' => { 'result' => example_prompt_result },
+          'partner' => { 'result' => false },
+          'other' => { 'result' => false },
+        }
+      },
+      {
+        'id' => 'NationalInsuranceRule',
+        'key' => 'national_insurance_32',
+        'run' => {
+          'client' => { 'result' => nino_prompt_result },
           'partner' => { 'result' => false },
           'other' => { 'result' => false },
         }
@@ -27,11 +36,11 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
     ]
   end
 
-  let(:prompt_key) { 'example_rule1' }
-  let(:result) { true }
+  let(:example_prompt_result) { true }
+  let(:nino_prompt_result) { false }
 
   before do
-    allow(validator).to receive(:has_passporting_benefit?).and_return(false)
+    allow(validator).to receive(:has_passporting_benefit?).and_return(has_passporting_benefit?)
   end
 
   describe '#validate' do
@@ -53,8 +62,8 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
       end
     end
 
-    context 'when case is indictable' do
-      let(:case_type) { CaseType::INDICTABLE.to_s }
+    context 'when there are no triggered evidence prompts' do
+      let(:example_prompt_result) { false }
 
       it 'does not add an error' do
         expect(errors).not_to receive(:add).with(:documents, :blank)
@@ -63,56 +72,25 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
       end
     end
 
-    context 'when case is in crown court' do
-      let(:case_type) { CaseType::ALREADY_IN_CROWN_COURT.to_s }
+    context 'when the only evidence prompt is for nino evidence' do
+      let(:example_prompt_result) { false }
+      let(:nino_prompt_result) { true }
 
-      it 'does not add an error' do
-        expect(errors).not_to receive(:add).with(:documents, :blank)
+      context 'when there is no passporting benefit' do
+        it 'does not add an error' do
+          expect(errors).not_to receive(:add).with(:documents, :blank)
 
-        subject.validate
+          subject.validate
+        end
       end
-    end
-
-    context 'when there are no evidence prompts' do
-      let(:result) { false }
-
-      it 'does not add an error' do
-        expect(errors).not_to receive(:add).with(:documents, :blank)
-
-        subject.validate
-      end
-    end
-
-    context 'the only evidence prompt is for nino evidence' do
-      let(:prompt_key) { :national_insurance_32 }
 
       context 'when there is a passporting benefit' do
-        before do
-          allow(validator).to receive(:has_passporting_benefit?).and_return(true)
-        end
+        let(:has_passporting_benefit?) { true }
 
-        context 'when applicant is not remanded in custody' do
-          before do
-            allow(kase).to receive_messages(is_client_remanded: 'no')
-          end
+        it 'adds errors for all failed validations' do
+          expect(errors).to receive(:add).with(:documents, :blank)
 
-          it 'adds errors for all failed validations' do
-            expect(errors).to receive(:add).with(:documents, :blank)
-
-            subject.validate
-          end
-        end
-
-        context 'when client is remanded in custody' do
-          before do
-            allow(kase).to receive_messages(is_client_remanded: 'yes', date_client_remanded: 1.month.ago.to_date)
-          end
-
-          it 'does not add an error' do
-            expect(errors).not_to receive(:add).with(:documents, :blank)
-
-            subject.validate
-          end
+          subject.validate
         end
       end
     end
@@ -135,6 +113,44 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
       end
 
       it { expect(subject.complete?).to be(true) }
+    end
+  end
+
+  describe '#applicable?' do
+    context 'when case is indictable' do
+      let(:case_type) { CaseType::INDICTABLE.to_s }
+
+      it 'the application does not require evidence validation' do
+        expect(subject.applicable?).to be(false)
+      end
+    end
+
+    context 'when case is in crown court' do
+      let(:case_type) { CaseType::ALREADY_IN_CROWN_COURT.to_s }
+
+      it 'the application does not require evidence validation' do
+        expect(subject.applicable?).to be(false)
+      end
+    end
+
+    context 'when client is remanded in custody' do
+      before do
+        allow(kase).to receive_messages(is_client_remanded: 'yes', date_client_remanded: 1.month.ago.to_date)
+      end
+
+      it 'the application does not require evidence validation' do
+        expect(subject.applicable?).to be(false)
+      end
+    end
+
+    context 'when the case is neither indictable or in crown court and client is not remanded is custody' do
+      before do
+        allow(kase).to receive_messages(is_client_remanded: 'no')
+      end
+
+      it 'the application does require evidence validation' do
+        expect(subject.applicable?).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Amends the evidence validation logic to display evidence prompts for court custody cases which was previously not being displayed
Also amends the warning text to add a warning for court custody cases

## Link to relevant ticket
[CRIMAPP-1189](https://dsdmoj.atlassian.net/browse/CRIMAPP-1189)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
**This was the text being displayed for court custody cases**
<img width="650" alt="Screenshot 2024-07-12 at 07 05 39" src="https://github.com/user-attachments/assets/f92c5082-18d3-4c37-94cb-3aa28bdf989d">

**This was the warning text that has been modified to include court custody cases (see below)**
<img width="877" alt="Screenshot 2024-07-17 at 11 08 34" src="https://github.com/user-attachments/assets/58afb0a5-ee06-46d9-9f50-6d242a584ba7">

### After changes:
<img width="877" alt="Screenshot 2024-07-17 at 12 03 56" src="https://github.com/user-attachments/assets/bcba6379-9729-450c-b6f2-6e6ce8884e40">


## How to manually test the feature


[CRIMAPP-1189]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ