### PR TITLE
CRIMAPP-835 Apply: Able to submit application with incomplete justification for legal aid details

### DIFF
--- a/app/presenters/tasks/ioj.rb
+++ b/app/presenters/tasks/ioj.rb
@@ -25,7 +25,12 @@ module Tasks
     def completed?
       return true if crime_application.ioj_passported?
 
-      ioj.present? && ioj.types.any?
+      ioj.present? && ioj.types.any? && ioj_attributes_present?
+    end
+
+    def ioj_attributes_present?
+      required_attributes = ioj.types.map { |type| "#{type}_justification" }
+      ioj.values_at(*required_attributes).all?(&:present?)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Mark `Case details` > `Justification for legal aid` : **`Completed`** if justification/details is present

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-835

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
