### PR TITLE
CRIMAPP-1284 Nullify stored CrimeApplication#date_stamp unless date_s…

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -112,6 +112,14 @@ class CrimeApplication < ApplicationRecord
     ::SectionsCompletenessValidator.new(self).validate
   end
 
+  # Ignore any stored date_stamp if the application is not date_stampable
+  def date_stamp
+    return if not_means_tested? || kase&.case_type.blank?
+    return unless CaseType.new(kase.case_type).date_stampable?
+
+    super
+  end
+
   def client_details_complete?
     valid?(:client_details)
   end

--- a/app/serializers/submission_serializer/sections/application_details.rb
+++ b/app/serializers/submission_serializer/sections/application_details.rb
@@ -10,7 +10,7 @@ module SubmissionSerializer
           json.application_type crime_application.application_type
           json.created_at crime_application.created_at
           json.submitted_at crime_application.submitted_at
-          json.date_stamp crime_application.date_stamp
+          json.date_stamp crime_application.date_stamp || crime_application.submitted_at
           json.is_means_tested crime_application.is_means_tested
           json.ioj_passport crime_application.ioj_passport
           json.means_passport(

--- a/app/services/datastore/application_submission.rb
+++ b/app/services/datastore/application_submission.rb
@@ -6,16 +6,11 @@ module Datastore
       @crime_application = crime_application
     end
 
-    # rubocop:disable Metrics/MethodLength
     def call
-      submitted_at = Time.current
-      date_stamp = crime_application.date_stamp || submitted_at
-
       Rails.error.handle(fallback: -> { false }) do
         CrimeApplication.transaction do
           crime_application.assign_attributes(
-            submitted_at:,
-            date_stamp:,
+            submitted_at: Time.current
           )
 
           DatastoreApi::Requests::CreateApplication.new(
@@ -28,7 +23,6 @@ module Datastore
         true
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def application_payload
       SubmissionSerializer::Application.new(

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CrimeApplication, type: :model do
-  subject { described_class.new(attributes) }
+  subject(:application) { described_class.new(attributes) }
 
   let(:attributes) { {} }
 
@@ -38,6 +38,43 @@ RSpec.describe CrimeApplication, type: :model do
       it 'has the right value' do
         expect(subject.not_means_tested?).to be(false)
       end
+    end
+  end
+
+  describe '#date_stamp' do
+    subject(:date_stamp) { application.date_stamp }
+
+    let(:stored_date_stamp) { '2024-01-01' }
+
+    before do
+      application.date_stamp = stored_date_stamp
+      application.case = Case.new(case_type:)
+    end
+
+    context 'when #case#case_type is passportable' do
+      let(:case_type) { CaseType::DATE_STAMPABLE.sample.to_s }
+
+      it { is_expected.to eq stored_date_stamp }
+    end
+
+    context 'when #case#case_type is not passportable' do
+      let(:case_type) { (CaseType::VALUES - CaseType::DATE_STAMPABLE).sample.to_s }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when #case is nil' do
+      let(:case_type) { nil }
+
+      before { application.case = nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when #case#case_type is nil' do
+      let(:case_type) { nil }
+
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/services/evidence/rules/20240429161240_lost_job_spec.rb
+++ b/spec/services/evidence/rules/20240429161240_lost_job_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Evidence::Rules::LostJob do
 
   include_context 'serializable application'
 
+  let(:case_type) { CaseType::EITHER_WAY }
+
   let(:date_job_lost) { nil }
 
   before do


### PR DESCRIPTION
## Description of change
Nullify stored CrimeApplication#date_stamp unless date_stampable

## Link to relevant ticket

[CRIMAPP-1284](https://dsdmoj.atlassian.net/browse/CRIMAPP-1284)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

As a caseworker, return an application with a date stamp earlier than today.
As a provider, change the case_type to 'indictable' and resubmit
As a caseworker, confirm date_stamp == submitted_at 


[CRIMAPP-1284]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ