### PR TITLE
[CRIMAPP-1190] Update evidence validation logic

### DIFF
--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -4,7 +4,7 @@ module Steps
       include TypeOfMeansAssessment
       include ApplicantAndPartner
 
-      delegate :documents, :evidence_prompts, to: :crime_application
+      delegate :documents, :evidence_prompts, :application_type, to: :crime_application
 
       validate do
         validator.validate if FeatureFlags.evidence_validation.enabled? && validator.applicable?

--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -4,7 +4,7 @@ module Steps
       include TypeOfMeansAssessment
       include ApplicantAndPartner
 
-      delegate :documents, :evidence_prompts, :application_type, to: :crime_application
+      delegate :documents, :evidence_prompts, :application_type, :cifc?, to: :crime_application
 
       validate do
         validator.validate if FeatureFlags.evidence_validation.enabled? && validator.applicable?

--- a/app/validators/supporting_evidence/answers_validator.rb
+++ b/app/validators/supporting_evidence/answers_validator.rb
@@ -30,13 +30,9 @@ module SupportingEvidence
 
     def client_remanded_in_custody?
       return true unless kase
-      return false if cifc?
+      return false if record.cifc?
 
       kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
-    end
-
-    def cifc?
-      record.application_type == ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s
     end
 
     def indictable_or_in_crown_court?

--- a/app/validators/supporting_evidence/answers_validator.rb
+++ b/app/validators/supporting_evidence/answers_validator.rb
@@ -11,6 +11,8 @@ module SupportingEvidence
     end
 
     def applicable?
+      return true if benefit_evidence_forthcoming?
+
       !(indictable_or_in_crown_court? || client_remanded_in_custody?)
     end
 
@@ -18,8 +20,8 @@ module SupportingEvidence
       errors.add(:documents, :blank) unless evidence_complete?
     end
 
-    # TODO: add branch for CIFC applications
     def evidence_complete?
+      return false if benefit_evidence_forthcoming? && !evidence_present?
       return true unless evidence_prompts_present?
       return true if nino_is_only_evidence_prompt && !has_passporting_benefit?
 
@@ -28,8 +30,13 @@ module SupportingEvidence
 
     def client_remanded_in_custody?
       return true unless kase
+      return false if cifc?
 
       kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
+    end
+
+    def cifc?
+      record.application_type == ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s
     end
 
     def indictable_or_in_crown_court?

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -15,6 +15,8 @@
       <p class="govuk-body" data-ruleset="<%= @form_object.prompt.ruleset %>">
         <%= t('.exempt', reasons: @form_object.prompt.exempt_reasons.to_sentence) %>
       </p>
+    <% elsif @form_object.application_type == 'change_in_financial_circumstances'  %>
+      <%= govuk_warning_text(text: t('.cifc_warning')) %>
     <% elsif @form_object.prompt.required? %>
       <%= govuk_warning_text(text: t('.reject_warning')) %>
 

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -11,7 +11,7 @@
 
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
-    <% if @form_object.application_type == 'change_in_financial_circumstances'  %>
+    <% if @form_object.cifc?  %>
       <%= govuk_warning_text(text: t('.cifc_warning')) %>
     <% elsif @form_object.prompt.exempt? %>
       <p class="govuk-body" data-ruleset="<%= @form_object.prompt.ruleset %>">

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -11,12 +11,12 @@
 
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
-    <% if @form_object.prompt.exempt? %>
+    <% if @form_object.application_type == 'change_in_financial_circumstances'  %>
+      <%= govuk_warning_text(text: t('.cifc_warning')) %>
+    <% elsif @form_object.prompt.exempt? %>
       <p class="govuk-body" data-ruleset="<%= @form_object.prompt.ruleset %>">
         <%= t('.exempt', reasons: @form_object.prompt.exempt_reasons.to_sentence) %>
       </p>
-    <% elsif @form_object.application_type == 'change_in_financial_circumstances'  %>
-      <%= govuk_warning_text(text: t('.cifc_warning')) %>
     <% elsif @form_object.prompt.required? %>
       <%= govuk_warning_text(text: t('.reject_warning')) %>
 

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -678,6 +678,7 @@ en:
     evidence:
       upload:
         edit:
+          cifc_warning: You must provide evidence of all changes in financial circumstances
           page_title: Upload supporting evidence
           heading: Upload supporting evidence
           exempt: Your client's application does not need any supporting evidence because %{reasons}. You may still upload any documents that will help your application.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,7 +33,7 @@ feature_flags:
     production: true
   evidence_validation:
     local: true
-    staging: false
+    staging: true
     production: false
   cifc_journey:
     local: true

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module Test
   CrimeApplicationValidatable = Struct.new(:is_means_tested, :kase, :ioj, :income, :documents, :applicant, :cifc?,
-                                           keyword_init: true) do
+                                           :application_type, keyword_init: true) do
     include ActiveModel::Validations
     validates_with ApplicationFulfilmentValidator
 
@@ -22,13 +22,14 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
 
   let(:arguments) do
     {
-      'is_means_tested' => is_means_tested,
-      'kase' => kase,
-      'applicant' => applicant,
-      'ioj' => ioj,
-      'income' => income,
-      'documents' => documents,
-      'cifc?' => cifc?,
+      is_means_tested: is_means_tested,
+      kase: kase,
+      applicant: applicant,
+      ioj: ioj,
+      income: income,
+      documents: documents,
+      cifc?: cifc?,
+      application_type: ApplicationType::INITIAL.to_s
     }
   end
 
@@ -39,18 +40,13 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
   }
 
   let(:applicant) { instance_double(Applicant, benefit_type: 'none') }
-
   let(:is_client_remanded) { nil }
   let(:date_client_remanded) { nil }
-
   let(:case_type) { 'either_way' }
-
   let(:ioj) { instance_double(Ioj, types: ioj_types) }
   let(:ioj_types) { [] }
-
   let(:income) { instance_double(Income, employment_status:) }
   let(:employment_status) { [] }
-
   let(:documents) { double(stored: stored_documents) }
   let(:stored_documents) { [] }
 
@@ -63,6 +59,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       # stub the other validation
       allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(true)
       allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
     end
 
     context 'when the application is means-passported' do
@@ -152,6 +149,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       # stub the other validation
       allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
       allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
     end
 
     context 'when the application is ioj-passported' do
@@ -189,6 +187,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
       allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(true)
       allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
     end
 
     context 'when the application has a case type' do
@@ -233,6 +232,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
 
     context 'when the required evidence has not been uploaded' do
       before do
+        allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
         allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(false)
       end
 
@@ -245,6 +245,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
 
     context 'when the required evidence has been uploaded' do
       before do
+        allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
         allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
       end
 
@@ -266,6 +267,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
     context 'with completed fields' do
       before do
         allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
+        allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
         allow_any_instance_of(Circumstances::AnswersValidator).to receive(:circumstances_complete?).and_return(true)
       end
 
@@ -277,6 +279,7 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
     context 'without incomplete fields' do
       before do
         allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
+        allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
         allow_any_instance_of(Circumstances::AnswersValidator).to receive(:circumstances_complete?).and_return(false)
       end
 

--- a/spec/validators/supporting_evidence/answers_validator_spec.rb
+++ b/spec/validators/supporting_evidence/answers_validator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
 
   before do
     allow(validator).to receive(:has_passporting_benefit?).and_return(has_passporting_benefit?)
-    allow(record).to receive(:application_type).and_return(ApplicationType::INITIAL.to_s)
+    allow(record).to receive_messages(application_type: ApplicationType::INITIAL.to_s, cifc?: false)
   end
 
   describe '#validate' do
@@ -173,8 +173,8 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
 
       context 'when the application type is change in financial circumstances' do
         before do
-          allow(record).to receive(:application_type)
-            .and_return(ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s)
+          allow(record).to receive_messages(application_type: ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s,
+                                            cifc?: true)
         end
 
         it 'the application does require evidence validation' do


### PR DESCRIPTION
## Description of change
Amends evidence validation logic for cifc and has benefit evidence scenarios

- If a user has answered that they will upload evidence during the benefit check, then they must upload at least one piece of evidence regardless of whether they have any evidence triggers 
- CIFC applications must also upload evidence if there are evidence triggers 
- There is warning text displayed for CIFC applications on the evidence upload page
- An evidence upload logic tree is attached below 

## Link to relevant ticket
[CRIMAPP-1170](https://dsdmoj.atlassian.net/browse/CRIMAPP-1170)
[CRIMAPP-1190](https://dsdmoj.atlassian.net/browse/CRIMAPP-1190)

## Notes for reviewer
Merging will turn on the evidence validation feature flag on staging

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="894" alt="Screenshot 2024-07-22 at 09 15 32" src="https://github.com/user-attachments/assets/445cf04b-1ef3-4aaf-a340-61c33c2e1c46">

## How to manually test the feature


[CRIMAPP-1170]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1190]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ