### PR TITLE
[CRIMAPP-1302] Amend class of 'Supply a controlled drug of class A - Cocaine'

### DIFF
--- a/config/data/offences.csv
+++ b/config/data/offences.csv
@@ -227,7 +227,7 @@ TH68054,Carried in / on a motor vehicle taken without the owners consent,CM Summ
 SX03015,Assault a girl under 13 by penetration with a part of your body / a thing - SOA 2003,CI Indictable,J,true
 SX03158,Offender 18 or over engage in non penetrative sexual activity with girl 13 to 15 - SOA 2003,CE Either Way,J,true
 MD71552,Possess a controlled drug of Class B - cannabinoid receptor agonists,CE Either Way,H,false
-MD71130,Supply a controlled drug of Class A - Cocaine,CE Either Way,C,true
+MD71130,Supply a controlled drug of Class A - Cocaine,CE Either Way,B,true
 COML062,Act of outraging public decency - common law,CE Either Way,H,true
 SX56029,"Indecent assault on boy under the age of 16 years (Sexual Offences Act 1956, s.14)",CE Either Way,D,true
 SX56029,"Indecent assault on boy under the age of 16 years (Indecency with Children Act 1960, s.1(1))",CE Either Way,J,true


### PR DESCRIPTION
## Description of change
Updated the class of offence "Supply a controlled drug of class A - Cocaine" from C to B.

## Link to relevant ticket
[CRIMAPP-1302](https://dsdmoj.atlassian.net/browse/CRIMAPP-1302)

## Screenshots of changes

### Before changes:
![crimapp-1302-before](https://github.com/user-attachments/assets/2de2d04d-acbe-44e8-abe3-ddf42e736866)
### After changes:
![crimapp-1302-after](https://github.com/user-attachments/assets/5f85b5a2-69d1-40c0-b61f-6acfd6a67774)


[CRIMAPP-1302]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ