### PR TITLE
[CRIMAPP-1090] Fix display of partner wages benefits row

### DIFF
--- a/app/presenters/summary/components/saving.rb
+++ b/app/presenters/summary/components/saving.rb
@@ -3,8 +3,6 @@ module Summary
     class Saving < BaseRecord
       GROUP_BY = :saving_type
 
-      include TypeOfMeansAssessment
-
       alias saving record
 
       private
@@ -33,7 +31,7 @@ module Summary
           )
         ]
 
-        if include_partner_in_means_assessment?
+        if saving.are_partners_wages_paid_into_account.present?
           answers << Components::ValueAnswer.new(
             :are_partners_wages_paid_into_account,
             saving.are_partners_wages_paid_into_account,

--- a/spec/presenters/summary/components/saving_spec.rb
+++ b/spec/presenters/summary/components/saving_spec.rb
@@ -18,15 +18,14 @@ RSpec.describe Summary::Components::Saving, type: :component do
       account_balance: '100.01',
       is_overdrawn: YesNoAnswer::NO,
       are_wages_paid_into_account: YesNoAnswer::YES,
-      are_partners_wages_paid_into_account: YesNoAnswer::NO,
+      are_partners_wages_paid_into_account: partners_wages,
       saving_type: :bank
     }
   end
 
-  let(:include_partner?) { false }
+  let(:partners_wages) { YesNoAnswer::NO }
 
   before do
-    allow(component).to receive(:include_partner_in_means_assessment?) { include_partner? }
     render_summary_component(component)
   end
 
@@ -101,16 +100,14 @@ RSpec.describe Summary::Components::Saving, type: :component do
     describe 'the partner wages question' do
       let(:wages_text) { "Partner's wages or benefits paid into this account?" }
 
-      context 'when partner is included in means assessment' do
-        let(:include_partner?) { true }
-
+      context 'when partner wages question was asked' do
         it 'is shown' do
           expect(page).to have_summary_row(wages_text, 'No')
         end
       end
 
-      context 'when partner is not included in means assessment' do
-        let(:include_partner?) { false }
+      context 'when partner wages question was not asked' do
+        let(:partners_wages) { nil }
 
         it 'is not shown' do
           expect(page).not_to have_content(wages_text)


### PR DESCRIPTION
## Description of change
The savings partner wages benefit question row was not displaying on the final review your application page

## Link to relevant ticket
[CRIMAPP-1090](https://dsdmoj.atlassian.net/browse/CRIMAPP-1090)

## Notes for reviewer
Not to be merged until after release 

## Screenshots of changes (if applicable)

### Before changes:
<img width="1054" alt="Screenshot 2024-07-18 at 11 26 39" src="https://github.com/user-attachments/assets/bb606bc8-d744-44a4-8cef-f7006e4298ff">

### After changes:
<img width="1055" alt="Screenshot 2024-07-18 at 11 26 03" src="https://github.com/user-attachments/assets/1149e766-35ab-485a-9caf-c6f8815e6e2c">

## How to manually test the feature

Create an application where you need to go through capital assessment and the client has a partner. Create a saving and fill in the questions. Check the partner wages benefit question row is displayed on the review your application page, the capital cya page and completed applications page 


[CRIMAPP-1090]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ