### PR TITLE
[LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-3X] fix validation issues

### DIFF
--- a/app/forms/concerns/steps/field_validation.rb
+++ b/app/forms/concerns/steps/field_validation.rb
@@ -1,0 +1,34 @@
+module Steps
+  module FieldValidation
+    extend ActiveSupport::Concern
+
+    # rubocop:disable Metrics/MethodLength
+    def numericality(attribute, options = {})
+      errors = []
+      value =
+        begin
+          Kernel.Float(send(attribute))
+        rescue ArgumentError, TypeError
+          nil
+        end
+
+      return errors << :not_a_number if value.nil?
+
+      options.each do |option, arg|
+        result = validate_numericality_option(option, arg, value)
+        errors << result if result.present?
+      end
+      errors
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def validate_numericality_option(option, arg, value)
+      case option
+      when :greater_than
+        :greater_than if value <= arg
+      end
+    end
+  end
+end

--- a/app/forms/steps/income/income_payment_fieldset_form.rb
+++ b/app/forms/steps/income/income_payment_fieldset_form.rb
@@ -1,6 +1,8 @@
 module Steps
   module Income
     class IncomePaymentFieldsetForm < Steps::BaseFormObject
+      include FieldValidation
+
       attribute :id, :string
       attribute :payment_type, :string
       attribute :amount, :pence
@@ -9,10 +11,7 @@ module Steps
 
       validate { presence_with_payment_type :amount }
       validate { presence_with_payment_type :frequency }
-
-      validates :amount, numericality: {
-        greater_than: 0
-      }
+      validate { numericality_with_payment_type(:amount, greater_than: 0) }
 
       validates :payment_types, presence: true, inclusion: { in: :payment_types }
       validates :frequency, inclusion: { in: :frequencies }
@@ -58,15 +57,21 @@ module Steps
       def presence_with_payment_type(attribute)
         return if send(attribute).present?
 
-        payment_type_str = I18n.t(
+        errors.add(attribute, :blank, payment_type: payment_type_presentable&.downcase!)
+      end
+
+      def numericality_with_payment_type(attribute, greater_than:)
+        numericality_errors = numericality(attribute, greater_than:)
+
+        numericality_errors.each do |error|
+          errors.add(attribute, error, payment_type: payment_type_presentable)
+        end
+      end
+
+      def payment_type_presentable
+        I18n.t(
           payment_type,
           scope: [:helpers, :label, :steps_income_income_payments_form, :types_options]
-        )&.downcase!
-
-        errors.add(
-          attribute,
-          :blank,
-          payment_type: payment_type_str
         )
       end
     end

--- a/app/validators/income_payments_validator.rb
+++ b/app/validators/income_payments_validator.rb
@@ -50,6 +50,6 @@ class IncomePaymentsValidator < ActiveModel::Validator
       "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",
       scope: [:activemodel, :errors, :models],
       payment_type: payment_type
-    )
+    ).capitalize
   end
 end

--- a/app/validators/partner_income_payments_validator.rb
+++ b/app/validators/partner_income_payments_validator.rb
@@ -50,6 +50,6 @@ class PartnerIncomePaymentsValidator < ActiveModel::Validator
       "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",
       scope: [:activemodel, :errors, :models],
       payment_type: payment_type
-    )
+    ).capitalize
   end
 end

--- a/spec/forms/concerns/steps/field_validation_spec.rb
+++ b/spec/forms/concerns/steps/field_validation_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Steps::FieldValidation do
+  subject(:assessable) do
+    assessable_class.new(number_attribute:)
+  end
+
+  let(:assessable_class) do
+    Struct.new(:number_attribute) do
+      include Steps::FieldValidation
+    end
+  end
+
+  let(:number_attribute) { nil }
+
+  describe '#numericality' do
+    subject(:numericality) { assessable.numericality(:number_attribute, options) }
+
+    let(:options) { {} }
+
+    context 'when the value is not a number' do
+      let(:number_attribute) { 'one' }
+
+      it { is_expected.to eq([:not_a_number]) }
+    end
+
+    context 'when the value must be greater than' do
+      let(:options) { { greater_than: 0 } }
+      let(:number_attribute) { '0' }
+
+      it { is_expected.to eq([:greater_than]) }
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Ensure that numericality validation messages on the Income Payment form have all the necessary information to construct an error message.

## Link to relevant ticket
[LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-3X](https://ministryofjustice.sentry.io/issues/5819702006/?alert_rule_id=15141078&alert_type=issue&notification_uuid=7c31a4d3-5779-4928-a581-03462cdf34a4&project=4507142444023808)

## Notes for reviewer
I've implemented a custom numericality validation method in order to have more control over the error messaging, i.e. to be able to provide the `payment_type` value to the error strings. The need for this comes from content changes that require more dynamic field-level error messaging - e.g. "Maintenance payments amount must be greater than 0" instead of "Amount must be greater than 0". Previously, these "fuller" error messages were only shown in the error summary box.

Initially I wanted to extend the default `NumericalityValidator` which does all the validation we could want, but I couldn't find a good way to extend it just so I could alter the error messaging.

What's also becoming clear is that we end up constructing error messages both at the attribute level and at the summary level when in most (all?) cases the summary error messages will be the same, just repeated above the form. Unless there are cases where summary errors need to differ from field-level errors, this seems like duplicated effort.