### PR TITLE
[CRIMAPP-1271] Validate hearing details on submission

### DIFF
--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -5,7 +5,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
 
   # More validations can be added here
   # Errors, when more than one, will maintain the order
-  def perform_validations # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+  def perform_validations # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     errors = []
 
     unless means_valid?
@@ -17,6 +17,12 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
     if record.is_means_tested == 'yes' && kase.case_type.nil?
       errors << [
         :base, :case_type_missing, { change_path: edit_steps_client_case_type_path }
+      ]
+    end
+
+    unless hearing_details_complete?
+      errors << [
+        :base, :hearing_details, { change_path: edit_steps_case_hearing_details_path }
       ]
     end
 
@@ -89,6 +95,10 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
     return true unless circumstances_validator.applicable?
 
     circumstances_validator.circumstances_complete?
+  end
+
+  def hearing_details_complete?
+    kase.hearing_court_name.present? && kase.hearing_date.present? && kase.is_first_court_hearing.present?
   end
 
   alias crime_application record

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -24,6 +24,7 @@ en:
             base:
               case_type_missing: A case type needs to be selected
               circumstances_reference_missing: Your client's MAAT ID or unique submission number (USN) needs to be completed
+              hearing_details: Hearing court details need to be completed
             means_passport:
               blank: Applicant is not passported on means
             ioj_passport:

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -36,12 +36,16 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
   let(:is_means_tested) { 'yes' }
 
   let(:kase) {
-    instance_double(Case, case_type:, is_client_remanded:, date_client_remanded:)
+    instance_double(Case, case_type:, is_client_remanded:, date_client_remanded:,
+                                  hearing_court_name:, hearing_date:, is_first_court_hearing:)
   }
 
   let(:applicant) { instance_double(Applicant, benefit_type: 'none') }
   let(:is_client_remanded) { nil }
   let(:date_client_remanded) { nil }
+  let(:hearing_court_name) { 'Court Name' }
+  let(:hearing_date) { Time.zone.today }
+  let(:is_first_court_hearing) { true }
   let(:case_type) { 'either_way' }
   let(:ioj) { instance_double(Ioj, types: ioj_types) }
   let(:ioj_types) { [] }
@@ -286,6 +290,33 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       it 'is invalid' do
         expect(subject).not_to be_valid
         expect(subject.errors.of_kind?(:base, :circumstances_reference_missing)).to be(true)
+      end
+    end
+  end
+
+  context 'when application is missing hearing details' do
+    before do
+      # stub the other validations
+      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
+      allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(true)
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
+    end
+
+    context 'with completed fields' do
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with incomplete fields' do
+      let(:hearing_court_name) { nil }
+      let(:hearing_date) { nil }
+      let(:is_first_court_hearing) { nil }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:base, :hearing_details)).to be(true)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Prevents applications from being submitted without court hearing details by validating the court hearing details are present at submission

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1271

## Notes for reviewer
More of a temporary fix as this could also happen on other case details pages. The section completeness validator would be better suited to handling this and should be displaying an error but i'll investigate that separately as it doesn't seem to be a quick fix

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="990" alt="Screenshot 2024-07-31 at 12 25 49" src="https://github.com/user-attachments/assets/84610e9c-f89f-460c-89ab-855ae1a8a385">

## How to manually test the feature
Start an initial application and submit without court hearing details (by skipping the page via the url and go straight to the ioj page `steps/case/ioj`). Keep going till you reach the submission page then try to submit, you should see an error message like the above 
