### PR TITLE
[CRIMAPP-835] Add IoJ answer validator

### DIFF
--- a/app/presenters/tasks/ioj.rb
+++ b/app/presenters/tasks/ioj.rb
@@ -8,29 +8,18 @@ module Tasks
       end
     end
 
-    def not_applicable?
-      return true if crime_application.cifc?
-
-      false
-    end
-
     def can_start?
       fulfilled?(CaseDetails)
     end
 
     def in_progress?
-      crime_application.ioj_passport.any? || ioj.present?
+      ioj.present?
     end
 
-    def completed?
-      return true if crime_application.ioj_passported?
+    private
 
-      ioj.present? && ioj.types.any? && ioj_attributes_present?
-    end
-
-    def ioj_attributes_present?
-      required_attributes = ioj.types.map { |type| "#{type}_justification" }
-      ioj.values_at(*required_attributes).all?(&:present?)
+    def validator
+      @validator ||= InterestsOfJustice::AnswersValidator.new(crime_application)
     end
   end
 end

--- a/app/validators/interests_of_justice/answers_validator.rb
+++ b/app/validators/interests_of_justice/answers_validator.rb
@@ -1,0 +1,37 @@
+module InterestsOfJustice
+  class AnswersValidator < BaseAnswerValidator
+    def initialize(crime_application)
+      record = crime_application.ioj || Ioj.new(case: crime_application.kase)
+
+      super(record:, crime_application:)
+    end
+
+    def applicable?
+      return false if crime_application.cifc?
+
+      true
+    end
+
+    def validate
+      return if complete?
+
+      errors.add(:ioj, :incomplete)
+      errors.add(:base, :incomplete_records)
+    end
+
+    def complete?
+      crime_application.ioj_passported? || ioj_answers_complete?
+    end
+
+    private
+
+    alias ioj record
+
+    def ioj_answers_complete?
+      return false unless ioj.present? && ioj.types.any?
+
+      required_attributes = ioj.types.map { |type| "#{type}_justification" }
+      ioj.values_at(*required_attributes).all?(&:present?)
+    end
+  end
+end

--- a/app/validators/sections_completeness_validator.rb
+++ b/app/validators/sections_completeness_validator.rb
@@ -10,17 +10,15 @@ class SectionsCompletenessValidator
 
   delegate :errors, to: :record
 
-  def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def validate # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
     if client_details_complete?
       errors.add(:benefit_type, :incomplete) unless passporting_benefit_complete?
       errors.add(:case_details, :incomplete) unless kase&.complete?
       errors.add(:income_assessment, :incomplete) unless income_assessment_complete?
-
       errors.add(:outgoings_assessment, :incomplete) unless outgoings_assessment_complete?
       errors.add(:capital_assessment, :incomplete) unless capital_assessment_complete?
-
       errors.add(:partner_details, :incomplete) unless partner_detail_complete?
-
+      errors.add(:interests_of_justice, :incomplete) unless interests_of_justice_complete?
       errors.add(:documents, :incomplete) unless evidence_upload_complete?
     else
       errors.add(:client_details, :incomplete)
@@ -36,6 +34,14 @@ class SectionsCompletenessValidator
     return false unless partner_detail
 
     partner_detail.complete?
+  end
+
+  def interests_of_justice_complete?
+    validator = InterestsOfJustice::AnswersValidator.new(crime_application)
+
+    return true unless validator.applicable?
+
+    validator.complete?
   end
 
   def income_assessment_complete?

--- a/spec/presenters/tasks/ioj_spec.rb
+++ b/spec/presenters/tasks/ioj_spec.rb
@@ -1,41 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::Ioj do
-  subject { described_class.new(crime_application:) }
+  subject(:task) { described_class.new(crime_application:) }
 
   let(:crime_application) do
     instance_double(
       CrimeApplication,
       to_param: '12345',
-      ioj_passport: ioj_passport,
       ioj: ioj,
-      cifc?: cifc?
     )
   end
 
-  let(:ioj) {
-    instance_double(Ioj, types: ioj_types, loss_of_liberty_justification: loss_of_liberty_justification)
-  }
-  let(:ioj_types) { [] }
-  let(:ioj_passport) { [] }
-  let(:cifc?) { false }
-  let(:loss_of_liberty_justification) { 'loss_of_liberty justification' }
+  let(:applicable?) { true }
+  let(:complete?) { false }
+  let(:ioj) { nil }
 
-  # We assume the completeness of the case details here, as
-  # their statuses are tested in its own spec, no need to repeat
-  let(:case_details_fulfilled) { true }
-
-  before do
-    RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
-    allow(
-      subject
-    ).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(case_details_fulfilled)
-
-    allow(ioj).to receive(:values_at).with('loss_of_liberty_justification').and_return([loss_of_liberty_justification])
+  let(:validator) do
+    instance_double(
+      InterestsOfJustice::AnswersValidator,
+      complete?: complete?, applicable?: applicable?
+    )
   end
 
-  after do
-    RSpec::Mocks.configuration.allow_message_expectations_on_nil = false
+  before do
+    allow(InterestsOfJustice::AnswersValidator).to receive(:new)
+      .with(crime_application).and_return(validator)
   end
 
   describe '#path' do
@@ -58,88 +47,41 @@ RSpec.describe Tasks::Ioj do
 
   describe '#not_applicable?' do
     it { expect(subject.not_applicable?).to be(false) }
-
-    context 'with change in financial circumstances application' do
-      let(:cifc?) { true }
-
-      before do
-        allow(FeatureFlags).to receive(:cifc_journey) {
-          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-        }
-      end
-
-      it { expect(subject.not_applicable?).to be(true) }
-    end
   end
 
   describe '#can_start?' do
-    context 'when the case details task has been completed' do
-      it { expect(subject.can_start?).to be(true) }
+    before do
+      allow(subject).to receive(:fulfilled?).with(Tasks::CaseDetails).and_return(true)
     end
 
-    context 'when the case details task has not been completed yet' do
-      let(:case_details_fulfilled) { false }
-
-      it { expect(subject.can_start?).to be(false) }
-    end
+    it { expect(subject.can_start?).to be(true) }
   end
 
   describe '#in_progress?' do
-    context 'when we have an Ioj passport record' do
-      let(:ioj_passport) { ['foobar'] }
+    context 'when we have an ioj record' do
+      let(:ioj) { double }
 
       it { expect(subject.in_progress?).to be(true) }
     end
 
-    context 'when we do not have an Ioj passport record' do
-      context 'and we have an Ioj record' do
-        it { expect(subject.in_progress?).to be(true) }
-      end
-
-      context 'and we do not yet have an Ioj record' do
-        let(:ioj) { nil }
-
-        it { expect(subject.in_progress?).to be(false) }
-      end
+    context 'when we do not have yet an ioj record' do
+      it { expect(subject.in_progress?).to be(false) }
     end
   end
 
   describe '#completed?' do
-    before do
-      allow(crime_application).to receive(:ioj_passported?).and_return(passporter_result)
+    subject(:completed?) { task.completed? }
+
+    context 'answers are complete' do
+      let(:complete?) { true }
+
+      it { is_expected.to be true }
     end
 
-    context 'when the application is Ioj passported (and there is no override)' do
-      let(:passporter_result) { true }
+    context 'answers are incomplete' do
+      let(:complete?) { false }
 
-      it { expect(subject.completed?).to be(true) }
-    end
-
-    context 'when the application is not Ioj passported (or there is override)' do
-      let(:passporter_result) { false }
-
-      context 'and there is no Ioj record yet' do
-        let(:ioj) { nil }
-
-        it { expect(subject.completed?).to be(false) }
-      end
-
-      context 'and we have completed the Ioj details' do
-        let(:ioj_types) { ['loss_of_liberty'] }
-
-        it { expect(subject.completed?).to be(true) }
-      end
-
-      context 'and we have not yet completed the Ioj details' do
-        it { expect(subject.completed?).to be(false) }
-
-        context 'when types are selected but relevant justification is missing' do
-          let(:ioj_types) { ['loss_of_liberty'] }
-          let(:loss_of_liberty_justification) { nil }
-
-          it { expect(subject.completed?).to be(false) }
-        end
-      end
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/validators/interests_of_justice/answers_validator_spec.rb
+++ b/spec/validators/interests_of_justice/answers_validator_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe InterestsOfJustice::AnswersValidator, type: :model do
+  subject(:validator) { described_class.new(record) }
+
+  let(:record) { crime_application }
+  let(:crime_application) { instance_double(CrimeApplication) }
+  let(:errors) { double(:errors) }
+  let(:non_means_tested) { false }
+  let(:cifc?) { false }
+  let(:ioj) { Ioj.new }
+  let(:ioj_passported?) { false }
+
+  before do
+    allow(crime_application).to receive_messages(
+      cifc?: cifc?,
+      ioj: ioj,
+      ioj_passported?: ioj_passported?
+    )
+  end
+
+  describe '#applicable?' do
+    subject(:applicable) { validator.applicable? }
+
+    it { is_expected.to be true }
+
+    context 'when cifc' do
+      let(:cifc?) { true }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#complete?' do
+    subject(:complete?) { validator.complete? }
+
+    let(:types) { [] }
+
+    before do
+      allow(ioj).to receive_messages(
+        types:
+      )
+    end
+
+    it { is_expected.to be false }
+
+    context 'when IoJ passported' do
+      let(:ioj_passported?) { true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when no IoJ types selected' do
+      it { is_expected.to be false }
+    end
+
+    context 'when IoJ types and justifications given' do
+      let(:types) { %w[reputation understanding] }
+
+      before do
+        allow(ioj).to receive_messages(
+          reputation_justification: 'reputation text',
+          understanding_justification: 'understanding text'
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when IoJ types selected but justifications missing' do
+      let(:types) { %w[reputation understanding] }
+
+      before do
+        allow(ioj).to receive_messages(
+          reputation_justification: 'reputation text',
+          understanding_justification: ''
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#validate' do
+    subject(:validate) { validator.validate }
+
+    let(:ioj) { Ioj.new(types: ['reputation']) }
+
+    context 'when incomplete' do
+      it 'adds errors to the IoJ record' do
+        validate
+        expect(ioj.errors.added?(:ioj, :incomplete)).to be true
+      end
+    end
+
+    context 'when complete' do
+      before do
+        ioj.reputation_justification = 'justification details'
+      end
+
+      it 'does not add an error' do
+        validate
+        expect(ioj.errors.added?(:ioj, :incomplete)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Validate Interests of Justice answers on Submission Review

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-835

## Notes for reviewer

Adds an answer validator for the IoJ task and adds it to the section completeness validator.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Confirm that an error message is shown when IoJ are required but have not been given (or have only been partially given). See ticket for details.
