### PR TITLE
[CRIMAPP-1310] Allow self assessment tax bill to be zero

### DIFF
--- a/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/client/self_assessment_tax_bill_form.rb
@@ -11,7 +11,7 @@ module Steps
 
         validates :applicant_self_assessment_tax_bill, inclusion: { in: YesNoAnswer.values }
         validates :applicant_self_assessment_tax_bill_amount,
-                  numericality: { greater_than: 0 }, if: -> { pays_self_assessment_tax_bill? }
+                  numericality: { greater_than_or_equal_to: 0 }, if: -> { pays_self_assessment_tax_bill? }
         validates :applicant_self_assessment_tax_bill_frequency,
                   inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
 

--- a/app/forms/steps/income/partner/self_assessment_tax_bill_form.rb
+++ b/app/forms/steps/income/partner/self_assessment_tax_bill_form.rb
@@ -11,7 +11,7 @@ module Steps
 
         validates :partner_self_assessment_tax_bill, inclusion: { in: YesNoAnswer.values }
         validates :partner_self_assessment_tax_bill_amount,
-                  numericality: { greater_than: 0 }, if: -> { pays_self_assessment_tax_bill? }
+                  numericality: { greater_than_or_equal_to: 0 }, if: -> { pays_self_assessment_tax_bill? }
         validates :partner_self_assessment_tax_bill_frequency,
                   inclusion: { in: PaymentFrequencyType.values }, if: -> { pays_self_assessment_tax_bill? }
 

--- a/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/client/self_assessment_tax_bill_form_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe Steps::Income::Client::SelfAssessmentTaxBillForm do
           expect(form.errors.of_kind?(:applicant_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
       end
+
+      context 'when amount is zero' do
+        let(:applicant_self_assessment_tax_bill_amount) { '0' }
+        let(:applicant_self_assessment_tax_bill_frequency) { PaymentFrequencyType::MONTHLY.to_s }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'when `applicant_self_assessment_tax_bill` is `No`' do

--- a/spec/forms/steps/income/partner/self_assessment_tax_bill_form_spec.rb
+++ b/spec/forms/steps/income/partner/self_assessment_tax_bill_form_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe Steps::Income::Partner::SelfAssessmentTaxBillForm do
           expect(form.errors.of_kind?(:partner_self_assessment_tax_bill_amount, :invalid)).to be(false)
         end
       end
+
+      context 'when amount is zero' do
+        let(:partner_self_assessment_tax_bill_amount) { '0' }
+        let(:partner_self_assessment_tax_bill_frequency) { PaymentFrequencyType::MONTHLY.to_s }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'when `partner_self_assessment_tax_bill` is `No`' do


### PR DESCRIPTION
## Description of change

Both client and partner self-assessment tax bills can be zero.

## Link to relevant ticket
[CRIMAPP-1310](https://dsdmoj.atlassian.net/browse/CRIMAPP-1310)

## Notes for reviewer

A person may receive a Self Assessment tax calculation which shows their liability as £0 p/a, but the validation prevents entry of 0 as an amount.

This would block the applicant continuing with the application.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1310]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ