### PR TITLE
Switch on ARC feature flag in production

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,7 +38,7 @@ feature_flags:
   arc:
     local: true
     staging: true
-    production: false
+    production: true
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is


### PR DESCRIPTION
## Description of change

Switch on the ARC feature flag in production so users see the ARC number option on the NINO page.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
