### PR TITLE
[CRIMAPP-695] updates to summary cards and review application page

### DIFF
--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -26,6 +26,11 @@ module Summary
         self.class.name.split('::').last.underscore.to_sym
       end
 
+      # May be overridden in subclasses.
+      def heading
+        nil
+      end
+
       def title
         I18n.t(
           name,

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -96,6 +96,10 @@ module Summary
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
+      def heading
+        :case_details_and_offences
+      end
+
       private
 
       def appeal_case_type?

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -32,7 +32,7 @@ module Summary
         unless post_submission_evidence?
           answers.push(Components::FreeTextAnswer.new(
                          :nino, applicant.nino,
-                         change_path: edit_steps_client_has_nino_path
+                         change_path: edit_steps_client_has_nino_path, show: true
                        ))
         end
 

--- a/app/presenters/summary/sections/employment_details.rb
+++ b/app/presenters/summary/sections/employment_details.rb
@@ -27,6 +27,10 @@ module Summary
         ].select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      def heading
+        :income_details unless crime_application.respond_to?(:navigation_stack)
+      end
     end
   end
 end

--- a/app/presenters/summary/sections/housing_payments.rb
+++ b/app/presenters/summary/sections/housing_payments.rb
@@ -24,6 +24,10 @@ module Summary
         ).select(&:show?)
       end
 
+      def heading
+        :outgoings unless crime_application.respond_to?(:navigation_stack)
+      end
+
       private
 
       def board_and_lodging_info # rubocop:disable Metrics/MethodLength

--- a/app/presenters/summary/sections/overview.rb
+++ b/app/presenters/summary/sections/overview.rb
@@ -65,6 +65,10 @@ module Summary
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
 
+      def heading
+        :application_details
+      end
+
       private
 
       def provider_details

--- a/app/presenters/summary/sections/overview.rb
+++ b/app/presenters/summary/sections/overview.rb
@@ -9,6 +9,9 @@ module Summary
       def answers
         relevant_answers =
           [
+            Components::ValueAnswer.new(
+              :application_type, crime_application.application_type
+            ),
             Components::FreeTextAnswer.new(
               :reference, crime_application.reference.to_s,
             ),

--- a/app/presenters/summary/sections/properties.rb
+++ b/app/presenters/summary/sections/properties.rb
@@ -1,6 +1,10 @@
 module Summary
   module Sections
     class Properties < BaseCapitalRecordsSection
+      def heading
+        :assets
+      end
+
       private
 
       def has_no_records_component

--- a/app/presenters/summary/sections/savings.rb
+++ b/app/presenters/summary/sections/savings.rb
@@ -1,6 +1,10 @@
 module Summary
   module Sections
     class Savings < BaseCapitalRecordsSection
+      def heading
+        :savings_and_investments
+      end
+
       private
 
       def has_no_records_component

--- a/app/presenters/summary/sections/supporting_evidence.rb
+++ b/app/presenters/summary/sections/supporting_evidence.rb
@@ -24,6 +24,14 @@ module Summary
         edit_steps_evidence_upload_path
       end
 
+      def heading
+        :supporting_evidence
+      end
+
+      def name
+        :files
+      end
+
       private
 
       def documents

--- a/app/presenters/summary/sections/trust_fund.rb
+++ b/app/presenters/summary/sections/trust_fund.rb
@@ -2,6 +2,8 @@ module Summary
   module Sections
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     class TrustFund < Sections::BaseSection
+      include TypeOfMeansAssessment
+
       def show?
         capital.present? && capital.will_benefit_from_trust_fund.present?
       end
@@ -27,6 +29,10 @@ module Summary
             show: will_benefit_from_trust_fund?
           )
         ].select(&:show?)
+      end
+
+      def heading
+        :savings_and_investments unless requires_full_capital?
       end
 
       private

--- a/app/views/steps/submission/shared/_list_section.html.erb
+++ b/app/views/steps/submission/shared/_list_section.html.erb
@@ -1,6 +1,6 @@
-<% unless list_section.headless? %>
-  <h2 class="govuk-heading-m">
-    <%= t(list_section.name, scope: 'summary.sections') %>
+<% if list_section.heading %>
+  <h2 class="govuk-heading-l">
+    <%= t(list_section.heading, scope: 'summary.sections') %>
   </h2>
 <% end %>
 

--- a/app/views/steps/submission/shared/_section.html.erb
+++ b/app/views/steps/submission/shared/_section.html.erb
@@ -1,3 +1,9 @@
+<% if section.heading %>
+  <h2 class="govuk-heading-l">
+    <%= t(section.heading, scope: 'summary.sections') %>
+  </h2>
+<% end %>
+
 <%= govuk_summary_card title: section.title do |card| %>
   <% if section.editable? && section.change_path %>
       <% card.with_action { govuk_link_to('Change', section.change_path, no_visited_state: true) } %>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -734,8 +734,8 @@ en:
             resubmission: Application updated
           what_happens_next:
             initial: We will check your application and email you with the outcome.
-            post_submission_evidence: We’ll check the evidence submitted and email you with the outcome.
-            change_in_financial_circumstances: We’ll check the new information submitted and email you with the outcome.
+            post_submission_evidence: We will check the evidence submitted and email you with the outcome.
+            change_in_financial_circumstances: We will check the new information submitted and email you with the outcome.
           view_application:
             initial: View completed application
             post_submission_evidence: View submitted evidence

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -52,6 +52,7 @@ en:
     does_not_get: Does not get
     does_not_pay: Does not pay
     sections:
+      application_details: Application details
       assets: Assets
       overview: Overview
       businesses: Businesses

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -52,6 +52,7 @@ en:
     does_not_get: Does not get
     does_not_pay: Does not pay
     sections:
+      assets: Assets
       overview: Overview
       businesses: Businesses
       business:
@@ -61,6 +62,7 @@ en:
       client_businesses: Client businesses
       partner_businesses: Partner businesses
       case_details: Case details
+      case_details_and_offences: Case details and offences
       client_details: Client details
       contact_details: Client contact details
       partner_details: Partner details
@@ -68,6 +70,7 @@ en:
       codefendant: Co-defendant
       details: Details
       dependants: Dependants
+      files: Files
       offences: Offences
       offence: Offence
       next_court_hearing: Next court hearing
@@ -86,6 +89,7 @@ en:
         one: "Other sources of income"
         other: "Other sources of income: client and partner"
       housing_payments: Housing payments
+      outgoings: Outgoings
       outgoings_payments_details:
         one: Payments %{ownership} makes
         other: Payments %{ownership} make
@@ -93,6 +97,7 @@ en:
       supporting_evidence: Supporting evidence
       more_information: Further information
       savings: Savings
+      savings_and_investments: Savings and investments
       saving:
         bank: Bank account
         building_society: Building society account
@@ -140,6 +145,12 @@ en:
 
     questions:
       # BEGIN overview section
+      application_type:
+        question: Application type
+        answers:
+          initial: Initial
+          change_in_financial_circumstances: Change in financial circumstances
+          post_submission_evidence: Post submission evidence
       reference:
         question: LAA reference number
       pre_cifc_maat_id_or_usn:
@@ -209,7 +220,7 @@ en:
       correspondence_address:
         question: Correspondence address
       correspondence_address_type:
-        question: Where to send correspondence
+        question: Correspondence
         answers:
           home_address: Same as usual home address
           providers_office_address: Provider’s office

--- a/spec/presenters/summary/sections/overview_spec.rb
+++ b/spec/presenters/summary/sections/overview_spec.rb
@@ -60,35 +60,40 @@ describe Summary::Sections::Overview do
 
     context 'when the application is completed' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(6)
+        expect(answers.count).to eq(7)
 
         answer = answers[0]
+        expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answer.question).to eq(:application_type)
+        expect(answer.value).to eq('initial')
+
+        answer = answers[1]
         expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answer.question).to eq(:reference)
         expect(answer.value).to eq('12345')
 
-        answer = answers[1]
+        answer = answers[2]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:means_tested)
         expect(answer.change_path).to match('applications/12345/steps/client/is_application_means_tested')
         expect(answer.value).to eq('yes')
 
-        answer = answers[2]
+        answer = answers[3]
         expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
         expect(answer.question).to eq(:date_stamp)
         expect(answer.value).to eq(Date.new(2023, 1, 20))
 
-        answer = answers[3]
+        answer = answers[4]
         expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
         expect(answer.question).to eq(:date_submitted)
         expect(answer.value).to eq(Date.new(2023, 1, 21))
 
-        answer = answers[4]
+        answer = answers[5]
         expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answer.question).to eq(:provider_email)
         expect(answer.value).to eq('provider@example.com')
 
-        answer = answers[5]
+        answer = answers[6]
         expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answer.question).to eq(:office_code)
         expect(answer.value).to eq('123AA')
@@ -98,24 +103,29 @@ describe Summary::Sections::Overview do
         let(:application_type) { 'post_submission_evidence' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(4)
+          expect(answers.count).to eq(5)
 
           answer = answers[0]
+          expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+          expect(answer.question).to eq(:application_type)
+          expect(answer.value).to eq('post_submission_evidence')
+
+          answer = answers[1]
           expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answer.question).to eq(:reference)
           expect(answer.value).to eq('12345')
 
-          answer = answers[1]
+          answer = answers[2]
           expect(answer).to be_an_instance_of(Summary::Components::DateAnswer)
           expect(answer.question).to eq(:date_submitted)
           expect(answer.value).to eq(Date.new(2023, 1, 21))
 
-          answer = answers[2]
+          answer = answers[3]
           expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answer.question).to eq(:provider_email)
           expect(answer.value).to eq('provider@example.com')
 
-          answer = answers[3]
+          answer = answers[4]
           expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answer.question).to eq(:office_code)
           expect(answer.value).to eq('123AA')
@@ -129,14 +139,14 @@ describe Summary::Sections::Overview do
       end
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(2)
+        expect(answers.count).to eq(3)
 
-        answer = answers[0]
+        answer = answers[1]
         expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answer.question).to eq(:reference)
         expect(answer.value).to eq('12345')
 
-        answer = answers[1]
+        answer = answers[2]
         expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answer.question).to eq(:means_tested)
         expect(answer.change_path).to match('applications/12345/steps/client/is_application_means_tested')
@@ -147,9 +157,9 @@ describe Summary::Sections::Overview do
         let(:application_type) { 'post_submission_evidence' }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(1)
+          expect(answers.count).to eq(2)
 
-          answer = answers[0]
+          answer = answers[1]
           expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
           expect(answer.question).to eq(:reference)
           expect(answer.value).to eq('12345')
@@ -164,9 +174,14 @@ describe Summary::Sections::Overview do
           let(:pre_cifc_maat_id) { '123456' }
 
           it 'has the correct rows' do
-            expect(answers.count).to eq(3)
+            expect(answers.count).to eq(4)
 
-            answer = answers[1]
+            answer = answers[0]
+            expect(answer).to be_an_instance_of(Summary::Components::ValueAnswer)
+            expect(answer.question).to eq(:application_type)
+            expect(answer.value).to eq('change_in_financial_circumstances')
+
+            answer = answers[2]
             expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
             expect(answer.question).to eq(:pre_cifc_maat_id_or_usn)
             expect(answer.change_path).to match('applications/12345/steps/circumstances/pre_cifc_reference_number')
@@ -179,9 +194,9 @@ describe Summary::Sections::Overview do
           let(:pre_cifc_usn) { '98765' }
 
           it 'has the correct rows' do
-            expect(answers.count).to eq(3)
+            expect(answers.count).to eq(4)
 
-            answer = answers[1]
+            answer = answers[2]
             expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
             expect(answer.question).to eq(:pre_cifc_maat_id_or_usn)
             expect(answer.change_path).to match('applications/12345/steps/circumstances/pre_cifc_reference_number')

--- a/spec/presenters/summary/sections/supporting_evidence_spec.rb
+++ b/spec/presenters/summary/sections/supporting_evidence_spec.rb
@@ -40,7 +40,7 @@ describe Summary::Sections::SupportingEvidence do
   end
 
   describe '#name' do
-    it { expect(subject.name).to eq(:supporting_evidence) }
+    it { expect(subject.name).to eq(:files) }
   end
 
   describe '#answers' do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -107,26 +107,30 @@ RSpec.describe 'Dashboard', :authorized do
     it 'has the application details' do
       assert_select 'dl.govuk-summary-list:nth-of-type(1)' do
         assert_select 'div.govuk-summary-list__row:nth-of-type(1)' do
+          assert_select 'dt:nth-of-type(1)', 'Application type'
+          assert_select 'dd:nth-of-type(1)', 'Initial'
+        end
+        assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
           assert_select 'dt:nth-of-type(1)', 'LAA reference number'
           assert_select 'dd:nth-of-type(1)', '6000001'
         end
-        assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(3)' do
           assert_select 'dt:nth-of-type(1)', 'Means tested application'
           assert_select 'dd:nth-of-type(1)', 'Yes'
         end
-        assert_select 'div.govuk-summary-list__row:nth-of-type(3)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(4)' do
           assert_select 'dt:nth-of-type(1)', 'Date stamp'
           assert_select 'dd:nth-of-type(1)', '24 October 2022 10:50am'
         end
-        assert_select 'div.govuk-summary-list__row:nth-of-type(4)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(5)' do
           assert_select 'dt:nth-of-type(1)', 'Date submitted'
           assert_select 'dd:nth-of-type(1)', '24 October 2022 10:50am'
         end
-        assert_select 'div.govuk-summary-list__row:nth-of-type(5)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(6)' do
           assert_select 'dt:nth-of-type(1)', 'Submitted by'
           assert_select 'dd:nth-of-type(1)', 'provider@example.com'
         end
-        assert_select 'div.govuk-summary-list__row:nth-of-type(6)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(7)' do
           assert_select 'dt:nth-of-type(1)', 'Office account number'
           assert_select 'dd:nth-of-type(1)', '1A123B'
         end
@@ -246,12 +250,12 @@ RSpec.describe 'Dashboard', :authorized do
       assert_select 'h1', 'Review the application'
 
       assert_select 'dl.govuk-summary-list:nth-of-type(1)' do
-        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row:nth-of-type(1)' do
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row:nth-of-type(2)' do
           assert_select 'dt:nth-of-type(1)', 'LAA reference number'
           assert_select 'dd:nth-of-type(1)', '6000002'
         end
 
-        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row:nth-of-type(2)' do
+        assert_select 'div.govuk-summary-list__row.govuk-summary-list__row:nth-of-type(3)' do
           assert_select 'dt:nth-of-type(1)', 'Means tested application'
           assert_select 'dd:nth-of-type(1)', 'Yes'
         end


### PR DESCRIPTION
## Description of change
Makes updates to summary cards and review the application screen to match figma designs

Updates: 

- Add headings to the review the application page (`Application details`, `Case details and offences`, `Income`, `Outgoings`, `Assets`, `Savings and investments`, `Supporting evidence`)
- Changes `Supporting evidence` summary card title to `Files` 
- Changes `Where to send correspondence` row to `Correspondence`
- Content changes to the application confirmed page for cifc and pse applications

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-695
https://dsdmoj.atlassian.net/browse/CRIMAPP-1292

## Notes for reviewer
The content in the checklists in the ticket are outdated and so the changes I have made match the designs in figma which also matches what is currently displayed on review. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1218" alt="Screenshot 2024-08-13 at 11 55 28" src="https://github.com/user-attachments/assets/53b91c5d-e094-46d0-ace2-83e3595f00a3">
<img width="1135" alt="Screenshot 2024-08-13 at 11 33 20" src="https://github.com/user-attachments/assets/3e4e573c-f9c8-43ed-b7f4-a75d7e7cc6f9">
<img width="1135" alt="Screenshot 2024-08-13 at 11 33 51" src="https://github.com/user-attachments/assets/a117911e-6a2f-46ae-bd9d-4d5590f7b1f6">
<img width="1135" alt="Screenshot 2024-08-13 at 11 33 57" src="https://github.com/user-attachments/assets/596dcf89-b325-4d83-a864-ecdda1f360d4">
<img width="1135" alt="Screenshot 2024-08-13 at 11 36 33" src="https://github.com/user-attachments/assets/3a4d9e2f-27d5-4abe-a3c2-38685ab475ea">
<img width="1135" alt="Screenshot 2024-08-13 at 11 34 59" src="https://github.com/user-attachments/assets/38421991-de0e-4b41-b267-2c5aa8c9b5d8">
<img width="843" alt="Screenshot 2024-08-13 at 11 46 42" src="https://github.com/user-attachments/assets/910d4faf-78cd-4b1d-ac5c-dac000bd0b9a">
<img width="830" alt="Screenshot 2024-08-13 at 11 47 02" src="https://github.com/user-attachments/assets/52d78ab5-3856-4ed0-b961-f026243ea25e">
<img width="1218" alt="Screenshot 2024-08-13 at 11 57 07" src="https://github.com/user-attachments/assets/2e8e8b9d-e8c8-4f48-a5fc-c788ccacfa80">
<img width="1135" alt="Screenshot 2024-08-13 at 11 57 51" src="https://github.com/user-attachments/assets/e7bf85b7-2058-48a8-9721-13729fe5d8be">


## How to manually test the feature
Create different applications e.g. initial, cifc etc.. and check the correct headings appear on the review the application page. It is also worth checking for regressions on the check your answers pages for the income, outgoings and capital sections