### PR TITLE
CRIMAPP-801 Prevent setting more than one home address

### DIFF
--- a/app/forms/steps/capital/property_form.rb
+++ b/app/forms/steps/capital/property_form.rb
@@ -32,6 +32,8 @@ module Steps
 
       validates_with CapitalAssessment::PropertyOwnershipValidator
 
+      validate :home_address, unless: :property_is_home_address?
+
       def persist!
         record.update(attributes)
       end
@@ -43,6 +45,19 @@ module Steps
 
       def person_has_home_address?
         crime_application.applicant.home_address?
+      end
+
+      def property_is_home_address?
+        return true if crime_application.properties.home_address.empty?
+
+        crime_application.properties.home_address.first.id == record.id
+      end
+
+      def home_address
+        return true unless is_home_address&.yes?
+
+        errors.add(:is_home_address, :invalid) if is_home_address&.yes? &&
+                                                  crime_application.properties.home_address.count >= 1
       end
     end
   end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -18,6 +18,8 @@ class Property < ApplicationRecord
 
   store_accessor :address, :address_line_one, :address_line_two, :city, :country, :postcode
 
+  scope :home_address, -> { where(is_home_address: YesNoAnswer::YES.to_s) }
+
   OPTIONAL_ADDRESS_ATTRIBUTES = %w[address_line_two].freeze
   REQUIRED_ADDRESS_ATTRIBUTES = Address::ADDRESS_ATTRIBUTES.map(&:to_s).reject { |a| a.in? OPTIONAL_ADDRESS_ATTRIBUTES }
   REQUIRED_ATTRIBUTES = {

--- a/app/services/evidence/rules/20240425120827_council_tax_payments.rb
+++ b/app/services/evidence/rules/20240425120827_council_tax_payments.rb
@@ -15,7 +15,6 @@ module Evidence
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/app/services/evidence/rules/20240425120837_childcare_costs.rb
+++ b/app/services/evidence/rules/20240425120837_childcare_costs.rb
@@ -15,7 +15,6 @@ module Evidence
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/app/services/evidence/rules/20240425183405_child_maintenance_costs.rb
+++ b/app/services/evidence/rules/20240425183405_child_maintenance_costs.rb
@@ -15,7 +15,6 @@ module Evidence
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/app/services/evidence/rules/20240429122128_restraint_or_freezing_order.rb
+++ b/app/services/evidence/rules/20240429122128_restraint_or_freezing_order.rb
@@ -11,7 +11,6 @@ module Evidence
           crime_application.income&.has_frozen_income_or_assets == 'yes') || false
       end
 
-      # TODO: Awaiting partner implementation
       partner do |_crime_application|
         false
       end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -932,6 +932,7 @@ en:
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
               inclusion: Select yes if the address of the property is the same as your client's home address
+              invalid: Client can only have 1 home address
             has_other_owners:
               inclusion: Select yes if anyone else owns part of the property
         steps/capital/commercial_form:
@@ -961,6 +962,7 @@ en:
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
               inclusion: Select yes if the address of the property is the same as your client's home address
+              invalid: Client can only have 1 home address
             has_other_owners:
               inclusion: Select yes if anyone else owns part of the property
         steps/capital/land_form:
@@ -993,6 +995,7 @@ en:
               less_than_or_equal_to: *land_partner_percentage_error
             is_home_address:
               inclusion: Select yes if the address of the land is the same as your client's home address
+              invalid: Client can only have 1 home address
             has_other_owners:
               inclusion: Select yes if anyone else owns part of the land
         steps/capital/property_address_form:


### PR DESCRIPTION
## Description of change
Adds validation to property form to prevent a property being declared as the client's home address if another property has already been declared as the client's home address

This is required for MAAT as MAAT will only display 1 of the assets that are declared as the home address, each subsequent asset declared as the home address will not display in MAAT. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-801

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1050" alt="Screenshot 2024-09-03 at 13 45 39" src="https://github.com/user-attachments/assets/8b8be397-ea56-4c42-aac7-312fe275b0ec">

## How to manually test the feature
