### PR TITLE
Fix update when has partner is set to no

### DIFF
--- a/app/forms/steps/client/has_partner_form.rb
+++ b/app/forms/steps/client/has_partner_form.rb
@@ -40,7 +40,19 @@ module Steps
         crime_application.partner&.destroy!
         crime_application.income&.update!(partner_employment_status: [])
         crime_application.payments.for_partner.destroy_all
-        crime_application.partner_detail&.destroy!
+        reset_partner_details
+      end
+
+      def reset_partner_details
+        partner_detail.update!(
+          relationship_to_partner: nil,
+          involvement_in_case: nil,
+          conflict_of_interest: nil,
+          has_same_address_as_client: nil,
+          relationship_status: nil,
+          separation_date: nil,
+          has_partner: 'no',
+        )
       end
     end
   end

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -119,7 +119,15 @@ RSpec.describe Steps::Client::HasPartnerForm do
         expect(crime_application.payments.size).to eq 3
         expect(income).to receive(:update!).with({ partner_employment_status: [] })
         expect(partner).to receive(:destroy!)
-        expect(partner_detail).to receive(:destroy!)
+        expect(partner_detail).to receive(:update!).with({
+                                                           has_partner: 'no',
+                                                           separation_date: nil,
+                                                           relationship_status: nil,
+                                                           has_same_address_as_client: nil,
+                                                           conflict_of_interest: nil,
+                                                           involvement_in_case: nil,
+                                                           relationship_to_partner: nil,
+                                                         }).and_return(true)
 
         expect(subject.save).to be(true)
         expect(crime_application.payments.for_client.size).to eq 1


### PR DESCRIPTION
## Description of change
Fixes bug with partner form, when setting has partner to 'no'
Partner details was being destroyed when it is required to store the has_partner attribute
Now, the attributes that need to be reset are reset and the has_partner value is set 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Start an application and when on the has partner screen select no. Click save and continue and then go back and confirm the value has been persisted. Continue with the application answering the relationship status question and then go back to the has partner screen and change your answer to yes. Confirm the relationship status attributes are reset. Finally, add a partner and then go back to the has partner screen and change your answer to no, confirm the partner attributes and partner details attributes (that are no longer required) are reset. 