### PR TITLE
CRIMAPP-758: Apply trust fund screen does not match current design

### DIFF
--- a/app/views/steps/capital/partner_trust_fund/edit.html.erb
+++ b/app/views/steps/capital/partner_trust_fund/edit.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:partner_will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:partner_will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }, hint: { text: t('.hint') }) do %>
         <%= f.govuk_radio_button :partner_will_benefit_from_trust_fund, YesNoAnswer::YES do %>
           <%= f.govuk_number_field :partner_trust_fund_amount_held, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
           <%= f.govuk_number_field :partner_trust_fund_yearly_dividend, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>

--- a/app/views/steps/capital/trust_fund/edit.html.erb
+++ b/app/views/steps/capital/trust_fund/edit.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }, hint: { text: t('.hint') }) do %>
         <%= f.govuk_radio_button :will_benefit_from_trust_fund, YesNoAnswer::YES do %>
           <%= f.govuk_number_field :trust_fund_amount_held, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
           <%= f.govuk_number_field :trust_fund_yearly_dividend, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -602,10 +602,12 @@ en:
         edit:
           page_title: Does your client stand to benefit from a trust fund?
           heading: Does your client stand to benefit from a trust fund?
+          hint: Including any trust funds inside and outside the UK.
       partner_trust_fund:
         edit:
-          page_title: Does the partner stand to benefit from a trust fund inside or outside the UK?
-          heading: Does the partner stand to benefit from a trust fund inside or outside the UK?
+          page_title: Does the partner stand to benefit from a trust fund?
+          heading: Does the partner stand to benefit from a trust fund?
+          hint: Including any trust funds inside and outside the UK.
 
       properties:
         confirm_destroy:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -600,8 +600,8 @@ en:
           remove_link_html: Remove <span class="govuk-visually-hidden">National Savings Certificate</span>
       trust_fund:
         edit:
-          page_title: Does your client stand to benefit from a trust fund inside or outside the UK?
-          heading: Does your client stand to benefit from a trust fund inside or outside the UK?
+          page_title: Does your client stand to benefit from a trust fund?
+          heading: Does your client stand to benefit from a trust fund?
       partner_trust_fund:
         edit:
           page_title: Does the partner stand to benefit from a trust fund inside or outside the UK?


### PR DESCRIPTION
## Description of change

Update text for:
- Capital assessment > partner_benefit_from_trust_fund
- Capital assessment > client_benefit_from_trust_fund

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-758

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
Client:
<img width="677" alt="Screenshot 2024-07-25 at 11 18 12" src="https://github.com/user-attachments/assets/a89bf1b5-b672-4ced-bb4f-615d486ab611">

Partner:
<img width="660" alt="Screenshot 2024-07-25 at 11 18 21" src="https://github.com/user-attachments/assets/6ab951e2-ea74-4164-9776-a56bc3bd9625">

### After changes:
Client:
<img width="657" alt="Screenshot 2024-07-25 at 11 19 33" src="https://github.com/user-attachments/assets/165eb728-4f3d-4477-9919-02bf16c37e7d">

Partner:
<img width="657" alt="Screenshot 2024-07-25 at 11 19 42" src="https://github.com/user-attachments/assets/4736e2cd-0a50-4d8f-a250-96eb7c8ff3e9">

## How to manually test the feature
