### PR TITLE
[CRIMAPP-1170] Update logic for cifc evidence validation

### DIFF
--- a/app/validators/supporting_evidence/answers_validator.rb
+++ b/app/validators/supporting_evidence/answers_validator.rb
@@ -11,7 +11,7 @@ module SupportingEvidence
     end
 
     def applicable?
-      return true if benefit_evidence_forthcoming? || record.cifc?
+      return true if evidence_required?
 
       !(indictable_or_in_crown_court? || client_remanded_in_custody?)
     end
@@ -21,11 +21,15 @@ module SupportingEvidence
     end
 
     def evidence_complete?
-      return false if (benefit_evidence_forthcoming? || record.cifc?) && !evidence_present?
+      return false if evidence_required? && !evidence_present?
       return true unless evidence_prompts_present?
       return true if nino_is_only_evidence_prompt && !has_passporting_benefit?
 
       evidence_present?
+    end
+
+    def evidence_required?
+      benefit_evidence_forthcoming? || record.cifc?
     end
 
     def client_remanded_in_custody?

--- a/app/validators/supporting_evidence/answers_validator.rb
+++ b/app/validators/supporting_evidence/answers_validator.rb
@@ -11,7 +11,7 @@ module SupportingEvidence
     end
 
     def applicable?
-      return true if benefit_evidence_forthcoming?
+      return true if benefit_evidence_forthcoming? || record.cifc?
 
       !(indictable_or_in_crown_court? || client_remanded_in_custody?)
     end
@@ -21,7 +21,7 @@ module SupportingEvidence
     end
 
     def evidence_complete?
-      return false if benefit_evidence_forthcoming? && !evidence_present?
+      return false if (benefit_evidence_forthcoming? || record.cifc?) && !evidence_present?
       return true unless evidence_prompts_present?
       return true if nino_is_only_evidence_prompt && !has_passporting_benefit?
 
@@ -30,7 +30,6 @@ module SupportingEvidence
 
     def client_remanded_in_custody?
       return true unless kase
-      return false if record.cifc?
 
       kase.is_client_remanded == 'yes' && kase.date_client_remanded.present?
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,7 +33,7 @@ feature_flags:
     production: true
   evidence_validation:
     local: true
-    staging: false
+    staging: true
     production: false
   cifc_journey:
     local: true

--- a/spec/validators/supporting_evidence/answers_validator_spec.rb
+++ b/spec/validators/supporting_evidence/answers_validator_spec.rb
@@ -113,6 +113,21 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
         end
       end
     end
+
+    context 'when the application type is change in financial circumstances' do
+      before do
+        allow(record).to receive_messages(application_type: ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s,
+                                          cifc?: true)
+      end
+
+      context 'and evidence has not been uploaded' do
+        it 'adds errors for all failed validations' do
+          expect(errors).to receive(:add).with(:documents, :blank)
+
+          subject.validate
+        end
+      end
+    end
   end
 
   describe '#complete?' do
@@ -150,6 +165,17 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
       end
     end
 
+    context 'when the application type is change in financial circumstances' do
+      before do
+        allow(record).to receive_messages(application_type: ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s,
+                                          cifc?: true)
+      end
+
+      it 'the application does require evidence validation' do
+        expect(subject.applicable?).to be(true)
+      end
+    end
+
     context 'when case is indictable' do
       let(:case_type) { CaseType::INDICTABLE.to_s }
 
@@ -171,21 +197,8 @@ RSpec.describe SupportingEvidence::AnswersValidator, type: :model do
         allow(kase).to receive_messages(is_client_remanded: 'yes', date_client_remanded: 1.month.ago.to_date)
       end
 
-      context 'when the application type is change in financial circumstances' do
-        before do
-          allow(record).to receive_messages(application_type: ApplicationType::CHANGE_IN_FINANCIAL_CIRCUMSTANCES.to_s,
-                                            cifc?: true)
-        end
-
-        it 'the application does require evidence validation' do
-          expect(subject.applicable?).to be(true)
-        end
-      end
-
-      context 'when the application type is not change in financial circumstances' do
-        it 'the application does not require evidence validation' do
-          expect(subject.applicable?).to be(false)
-        end
+      it 'the application does not require evidence validation' do
+        expect(subject.applicable?).to be(false)
       end
     end
 


### PR DESCRIPTION
## Description of change
Updates logic to ensure cifc applications cannot be submitted unless at least one piece of evidence has been uploaded regardless of case type or court custody status

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1170

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Test scenarios found in the ticket comments
