### PR TITLE
Reduce minimum file size upload limit to 3kb

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -17,7 +17,7 @@ class DocumentsController < ApplicationController
     document.url = download_crime_application_document_path(current_crime_application, document)
 
     respond_with(document, location: evidence_upload_step) do |format|
-      if document.invalid?(:scan) || document.invalid?(:storage)
+      if document.invalid?(:storage) || document.invalid?(:scan)
         format.html { redirect_to evidence_upload_step }
         format.json do
           render json: document.as_json.merge(error_message: error_for(document)),

--- a/app/javascript/local/dropzone-cfg.js
+++ b/app/javascript/local/dropzone-cfg.js
@@ -2,12 +2,12 @@
 
 import Dropzone from "dropzone"
 
-const MIN_FILE_SIZE = 5000 // Bytes = 5KB
+const MIN_FILE_SIZE = 3000 // Bytes = 3KB
 const MAX_FILE_SIZE = 1000000 // Bytes = 10MB
 
 const ERR_GENERIC = 'could not be uploaded – try again'
 const ERR_FILE_SIZE_TOO_BIG = 'must be smaller than 10MB'
-const ERR_FILE_SIZE_TOO_SMALL = 'must be bigger than 5KB'
+const ERR_FILE_SIZE_TOO_SMALL = 'must be bigger than 3KB'
 const ERR_CONTENT_TYPE = 'must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF'
 const ALLOWED_CONTENT_TYPES = [
   // dropzone checks both the mimetype and the file extension so this list covers everything

--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,5 +1,5 @@
 class FileUploadValidator < ActiveModel::Validator
-  MIN_FILE_SIZE = 5 # KB
+  MIN_FILE_SIZE = 3 # KB
   MAX_FILE_SIZE = 10 # MB
 
   ALLOWED_CONTENT_TYPES = %w[

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Document, type: :model do
 
     context 'criteria' do
       context 'file is too small' do
-        let(:attributes) { super().merge(file_size: 3.kilobytes) }
+        let(:attributes) { super().merge(file_size: 2.kilobytes) }
 
         it 'has a validation error on the field' do
           expect(subject).not_to be_valid(:criteria)


### PR DESCRIPTION
## Description of change
Reduces the minimum upload file size limit to 3kb from 5kb to fix a reported issue where a user could not upload some files. The minimum file size limit was previously arbitrarily chosen and it appears 5kb is too high a threshold and files uploaded could be lower in size. So the decision was taken to reduce and monitor whether this appears to be a better threshold. 

The order of checks are also modified to check the document is valid on storage before checking if the document passes the scan. This is because the error message the user saw was related to the scan service failing. If the size validation checks are ran first it will show the correct error message and not interfere with the scan which seems to pass after

## Link to relevant ticket
Link to [slack thread](https://mojdt.slack.com/archives/C06GX24DV26/p1723044937239579)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
I have the files in question from the user and have validated the solution locally 