### PR TITLE
[CRIMAPP-1243] Prevent saving attributes as empty string

### DIFF
--- a/app/forms/steps/capital/other_investment_type_form.rb
+++ b/app/forms/steps/capital/other_investment_type_form.rb
@@ -16,8 +16,6 @@ module Steps
       private
 
       def persist!
-        return true if investment_type == ''
-
         @investment = crime_application.investments.create!(investment_type:)
       end
 

--- a/app/forms/steps/capital/other_property_type_form.rb
+++ b/app/forms/steps/capital/other_property_type_form.rb
@@ -22,8 +22,6 @@ module Steps
       end
 
       def persist!
-        return true if property_type == ''
-
         @property = incomplete_property_for_type || crime_application.properties.create!(property_type:)
       end
 

--- a/app/forms/steps/capital/other_saving_type_form.rb
+++ b/app/forms/steps/capital/other_saving_type_form.rb
@@ -16,8 +16,6 @@ module Steps
       private
 
       def persist!
-        return true if saving_type == ''
-
         @saving = crime_application.savings.create!(saving_type:)
       end
 

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -4,3 +4,7 @@ GOVUKDesignSystemFormBuilder::FormBuilder.class_eval do
   require 'form_builder_helper'
   include FormBuilderHelper
 end
+
+GOVUKDesignSystemFormBuilder.configure do |conf|
+  conf.default_collection_radio_buttons_include_hidden = false
+end


### PR DESCRIPTION
## Description of change
Fixes a bug where when users clicked save and come back later on a form (typically a radio button form), an empty string was saved which then threw an error when submitting the application as the value does not conform to the schema. 

This has been fixed by adding config to the form builder to not include hidden input fields that have been populated with a blank value when rendering radio buttons. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1243

## Notes for reviewer
Note this won't fix any existing applications that have the bug, it will just prevent new draft applications from getting into this state 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Start an application and navigate to a form with radio buttons e.g. case type. Select save and come back later and verify that the attribute is still `nil` and not an empty string. You may also want to check the validation is still working as expected.
