### PR TITLE
CRIMAPP-1105: Show assets section incomplete if owners information is missing

### DIFF
--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -65,6 +65,10 @@ class Property < ApplicationRecord
   end
 
   def property_owners_complete?
-    property_owners.all?(&:complete?)
+    return true if has_other_owners == YesNoAnswer::NO.to_s || has_other_owners.nil?
+
+    (has_other_owners == YesNoAnswer::YES.to_s) &&
+      property_owners.present? &&
+      property_owners.all?(&:complete?)
   end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -53,7 +53,7 @@ class Property < ApplicationRecord
     return false unless property_type
 
     values_at(*REQUIRED_ATTRIBUTES[property_type.to_sym]).all?(&:present?) &&
-      address_complete? && property_owners_complete?
+      address_complete? && property_owners_complete? && property_ownership_valid?
   end
 
   def address_complete?
@@ -70,5 +70,14 @@ class Property < ApplicationRecord
     (has_other_owners == YesNoAnswer::YES.to_s) &&
       property_owners.present? &&
       property_owners.all?(&:complete?)
+  end
+
+  def property_ownership_valid?
+    percentage_ownerships = []
+    percentage_ownerships << percentage_applicant_owned unless percentage_applicant_owned.nil?
+    percentage_ownerships << percentage_partner_owned unless percentage_partner_owned.nil?
+    percentage_ownerships << property_owners.sum(&:percentage_owned) if property_owners_complete?
+
+    percentage_ownerships.sum == 100
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -23,11 +23,16 @@ RSpec.describe Property, type: :model do
       is_home_address: is_home_address,
       has_other_owners: has_other_owners,
       address: nil,
+      property_owners: []
     }
   end
 
   describe '#complete?' do
     subject { instance.complete? }
+
+    before do
+      allow(instance).to receive(:property_ownership_valid?).and_return(true)
+    end
 
     context 'when property_type is residential' do
       let(:property_type) { PropertyType::RESIDENTIAL.to_s }
@@ -185,6 +190,92 @@ RSpec.describe Property, type: :model do
       let(:attributes) { required_attributes.merge(property_owners: []) }
 
       it { is_expected.to be true }
+    end
+  end
+
+  describe '#has_percentage_complete?' do
+    subject { instance.property_ownership_valid? }
+
+    context 'when partner is not present' do
+      context 'when valid' do
+        let(:attributes) { required_attributes.merge(percentage_applicant_owned: 100) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when invalid' do
+        let(:attributes) { required_attributes.merge(percentage_applicant_owned: 60) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when other owners are present' do
+        let(:has_other_owners) { 'yes' }
+
+        context 'when valid' do
+          let(:attributes) {
+            required_attributes.merge(
+              percentage_applicant_owned: 60,
+              property_owners: [PropertyOwner.new(percentage_owned: 40, name: 'name', relationship: 'relationship')]
+            )
+          }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when invalid' do
+          let(:attributes) {
+            required_attributes.merge(
+              percentage_applicant_owned: 50,
+              property_owners: [PropertyOwner.new(percentage_owned: 40, name: 'name', relationship: 'relationship')]
+            )
+          }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'when partner is present' do
+      context 'when valid' do
+        let(:attributes) { required_attributes.merge(percentage_applicant_owned: 60, percentage_partner_owned: 40) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when invalid' do
+        let(:attributes) { required_attributes.merge(percentage_applicant_owned: 60, percentage_partner_owned: 30) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when other owners are present' do
+        let(:has_other_owners) { 'yes' }
+
+        context 'when valid' do
+          let(:attributes) {
+            required_attributes.merge(
+              percentage_applicant_owned: 60,
+              percentage_partner_owned: 30,
+              property_owners: [PropertyOwner.new(percentage_owned: 10, name: 'name', relationship: 'relationship')]
+            )
+          }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when invalid' do
+          let(:attributes) {
+            required_attributes.merge(
+              percentage_applicant_owned: 50,
+              percentage_partner_owned: 30,
+              property_owners: [PropertyOwner.new(percentage_owned: 10, name: 'name', relationship: 'relationship')]
+            )
+          }
+
+          it { is_expected.to be false }
+        end
+      end
     end
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -170,6 +170,14 @@ RSpec.describe Property, type: :model do
 
         it { is_expected.to be false }
       end
+
+      context 'with property owners missing' do
+        let(:attributes) do
+          required_attributes.merge(property_owners: [])
+        end
+
+        it { is_expected.to be false }
+      end
     end
 
     context 'when property has no other owners' do

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Property, type: :model do
       percentage_partner_owned: nil,
       is_home_address: is_home_address,
       has_other_owners: has_other_owners,
-      address: nil,
-      property_owners: []
+      address: nil
     }
   end
 


### PR DESCRIPTION
## Description of change
Fix definition of 'incomplete' for property

- check presence of owners details if property has owners
- Sum of ownership percentage should be 0 (Applicant + Partner(if present) + Owners(if present) )

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1105

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1099" alt="b7b21516-896e-465d-b5dd-d479c5aa4b05" src="https://github.com/user-attachments/assets/97d347b6-7885-4d37-bd63-77678efe7e5f">


### After changes:
<img width="700" alt="Screenshot 2024-07-25 at 09 55 04" src="https://github.com/user-attachments/assets/627b2039-d2f5-4741-96f9-aa9fceefb5b6">


## How to manually test the feature
