### PR TITLE
[CRIMAPP-1287] Income assessment error message updates

### DIFF
--- a/app/forms/steps/income/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/income_payment_fieldset_form.rb
@@ -7,12 +7,15 @@ module Steps
       attribute :frequency, :string
       attribute :details, :string
 
+      validate { presence_with_payment_type :amount }
+      validate { presence_with_payment_type :frequency }
+
       validates :amount, numericality: {
         greater_than: 0
       }
 
       validates :payment_types, presence: true, inclusion: { in: :payment_types }
-      validates :frequency, presence: true, inclusion: { in: :frequencies }
+      validates :frequency, inclusion: { in: :frequencies }
 
       validate :details_only_when_other?
 
@@ -50,6 +53,21 @@ module Steps
         elsif (payment_type != IncomePaymentType::OTHER.to_s) && details.present?
           errors.add(:details, :invalid)
         end
+      end
+
+      def presence_with_payment_type(attribute)
+        return if send(attribute).present?
+
+        payment_type_str = I18n.t(
+          payment_type,
+          scope: [:helpers, :label, :steps_income_income_payments_form, :types_options]
+        )&.downcase!
+
+        errors.add(
+          attribute,
+          :blank,
+          payment_type: payment_type_str
+        )
       end
     end
   end

--- a/app/forms/steps/income/partner/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/partner/income_payment_fieldset_form.rb
@@ -8,12 +8,15 @@ module Steps
         attribute :frequency, :string
         attribute :details, :string
 
+        validate { presence_with_payment_type :amount }
+        validate { presence_with_payment_type :frequency }
+
         validates :amount, numericality: {
           greater_than: 0
         }
 
         validates :payment_types, presence: true, inclusion: { in: :payment_types }
-        validates :frequency, presence: true, inclusion: { in: :frequencies }
+        validates :frequency, inclusion: { in: :frequencies }
 
         validate :details_only_when_other?
 
@@ -51,6 +54,21 @@ module Steps
           elsif (payment_type != IncomePaymentType::OTHER.to_s) && details.present?
             errors.add(:details, :invalid)
           end
+        end
+
+        def presence_with_payment_type(attribute)
+          return if send(attribute).present?
+
+          payment_type_str = I18n.t(
+            payment_type,
+            scope: [:helpers, :label, :steps_income_income_payments_form, :types_options]
+          )&.downcase!
+
+          errors.add(
+            attribute,
+            :blank,
+            payment_type: payment_type_str
+          )
         end
       end
     end

--- a/app/validators/deductions_validator.rb
+++ b/app/validators/deductions_validator.rb
@@ -45,13 +45,15 @@ class DeductionsValidator < ActiveModel::Validator
   def error_message(obj, error)
     deduction_type = I18n.t(
       obj.deduction_type,
-      scope: [:helpers, :label, :steps_income_deductions_form, :types_options]
+      scope: [:helpers, :label, :steps_income_client_deductions_form, :types_options]
     )
+    deduction_type&.downcase! if obj.deduction_type == DeductionType::OTHER.to_s
 
     I18n.t(
       "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",
       scope: [:activemodel, :errors, :models],
-      deduction_type: deduction_type
+      deduction_type: deduction_type,
+      count: obj.deduction_type == DeductionType::OTHER.to_s ? 2 : 1
     )
   end
 end

--- a/app/validators/income_payments_validator.rb
+++ b/app/validators/income_payments_validator.rb
@@ -44,7 +44,7 @@ class IncomePaymentsValidator < ActiveModel::Validator
     payment_type = I18n.t(
       obj.payment_type,
       scope: [:helpers, :label, :steps_income_income_payments_form, :types_options]
-    )
+    )&.downcase!
 
     I18n.t(
       "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -605,38 +605,31 @@ en:
           attributes:
             base:
               none_selected: Select which payments your client gets, or select 'They do not get any of these payments'
-        steps/income/income_payment_fieldset_form:
+        steps/income/income_payment_fieldset_form: &income_payment_fieldset_form
           summary:
             amount:
               greater_than: "%{payment_type} amount must be greater than 0"
               not_a_number: "%{payment_type} amount is not a number"
+              blank: "Enter amount for %{payment_type}"
             details:
               invalid: "Cannot add additional details for %{payment_type}"
               blank: Enter the other sources of income they get
             frequency:
-              blank: "%{payment_type} frequency can't be blank"
+              blank: "Select how often they receive %{payment_type}"
               inclusion: "%{payment_type} frequency is not included in the list - must be one of Every week, Every 2 weeks, Every 4 weeks, Monthly or Yearly"
           attributes:
             amount:
-              blank: Enter an amount
+              greater_than: "%{payment_type} amount must be greater than 0"
+              blank: "Enter amount for %{payment_type}"
+            frequency:
+              blank: "Select how often they receive %{payment_type}"
+            details:
+              blank: Enter the other sources of income they get
         steps/income/partner/income_payments_form:
           attributes:
             base:
               none_selected: Select which payments the partner gets, or select 'They do not get any of these payments'
-        steps/income/partner/income_payment_fieldset_form:
-          summary:
-            amount:
-              greater_than: "%{payment_type} amount must be greater than 0"
-              not_a_number: "%{payment_type} amount is not a number"
-            details:
-              invalid: "Cannot add additional details for %{payment_type}"
-              blank: Enter the other sources of income they get
-            frequency:
-              blank: "%{payment_type} frequency can't be blank"
-              inclusion: "%{payment_type} frequency is not included in the list - must be one of Every week, Every 2 weeks, Every 4 weeks, Monthly or Yearly"
-          attributes:
-            amount:
-              blank: Enter an amount
+        steps/income/partner/income_payment_fieldset_form: *income_payment_fieldset_form
         steps/income/income_benefits_form:
           attributes:
             base:
@@ -1208,52 +1201,36 @@ en:
           attributes:
             base:
               none_selected: Select and enter a deduction or select that your client does not have deductions taken from their pay
-        steps/income/client/deduction_fieldset_form:
+        steps/income/client/deduction_fieldset_form: &deduction_fieldset_form
           summary:
             amount:
-              blank: Enter amount
+              blank: Enter how much %{deduction_type} gets deducted
+              blank_alt: Enter amount of %{deduction_type}
               not_a_number: Enter amount
               greater_than: Amount must be greater than 0
             frequency:
-              blank: Select how often the amount gets deducted
+              blank:
+                one: Select how often the %{deduction_type} gets deducted
+                other: Select how often the %{deduction_type} get deducted
               inclusion: Select how often the amount gets deducted
             details:
-              blank: Enter details
+              blank: Enter details of other deductions
               invalid: Details not required
           attributes:
             amount:
-              blank: Enter amount
+              blank: Enter how much %{deduction_type} gets deducted
+              blank_alt: Enter amount of %{deduction_type}
               not_a_number: Enter amount
               greater_than: Amount must be greater than 0
             frequency:
-              blank: Select how often the amount gets deducted
-              inclusion: Select how often they get this payment
-            details:
-              blank: Enter details
-              invalid: Details not required
-        steps/income/partner/deduction_fieldset_form:
-          summary:
-            amount:
-              blank: Enter amount
-              not_a_number: Enter amount
-              greater_than: Amount must be greater than 0
-            frequency:
-              blank: Select how often the amount gets deducted
+              blank:
+                one: Select how often the %{deduction_type} gets deducted
+                other: Select how often the %{deduction_type} get deducted
               inclusion: Select how often the amount gets deducted
             details:
-              blank: Enter details
+              blank: Enter details of other deductions
               invalid: Details not required
-          attributes:
-            amount:
-              blank: Enter amount
-              not_a_number: Enter amount
-              greater_than: Amount must be greater than 0
-            frequency:
-              blank: Select how often the amount gets deducted
-              inclusion: Select how often they get this payment
-            details:
-              blank: Enter details
-              invalid: Details not required
+        steps/income/partner/deduction_fieldset_form: *deduction_fieldset_form
         steps/evidence/upload_form:
           attributes:
             documents:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -159,11 +159,11 @@ en:
         frequency: How often do they get this payment?
       steps_income_client_deductions_form:
         income_tax:
-          frequency: Select how often this gets deducted
+          frequency: How often does this get deducted?
         national_insurance:
-          frequency: Select how often this gets deducted
+          frequency: How often does this get deducted?
         other:
-          frequency: Select how often this gets deducted
+          frequency: How often does this get deducted?
       steps_income_client_employments_summary_form:
         add_client_employment: Do you want to add another job?
       steps_income_partner_employments_summary_form:
@@ -749,10 +749,10 @@ en:
         deduction_attributes:
           amount: What is their salary or wage?
         income_tax:
-          amount: *amount_label
+          amount: How much?
           frequency_options: *frequency_options
         national_insurance:
-          amount: *amount_label
+          amount: How much?
           frequency_options: *frequency_options
         other:
           amount: Enter total amount of all other deductions

--- a/spec/forms/steps/income/client/deduction_fieldset_form_spec.rb
+++ b/spec/forms/steps/income/client/deduction_fieldset_form_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Client::DeductionFieldsetForm do
+  it_behaves_like 'a deduction fieldset form', described_class, false
+end

--- a/spec/forms/steps/income/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/income_payments_form_spec.rb
@@ -135,7 +135,8 @@ RSpec.describe Steps::Income::IncomePaymentsForm do
           end
 
           it 'has error messages' do
-            expect(subject.errors.count).to be(3)
+            expect(subject.errors.count).to be(4)
+            expect(subject.errors.of_kind?('maintenance-amount', :blank)).to be(true)
             expect(subject.errors.of_kind?('maintenance-amount', :not_a_number)).to be(true)
             expect(subject.errors.of_kind?('maintenance-frequency', :inclusion)).to be(true)
             expect(subject.errors.of_kind?('student-loan-grant-details', :invalid)).to be(true)

--- a/spec/forms/steps/income/partner/deduction_fieldset_form_spec.rb
+++ b/spec/forms/steps/income/partner/deduction_fieldset_form_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Income::Partner::DeductionFieldsetForm do
+  it_behaves_like 'a deduction fieldset form', described_class, true
+end

--- a/spec/forms/steps/income/partner/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_payments_form_spec.rb
@@ -132,7 +132,8 @@ RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
           end
 
           it 'has error messages' do
-            expect(subject.errors.count).to be(3)
+            expect(subject.errors.count).to be(4)
+            expect(subject.errors.of_kind?('maintenance-amount', :blank)).to be(true)
             expect(subject.errors.of_kind?('maintenance-amount', :not_a_number)).to be(true)
             expect(subject.errors.of_kind?('maintenance-frequency', :inclusion)).to be(true)
             expect(subject.errors.of_kind?('student-loan-grant-details', :invalid)).to be(true)

--- a/spec/support/shared_examples/deduction_shared_examples.rb
+++ b/spec/support/shared_examples/deduction_shared_examples.rb
@@ -1,0 +1,57 @@
+RSpec.shared_examples 'a deduction fieldset form' do |fieldset_class, partnered|
+  subject { fieldset_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application: crime_application,
+      record: employment,
+      deduction_type: deduction_type
+    }
+  end
+
+  let(:crime_application) {
+    income = Income.new(
+      partner_employment_status: partnered ? ['employed'] : nil,
+      employment_status: ['employed'],
+    )
+    CrimeApplication.new(income:)
+  }
+  let(:employment) {
+    ownership_type = partnered ? OwnershipType::PARTNER.to_s : OwnershipType::APPLICANT.to_s
+    Employment.create!(crime_application:, ownership_type:)
+  }
+  let(:deduction_type) { nil }
+
+  describe 'validation' do
+    context 'when the deduction type is income_tax' do
+      let(:deduction_type) { 'income_tax' }
+
+      it { is_expected.to validate_presence_of(:amount, :blank, 'Enter how much Income Tax gets deducted') }
+      it { is_expected.to validate_presence_of(:frequency, :blank, 'Select how often the Income Tax gets deducted') }
+    end
+
+    context 'when the deduction type is national_insurance' do
+      let(:deduction_type) { 'national_insurance' }
+
+      it { is_expected.to validate_presence_of(:amount, :blank, 'Enter how much National Insurance gets deducted') }
+
+      it {
+        expect(subject).to validate_presence_of(:frequency, :blank,
+                                                'Select how often the National Insurance gets deducted')
+      }
+    end
+
+    context 'when the deduction type is other' do
+      let(:deduction_type) { 'other' }
+
+      it { is_expected.to validate_presence_of(:amount, :blank, 'Enter amount of other deductions') }
+
+      it {
+        expect(subject).to validate_presence_of(:frequency, :blank,
+                                                'Select how often the other deductions get deducted')
+      }
+
+      it { is_expected.to validate_presence_of(:details, :blank, 'Enter details of other deductions') }
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
- Update input labels on the Deductions form
- Update error messages on the Deductions form
- Update error messages on the Payments form

## Link to relevant ticket
[CRIMAPP-1287](https://dsdmoj.atlassian.net/browse/CRIMAPP-1287)

## Notes for reviewer
There's some complexity introduced to resolve the correct errors messages in the deductions form. The error messages break the pattern of `"Enter how much %{deduction_type} gets deducted"` when the deduction type is "Other deductions" -- it becomes `"Enter amount of other deductions"`. Also, I've used `count` to deal with the fact that "Other deductions" is plural and the message needs to make grammatical sense.

[CRIMAPP-1287]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ