### PR TITLE
LAA-CRIMINAL-APPLICATIONS-DATASTORE-6 Make MeansPassporter stateless

### DIFF
--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -2,19 +2,23 @@ module Passporting
   class MeansPassporter < BasePassporter
     include TypeOfMeansAssessment
 
-    def call
-      crime_application.update(means_passport:)
+    def call(persist: false)
+      crime_application.update(means_passport:) unless persist
 
       passported?
     end
 
     def means_passport
+      return @means_passport if @means_passport
+
       passport = []
       passport << MeansPassportType::ON_NOT_MEANS_TESTED if app_not_means_tested?
       passport << MeansPassportType::ON_AGE_UNDER18      if age_passported?
       passport << MeansPassportType::ON_BENEFIT_CHECK    if benefit_check_passed?
-      passport
+
+      @means_passport = passport
     end
+    alias passport_types_collection means_passport
 
     def passported?
       not_means_tested? || age_passported? || benefit_check_passported?
@@ -24,28 +28,27 @@ module Passporting
       app_not_means_tested?
     end
 
-    # Age based passporting persists on resubmission
     def age_passported?
-      return passported_on?(MeansPassportType::ON_AGE_UNDER18) if resubmission?
+      parent_was_age_passported? || applicant_under18?
+    end
 
-      applicant_under18?
+    def parent_was_age_passported?
+      return false unless resubmission?
+      return false if crime_application.means_passport.blank?
+
+      crime_application.means_passport.include?(MeansPassportType::ON_AGE_UNDER18.to_s)
     end
 
     def benefit_check_passported?
       benefit_check_passed?
     end
 
-    def passport_types_collection
-      crime_application.means_passport
-    end
-
     private
 
     def app_not_means_tested?
       return false unless FeatureFlags.non_means_tested.enabled?
-      return true if crime_application.is_means_tested == 'no'
 
-      false
+      crime_application.is_means_tested == 'no'
     end
 
     def applicant_under18?

--- a/app/services/passporting/means_passporter.rb
+++ b/app/services/passporting/means_passporter.rb
@@ -2,9 +2,7 @@ module Passporting
   class MeansPassporter < BasePassporter
     include TypeOfMeansAssessment
 
-    def call(persist: false)
-      crime_application.update(means_passport:) unless persist
-
+    def call
       passported?
     end
 

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -5,7 +5,7 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
 
   # More validations can be added here
   # Errors, when more than one, will maintain the order
-  def perform_validations # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def perform_validations # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
     errors = []
 
     unless means_valid?
@@ -17,12 +17,6 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
     if record.is_means_tested == 'yes' && kase.case_type.nil?
       errors << [
         :base, :case_type_missing, { change_path: edit_steps_client_case_type_path }
-      ]
-    end
-
-    unless hearing_details_complete?
-      errors << [
-        :base, :hearing_details, { change_path: edit_steps_case_hearing_details_path }
       ]
     end
 
@@ -95,10 +89,6 @@ class ApplicationFulfilmentValidator < BaseFulfilmentValidator
     return true unless circumstances_validator.applicable?
 
     circumstances_validator.circumstances_complete?
-  end
-
-  def hearing_details_complete?
-    kase.hearing_court_name.present? && kase.hearing_date.present? && kase.is_first_court_hearing.present?
   end
 
   alias crime_application record

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -24,7 +24,6 @@ en:
             base:
               case_type_missing: A case type needs to be selected
               circumstances_reference_missing: Your client's MAAT ID or unique submission number (USN) needs to be completed
-              hearing_details: Hearing court details need to be completed
             means_passport:
               blank: Applicant is not passported on means
             ioj_passport:

--- a/spec/support/shared_contexts/serializable_application.rb
+++ b/spec/support/shared_contexts/serializable_application.rb
@@ -34,7 +34,7 @@ RSpec.shared_context 'serializable application' do # rubocop:disable RSpec/Multi
       date_of_birth: (age_passported? ? 17 : 19).years.ago
     )
 
-    CrimeApplication.new(
+    CrimeApplication.create(
       id: SecureRandom.uuid,
       income: income,
       case: Case.new(case_type:),

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -36,16 +36,12 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
   let(:is_means_tested) { 'yes' }
 
   let(:kase) {
-    instance_double(Case, case_type:, is_client_remanded:, date_client_remanded:,
-                                  hearing_court_name:, hearing_date:, is_first_court_hearing:)
+    instance_double(Case, case_type:, is_client_remanded:, date_client_remanded:)
   }
 
   let(:applicant) { instance_double(Applicant, benefit_type: 'none') }
   let(:is_client_remanded) { nil }
   let(:date_client_remanded) { nil }
-  let(:hearing_court_name) { 'Court Name' }
-  let(:hearing_date) { Time.zone.today }
-  let(:is_first_court_hearing) { true }
   let(:case_type) { 'either_way' }
   let(:ioj) { instance_double(Ioj, types: ioj_types) }
   let(:ioj_types) { [] }
@@ -290,33 +286,6 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
       it 'is invalid' do
         expect(subject).not_to be_valid
         expect(subject.errors.of_kind?(:base, :circumstances_reference_missing)).to be(true)
-      end
-    end
-  end
-
-  context 'when application is missing hearing details' do
-    before do
-      # stub the other validations
-      allow_any_instance_of(Passporting::MeansPassporter).to receive(:call).and_return(true)
-      allow_any_instance_of(Passporting::IojPassporter).to receive(:call).and_return(true)
-      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:evidence_complete?).and_return(true)
-      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive(:applicable?).and_return(true)
-    end
-
-    context 'with completed fields' do
-      it 'is valid' do
-        expect(subject).to be_valid
-      end
-    end
-
-    context 'with incomplete fields' do
-      let(:hearing_court_name) { nil }
-      let(:hearing_date) { nil }
-      let(:is_first_court_hearing) { nil }
-
-      it 'is invalid' do
-        expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:base, :hearing_details)).to be(true)
       end
     end
   end


### PR DESCRIPTION
## Description of change

Refactor MeansPassporter to be stateless.

## Link to relevant ticket

[LAA-CRIMINAL-APPLICATIONS-DATASTORE-6](https://ministryofjustice.sentry.io/issues/5635408008/) and others

## Notes for reviewer

Previously, persisting `CrimeApplication#means_passport` within `MeansPassporter#call` caused validation errors to be reset each time `MeansPassporter#call` was invoked. Where multiple validations were run each using the MeansPassporter, only the latest set of errors would exist on the record.

The only known requirement for persisting this value is to allow the consideration of the previous submission's `means_passport` for U18 applications when returns are processed. However, this assumption may not cover all cases, so thorough regression testing is essential. Essentially, after this change, persistence and rehydration of the `means_passport` occur during submission and re-opening of the application. Outside these points, the `means_passport` for a given application will be dynamically derived. If the application is a resubmission, the stored `CrimeApplication#means_passport` will be considered by the `MeansPassporter`

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

To test the fix:

1. Create a means-passported application.
2. Confirm that the application cannot be submitted without a hearing date. Refer to the instructions here: [Slack thread](https://mojdt.slack.com/archives/C056U956ESH/p1722418162411259?thread_ts=1722354722.961199&cid=C056U956ESH).
(see https://dsdmoj.atlassian.net/browse/CRIMAPP-1271 )

To test for regressions:

1. Submit a U18 application with a birthday set to tomorrow.
2. Wait until the applicant turns 18, return the application, and verify that the application remains U18 passported upon rehydration.