### PR TITLE
[CRIMAPP-1325] Only return partner as benefit check subject if partner is present

### DIFF
--- a/app/models/concerns/type_of_means_assessment.rb
+++ b/app/models/concerns/type_of_means_assessment.rb
@@ -85,7 +85,7 @@ module TypeOfMeansAssessment # rubocop:disable Metrics/ModuleLength
   def benefit_check_subject
     return applicant unless include_partner_in_means_assessment?
     return applicant unless benefit_check_not_required(applicant)
-    return partner unless benefit_check_not_required(partner)
+    return partner if partner && !benefit_check_not_required(partner)
 
     applicant
   end

--- a/spec/models/concerns/type_of_means_assessment_spec.rb
+++ b/spec/models/concerns/type_of_means_assessment_spec.rb
@@ -602,6 +602,16 @@ RSpec.describe TypeOfMeansAssessment do
 
         it { is_expected.to be applicant }
       end
+
+      context 'when partner is nil' do
+        let(:partner) { nil }
+
+        before do
+          allow(applicant).to receive(:benefit_type).and_return('none')
+        end
+
+        it { is_expected.to be applicant }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Fixes an error where `benefit_check_subject` was returning `nil` as the guard clause which checks whether the partner is the benefit check recipient was no longer confirming whether there is a partner before doing the check. [See diff here](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/1118/files#diff-2a14e4586f650173e396d6bf21ce071a95efee6e878b446ecf4f67ecf954c73fL88). This is a regression following the work to add the arc radio button.

## Link to relevant ticket
[Link to sentry error](https://ministryofjustice.sentry.io/issues/5775380732/?project=4507142444023808&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=2)

## Notes for reviewer
The application that was encountering this error is somehow in a state where the client has no partner but there are partner data still present (partner details like name, nino etc.. and even income information).  I have [created a ticket](https://dsdmoj.atlassian.net/browse/CRIMAPP-1327) to have a fix the reset behaviour and potentially debug how that happened

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
