### PR TITLE
Handle when has other owners is nil value

### DIFF
--- a/app/forms/steps/capital/property_form.rb
+++ b/app/forms/steps/capital/property_form.rb
@@ -38,7 +38,7 @@ module Steps
 
       def before_save
         record.address = nil if is_home_address&.yes?
-        record.property_owners.destroy_all if has_other_owners.no?
+        record.property_owners.destroy_all if has_other_owners&.no?
       end
 
       def person_has_home_address?


### PR DESCRIPTION
## Description of change
Apply breaks when the property form is saved and the other owners question has not been answered (i.e. save and come back later). This pr checks has other owners is not nil checking the value of the attribute

## Link to relevant ticket
[Sentry error](https://ministryofjustice.sentry.io/issues/5672124052/?project=4507142444023808&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=3)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature