### PR TITLE
[CRIMAPP-1299] Allow partner with conflict to skip nino

### DIFF
--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -97,9 +97,9 @@ module Decisions
     end
 
     def determine_nino_routing
-      return edit('steps/partner/nino') if partner_is_recipient?
+      subject = partner_is_recipient? ? 'partner' : 'client'
 
-      edit('steps/client/has_nino')
+      edit('steps/shared/nino', subject:)
     end
 
     def determine_client_details_routing

--- a/app/services/decisions/partner_decision_tree.rb
+++ b/app/services/decisions/partner_decision_tree.rb
@@ -37,7 +37,7 @@ module Decisions
       if form_object.conflict_of_interest.yes?
         exit_partner_journey
       else
-        edit(:nino)
+        edit('steps/shared/nino', subject: 'partner')
       end
     end
 

--- a/app/validators/partner_details/answers_validator.rb
+++ b/app/validators/partner_details/answers_validator.rb
@@ -44,6 +44,7 @@ module PartnerDetails
     end
 
     def nino?
+      return true unless include_partner_in_means_assessment?
       return true if crime_application.partner&.has_nino == 'no'
 
       crime_application.partner&.nino.present? || crime_application.partner&.arc.present?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,7 +41,7 @@ feature_flags:
     production: true
   arc:
     local: true
-    staging: true
+    staging: false
     production: false
 
 # NOTE: consider if the setting you are adding here

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -275,14 +275,14 @@ RSpec.describe Decisions::DWPDecisionTree do
       let(:will_enter_nino) { YesNoAnswer::YES }
 
       context 'when the benefit check recipient is the applicant' do
-        it { is_expected.to have_destination('steps/client/has_nino', :edit, id: crime_application) }
+        it { is_expected.to have_destination('steps/shared/nino', :edit, id: crime_application, subject: 'client') }
       end
 
       context 'when the benefit check recipient is the partner' do
         let(:has_passporting_benefit) { true }
         let(:partner) { double(Partner, has_passporting_benefit?: has_passporting_benefit) }
 
-        it { is_expected.to have_destination('steps/partner/nino', :edit, id: crime_application) }
+        it { is_expected.to have_destination('steps/shared/nino', :edit, id: crime_application, subject: 'partner') }
       end
     end
 

--- a/spec/services/decisions/partner_decision_tree_spec.rb
+++ b/spec/services/decisions/partner_decision_tree_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Decisions::PartnerDecisionTree do
       context 'when partner does not have conflict of interest' do
         let(:conflict_of_interest) { YesNoAnswer::NO }
 
-        it { is_expected.to have_destination(:nino, :edit, id: crime_application) }
+        it { is_expected.to have_destination('steps/shared/nino', :edit, id: crime_application, subject: 'partner') }
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe Decisions::PartnerDecisionTree do
       context 'when partner does not have conflict of interest' do
         let(:conflict_of_interest) { YesNoAnswer::NO }
 
-        it { is_expected.to have_destination(:nino, :edit, id: crime_application) }
+        it { is_expected.to have_destination('steps/shared/nino', :edit, id: crime_application, subject: 'partner') }
       end
     end
   end


### PR DESCRIPTION
## Description of change

- Partner with a conflict and without a nino cab be complete on task list.
- Disable Arc question on staging for regression testing

## Link to relevant ticket

[CRIMAPP-1299](https://dsdmoj.atlassian.net/browse/CRIMAPP-1299)

## Notes for reviewer

Changes brought in with the feature flagged ARC work cause a number of regressions in the partner Nino code. This PR fixes those.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1299]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ