### PR TITLE
CRIMAPP-1277 Missing validation on Income payments and Benefits pages

### DIFF
--- a/app/forms/steps/income/income_benefits_form.rb
+++ b/app/forms/steps/income/income_benefits_form.rb
@@ -13,6 +13,8 @@ module Steps
 
       attribute :income_benefits, array: true, default: [] # Used by BaseFormObject
 
+      validate { errors.add(:base, :none_selected) if @types.nil? }
+
       validates_with IncomeBenefitsValidator
 
       IncomeBenefitType.values.each do |type| # rubocop:disable Style/HashEachMethods

--- a/app/forms/steps/income/income_payments_form.rb
+++ b/app/forms/steps/income/income_payments_form.rb
@@ -13,6 +13,8 @@ module Steps
 
       attribute :income_payments, array: true, default: [] # Used by BaseFormObject
 
+      validate { errors.add(:base, :none_selected) if @types.nil? }
+
       validates_with IncomePaymentsValidator
 
       IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.each do |type|

--- a/app/forms/steps/income/partner/income_benefits_form.rb
+++ b/app/forms/steps/income/partner/income_benefits_form.rb
@@ -14,6 +14,8 @@ module Steps
 
         attribute :income_benefits, array: true, default: [] # Used by BaseFormObject
 
+        validate { errors.add(:base, :none_selected) if @types.nil? }
+
         validates_with PartnerIncomeBenefitsValidator
 
         IncomeBenefitType.values.each do |type| # rubocop:disable Style/HashEachMethods

--- a/app/forms/steps/income/partner/income_payments_form.rb
+++ b/app/forms/steps/income/partner/income_payments_form.rb
@@ -14,6 +14,8 @@ module Steps
 
         attribute :income_payments, array: true, default: [] # Used by BaseFormObject
 
+        validate { errors.add(:base, :none_selected) if @types.nil? }
+
         validates_with PartnerIncomePaymentsValidator
 
         IncomePaymentType::OTHER_INCOME_PAYMENT_TYPES.each do |type|

--- a/spec/forms/steps/income/partner/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_benefits_form_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Steps::Income::Partner::IncomeBenefitsForm do
           {
             'steps_income_income_benefits_form' => {
               'income_benefits' => [''],
-              'types' => %w[child jsa other],
+              'types' => types,
 
               'child' =>  { 'amount' => '', 'frequency' => 'every week' },
               'working_or_child_tax_credit' => { 'amount' => '', 'frequency' => '' },
@@ -116,17 +116,34 @@ RSpec.describe Steps::Income::Partner::IncomeBenefitsForm do
           }
         end
 
-        it 'is invalid' do
-          expect(subject).not_to be_valid
+        context 'when benefit types are selected' do
+          let(:types) { %w[child jsa other] }
+
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+          end
+
+          it 'has error messages' do
+            expect(subject.errors.of_kind?('child-amount', :not_a_number)).to be(true)
+            expect(subject.errors.of_kind?('child-frequency', :inclusion)).to be(true)
+            expect(subject.errors.of_kind?('jsa-details', :invalid)).to be(true)
+
+            # Error attributes should respond
+            expect(subject.send(:'child-amount')).to be_nil
+          end
         end
 
-        it 'has error messages' do
-          expect(subject.errors.of_kind?('child-amount', :not_a_number)).to be(true)
-          expect(subject.errors.of_kind?('child-frequency', :inclusion)).to be(true)
-          expect(subject.errors.of_kind?('jsa-details', :invalid)).to be(true)
+        context 'when benefit types are not selected' do
+          let(:types) { [] }
 
-          # Error attributes should respond
-          expect(subject.send(:'child-amount')).to be_nil
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+          end
+
+          it 'has error messages' do
+            expect(subject.errors.count).to be(1)
+            expect(subject.errors.of_kind?('base', :none_selected)).to be(true)
+          end
         end
       end
     end

--- a/spec/forms/steps/income/partner/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_payments_form_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
   subject(:form) { described_class.new(crime_application:) }
 
@@ -108,7 +108,7 @@ RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
           {
             'steps_income_income_payments_form' => {
               'income_payments' => [''],
-              'types' => %w[maintenance student_loan_grant rent other],
+              'types' => types,
 
               'maintenance' =>  { 'amount' => '', 'frequency' => 'every week' },
               'private_pension' => { 'amount' => '', 'frequency' => '' },
@@ -124,19 +124,38 @@ RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
           }
         end
 
-        it 'is invalid' do
-          expect(subject).not_to be_valid
+        context 'when payment types are selected' do
+          let(:types) { %w[maintenance student_loan_grant rent other] }
+
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+          end
+
+          it 'has error messages' do
+            expect(subject.errors.count).to be(3)
+            expect(subject.errors.of_kind?('maintenance-amount', :not_a_number)).to be(true)
+            expect(subject.errors.of_kind?('maintenance-frequency', :inclusion)).to be(true)
+            expect(subject.errors.of_kind?('student-loan-grant-details', :invalid)).to be(true)
+
+            # Error attributes should respond
+            expect(subject.send(:'maintenance-amount')).to be_nil
+          end
         end
 
-        it 'has error messages' do
-          expect(subject.errors.of_kind?('maintenance-amount', :not_a_number)).to be(true)
-          expect(subject.errors.of_kind?('maintenance-frequency', :inclusion)).to be(true)
-          expect(subject.errors.of_kind?('student-loan-grant-details', :invalid)).to be(true)
+        context 'when payment types are not selected' do
+          let(:types) { [] }
 
-          # Error attributes should respond
-          expect(subject.send(:'maintenance-amount')).to be_nil
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+          end
+
+          it 'has error messages' do
+            expect(subject.errors.count).to be(1)
+            expect(subject.errors.of_kind?('base', :none_selected)).to be(true)
+          end
         end
       end
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## Description of change
Add validation message if none of the `income payments` or `income benefits` are selected

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1277

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
income payments
![Screenshot 2024-08-13 at 13 57 22](https://github.com/user-attachments/assets/7049d931-f257-4ca3-b312-75f54920ecd8)

income benefits
![Screenshot 2024-08-13 at 13 56 47](https://github.com/user-attachments/assets/22692b7b-9ff2-4750-a792-7d5082ac79c7)


## How to manually test the feature
