### PR TITLE
CRIMAPP-1235 Add validation for national savings certificate format

### DIFF
--- a/app/forms/steps/capital/national_savings_certificates_form.rb
+++ b/app/forms/steps/capital/national_savings_certificates_form.rb
@@ -5,13 +5,18 @@ module Steps
       include OwnershipConfirmation
       include ApplicantOrPartner
 
+      # match any alphanumeric string that does not contain any special characters
+      # this is to avoid modsec errors, specifically strings ending with - (dash)
+      NSC_REGEXP = /\A[\w\s]+\z/
+
       delegate :national_savings_certificate_type, to: :record
 
       attribute :holder_number, :string
       attribute :certificate_number, :string
       attribute :value, :pence
 
-      validates :holder_number, :certificate_number, :value, presence: true
+      validates :holder_number, format: { with: NSC_REGEXP }, presence: true
+      validates :certificate_number, :value, presence: true
 
       def persist!
         record.update(attributes)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1091,6 +1091,7 @@ en:
           attributes:
             holder_number:
               blank: Enter the customer number or holder number
+              invalid: Enter a valid customer number or holder number
             certificate_number:
               blank: Enter the certificate number
             value:

--- a/spec/forms/steps/capital/national_savings_certificates_form_spec.rb
+++ b/spec/forms/steps/capital/national_savings_certificates_form_spec.rb
@@ -124,5 +124,23 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when customer/holder number is invalid' do
+      let(:attributes) do
+        {
+          holder_number: '12345--',
+          certificate_number: '345B',
+          ownership_type: OwnershipType::APPLICANT,
+          value: '100.01',
+          confirm_in_applicants_name: YesNoAnswer::YES
+        }
+      end
+
+      it 'does not update the record' do
+        expect(record).not_to receive(:update)
+
+        expect(subject.save).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change

Add validation to prevent user entering strings that end with '-' to avoid modsec errors. It is still possible to enter strings that contain '-' just not those ending in dashes. 

## Link to relevant ticket

[CRIMAPP-1235](https://dsdmoj.atlassian.net/browse/CRIMAPP-1235)

## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="1347" alt="Screenshot 2024-07-22 at 12 46 24" src="https://github.com/user-attachments/assets/9ab7903e-067e-4e2a-bbe6-82a06260638b">


### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1235]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ