### PR TITLE
CRIMAPP-1242 fix download for files with comma in name

### DIFF
--- a/app/services/datastore/documents/download.rb
+++ b/app/services/datastore/documents/download.rb
@@ -30,7 +30,7 @@ module Datastore
 
       def response_content_disposition
         # To force download of file rather than opening in another window
-        "attachment; filename=#{@document.filename}"
+        %(attachment; filename="#{@document.filename}")
       end
 
       def context

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -8,11 +8,16 @@ RSpec.describe Datastore::Documents::Download do
   let(:s3_object_key) { '123/abcdef1234' }
   let(:content_type) { 'application/pdf' }
   let(:filename) { 'bankstatement.pdf' }
+  let(:expected_query) do
+    { object_key: %r{123/.*}, s3_opts: { expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
+                                         response_content_disposition:  "attachment; filename=\"#{filename}\"" } }
+  end
 
   describe '#call' do
     context 'when a document exists' do
       before do
         stub_request(:put, 'http://datastore-webmock/api/v1/documents/presign_download')
+          .with(body: expected_query)
           .to_return(status: 200, body: '{"object_key":"123/abcdef1234", "url":"https://secure.com/123/abcdef1234?fileinfo"}')
       end
 


### PR DESCRIPTION
## Description of change

Ensure download disposition filename is wrapped in double quotes.

## Link to relevant ticket

[CRIMAPP-1242](https://dsdmoj.atlassian.net/browse/CRIMAPP-1242)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1242]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ