### PR TITLE
CRIMAPP-1277 Missing validation on outgoings payments

### DIFF
--- a/app/forms/steps/outgoings/outgoings_payments_form.rb
+++ b/app/forms/steps/outgoings/outgoings_payments_form.rb
@@ -19,6 +19,8 @@ module Steps
 
       attribute :outgoings_payments, array: true, default: [] # Used by BaseFormObject
 
+      validate { errors.add(:base, :none_selected) if @types.nil? }
+
       validates_with OutgoingsPaymentsValidator
 
       OutgoingsPaymentType::OTHER_PAYMENT_TYPES.each do |type|

--- a/spec/forms/steps/outgoings/outgoings_payments_form_spec.rb
+++ b/spec/forms/steps/outgoings/outgoings_payments_form_spec.rb
@@ -72,8 +72,7 @@ RSpec.describe Steps::Outgoings::OutgoingsPaymentsForm do
           {
             'steps_outgoings_outgoings_payments_form' => {
               'outgoings_payments' => [''],
-              'types' => %w[childcare maintenance legal_aid_contribution],
-
+              'types' => types,
               'childcare' =>  { 'amount' => '', 'frequency' => 'every week' },
               'maintenance' => { 'amount' => '3.00', 'frequency' => 'annual' },
               'legal_aid_contribution' => { 'amount' => '44', 'frequency' => 'week', 'case_reference' => 'CASE1234' },
@@ -81,16 +80,34 @@ RSpec.describe Steps::Outgoings::OutgoingsPaymentsForm do
           }
         end
 
-        it 'is invalid' do
-          expect(subject).not_to be_valid
+        context 'when outgoings payment types are selected' do
+          let(:types) { %w[childcare maintenance legal_aid_contribution] }
+
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+          end
+
+          it 'has error messages' do
+            expect(subject.errors.count).to be(2)
+            expect(subject.errors.of_kind?('childcare-amount', :not_a_number)).to be(true)
+            expect(subject.errors.of_kind?('childcare-frequency', :inclusion)).to be(true)
+
+            # Error attributes should respond
+            expect(subject.send(:'childcare-amount')).to be_nil
+          end
         end
 
-        it 'has error messages' do
-          expect(subject.errors.of_kind?('childcare-amount', :not_a_number)).to be(true)
-          expect(subject.errors.of_kind?('childcare-frequency', :inclusion)).to be(true)
+        context 'when outgoings payment types are not selected' do
+          let(:types) { [] }
 
-          # Error attributes should respond
-          expect(subject.send(:'childcare-amount')).to be_nil
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+          end
+
+          it 'has error messages' do
+            expect(subject.errors.count).to be(1)
+            expect(subject.errors.of_kind?('base', :none_selected)).to be(true)
+          end
         end
       end
     end


### PR DESCRIPTION
## Description of change
Add validation message if none of the outgoings payments are selected

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1277

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
outgoings payments
![Screenshot 2024-08-13 at 14 45 22](https://github.com/user-attachments/assets/d1f64fe5-40b5-4e45-a045-60f50a0d87c3)




## How to manually test the feature
