### PR TITLE
Use schema version that sets default outgoings to []

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.1'
+    tag: 'v1.2.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1ae303e88d01904ab1439dea45c60dd644a20f7b
-  tag: v1.2.1
+  revision: 1e85ed422daa658123518ca62a4d141cd87063a8
+  tag: v1.2.2
   specs:
-    laa-criminal-legal-aid-schemas (1.2.1)
+    laa-criminal-legal-aid-schemas (1.2.2)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/services/adapters/structs/outgoings_details.rb
+++ b/app/services/adapters/structs/outgoings_details.rb
@@ -4,7 +4,7 @@ module Adapters
       include TypesOfOutgoings
 
       def outgoings_payments
-        return [] unless outgoings
+        return [] unless __getobj__
 
         @outgoings_payments ||= outgoings.map { |struct| OutgoingsPayment.new(**struct) }
       end


### PR DESCRIPTION
## Description of change

Use a version of the schema that default OutgoingsDetails#outgoings to an empty array.

## Link to relevant ticket

Fixes: [LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-2N](https://ministryofjustice.sentry.io/issues/5656868879/)

## Notes for reviewer

Rehydration was failing on means passported applications because outgoings was nil. The version of the schema used here defaults outgoings to an empty array.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

1. Return a U18 passported application. 
2. Confirm that it cannot be re-hydrated. 
3. Updated to this branch. 
4. Confirm that it can be rehydrated.
