### PR TITLE
[CRIMAPP-1296] Validate hearing date

### DIFF
--- a/app/forms/steps/case/hearing_details_form.rb
+++ b/app/forms/steps/case/hearing_details_form.rb
@@ -9,8 +9,9 @@ module Steps
       attribute :is_first_court_hearing, :value_object, source: FirstHearingAnswer
 
       validates :hearing_court_name, presence: true
+      # hearing_date must fall between 01/01/2010 - 31/12/2035 as per validation in MAAT; latest update LASB-3572
       validates :hearing_date, presence: true,
-                multiparam_date: { allow_future: true }
+                multiparam_date: { allow_future: true, earliest_year: 2010, latest_year: 2035 }
 
       validates :is_first_court_hearing, inclusion: { in: :choices }
 

--- a/spec/forms/steps/case/hearing_details_form_spec.rb
+++ b/spec/forms/steps/case/hearing_details_form_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Steps::Case::HearingDetailsForm do
     context 'hearing_date' do
       it_behaves_like 'a multiparam date validation',
                       attribute_name: :hearing_date,
-                      allow_future: true
+                      allow_future: true,
+                      earliest_year: 2010,
+                      latest_year: 2035
     end
 
     # rubocop:disable Style/HashSyntax

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -60,6 +60,9 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
   let(:earliest_year) do
     options[:earliest_year] || MultiparamDateValidator::DEFAULT_OPTIONS[:earliest_year]
   end
+  let(:latest_year) do
+    options[:latest_year] || MultiparamDateValidator::DEFAULT_OPTIONS[:latest_year]
+  end
 
   before do
     subject.public_send(:"#{attribute_name}=", date)
@@ -111,7 +114,7 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
   end
 
   context 'when year is invalid (too futuristic)' do
-    let(:date) { { 3 => 25, 2 => 12, 1 => 2051 } }
+    let(:date) { { 3 => 25, 2 => 12, 1 => latest_year + 1 } }
 
     it 'has a validation error on the field' do
       expect(subject).not_to be_valid


### PR DESCRIPTION
## Description of change
Validate that `hearing_date` is in the 01/01/2010 - 31/12/2035 range. This is to align it with the validation in MAAT. The current upper limit is 31/12/2025, but it is to be updated to 31/12/2035 (MAAT ticket LASB-3572).

## Link to relevant ticket
[CRIMAPP-1296](https://dsdmoj.atlassian.net/browse/CRIMAPP-1296)

## Screenshots of changes (if applicable)
![image](https://github.com/user-attachments/assets/40352c22-7543-4838-89f4-fd45a8487cc7)
![image](https://github.com/user-attachments/assets/66c36731-55ab-48b9-a0e5-dd64617e3a26)


[LASB-3572]: https://dsdmoj.atlassian.net/browse/LASB-3572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1296]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ