### PR TITLE
[CRIMAPP-1329] Evidence triggers code cleanup

### DIFF
--- a/app/services/evidence/rules/20240425120658_housing_costs.rb
+++ b/app/services/evidence/rules/20240425120658_housing_costs.rb
@@ -19,10 +19,6 @@ module Evidence
 
         total > THRESHOLD
       end
-
-      partner do |_crime_application|
-        false
-      end
     end
   end
 end

--- a/app/services/evidence/rules/20240425120827_council_tax_payments.rb
+++ b/app/services/evidence/rules/20240425120827_council_tax_payments.rb
@@ -14,10 +14,6 @@ module Evidence
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
-
-      partner do |_crime_application|
-        false
-      end
     end
   end
 end

--- a/app/services/evidence/rules/20240425120837_childcare_costs.rb
+++ b/app/services/evidence/rules/20240425120837_childcare_costs.rb
@@ -14,10 +14,6 @@ module Evidence
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
-
-      partner do |_crime_application|
-        false
-      end
     end
   end
 end

--- a/app/services/evidence/rules/20240425183405_child_maintenance_costs.rb
+++ b/app/services/evidence/rules/20240425183405_child_maintenance_costs.rb
@@ -14,10 +14,6 @@ module Evidence
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
-
-      partner do |_crime_application|
-        false
-      end
     end
   end
 end

--- a/app/services/evidence/rules/20240426002316_self_assessed.rb
+++ b/app/services/evidence/rules/20240426002316_self_assessed.rb
@@ -11,7 +11,7 @@ module Evidence
           crime_application.income&.applicant_self_assessment_tax_bill == 'yes'
       end
 
-      partner do |crime_application, _partner|
+      partner do |crime_application|
         crime_application.outgoings&.partner_income_tax_rate_above_threshold == 'yes' ||
           crime_application.income&.partner_self_assessment_tax_bill == 'yes'
       end

--- a/app/services/evidence/rules/20240426020839_pension_income.rb
+++ b/app/services/evidence/rules/20240426020839_pension_income.rb
@@ -10,13 +10,13 @@ module Evidence
       key :income_private_pension_5
       group :income
 
-      client do |crime_application, _applicant|
+      client do |crime_application|
         payment = crime_application.income&.client_private_pension_payment
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      partner do |crime_application, _partner|
+      partner do |crime_application|
         payment = crime_application.income&.partner_private_pension_payment
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD

--- a/app/services/evidence/rules/20240426022536_maintenance_income.rb
+++ b/app/services/evidence/rules/20240426022536_maintenance_income.rb
@@ -9,13 +9,13 @@ module Evidence
       key :income_maintenance_6
       group :income
 
-      client do |crime_application, _applicant|
+      client do |crime_application|
         payment = crime_application.income&.client_maintenance_payment
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD
       end
 
-      partner do |crime_application, _partner|
+      partner do |crime_application|
         payment = crime_application.income&.partner_maintenance_payment
 
         payment.present? && payment.prorated_monthly.to_f > THRESHOLD

--- a/app/services/evidence/rules/20240426024826_interest_and_investments.rb
+++ b/app/services/evidence/rules/20240426024826_interest_and_investments.rb
@@ -6,11 +6,11 @@ module Evidence
       key :income_investments_7
       group :income
 
-      client do |crime_application, _applicant|
+      client do |crime_application|
         crime_application.income&.client_interest_investment_payment.present?
       end
 
-      partner do |crime_application, _partner|
+      partner do |crime_application|
         crime_application.income&.partner_interest_investment_payment.present?
       end
     end

--- a/app/services/evidence/rules/20240426030038_rental_income.rb
+++ b/app/services/evidence/rules/20240426030038_rental_income.rb
@@ -6,11 +6,11 @@ module Evidence
       key :income_rent_8
       group :income
 
-      client do |crime_application, _applicant|
+      client do |crime_application|
         crime_application.income&.client_rent_payment.present?
       end
 
-      partner do |crime_application, _partner|
+      partner do |crime_application|
         crime_application.income&.partner_rent_payment.present?
       end
     end

--- a/app/services/evidence/rules/20240426030754_any_other_income.rb
+++ b/app/services/evidence/rules/20240426030754_any_other_income.rb
@@ -6,11 +6,11 @@ module Evidence
       key :income_other_9
       group :income
 
-      client do |crime_application, _applicant|
+      client do |crime_application|
         crime_application.income&.client_other_payment.present?
       end
 
-      partner do |crime_application, _partner|
+      partner do |crime_application|
         crime_application.income&.partner_other_payment.present?
       end
     end


### PR DESCRIPTION
## Description of change

The partner outgoing evidence triggers were combined with the client outgoings triggers and appear under the same heading: `Evidence of your client and the partner’s outgoings` instead of separate headings. Implemented [here](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/937/files). See slack discussion [here](https://mojdt.slack.com/archives/C05PAUPJJ10/p1718373287716269?thread_ts=1718016750.660689&cid=C05PAUPJJ10).

So this PR cleans up any unrequired code that was left behind

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1329

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
