### PR TITLE
Check for presence of outgoings before calculating evidence triggers

### DIFF
--- a/app/services/evidence/rules/20240425120658_housing_costs.rb
+++ b/app/services/evidence/rules/20240425120658_housing_costs.rb
@@ -10,10 +10,11 @@ module Evidence
       group :outgoings
 
       client do |crime_application|
-        costs = [
-          crime_application.outgoings&.rent,
-          crime_application.outgoings&.mortgage
-        ]
+        costs = if crime_application.outgoings&.outgoings.present?
+                  [crime_application.outgoings.rent, crime_application.outgoings.mortgage]
+                else
+                  []
+                end
 
         total = costs.compact.sum { |x| x.prorated_monthly.to_f }
 

--- a/app/services/evidence/rules/20240425120827_council_tax_payments.rb
+++ b/app/services/evidence/rules/20240425120827_council_tax_payments.rb
@@ -10,12 +10,11 @@ module Evidence
       group :outgoings
 
       client do |crime_application|
-        payment = crime_application.outgoings&.council_tax
+        payment = crime_application.outgoings&.outgoings.present? ? crime_application.outgoings.council_tax : nil
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/app/services/evidence/rules/20240425120837_childcare_costs.rb
+++ b/app/services/evidence/rules/20240425120837_childcare_costs.rb
@@ -10,12 +10,11 @@ module Evidence
       group :outgoings
 
       client do |crime_application|
-        payment = crime_application.outgoings&.childcare
+        payment = crime_application.outgoings&.outgoings.present? ? crime_application.outgoings.childcare : nil
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/app/services/evidence/rules/20240425183405_child_maintenance_costs.rb
+++ b/app/services/evidence/rules/20240425183405_child_maintenance_costs.rb
@@ -10,12 +10,11 @@ module Evidence
       group :outgoings
 
       client do |crime_application|
-        payment = crime_application.outgoings&.maintenance
+        payment = crime_application.outgoings&.outgoings.present? ? crime_application.outgoings.maintenance : nil
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/app/services/evidence/rules/20240429122128_restraint_or_freezing_order.rb
+++ b/app/services/evidence/rules/20240429122128_restraint_or_freezing_order.rb
@@ -11,7 +11,6 @@ module Evidence
           crime_application.income&.has_frozen_income_or_assets == 'yes') || false
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end


### PR DESCRIPTION
## Description of change
Fixes bug where the evidence upload page breaks when there are no outgoings because the presence of outgoings is not being checked properly

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Start an application and go through the income assessment section answering no to every question. You should be taken to the evidence upload page rather than the outgoings flow. Confirm the evidence upload page loads rather than breaking