### PR TITLE
[CRIMAPP-1289] Add explicit 'not provided' for house_type

### DIFF
--- a/app/presenters/summary/components/property.rb
+++ b/app/presenters/summary/components/property.rb
@@ -136,7 +136,7 @@ module Summary
         if property.house_type == ::Property::OTHER_HOUSE_TYPE
           property.other_house_type
         else
-          I18n.t(property.house_type, scope: [:summary, :sections, :property, :house_type])
+          I18n.t(property.house_type.presence || :absence_answer, scope: [:summary, :sections, :property, :house_type])
         end
       end
 

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -126,6 +126,7 @@ en:
         land: Land
         house_type:
           <<: *HOUSE_TYPE
+          absence_answer: *absence_not_provided
       property_owners:
         relationship:
           <<: *RELATIONSHIP

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -791,7 +791,7 @@ en:
         absence_answer: *absence_none
       bedrooms:
         question: Bedrooms
-        absence_answer: *absence_none
+        absence_answer: *absence_not_provided
       size_in_acres:
         question: Size of land
         absence_answer: *absence_none

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Summary::Components::Property, type: :component do
         )
         expect(page).to have_summary_row(
           'Bedrooms',
-          'None',
+          'Not provided',
         )
         expect(page).to have_summary_row(
           'Property value',

--- a/spec/presenters/summary/components/property_spec.rb
+++ b/spec/presenters/summary/components/property_spec.rb
@@ -217,7 +217,11 @@ RSpec.describe Summary::Components::Property, type: :component do
         }
       end
 
-      it 'renders as summary list with the correct absence_answer' do
+      it 'renders as summary list with the correct absence_answer' do # rubocop:disable RSpec/ExampleLength
+        expect(page).to have_summary_row(
+          'Type of property',
+          'Not provided',
+        )
         expect(page).to have_summary_row(
           'Bedrooms',
           'None',


### PR DESCRIPTION
## Description of change
Forces blank string `house_type` field to be output in the Capital Assesment summary table with 'not provided'.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1289
## Notes for reviewer
- This bug just does not manifest in localhost but does so in staging and presumably production. The change makes the 'absence' answer explicit. 
- Also updates the 'Bedrooms' field to show 'Not provided' rather than 'None' because it makes more sense to do so.
## Screenshots of changes (if applicable)

### Before changes:
If `house_type` is saved with a blank string (``) then localhost will throw an exception:
<img width="841" alt="Screenshot 2024-09-05 at 13 53 45" src="https://github.com/user-attachments/assets/fa84bc64-01fa-44e8-a039-bb294c525c03">


But if the `house_type` is `nil` then the word 'None' is output:
<img width="818" alt="Screenshot 2024-09-05 at 13 54 44" src="https://github.com/user-attachments/assets/51c8e187-e94f-42df-8994-234f509f8b81">



### After changes:
<img width="843" alt="Screenshot 2024-09-05 at 13 49 39" src="https://github.com/user-attachments/assets/0e08d55e-13cf-4d05-bd96-a47f3bbbee69">


## How to manually test the feature
Follow instructions to reproduce in ticket
