### PR TITLE
CRIMAPP-1012 split partner involvement question into two pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,8 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.6'
+    ref: '36076b25d6ab8b6305f7ee3eae88872e95a0c84d'
+# tag: 'v1.2.9'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a118338056bb1d8de1b6ed52e58247caa21e9bbb
-  tag: v1.2.6
+  revision: 36076b25d6ab8b6305f7ee3eae88872e95a0c84d
+  ref: 36076b25d6ab8b6305f7ee3eae88872e95a0c84d
   specs:
-    laa-criminal-legal-aid-schemas (1.2.6)
+    laa-criminal-legal-aid-schemas (1.2.8)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/controllers/steps/partner/involvement_type_controller.rb
+++ b/app/controllers/steps/partner/involvement_type_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Partner
+    class InvolvementTypeController < Steps::PartnerStepController
+      def edit
+        @form_object = InvolvementTypeForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(InvolvementTypeForm, as: :involvement_type)
+      end
+    end
+  end
+end

--- a/app/forms/steps/client/has_partner_form.rb
+++ b/app/forms/steps/client/has_partner_form.rb
@@ -46,6 +46,7 @@ module Steps
       def reset_partner_details
         partner_detail.update!(
           relationship_to_partner: nil,
+          involved_in_case: nil,
           involvement_in_case: nil,
           conflict_of_interest: nil,
           has_same_address_as_client: nil,

--- a/app/forms/steps/partner/involvement_form.rb
+++ b/app/forms/steps/partner/involvement_form.rb
@@ -4,11 +4,11 @@ module Steps
       include Steps::HasOneAssociation
       has_one_association :partner_detail
 
-      attribute :involvement_in_case, :value_object, source: PartnerInvolvementType
-      validates :involvement_in_case, inclusion: { in: :choices }
+      attribute :involved_in_case, :value_object, source: YesNoAnswer
+      validates :involved_in_case, inclusion: { in: :choices }
 
       def choices
-        PartnerInvolvementType.values
+        YesNoAnswer.values
       end
 
       private
@@ -24,7 +24,7 @@ module Steps
       end
 
       def reset_address!
-        return if involvement_in_case.to_s == 'none'
+        return if involved_in_case.to_s == 'no'
         return if crime_application.partner&.home_address.nil?
 
         crime_application.partner.home_address.destroy!

--- a/app/forms/steps/partner/involvement_type_form.rb
+++ b/app/forms/steps/partner/involvement_type_form.rb
@@ -1,0 +1,25 @@
+module Steps
+  module Partner
+    class InvolvementTypeForm < Steps::BaseFormObject
+      include Steps::HasOneAssociation
+      has_one_association :partner_detail
+
+      attribute :involvement_in_case, :value_object, source: PartnerInvolvementType
+      validates :involvement_in_case, inclusion: { in: :choices }
+
+      def choices
+        PartnerInvolvementType.values
+      end
+
+      private
+
+      def persist!
+        ::PartnerDetail.transaction do
+          partner_detail.update!(attributes)
+
+          true
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -45,8 +45,8 @@ module TypeOfMeansAssessment # rubocop:disable Metrics/ModuleLength
   def include_partner_in_means_assessment?
     return false if non_means_tested?
     return false unless partner.present? || partner_detail.present?
-    return true if partner_involvement_in_case == PartnerInvolvementType::NONE.to_s
-    return false unless partner_involvement_in_case == PartnerInvolvementType::CODEFENDANT.to_s
+    return true if partner_involved_in_case == YesNoAnswer::NO.to_s
+    return false unless partner_involvement_type == PartnerInvolvementType::CODEFENDANT.to_s
 
     partner_conflict_of_interest == 'no'
   end
@@ -98,9 +98,15 @@ module TypeOfMeansAssessment # rubocop:disable Metrics/ModuleLength
     person&.benefit_type == 'none' || person&.arc.present?
   end
 
+  def partner_involved_in_case
+    return partner_detail.involved_in_case if partner_detail
+
+    partner&.involved_in_case
+  end
+
   # involvement_in_case is stored on partner_detail when a database applications and
   # partner when a datastore application.
-  def partner_involvement_in_case
+  def partner_involvement_type
     return partner_detail.involvement_in_case if partner_detail
 
     partner&.involvement_in_case

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -39,12 +39,12 @@ module Summary
             change_path: edit_steps_nino_path(subject: 'partner')
           ),
           Components::ValueAnswer.new(
-            :involvement_in_case, partner.involved_in_case,
+            :involved_in_case, partner.involved_in_case,
             change_path: edit_steps_partner_involvement_path
           ),
           Components::ValueAnswer.new(
             :involvement_in_case, partner.involvement_in_case,
-            change_path: edit_steps_partner_involvement_path
+            change_path: edit_steps_partner_involvement_type_path
           ),
           Components::ValueAnswer.new(
             :conflict_of_interest, partner.conflict_of_interest,

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -39,6 +39,10 @@ module Summary
             change_path: edit_steps_nino_path(subject: 'partner')
           ),
           Components::ValueAnswer.new(
+            :involvement_in_case, partner.involved_in_case,
+            change_path: edit_steps_partner_involvement_path
+          ),
+          Components::ValueAnswer.new(
             :involvement_in_case, partner.involvement_in_case,
             change_path: edit_steps_partner_involvement_path
           ),

--- a/app/serializers/submission_serializer/definitions/partner.rb
+++ b/app/serializers/submission_serializer/definitions/partner.rb
@@ -18,6 +18,7 @@ module SubmissionSerializer
           json.nino partner.nino
           json.arc partner.arc
 
+          json.involved_in_case partner_detail.involved_in_case
           json.involvement_in_case partner_detail.involvement_in_case
           json.conflict_of_interest partner_detail.conflict_of_interest
 

--- a/app/services/decisions/partner_decision_tree.rb
+++ b/app/services/decisions/partner_decision_tree.rb
@@ -1,6 +1,6 @@
 module Decisions
   class PartnerDecisionTree < BaseDecisionTree
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     def destination
       case step_name
       when :relationship
@@ -9,6 +9,8 @@ module Decisions
         edit(:involvement)
       when :involvement
         after_involvement
+      when :involvement_type
+        after_involvement_type
       when :conflict
         after_conflict
       when :nino
@@ -19,15 +21,21 @@ module Decisions
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     private
 
     def after_involvement
+      if form_object.involved_in_case == YesNoAnswer::YES
+        edit(:involvement_type)
+      else
+        edit('steps/shared/nino', subject: 'partner')
+      end
+    end
+
+    def after_involvement_type
       if form_object.involvement_in_case == PartnerInvolvementType::CODEFENDANT
         edit(:conflict)
-      elsif form_object.involvement_in_case == PartnerInvolvementType::NONE
-        edit('steps/shared/nino', subject: 'partner')
       else
         exit_partner_journey
       end

--- a/app/validators/partner_details/answers_validator.rb
+++ b/app/validators/partner_details/answers_validator.rb
@@ -16,13 +16,16 @@ module PartnerDetails
       errors.empty?
     end
 
-    def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
       return unless applicable?
 
       errors.add(:relationship_to_partner, :incomplete) if record.relationship_to_partner.blank?
       errors.add(:details, :blank) unless partner_details_complete?
       errors.add(:involved_in_case, :incomplete) if record.involved_in_case.blank?
-      errors.add(:involvement_in_case, :incomplete) if record.involvement_in_case.blank?
+      if record.involvement_in_case.blank? && record.involved_in_case == 'yes'
+        errors.add(:involvement_in_case,
+                   :incomplete)
+      end
       errors.add(:nino, :incomplete) unless nino?
       errors.add(:conflict_of_interest, :incomplete) unless conflict_of_interest?
 

--- a/app/validators/partner_details/answers_validator.rb
+++ b/app/validators/partner_details/answers_validator.rb
@@ -21,6 +21,7 @@ module PartnerDetails
 
       errors.add(:relationship_to_partner, :incomplete) if record.relationship_to_partner.blank?
       errors.add(:details, :blank) unless partner_details_complete?
+      errors.add(:involved_in_case, :incomplete) if record.involved_in_case.blank?
       errors.add(:involvement_in_case, :incomplete) if record.involvement_in_case.blank?
       errors.add(:nino, :incomplete) unless nino?
       errors.add(:conflict_of_interest, :incomplete) unless conflict_of_interest?

--- a/app/value_objects/partner_involvement_type.rb
+++ b/app/value_objects/partner_involvement_type.rb
@@ -3,6 +3,5 @@ class PartnerInvolvementType < ValueObject
     VICTIM = new(:victim),
     PROSECUTION_WITNESS = new(:prosecution_witness),
     CODEFENDANT = new(:codefendant),
-    NONE = new(:none),
   ].freeze
 end

--- a/app/views/steps/partner/involvement_type/edit.html.erb
+++ b/app/views/steps/partner/involvement_type/edit.html.erb
@@ -6,9 +6,9 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :involved_in_case, legend: { tag: 'h1', size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :involvement_in_case, legend: { tag: 'h1', size: 'xl' } do %>
         <% @form_object.choices.each_with_index do |choice, index| %>
-          <%= f.govuk_radio_button :involved_in_case, choice.value, link_errors: index.zero? %>
+          <%= f.govuk_radio_button :involvement_in_case, choice.value, link_errors: index.zero? %>
         <% end %>
       <% end %>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -190,12 +190,16 @@ en:
               inclusion: Select what your client's relationship to their partner is
         steps/partner/involvement_form:
           attributes:
+            involved_in_case:
+              inclusion: Select yes if the partner is involved in your client's case
+        steps/partner/involvement_type_form:
+          attributes:
             involvement_in_case:
-              inclusion: Select how the partner is involved in your client's case or select 'no, the partner is not involved'
+              inclusion: Select how the partner is involved in your client's case
         steps/partner/conflict_form:
           attributes:
             conflict_of_interest:
-              inclusion: Select yes if the partner has a confilct of interest
+              inclusion: Select yes if the partner has a conflict of interest
         steps/partner/same_address_form:
           attributes:
             has_same_address_as_client:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -77,7 +77,9 @@ en:
       steps_partner_details_form:
         date_of_birth: Date of birth
       steps_partner_involvement_form:
-        involvement_in_case: Is the partner involved in your client’s case?
+        involved_in_case: Is the partner involved in your client’s case?
+      steps_partner_involvement_type_form:
+        involvement_in_case: How is the partner involved in your client’s case?
       steps_partner_conflict_form:
         conflict_of_interest: Does the partner have a conflict of interest?
       steps_partner_same_address_form:
@@ -626,11 +628,13 @@ en:
         last_name: Last name
         other_names: Other names (optional)
       steps_partner_involvement_form:
+        involved_in_case_options:
+          <<: *YESNO
+      steps_partner_involvement_type_form:
         involvement_in_case_options:
           victim: Victim
           prosecution_witness: Prosecution witness
           codefendant: Co-defendant
-          none: No, the partner is not involved
       steps_partner_conflict_form:
         conflict_of_interest_options:
           <<: *YESNO

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -94,6 +94,9 @@ en:
       involvement:
         edit:
           page_title: Is the partner involved in your client’s case?
+      involvement_type:
+        edit:
+          page_title: How is the partner involved in your client’s case?
       conflict:
         edit:
           page_title: Does the partner have a conflict of interest?

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -245,13 +245,16 @@ en:
           married_or_partnership: Married or in a civil partnership
           living_together: Living together
           prefer_not_to_say: They prefer not to say
-      involvement_in_case:
+      involved_in_case:
         question: Partner involved in the case?
+        answers:
+          <<: *YESNO
+      involvement_in_case:
+        question: How partner involved
         answers:
           victim: Victim
           prosecution_witness: Prosecution witness
           codefendant: Co-defendant
-          none: 'No'
       has_same_address_as_client:
         question: Lives at same address as client?
         answers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
         edit_step :client_relationship_to_partner, alias: :relationship
         edit_step :partner_details, alias: :details
         edit_step :partner_involved_in_case, alias: :involvement
+        edit_step :how_partner_involved_in_case, alias: :involvement_type
         edit_step :partner_conflict_of_interest, alias: :conflict
         edit_step :do_client_and_partner_live_same_address, alias: :same_address
         edit_step :enter_partner_address, alias: :address

--- a/db/migrate/20240829093426_add_involved_in_case_to_partner.rb
+++ b/db/migrate/20240829093426_add_involved_in_case_to_partner.rb
@@ -1,0 +1,5 @@
+class AddInvolvedInCaseToPartner < ActiveRecord::Migration[7.0]
+  def change
+    add_column :partner_details, :involved_in_case, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_21_151632) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_29_093426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -315,6 +315,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_21_151632) do
     t.string "has_partner"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "involved_in_case"
     t.index ["crime_application_id"], name: "index_partner_details_on_crime_application_id", unique: true
   end
 

--- a/spec/controllers/steps/capital/national_savings_certificates_controller_spec.rb
+++ b/spec/controllers/steps/capital/national_savings_certificates_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Steps::Capital::NationalSavingsCertificatesController, type: :con
   let(:crime_application) do
     CrimeApplication.create!(
       partner: Partner.new,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/controllers/steps/dwp/has_benefit_evidence_controller_spec.rb
+++ b/spec/controllers/steps/dwp/has_benefit_evidence_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Steps::DWP::HasBenefitEvidenceController, type: :controller do
   let(:applicant) { Applicant.new }
   let(:partner) { Partner.new }
-  let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'victim') }
+  let(:partner_detail) { PartnerDetail.new(involved_in_case: 'yes', involvement_in_case: 'victim') }
 
   let(:existing_case) do
     CrimeApplication.create(partner:,
@@ -14,7 +14,7 @@ RSpec.describe Steps::DWP::HasBenefitEvidenceController, type: :controller do
   it_behaves_like 'a step that can be drafted', Steps::DWP::HasBenefitEvidenceForm
 
   context 'when benefit check is on applicant' do
-    let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'none') }
+    let(:partner_detail) { PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil) }
     let(:applicant) { Applicant.new(benefit_type: 'none') }
     let(:partner) { Partner.new(benefit_type: 'none') }
 
@@ -22,7 +22,7 @@ RSpec.describe Steps::DWP::HasBenefitEvidenceController, type: :controller do
   end
 
   context 'when benefit check is on partner' do
-    let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'none') }
+    let(:partner_detail) { PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil) }
     let(:applicant) { Applicant.new(benefit_type: 'none') }
     let(:partner) { Partner.new(benefit_type: 'universal_credit') }
 

--- a/spec/controllers/steps/income/businesses_summary_controller_spec.rb
+++ b/spec/controllers/steps/income/businesses_summary_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Income::BusinessesSummaryController, type: :controller do
       businesses: businesses,
       applicant: Applicant.new,
       partner: Partner.new,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none')
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil)
     )
   end
 

--- a/spec/controllers/steps/partner/involvement_type_controller_spec.rb
+++ b/spec/controllers/steps/partner/involvement_type_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Partner::InvolvementTypeController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Partner::InvolvementTypeForm, Decisions::PartnerDecisionTree
+end

--- a/spec/forms/steps/client/has_partner_form_spec.rb
+++ b/spec/forms/steps/client/has_partner_form_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe Steps::Client::HasPartnerForm do
                                                            relationship_status: nil,
                                                            has_same_address_as_client: nil,
                                                            conflict_of_interest: nil,
+                                                           involved_in_case: nil,
                                                            involvement_in_case: nil,
                                                            relationship_to_partner: nil,
                                                          }).and_return(true)

--- a/spec/forms/steps/income/client/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/client/employment_income_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
   let(:crime_application) do
     CrimeApplication.new(
       partner: Partner.new,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: applicant
     )
   end

--- a/spec/forms/steps/income/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/income_payments_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Steps::Income::IncomePaymentsForm do
       case: Case.new,
       income: Income.new,
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/forms/steps/income/partner/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/partner/employment_income_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
   let(:crime_application) do
     CrimeApplication.new(
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/forms/steps/income/partner/income_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_benefits_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Steps::Income::Partner::IncomeBenefitsForm do
     CrimeApplication.new(
       case: case_record,
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/forms/steps/income/partner/income_payments_form_spec.rb
+++ b/spec/forms/steps/income/partner/income_payments_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Steps::Income::Partner::IncomePaymentsForm do
       case: Case.new,
       income: Income.new,
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/forms/steps/income/partner/other_work_benefits_form_spec.rb
+++ b/spec/forms/steps/income/partner/other_work_benefits_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Steps::Income::Partner::OtherWorkBenefitsForm do
   let(:crime_application) do
     CrimeApplication.new(
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/forms/steps/partner/involvement_form_spec.rb
+++ b/spec/forms/steps/partner/involvement_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Partner::InvolvementForm do
   let(:arguments) do
     {
       crime_application:,
-      involvement_in_case:
+      involved_in_case:
     }
   end
 
@@ -20,38 +20,38 @@ RSpec.describe Steps::Partner::InvolvementForm do
 
   let(:partner_detail) { instance_double(PartnerDetail) }
   let(:partner) { instance_double(Partner) }
-  let(:involvement_in_case) { nil }
+  let(:involved_in_case) { nil }
   let(:home_address) { instance_double(Address) }
 
   describe '#choices' do
     it 'returns the possible choices' do
       expect(
         subject.choices.map(&:to_s)
-      ).to match_array(%w[victim prosecution_witness codefendant none])
+      ).to match_array(%w[yes no])
     end
   end
 
   describe '#save' do
-    context 'when `involvement_in_case` is not provided' do
+    context 'when `involved_in_case` is not provided' do
       it 'has a validation error on the field' do
         expect(subject.save).to be(false)
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:involvement_in_case, :inclusion)).to be(true)
+        expect(subject.errors.of_kind?(:involved_in_case, :inclusion)).to be(true)
       end
     end
 
-    context 'when `involvement_in_case` is invalid' do
-      let(:involvement_in_case) { 'maybe' }
+    context 'when `involved_in_case` is invalid' do
+      let(:involved_in_case) { 'maybe' }
 
       it 'has a validation error on the field' do
         expect(subject.save).to be(false)
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:involvement_in_case, :inclusion)).to be(true)
+        expect(subject.errors.of_kind?(:involved_in_case, :inclusion)).to be(true)
       end
     end
 
-    context 'when `involvement_in_case` is not `none`' do
-      let(:involvement_in_case) { 'victim' }
+    context 'when `involved_in_case` is `yes`' do
+      let(:involved_in_case) { 'yes' }
 
       before do
         allow(home_address).to receive(:destroy!).and_return(true)
@@ -62,15 +62,15 @@ RSpec.describe Steps::Partner::InvolvementForm do
         expect(home_address).to receive(:destroy!)
 
         expect(partner_detail).to receive(:update!).with(
-          { 'involvement_in_case' => PartnerInvolvementType::VICTIM }
+          { 'involved_in_case' => YesNoAnswer::YES }
         ).and_return(true)
 
         expect(subject.save).to be(true)
       end
     end
 
-    context 'when `involvement_in_case` is `none`' do
-      let(:involvement_in_case) { 'none' }
+    context 'when `involved_in_case` is `no`' do
+      let(:involved_in_case) { 'no' }
 
       before do
         allow(home_address).to receive(:destroy!).and_return(true)
@@ -81,7 +81,7 @@ RSpec.describe Steps::Partner::InvolvementForm do
         expect(home_address).not_to receive(:destroy!)
 
         expect(partner_detail).to receive(:update!).with(
-          { 'involvement_in_case' => PartnerInvolvementType::NONE }
+          { 'involved_in_case' => YesNoAnswer::NO }
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/forms/steps/partner/involvement_type_form_spec.rb
+++ b/spec/forms/steps/partner/involvement_type_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Partner::InvolvementTypeForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      crime_application:,
+      involvement_in_case:
+    }
+  end
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      partner_detail:,
+      partner:,
+    )
+  end
+
+  let(:partner_detail) { instance_double(PartnerDetail) }
+  let(:partner) { instance_double(Partner) }
+  let(:involvement_in_case) { nil }
+
+  describe '#choices' do
+    it 'returns the possible choices' do
+      expect(
+        subject.choices.map(&:to_s)
+      ).to match_array(%w[victim prosecution_witness codefendant])
+    end
+  end
+
+  describe '#save' do
+    context 'when `involvement_in_case` is not provided' do
+      it 'has a validation error on the field' do
+        expect(subject.save).to be(false)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:involvement_in_case, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `involvement_in_case` is invalid' do
+      let(:involvement_in_case) { 'maybe' }
+
+      it 'has a validation error on the field' do
+        expect(subject.save).to be(false)
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:involvement_in_case, :inclusion)).to be(true)
+      end
+    end
+
+    context 'when `involvement_in_case` is `victim`' do
+      let(:involvement_in_case) { 'victim' }
+
+      it 'saves the record' do
+        expect(partner_detail).to receive(:update!).with(
+          { 'involvement_in_case' => PartnerInvolvementType::VICTIM }
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/lib/employment_income_payments_calculator_spec.rb
+++ b/spec/lib/employment_income_payments_calculator_spec.rb
@@ -7,7 +7,7 @@ describe EmploymentIncomePaymentsCalculator do
   let(:income) { Income.new(employment_status: ['employed'], partner_employment_status: ['employed']) }
   let(:applicant) { Applicant.new }
   let(:partner) { Partner.new }
-  let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'none') }
+  let(:partner_detail) { PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil) }
 
   before do
     allow(MeansStatus).to receive(:full_means_required?).and_return(true)

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe TypeOfMeansAssessment do
       it { is_expected.to be false }
     end
 
-    context 'when the client does not have partner' do
+    context 'when the client does not have a partner' do
       let(:partner_detail) do
-        instance_double(PartnerDetail, has_partner: 'no', involvement_in_case: nil)
+        instance_double(PartnerDetail, has_partner: 'no', involved_in_case: nil, involvement_in_case: nil)
       end
 
       it { is_expected.to be false }
@@ -107,7 +107,7 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'when client has a partner but we do not know their involvement' do
       let(:partner_detail) do
-        instance_double(PartnerDetail, has_partner: 'yes', involvement_in_case: nil)
+        instance_double(PartnerDetail, has_partner: 'yes', involved_in_case: nil, involvement_in_case: nil)
       end
 
       it { is_expected.to be false }
@@ -115,7 +115,7 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'when client has a partner and they are not involved in the case' do
       let(:partner_detail) do
-        instance_double(PartnerDetail, involvement_in_case: 'none', has_partner: 'yes')
+        instance_double(PartnerDetail, involved_in_case: 'no', has_partner: 'yes')
       end
 
       it { is_expected.to be true }
@@ -123,7 +123,12 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'when client has a partner and they are a prosecution witness' do
       let(:partner_detail) do
-        instance_double(PartnerDetail, involvement_in_case: 'prosecution_witness', has_partner: 'yes')
+        instance_double(
+          PartnerDetail,
+          involved_in_case: 'yes',
+          involvement_in_case: 'prosecution_witness',
+          has_partner: 'yes'
+        )
       end
 
       it { is_expected.to be false }
@@ -131,7 +136,12 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'when client has a partner and they are a victim' do
       let(:partner_detail) do
-        instance_double(PartnerDetail, involvement_in_case: 'victim', has_partner: 'yes')
+        instance_double(
+          PartnerDetail,
+          involved_in_case: 'yes',
+          involvement_in_case: 'victim',
+          has_partner: 'yes'
+        )
       end
 
       it { is_expected.to be false }
@@ -141,6 +151,7 @@ RSpec.describe TypeOfMeansAssessment do
       let(:partner_detail) do
         instance_double(
           PartnerDetail,
+          involved_in_case: 'yes',
           involvement_in_case: 'codefendant',
           conflict_of_interest: conflict_of_interest,
           has_partner: 'yes',
@@ -446,7 +457,13 @@ RSpec.describe TypeOfMeansAssessment do
         end
 
         context 'when partner not means assessed' do
-          let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'victim') }
+          let(:partner_detail) {
+            instance_double(
+              PartnerDetail,
+              involved_in_case: 'yes',
+              involvement_in_case: 'victim'
+            )
+          }
 
           before do
             allow(income).to receive_messages(
@@ -460,7 +477,13 @@ RSpec.describe TypeOfMeansAssessment do
         end
 
         context 'when partner means assessed' do
-          let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'none') }
+          let(:partner_detail) {
+            instance_double(
+              PartnerDetail,
+              involved_in_case: 'no',
+              involvement_in_case: nil
+            )
+          }
 
           it { is_expected.to be true }
         end
@@ -542,13 +565,13 @@ RSpec.describe TypeOfMeansAssessment do
     end
 
     context 'when partner is not included in means assessment' do
-      let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'victim') }
+      let(:partner_detail) { instance_double(PartnerDetail, involved_in_case: 'yes', involvement_in_case: 'victim') }
 
       it { is_expected.to be applicant }
     end
 
     context 'when applicant is benefit check recipient' do
-      let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'none') }
+      let(:partner_detail) { instance_double(PartnerDetail, involved_in_case: 'no') }
       let(:benefit_type) { BenefitType::UNIVERSAL_CREDIT.to_s }
 
       before do
@@ -560,7 +583,7 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'when partner is benefit check recipient' do
       let(:partner) { instance_double(Partner) }
-      let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'none') }
+      let(:partner_detail) { instance_double(PartnerDetail, involved_in_case: 'no') }
 
       context 'when applicant benefit type is none' do
         before do
@@ -583,7 +606,7 @@ RSpec.describe TypeOfMeansAssessment do
 
     context 'defaults to applicant' do
       let(:partner) { instance_double(Partner) }
-      let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'none') }
+      let(:partner_detail) { instance_double(PartnerDetail, involved_in_case: 'no') }
 
       context 'when both the applicant and partner benefit type is none' do
         before do

--- a/spec/models/income_spec.rb
+++ b/spec/models/income_spec.rb
@@ -469,7 +469,7 @@ payment_type: IncomePaymentType::WORK_BENEFITS.to_s)
         crime_application.save!
       end
 
-      let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'none') }
+      let(:partner_detail) { PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil) }
 
       it { is_expected.to be true }
 
@@ -478,7 +478,7 @@ payment_type: IncomePaymentType::WORK_BENEFITS.to_s)
       end
 
       context 'when partner has contrary interest' do
-        let(:partner_detail) { PartnerDetail.new(involvement_in_case: 'victim') }
+        let(:partner_detail) { PartnerDetail.new(involved_in_case: 'yes', involvement_in_case: 'victim') }
 
         it 'only includes applicant payments' do
           expect(income.all_income_total).to eq 200

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -11,7 +11,7 @@ describe Summary::HtmlPresenter do
   let(:database_application) do
     instance_double(
       CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'),
-      partner: double(first_name: 'Test first name', arc: nil), partner_detail: double(PartnerDetail, involvement_in_case: 'none'),
+      partner: double(first_name: 'Test first name', arc: nil), partner_detail: double(PartnerDetail, involved_in_case: 'no', involvement_in_case: nil),
       kase: (double case_type: 'either_way'), ioj: double, status: :in_progress,
       income: income,
       outgoings: outgoings,

--- a/spec/presenters/summary/sections/other_outgoings_details_spec.rb
+++ b/spec/presenters/summary/sections/other_outgoings_details_spec.rb
@@ -75,7 +75,7 @@ describe Summary::Sections::OtherOutgoingsDetails do
         let(:partner_detail) do
           instance_double(
             PartnerDetail,
-            involvement_in_case: 'none',
+            involved_in_case: 'no', involvement_in_case: nil,
           )
         end
 

--- a/spec/presenters/summary/sections/partner_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_details_spec.rb
@@ -146,10 +146,10 @@ describe Summary::Sections::PartnerDetails do
       it 'has the correct rows' do
         expect(answers.count).to eq(10)
 
-        expect(answers[8]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[8].question).to eq(:has_same_address_as_client)
-        expect(answers[8].change_path).to match(client_partner_same_address_path)
-        expect(answers[8].value).to eq('yes')
+        expect(answers[9]).to be_an_instance_of(Summary::Components::ValueAnswer)
+        expect(answers[9].question).to eq(:has_same_address_as_client)
+        expect(answers[9].change_path).to match(client_partner_same_address_path)
+        expect(answers[9].value).to eq('yes')
       end
     end
 

--- a/spec/presenters/summary/sections/partner_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_details_spec.rb
@@ -25,6 +25,7 @@ describe Summary::Sections::PartnerDetails do
       date_of_birth: Date.new(1999, 1, 20),
       nino: nino,
       arc: arc,
+      involved_in_case: 'yes',
       involvement_in_case: 'codefendant',
       conflict_of_interest: 'no',
       has_same_address_as_client: has_same_address_as_client,
@@ -80,7 +81,7 @@ describe Summary::Sections::PartnerDetails do
     client_partner_same_address_path = 'applications/12345/steps/partner/do_client_and_partner_live_same_address'
 
     it 'has the correct rows' do
-      expect(answers.count).to eq(10)
+      expect(answers.count).to eq(11)
 
       expect(answers[0]).to be_an_instance_of(Summary::Components::ValueAnswer)
       expect(answers[0].question).to eq(:relationship_to_partner)
@@ -113,24 +114,29 @@ describe Summary::Sections::PartnerDetails do
       expect(answers[5].value).to eq('123456')
 
       expect(answers[6]).to be_an_instance_of(Summary::Components::ValueAnswer)
-      expect(answers[6].question).to eq(:involvement_in_case)
+      expect(answers[6].question).to eq(:involved_in_case)
       expect(answers[6].change_path).to match('applications/12345/steps/partner/partner_involved_in_case')
-      expect(answers[6].value).to eq('codefendant')
+      expect(answers[6].value).to eq('yes')
 
       expect(answers[7]).to be_an_instance_of(Summary::Components::ValueAnswer)
-      expect(answers[7].question).to eq(:conflict_of_interest)
-      expect(answers[7].change_path).to match('applications/12345/steps/partner/partner_conflict_of_interest')
-      expect(answers[7].value).to eq('no')
+      expect(answers[7].question).to eq(:involvement_in_case)
+      expect(answers[7].change_path).to match('applications/12345/steps/partner/how_partner_involved_in_case')
+      expect(answers[7].value).to eq('codefendant')
 
       expect(answers[8]).to be_an_instance_of(Summary::Components::ValueAnswer)
-      expect(answers[8].question).to eq(:has_same_address_as_client)
-      expect(answers[8].change_path).to match(client_partner_same_address_path)
+      expect(answers[8].question).to eq(:conflict_of_interest)
+      expect(answers[8].change_path).to match('applications/12345/steps/partner/partner_conflict_of_interest')
       expect(answers[8].value).to eq('no')
 
-      expect(answers[9]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-      expect(answers[9].question).to eq(:home_address)
-      expect(answers[9].change_path).to be_nil
-      expect(answers[9].value).to eq("Test\r\nHome\r\nCity\r\nPostcode\r\nCountry")
+      expect(answers[9]).to be_an_instance_of(Summary::Components::ValueAnswer)
+      expect(answers[9].question).to eq(:has_same_address_as_client)
+      expect(answers[9].change_path).to match(client_partner_same_address_path)
+      expect(answers[9].value).to eq('no')
+
+      expect(answers[10]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+      expect(answers[10].question).to eq(:home_address)
+      expect(answers[10].change_path).to be_nil
+      expect(answers[10].value).to eq("Test\r\nHome\r\nCity\r\nPostcode\r\nCountry")
     end
 
     context 'when partner has same home address as client' do
@@ -138,7 +144,7 @@ describe Summary::Sections::PartnerDetails do
       let(:home_address) { nil }
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(9)
+        expect(answers.count).to eq(10)
 
         expect(answers[8]).to be_an_instance_of(Summary::Components::ValueAnswer)
         expect(answers[8].question).to eq(:has_same_address_as_client)
@@ -152,7 +158,7 @@ describe Summary::Sections::PartnerDetails do
       let(:arc) { 'ABC12/345678/A' }
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(11)
+        expect(answers.count).to eq(12)
 
         expect(answers[5]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
         expect(answers[5].question).to eq(:nino)

--- a/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_benefits_details_spec.rb
@@ -9,7 +9,7 @@ describe Summary::Sections::PartnerIncomeBenefitsDetails do
       to_param: '12345',
       income: income,
       partner: instance_double(Partner),
-      partner_detail: instance_double(PartnerDetail, involvement_in_case: 'none'),
+      partner_detail: instance_double(PartnerDetail, involved_in_case: 'no', involvement_in_case: nil),
       non_means_tested?: false
     )
   end

--- a/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_income_payments_details_spec.rb
@@ -9,7 +9,7 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
       to_param: '12345',
       income: income,
       applicant: applicant,
-      partner_detail: instance_double(PartnerDetail, involvement_in_case:),
+      partner_detail: instance_double(PartnerDetail, involved_in_case:, involvement_in_case:),
       partner: partner,
       non_means_tested?: false
     )
@@ -26,7 +26,8 @@ describe Summary::Sections::PartnerIncomePaymentsDetails do
     )
   end
 
-  let(:involvement_in_case) { 'none' }
+  let(:involved_in_case) { 'no' }
+  let(:involvement_in_case) { nil }
   let(:income_payments) { [] }
   let(:partner_has_no_income_payments) { nil }
 

--- a/spec/presenters/summary/sections/passporting_benefit_check_partner_spec.rb
+++ b/spec/presenters/summary/sections/passporting_benefit_check_partner_spec.rb
@@ -9,7 +9,7 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
       CrimeApplication,
       to_param: '12345',
       applicant: applicant,
-      partner_detail: instance_double(PartnerDetail, involvement_in_case:),
+      partner_detail: instance_double(PartnerDetail, involved_in_case:, involvement_in_case:),
       partner: partner,
       is_means_tested: is_means_tested,
       non_means_tested?: false
@@ -33,7 +33,8 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
   let(:benefit_check_status) { nil }
   let(:confirm_details) { nil }
   let(:has_benefit_evidence) { nil }
-  let(:involvement_in_case) { 'none' }
+  let(:involved_in_case) { 'no' }
+  let(:involvement_in_case) { nil }
   let(:is_means_tested) { 'yes' }
 
   before do
@@ -68,6 +69,7 @@ describe Summary::Sections::PassportingBenefitCheckPartner do
     end
 
     context 'when the partner is included in the means assessment' do
+      let(:involved_in_case) { 'yes' }
       let(:involvement_in_case) { 'victim' }
 
       it 'does not show this section' do

--- a/spec/requests/businesses_summary_spec.rb
+++ b/spec/requests/businesses_summary_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Businesses summary page', :authorized do
       income: Income.new,
       applicant: Applicant.new,
       partner: Partner.new,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       businesses: [business, partner_business]
     )
   end
@@ -89,13 +89,14 @@ RSpec.describe 'Businesses summary page', :authorized do
 
   describe 'list of added businesses in summary page' do
     before do
-      PartnerDetail.update_all(involvement_in_case:) # rubocop:disable Rails/SkipsModelValidations
+      PartnerDetail.update_all(involved_in_case:, involvement_in_case:) # rubocop:disable Rails/SkipsModelValidations
 
       get edit_steps_income_businesses_summary_path(crime_application, subject: subject_type)
     end
 
     context 'when subject is client' do
-      let(:involvement_in_case) { 'none' }
+      let(:involved_in_case) { 'no' }
+      let(:involvement_in_case) { nil }
       let(:subject_type) { SubjectType::APPLICANT }
 
       it 'lists the businesses with their details and action links' do
@@ -111,7 +112,8 @@ RSpec.describe 'Businesses summary page', :authorized do
 
     context 'when subject is partner' do
       let(:subject_type) { SubjectType::PARTNER }
-      let(:involvement_in_case) { 'none' }
+      let(:involved_in_case) { 'no' }
+      let(:involvement_in_case) { nil }
 
       it 'lists the partners businesses' do
         expect(response).to have_http_status(:success)
@@ -120,7 +122,8 @@ RSpec.describe 'Businesses summary page', :authorized do
       end
 
       context 'when partner has a contrary interest' do
-        let(:involvement_in_case) { 'victim' }
+        let(:involved_in_case) { YesNoAnswer::YES }
+        let(:involvement_in_case) { PartnerInvolvementType::VICTIM }
 
         it 'redirects page not found' do
           expect(response).to redirect_to(/not_found/)

--- a/spec/serializers/submission_serializer/sections/capital_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/capital_details_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe SubmissionSerializer::Sections::CapitalDetails do
     )
   end
 
-  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:partner_detail) { instance_double(PartnerDetail, involved_in_case:, involvement_in_case:) }
   let(:partner) { instance_double(Partner) }
-  let(:involvement_in_case) { 'none' }
+  let(:involved_in_case) { 'no' }
+  let(:involvement_in_case) { nil }
 
   let(:capital) do
     instance_double(

--- a/spec/serializers/submission_serializer/sections/client_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/client_details_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
           relationship_to_partner: relationship_to_partner,
           relationship_status: relationship_status,
           separation_date: nil,
+          involved_in_case: 'no',
           involvement_in_case: nil,
           has_partner: has_partner,
         )
@@ -193,6 +194,7 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
       let(:partner_detail) do
         instance_double(
           PartnerDetail,
+          involved_in_case: 'yes',
           involvement_in_case: 'victim',
           conflict_of_interest: nil,
           has_same_address_as_client: nil,
@@ -213,6 +215,7 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
           nino: nil,
           has_arc: nil,
           arc: nil,
+          involved_in_case: 'yes',
           involvement_in_case: 'victim',
           conflict_of_interest: nil,
           has_same_address_as_client: nil,
@@ -275,6 +278,7 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
       let(:partner_detail) do
         instance_double(
           PartnerDetail,
+          involved_in_case: 'yes',
           involvement_in_case: 'victim',
           conflict_of_interest: nil,
           has_same_address_as_client: nil,
@@ -295,6 +299,7 @@ RSpec.describe SubmissionSerializer::Sections::ClientDetails do
           nino: nil,
           has_arc: nil,
           arc: nil,
+          involved_in_case: 'yes',
           involvement_in_case: 'victim',
           conflict_of_interest: nil,
           is_included_in_means_assessment: false

--- a/spec/serializers/submission_serializer/sections/income_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/income_details_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe SubmissionSerializer::Sections::IncomeDetails do
   end
 
   let(:partner) { instance_double(Partner) }
-  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
-  let(:involvement_in_case) { 'none' }
+  let(:partner_detail) { instance_double(PartnerDetail, involved_in_case:, involvement_in_case:) }
+  let(:involved_in_case) { 'no' }
+  let(:involvement_in_case) { nil }
   let(:deductions_double) { double('deductions_collection', complete: deductions) }
 
   let(:income) do

--- a/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
+++ b/spec/serializers/submission_serializer/sections/outgoings_details_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe SubmissionSerializer::Sections::OutgoingsDetails do
     instance_double(CrimeApplication, outgoings: outgoings, partner_detail: partner_detail, partner: partner,
   non_means_tested?: false)
   }
-  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:partner_detail) { instance_double(PartnerDetail, involved_in_case:, involvement_in_case:) }
   let(:partner) { instance_double(Partner) }
-  let(:involvement_in_case) { 'none' }
+  let(:involved_in_case) { 'no' }
+  let(:involvement_in_case) { nil }
 
   let(:outgoings) do
     instance_double(

--- a/spec/services/datastore/application_submission_spec.rb
+++ b/spec/services/datastore/application_submission_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Datastore::ApplicationSubmission do
     partner_details = PartnerDetail.create( # rubocop:disable Lint/UselessAssignment
       crime_application: app,
       relationship_to_partner: 'married_or_partnership',
-      involvement_in_case: 'none',
+      involved_in_case: 'no', involvement_in_case: nil,
       has_same_address_as_client: 'no',
       conflict_of_interest: 'no',
       has_partner: 'yes',

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -19,7 +19,10 @@ RSpec.describe Decisions::CapitalDecisionTree do
   let(:capital) { instance_double(Capital) }
   let(:income) { instance_double(Income, has_frozen_income_or_assets:) }
   let(:has_frozen_income_or_assets) { nil }
-  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:, conflict_of_interest:) }
+  let(:partner_detail) {
+    instance_double(PartnerDetail, involved_in_case:, involvement_in_case:, conflict_of_interest:)
+  }
+  let(:involved_in_case) { nil }
   let(:involvement_in_case) { nil }
   let(:conflict_of_interest) { nil }
 
@@ -473,12 +476,14 @@ RSpec.describe Decisions::CapitalDecisionTree do
     let(:step_name) { :premium_bonds }
 
     context 'when partner is included' do
-      let(:involvement_in_case) { PartnerInvolvementType::NONE.to_s }
+      let(:involved_in_case) { YesNoAnswer::NO.to_s }
+      let(:involvement_in_case) { nil }
 
       it { is_expected.to have_destination(:partner_premium_bonds, :edit, id: crime_application) }
     end
 
     context 'when partner is not included' do
+      let(:involved_in_case) { 'yes' }
       let(:involvement_in_case) { PartnerInvolvementType::VICTIM.to_s }
 
       it { is_expected.to have_destination(:has_national_savings_certificates, :edit, id: crime_application) }
@@ -514,6 +519,7 @@ RSpec.describe Decisions::CapitalDecisionTree do
 
     context 'when there is a partner' do
       context 'when partner is not included' do
+        let(:involved_in_case) { 'yes' }
         let(:involvement_in_case) { PartnerInvolvementType::VICTIM.to_s }
 
         context 'when has_frozen_income_or_assets is nil' do
@@ -528,7 +534,8 @@ RSpec.describe Decisions::CapitalDecisionTree do
       end
 
       context 'when partner is included' do
-        let(:involvement_in_case) { PartnerInvolvementType::NONE.to_s }
+        let(:involved_in_case) { YesNoAnswer::NO.to_s }
+        let(:involvement_in_case) { nil }
 
         it { is_expected.to have_destination(:partner_trust_fund, :edit, id: crime_application) }
       end

--- a/spec/services/decisions/dwp_decision_tree_spec.rb
+++ b/spec/services/decisions/dwp_decision_tree_spec.rb
@@ -120,19 +120,23 @@ RSpec.describe Decisions::DWPDecisionTree do
         let(:feature_flag_means_journey_enabled) { true }
 
         context 'and the partner is included in the means assessment' do
-          let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'none') }
+          let(:partner_detail) { instance_double(PartnerDetail, involved_in_case: 'no', involvement_in_case: nil) }
 
           it { is_expected.to have_destination(:partner_benefit_type, :edit, id: crime_application) }
         end
 
         context 'and the partner is not included in the means assessment' do
-          let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'victim') }
+          let(:partner_detail) {
+            instance_double(PartnerDetail, involved_in_case: 'yes', involvement_in_case: 'victim')
+          }
 
           it { is_expected.to have_destination('/steps/case/urn', :edit, id: crime_application) }
         end
 
         context 'and the partner has an arc number' do
-          let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case: 'victim') }
+          let(:partner_detail) {
+            instance_double(PartnerDetail, involved_in_case: 'yes', involvement_in_case: 'victim')
+          }
           let(:partner_double) { instance_double(Partner, arc:) }
           let(:arc) { 'ABC12/345678/A' }
 

--- a/spec/services/decisions/income_decision_tree_spec.rb
+++ b/spec/services/decisions/income_decision_tree_spec.rb
@@ -1119,7 +1119,7 @@ RSpec.describe Decisions::IncomeDecisionTree do
     let(:step_name) { :dependants_finished }
 
     context 'when the partner is included in means assessment' do
-      let(:partner_detail) { double(PartnerDetail, involvement_in_case: 'none') }
+      let(:partner_detail) { double(PartnerDetail, involved_in_case: 'no', involvement_in_case: nil) }
 
       it { is_expected.to have_destination(:partner_employment_status, :edit, id: crime_application) }
     end

--- a/spec/services/decisions/outgoings_decision_tree_spec.rb
+++ b/spec/services/decisions/outgoings_decision_tree_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Decisions::OutgoingsDecisionTree do
   subject { described_class.new(form_object, as: step_name) }
 
@@ -18,8 +19,11 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
   let(:outgoings) { instance_double(Outgoings) }
   let(:kase) { instance_double(Case, case_type:) }
   let(:case_type) { nil }
-  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:, conflict_of_interest:) }
+  let(:partner_detail) {
+    instance_double(PartnerDetail, involved_in_case:, involvement_in_case:, conflict_of_interest:)
+  }
   let(:partner) { instance_double(Partner) }
+  let(:involved_in_case) { nil }
   let(:involvement_in_case) { nil }
   let(:conflict_of_interest) { nil }
 
@@ -143,6 +147,7 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       end
 
       context 'when partner is victim' do
+        let(:involved_in_case) { 'yes' }
         let(:involvement_in_case) { 'victim' }
         let(:conflict_of_interest) { nil }
 
@@ -150,6 +155,7 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
       end
 
       context 'when partner is codefendant with a conflict' do
+        let(:involved_in_case) { 'yes' }
         let(:involvement_in_case) { 'codefendant' }
         let(:conflict_of_interest) { 'yes' }
 
@@ -159,7 +165,8 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
 
     context 'and there is a relevant partner' do
       context 'has correct next step' do
-        let(:involvement_in_case) { 'none' }
+        let(:involved_in_case) { 'no' }
+        let(:involvement_in_case) { nil }
 
         it { is_expected.to have_destination(:partner_income_tax_rate, :edit, id: crime_application) }
       end
@@ -217,3 +224,4 @@ RSpec.describe Decisions::OutgoingsDecisionTree do
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/services/dwp/benefit_check_status_service_spec.rb
+++ b/spec/services/dwp/benefit_check_status_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe DWP::BenefitCheckStatusService do
     end
 
     context 'when person is not benefit check recipient' do
-      let(:partner_detail) { double(PartnerDetail, involvement_in_case: 'none') }
+      let(:partner_detail) { double(PartnerDetail, involved_in_case: 'no', involvement_in_case: nil) }
       let(:benefit_type) { 'none' }
       let(:partner) { double(Partner, id: '234', benefit_type: 'universal_credit', arc: nil) }
 

--- a/spec/support/shared_contexts/serializable_application.rb
+++ b/spec/support/shared_contexts/serializable_application.rb
@@ -11,7 +11,8 @@ RSpec.shared_context 'serializable application' do # rubocop:disable RSpec/Multi
 
   let(:crime_application) do
     PartnerDetail.new(
-      involvement_in_case: include_partner? ? 'none' : 'victim'
+      involved_in_case: include_partner? ? 'yes' : nil,
+      involvement_in_case: include_partner? ? nil : 'victim'
     )
 
     employment_status = []
@@ -34,6 +35,11 @@ RSpec.shared_context 'serializable application' do # rubocop:disable RSpec/Multi
       date_of_birth: (age_passported? ? 17 : 19).years.ago
     )
 
+    partner_detail = PartnerDetail.new(
+      involved_in_case: include_partner? ? 'no' : 'yes',
+      involvement_in_case: include_partner? ? nil : 'victim'
+    )
+
     CrimeApplication.create(
       id: SecureRandom.uuid,
       income: income,
@@ -48,7 +54,7 @@ RSpec.shared_context 'serializable application' do # rubocop:disable RSpec/Multi
       applicant: applicant,
       partner: Partner.new,
       capital: Capital.new,
-      partner_detail: PartnerDetail.new(involvement_in_case: include_partner? ? 'none' : 'victim'),
+      partner_detail: partner_detail,
       usn: 691_231,
       created_at: Time.zone.now
     )

--- a/spec/support/shared_examples/business_resource_step_controller.rb
+++ b/spec/support/shared_examples/business_resource_step_controller.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'a business resource step controller' do |form_class|
     CrimeApplication.create(
       applicant: Applicant.new,
       partner: Partner.new,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       businesses: [
         Business.new(business_type: 'partnership', ownership_type: 'applicant'),
         Business.new(business_type: 'self_employed', ownership_type: 'partner')

--- a/spec/support/shared_examples/payment_shared_examples.rb
+++ b/spec/support/shared_examples/payment_shared_examples.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'a payment fieldset form' do |fieldset_class|
   let(:crime_application) do
     CrimeApplication.new(
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end
@@ -121,7 +121,7 @@ RSpec.shared_examples 'a payment form' do |payment_class, has_none_attr|
       case: case_record,
       income: income,
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/support/shared_examples/step_controller_shared_examples.rb
+++ b/spec/support/shared_examples/step_controller_shared_examples.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
           CrimeApplication.create(
             applicant: Applicant.new,
             partner: Partner.new,
-            partner_detail: PartnerDetail.new(involvement_in_case: false)
+            partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil)
           )
         end
       end

--- a/spec/validators/capital_assessment/answers_validator_spec.rb
+++ b/spec/validators/capital_assessment/answers_validator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
   subject(:validator) { described_class.new(record:, crime_application:) }
 
@@ -9,9 +10,10 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
   non_means_tested?: false)
   }
   let(:income) { instance_double(Income) }
-  let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:) }
+  let(:partner_detail) { instance_double(PartnerDetail, involved_in_case:, involvement_in_case:) }
   let(:partner) { nil }
   let(:errors) { double(:errors) }
+  let(:involved_in_case) { nil }
   let(:involvement_in_case) { nil }
   let(:requires_full_means_assessment?) { true }
   let(:requires_full_capital?) { true }
@@ -103,7 +105,8 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
     end
 
     context 'when validation fails' do
-      let(:involvement_in_case) { PartnerInvolvementType::NONE.to_s }
+      let(:involved_in_case) { YesNoAnswer::NO.to_s }
+      let(:involvement_in_case) { nil }
 
       let(:attributes) do
         {
@@ -345,7 +348,8 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
   end
 
   describe '#partner_premium_bonds_complete?' do
-    let(:involvement_in_case) { PartnerInvolvementType::NONE.to_s }
+    let(:involved_in_case) { YesNoAnswer::NO.to_s }
+    let(:involvement_in_case) { nil }
 
     it 'returns false when not answered' do
       allow(record).to receive(:partner_has_premium_bonds).and_return('nil')
@@ -474,7 +478,8 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
   end
 
   describe '#partner_trust_fund_complete?' do
-    let(:involvement_in_case) { PartnerInvolvementType::NONE.to_s }
+    let(:involved_in_case) { YesNoAnswer::NO.to_s }
+    let(:involvement_in_case) { nil }
 
     it 'returns false when not answered' do
       allow(record).to receive(:partner_will_benefit_from_trust_fund).and_return('nil')
@@ -544,3 +549,4 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/validators/income_assessment/answers_validator_spec.rb
+++ b/spec/validators/income_assessment/answers_validator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe IncomeAssessment::AnswersValidator, type: :model do
     CrimeApplication.new(
       case: Case.new(case_type: 'summary_only'),
       partner: partner,
-      partner_detail: PartnerDetail.new(involvement_in_case: 'none'),
+      partner_detail: PartnerDetail.new(involved_in_case: 'no', involvement_in_case: nil),
       applicant: Applicant.new
     )
   end

--- a/spec/validators/outgoings_assessment/answers_validator_spec.rb
+++ b/spec/validators/outgoings_assessment/answers_validator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
   let(:crime_application) { instance_double(CrimeApplication, partner: nil, non_means_tested?: false) }
   let(:errors) { [] }
   let(:requires_full_means_assessment?) { true }
+  let(:involved_in_case?) { nil }
   let(:involvement_in_case?) { nil }
 
   before do
@@ -21,6 +22,10 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
     allow(crime_application).to receive(:partner_detail).and_return(
       instance_double(PartnerDetail)
     )
+
+    allow(crime_application).to receive_message_chain(:partner_detail, :involved_in_case) {
+      involved_in_case?
+    }
 
     allow(crime_application).to receive_message_chain(:partner_detail, :involvement_in_case) {
       involvement_in_case?
@@ -68,7 +73,7 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
     context 'when all validations pass' do
       let(:errors) { [] }
 
-      let(:involvement_in_case?) { 'none' }
+      let(:involved_in_case?) { 'no' }
 
       before do
         allow(record).to receive_message_chain(:outgoings_payments, :rent) {
@@ -112,7 +117,7 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
 
     context 'when validations fail' do
       let(:errors) { double(:errors) }
-      let(:involvement_in_case?) { 'none' }
+      let(:involved_in_case?) { 'no' }
 
       before do
         allow(record).to receive_message_chain(:outgoings_payments, :rent) {
@@ -341,7 +346,7 @@ RSpec.describe OutgoingsAssessment::AnswersValidator, type: :model do
   end
 
   describe '#partner_income_tax_rate_complete?' do
-    let(:involvement_in_case?) { 'none' }
+    let(:involved_in_case?) { 'no' }
 
     context 'when partner_income_tax_rate_above_threshold is present' do
       before do

--- a/spec/validators/partner_details/answers_validator_spec.rb
+++ b/spec/validators/partner_details/answers_validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
       relationship_status: nil,
       separation_date: nil,
       relationship_to_partner: 'married_or_partnership',
+      involved_in_case: 'no',
       involvement_in_case: 'none',
       conflict_of_interest: 'no',
       has_same_address_as_client: 'no',
@@ -98,10 +99,26 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
         it { is_expected.to be false }
       end
 
+      context 'without involved in case' do
+        before { partner_detail.involved_in_case = nil }
+
+        it { is_expected.to be false }
+      end
+
       context 'without involvement in case' do
         before { partner_detail.involvement_in_case = nil }
 
-        it { is_expected.to be false }
+        context 'when partner involved in case = yes' do
+          before { partner_detail.involved_in_case = 'yes' }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when partner involved in case = no' do
+          before { partner_detail.involved_in_case = 'no' }
+
+          it { is_expected.to be true }
+        end
       end
 
       context 'without nino' do
@@ -144,12 +161,12 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
     let(:has_partner) { 'yes' }
 
     context 'when not complete' do
-      before { partner_detail.involvement_in_case = nil }
+      before { partner_detail.involved_in_case = nil }
 
       it 'adds errors' do
         subject.validate
 
-        expect(subject.errors.of_kind?('involvement_in_case', :incomplete)).to be(true)
+        expect(subject.errors.of_kind?('involved_in_case', :incomplete)).to be(true)
         expect(subject.errors.of_kind?('base', :incomplete_records)).to be(true)
       end
     end

--- a/spec/validators/passporting_benefit_check/answers_validator_spec.rb
+++ b/spec/validators/passporting_benefit_check/answers_validator_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe PassportingBenefitCheck::AnswersValidator, type: :model do
     end
 
     context 'when the partner is the benefit check recipient' do
-      let(:partner_detail) { double(PartnerDetail, involvement_in_case: 'none') }
+      let(:partner_detail) { double(PartnerDetail, involved_in_case: 'no', involvement_in_case: nil) }
       let(:benefit_type) { BenefitType::NONE.to_s }
       let(:partner) {
         double(Partner, id: '234', benefit_type: BenefitType::UNIVERSAL_CREDIT.to_s,


### PR DESCRIPTION
## Description of change

Split the partner involvement question into two separate questions/pages.
The first question is `Is the partner involved in your client's case?` followed by `How is the partner involved in your client's case?`
Add a new Yes/No attribute `involved_in_case` and remove `None` from `PartnerInvolvementType` as it will no longer be displayed as an option on the involvement type page. 

## Link to relevant ticket

[CRIMAPP-1012](https://dsdmoj.atlassian.net/browse/CRIMAPP-1012)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1176" alt="Screenshot 2024-08-29 at 17 08 49" src="https://github.com/user-attachments/assets/e4876c47-a459-4caa-bb64-515f52c93b3e">

### After changes:
<img width="1186" alt="Screenshot 2024-08-29 at 17 05 53" src="https://github.com/user-attachments/assets/4ca2dc10-05c7-4e7c-b4b2-8cdcebc52578">
<img width="1180" alt="Screenshot 2024-08-29 at 17 06 26" src="https://github.com/user-attachments/assets/0491960c-d4ca-4093-9248-97cb739508bb">

## How to manually test the feature


[CRIMAPP-1012]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ