### PR TITLE
[CRIMAPP-801] Remove save and come back later button from property form

### DIFF
--- a/app/forms/steps/capital/property_form.rb
+++ b/app/forms/steps/capital/property_form.rb
@@ -56,8 +56,7 @@ module Steps
       def home_address
         return true unless is_home_address&.yes?
 
-        errors.add(:is_home_address, :invalid) if is_home_address&.yes? &&
-                                                  crime_application.properties.home_address.count >= 1
+        errors.add(:is_home_address, :invalid) if crime_application.properties.home_address.count >= 1
       end
     end
   end

--- a/app/views/steps/capital/commercial_property/edit.html.erb
+++ b/app/views/steps/capital/commercial_property/edit.html.erb
@@ -24,7 +24,7 @@
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
 
-      <%= f.continue_button %>
+      <%= f.continue_button(secondary: false)  %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/capital/land/edit.html.erb
+++ b/app/views/steps/capital/land/edit.html.erb
@@ -25,7 +25,7 @@
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
 
-      <%= f.continue_button %>
+      <%= f.continue_button(secondary: false)  %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/capital/residential_property/edit.html.erb
+++ b/app/views/steps/capital/residential_property/edit.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
 
-      <%= f.continue_button %>
+      <%= f.continue_button(secondary: false)  %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Description of change
Removes the save and come back later button from the property form pages (residential, land, commercial) in order to stop users from saving more than one property as the client's home address. This was addressed in a previous pr but during qa, it was discovered that this could still occur via the save and come back later button as the save and come back later functionality currently skips validations so the error is not picked up. 

I’ve looked into displaying an error on the assets summary page (using the incomplete tag) and also displaying the error on the review application page (`You need to complete all questions before you can submit the application`). However, ultimately, this proved difficult as the validations in the property model require global knowledge of all the properties and also leads to duplication of the validation logic 

I also discussed the following options: 
1. Potentially introducing a new attribute `home_address_id` where the id would be replaced when the form is saved so there will only ever be one home address
2. Hiding the home address question if the home address has been set 

But ultimately decided it is better if the home address question is explicitly answered by the user and the user is easily given the option to change their answer if they have previously made an error 

So in the end I opted to remove the save and back later button from these forms.  

The only potential issue I forsee with this is users thinking this is a bug but happy to discuss if there are concerns

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-801

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1148" alt="Screenshot 2024-09-09 at 18 21 34" src="https://github.com/user-attachments/assets/6e95b631-412d-4304-9296-640454426482">

### After changes:
<img width="1148" alt="Screenshot 2024-09-09 at 18 20 53" src="https://github.com/user-attachments/assets/3d03b0ca-860f-457e-a0a3-e7acf13e6a47">


## How to manually test the feature
