### PR TITLE
Using ping for liveness probe and add startup probe

### DIFF
--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -47,14 +47,25 @@ spec:
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /ping
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 30
+          failureThreshold: 1
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /ping
+            port: 3000
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+              - name: X-Forwarded-Ssl
+                value: "on"
+          failureThreshold: 20
           periodSeconds: 10
         envFrom:
           - configMapRef:


### PR DESCRIPTION
## Description of change

- Use ping for livenessProbe on production deployment
- Add startup probe to production deployment

## Link to relevant ticket

## Notes for reviewer
Applies changes tested on staging to production from:
https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/1162

Using the healthcheck for the liveness probe was causing slow database connection to trigger restarts and pod crash looping. This change is for staging only and tests using ping instead of health for liveness. It also adds a startup probe. (e.g. https://mojdt.slack.com/archives/C056U956ESH/p1725882930025509 )

More discussion here: https://dsdmoj.atlassian.net/browse/CRIMAPP-345?focusedCommentId=499712

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature