### PR TITLE
CRIMAPP-1225: Fix 'income_above_threshold' text for joint income on CYA page

### DIFF
--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -8,20 +8,12 @@ module Summary
       end
 
       def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-        answers = []
-        answers << if include_partner_in_means_assessment?
-                     Components::ValueAnswer.new(
-                       :joint_income_above_threshold, income.income_above_threshold,
-                       change_path: edit_steps_income_income_before_tax_path
-                     )
-                   else
-                     Components::ValueAnswer.new(
-                       :income_above_threshold, income.income_above_threshold,
-                       change_path: edit_steps_income_income_before_tax_path
-                     )
-                   end
-
-        answers << [
+        [
+          Components::ValueAnswer.new(
+            :income_above_threshold, income.income_above_threshold,
+            change_path: edit_steps_income_income_before_tax_path,
+            i18n_opts: { prefix: income_above_threshold_prefix }
+          ),
           Components::ValueAnswer.new(
             :has_frozen_income_or_assets, income.has_frozen_income_or_assets,
             change_path: edit_steps_income_frozen_income_savings_assets_path
@@ -34,13 +26,15 @@ module Summary
           Components::ValueAnswer.new(
             :has_savings, income.has_savings,
             change_path: edit_steps_income_has_savings_path
-          ),
-        ]
-
-        answers.flatten.select(&:show?)
+          )
+        ].select(&:show?)
       end
 
       private
+
+      def income_above_threshold_prefix
+        include_partner_in_means_assessment? ? 'Joint annual income' : 'Income'
+      end
 
       def property_ownership_type
         return unless include_partner_in_means_assessment?

--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -8,11 +8,20 @@ module Summary
       end
 
       def answers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-        [
-          Components::ValueAnswer.new(
-            :income_above_threshold, income.income_above_threshold,
-            change_path: edit_steps_income_income_before_tax_path
-          ),
+        answers = []
+        answers << if include_partner_in_means_assessment?
+                     Components::ValueAnswer.new(
+                       :joint_income_above_threshold, income.income_above_threshold,
+                       change_path: edit_steps_income_income_before_tax_path
+                     )
+                   else
+                     Components::ValueAnswer.new(
+                       :income_above_threshold, income.income_above_threshold,
+                       change_path: edit_steps_income_income_before_tax_path
+                     )
+                   end
+
+        answers << [
           Components::ValueAnswer.new(
             :has_frozen_income_or_assets, income.has_frozen_income_or_assets,
             change_path: edit_steps_income_frozen_income_savings_assets_path
@@ -26,7 +35,9 @@ module Summary
             :has_savings, income.has_savings,
             change_path: edit_steps_income_has_savings_path
           ),
-        ].select(&:show?)
+        ]
+
+        answers.flatten.select(&:show?)
       end
 
       private

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -418,6 +418,10 @@ en:
         question: Income more than £12,475 a year before tax?
         answers:
           <<: *YESNO
+      joint_income_above_threshold:
+        question: Joint annual income more than £12,475 a year before tax?
+        answers:
+          <<: *YESNO
       has_frozen_income_or_assets:
         question: Income, savings or assets under a restraint or freezing order
         answers: *YESNO

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -415,11 +415,7 @@ en:
 
       # BEGIN income details section
       income_above_threshold:
-        question: Income more than £12,475 a year before tax?
-        answers:
-          <<: *YESNO
-      joint_income_above_threshold:
-        question: Joint annual income more than £12,475 a year before tax?
+        question: "%{prefix} more than £12,475 a year before tax?"
         answers:
           <<: *YESNO
       has_frozen_income_or_assets:

--- a/spec/presenters/summary/sections/income_details_spec.rb
+++ b/spec/presenters/summary/sections/income_details_spec.rb
@@ -90,7 +90,7 @@ describe Summary::Sections::IncomeDetails do
       let(:expected_labels) do
         [
           'Client or partner owns home, land or property?',
-          'Income more than £12,475 a year before tax?',
+          'Joint annual income more than £12,475 a year before tax?',
           'Income, savings or assets under a restraint or freezing order',
           'Savings or investments?'
         ]


### PR DESCRIPTION
## Description of change

Fix 'income_above_threshold' text on CYAs page based on the following:

- When partner is included show "Joint annual income more than £12,475 a year before tax?"
- When partner is not included show "Income more than £12,475 a year before tax?" 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1225

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="924" alt="Screenshot 2024-07-22 at 12 02 40" src="https://github.com/user-attachments/assets/7241816d-b86d-4010-8608-e692fdcb6a15">

### After changes:
<img width="943" alt="Screenshot 2024-07-22 at 12 02 18" src="https://github.com/user-attachments/assets/e90a7f88-1865-4d0f-b0ad-683e4cef9f22">

## How to manually test the feature
http://localhost:3000/applications/:id/steps/income/check_your_answers_income
