### PR TITLE
[CRIMAPP-1249] applications default to being means tested

### DIFF
--- a/app/forms/steps/client/is_means_tested_form.rb
+++ b/app/forms/steps/client/is_means_tested_form.rb
@@ -5,6 +5,11 @@ module Steps
 
       validates_inclusion_of :is_means_tested, in: :choices
 
+      # CRIMAPP-1249 temporary fix to default application to being means tested
+      def is_means_tested
+        super || YesNoAnswer::YES
+      end
+
       def choices
         YesNoAnswer.values
       end

--- a/spec/forms/steps/client/is_means_tested_form_spec.rb
+++ b/spec/forms/steps/client/is_means_tested_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Client::IsMeansTestedForm do
-  subject { described_class.new(arguments) }
+  subject(:form) { described_class.new(arguments) }
 
   let(:arguments) do
     {
@@ -21,8 +21,14 @@ RSpec.describe Steps::Client::IsMeansTestedForm do
     end
   end
 
+  describe '#is_means_tested' do
+    it 'is yes by default' do
+      expect(form.is_means_tested).to eq YesNoAnswer::YES
+    end
+  end
+
   describe '#save' do
-    context 'when `is_means_tested` is not provided' do
+    context 'when `is_means_tested` is not provided', skip: 'CRIMAPP-1249 temporary behaviour change' do
       it 'returns false' do
         expect(subject.save).to be(false)
       end
@@ -47,11 +53,11 @@ RSpec.describe Steps::Client::IsMeansTestedForm do
     end
 
     context 'when `is_means_tested` is valid' do
-      let(:is_means_tested) { 'yes' }
+      let(:is_means_tested) { 'no' }
 
       it 'saves the record' do
         expect(crime_application).to receive(:update).with(
-          { 'is_means_tested' => YesNoAnswer::YES }
+          { 'is_means_tested' => YesNoAnswer::NO }
         ).and_return(true)
 
         expect(subject.save).to be(true)


### PR DESCRIPTION
## Description of change

Default initial applications to being means tested
This is a temporary change whilst content based options explored.

## Link to relevant ticket
[CRIMAPP-1249](https://dsdmoj.atlassian.net/browse/CRIMAPP-1249)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1249]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ