### PR TITLE
CRIMAPP-1334  Apply - ARC and NINO displayed on Review application page

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -27,5 +27,17 @@ class Person < ApplicationRecord
     datum.in_time_zone('London').to_date - 18.years >= date_of_birth
   end
 
+  def nino
+    return unless has_nino == YesNoAnswer::YES.to_s
+
+    super
+  end
+
+  def arc
+    return unless has_arc == YesNoAnswer::YES.to_s
+
+    super
+  end
+
   delegate :capital, :income, to: :crime_application
 end

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -40,7 +40,6 @@ module Summary
                          :arc, applicant.arc,
                          change_path: edit_steps_nino_path(subject: 'client'),
                        ))
-
         end
 
         answers.push(

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -30,16 +30,20 @@ module Summary
         ]
 
         unless post_submission_evidence?
-          answers.push(Components::FreeTextAnswer.new(
-                         :nino, applicant.nino,
-                         change_path: edit_steps_nino_path(subject: 'client'),
-                         show: true
-                       ))
+          if applicant.has_nino == YesNoAnswer::YES.to_s
+            answers.push(Components::FreeTextAnswer.new(
+                           :nino, applicant.nino,
+                           change_path: edit_steps_nino_path(subject: 'client'),
+                           show: true
+                         ))
+          end
 
-          answers.push(Components::FreeTextAnswer.new(
-                         :arc, applicant.arc,
-                         change_path: edit_steps_nino_path(subject: 'client'),
-                       ))
+          if applicant.has_arc == YesNoAnswer::YES.to_s
+            answers.push(Components::FreeTextAnswer.new(
+                           :arc, applicant.arc,
+                           change_path: edit_steps_nino_path(subject: 'client'),
+                         ))
+          end
         end
 
         answers.push(

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -30,20 +30,17 @@ module Summary
         ]
 
         unless post_submission_evidence?
-          if applicant.has_nino == YesNoAnswer::YES.to_s
-            answers.push(Components::FreeTextAnswer.new(
-                           :nino, applicant.nino,
-                           change_path: edit_steps_nino_path(subject: 'client'),
-                           show: true
-                         ))
-          end
+          answers.push(Components::FreeTextAnswer.new(
+                         :nino, applicant.nino,
+                         change_path: edit_steps_nino_path(subject: 'client'),
+                         show: true
+                       ))
 
-          if applicant.has_arc == YesNoAnswer::YES.to_s
-            answers.push(Components::FreeTextAnswer.new(
-                           :arc, applicant.arc,
-                           change_path: edit_steps_nino_path(subject: 'client'),
-                         ))
-          end
+          answers.push(Components::FreeTextAnswer.new(
+                         :arc, applicant.arc,
+                         change_path: edit_steps_nino_path(subject: 'client'),
+                       ))
+
         end
 
         answers.push(

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -7,7 +7,7 @@ module Summary
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
-        answers = [
+        [
           Components::ValueAnswer.new(
             :relationship_to_partner, applicant.relationship_to_partner,
             change_path: edit_steps_partner_relationship_path
@@ -28,40 +28,31 @@ module Summary
           Components::DateAnswer.new(
             :date_of_birth, partner.date_of_birth,
             change_path: edit_steps_partner_details_path
-          )
-        ]
-
-        if partner.has_nino == YesNoAnswer::YES.to_s
-          answers << Components::FreeTextAnswer.new(
+          ),
+          Components::FreeTextAnswer.new(
             :nino, partner.nino,
-            change_path: edit_steps_nino_path(subject: 'partner'),
-            show: true,
-          )
-        end
-
-        if partner.has_arc == YesNoAnswer::YES.to_s
-          answers << Components::FreeTextAnswer.new(
+            change_path: edit_steps_nino_path(subject: 'partner')
+          ),
+          Components::FreeTextAnswer.new(
             :arc, partner.arc,
             change_path: edit_steps_nino_path(subject: 'partner')
+          ),
+          Components::ValueAnswer.new(
+            :involvement_in_case, partner.involvement_in_case,
+            change_path: edit_steps_partner_involvement_path
+          ),
+          Components::ValueAnswer.new(
+            :conflict_of_interest, partner.conflict_of_interest,
+            change_path: edit_steps_partner_conflict_path
+          ),
+          Components::ValueAnswer.new(
+            :has_same_address_as_client, partner.has_same_address_as_client,
+            change_path: edit_steps_partner_same_address_path
+          ),
+          Components::FreeTextAnswer.new(
+            :home_address, partner_home_address
           )
-        end
-
-        answers << Components::ValueAnswer.new(
-          :involvement_in_case, partner.involvement_in_case,
-          change_path: edit_steps_partner_involvement_path
-        )
-        answers << Components::ValueAnswer.new(
-          :conflict_of_interest, partner.conflict_of_interest,
-          change_path: edit_steps_partner_conflict_path
-        )
-        answers << Components::ValueAnswer.new(
-          :has_same_address_as_client, partner.has_same_address_as_client,
-          change_path: edit_steps_partner_same_address_path
-        )
-        answers << Components::FreeTextAnswer.new(
-          :home_address, partner_home_address,
-        )
-        answers.select(&:show?)
+        ].select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -51,7 +51,7 @@ module Summary
           ),
           Components::FreeTextAnswer.new(
             :home_address, partner_home_address
-          )
+          ),
         ].select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -39,12 +39,13 @@ module Summary
           )
         end
 
-        if partner.has_nino == YesNoAnswer::YES.to_s
+        if partner.has_arc == YesNoAnswer::YES.to_s
           answers << Components::FreeTextAnswer.new(
             :arc, partner.arc,
             change_path: edit_steps_nino_path(subject: 'partner')
           )
         end
+
         answers << Components::ValueAnswer.new(
           :involvement_in_case, partner.involvement_in_case,
           change_path: edit_steps_partner_involvement_path

--- a/app/presenters/summary/sections/partner_details.rb
+++ b/app/presenters/summary/sections/partner_details.rb
@@ -7,7 +7,7 @@ module Summary
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
-        [
+        answers = [
           Components::ValueAnswer.new(
             :relationship_to_partner, applicant.relationship_to_partner,
             change_path: edit_steps_partner_relationship_path
@@ -28,32 +28,39 @@ module Summary
           Components::DateAnswer.new(
             :date_of_birth, partner.date_of_birth,
             change_path: edit_steps_partner_details_path
-          ),
-          Components::FreeTextAnswer.new(
+          )
+        ]
+
+        if partner.has_nino == YesNoAnswer::YES.to_s
+          answers << Components::FreeTextAnswer.new(
             :nino, partner.nino,
             change_path: edit_steps_nino_path(subject: 'partner'),
             show: true,
-          ),
-          Components::FreeTextAnswer.new(
+          )
+        end
+
+        if partner.has_nino == YesNoAnswer::YES.to_s
+          answers << Components::FreeTextAnswer.new(
             :arc, partner.arc,
             change_path: edit_steps_nino_path(subject: 'partner')
-          ),
-          Components::ValueAnswer.new(
-            :involvement_in_case, partner.involvement_in_case,
-            change_path: edit_steps_partner_involvement_path
-          ),
-          Components::ValueAnswer.new(
-            :conflict_of_interest, partner.conflict_of_interest,
-            change_path: edit_steps_partner_conflict_path
-          ),
-          Components::ValueAnswer.new(
-            :has_same_address_as_client, partner.has_same_address_as_client,
-            change_path: edit_steps_partner_same_address_path
-          ),
-          Components::FreeTextAnswer.new(
-            :home_address, partner_home_address,
-          ),
-        ].select(&:show?)
+          )
+        end
+        answers << Components::ValueAnswer.new(
+          :involvement_in_case, partner.involvement_in_case,
+          change_path: edit_steps_partner_involvement_path
+        )
+        answers << Components::ValueAnswer.new(
+          :conflict_of_interest, partner.conflict_of_interest,
+          change_path: edit_steps_partner_conflict_path
+        )
+        answers << Components::ValueAnswer.new(
+          :has_same_address_as_client, partner.has_same_address_as_client,
+          change_path: edit_steps_partner_same_address_path
+        )
+        answers << Components::FreeTextAnswer.new(
+          :home_address, partner_home_address,
+        )
+        answers.select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -9,14 +9,6 @@ module Adapters
         CorrespondenceAddress.new(super.attributes) if super
       end
 
-      def has_nino
-        if nino.present?
-          'yes'
-        else
-          arc.present? ? nil : 'no'
-        end
-      end
-
       def serializable_hash(options = {})
         super(
           options.merge(

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -9,14 +9,6 @@ module Adapters
         CorrespondenceAddress.new(super.attributes) if super
       end
 
-      # def has_nino
-      #   if nino.present?
-      #     'yes'
-      #   else
-      #     arc.present? ? nil : 'no'
-      #   end
-      # end
-
       def serializable_hash(options = {})
         super(
           options.merge(

--- a/app/services/adapters/structs/applicant.rb
+++ b/app/services/adapters/structs/applicant.rb
@@ -9,6 +9,14 @@ module Adapters
         CorrespondenceAddress.new(super.attributes) if super
       end
 
+      # def has_nino
+      #   if nino.present?
+      #     'yes'
+      #   else
+      #     arc.present? ? nil : 'no'
+      #   end
+      # end
+
       def serializable_hash(options = {})
         super(
           options.merge(

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -142,4 +142,64 @@ RSpec.describe Person, type: :model do
       end
     end
   end
+
+  describe '#nino' do
+    before do
+      attributes.merge!(has_nino: has_nino, nino: 'AB123456A')
+    end
+
+    context 'when has_nino is `yes`' do
+      let(:has_nino) { 'yes' }
+
+      it 'returns nino' do
+        expect(subject.nino).to eq('AB123456A')
+      end
+    end
+
+    context 'when has_nino is `no`' do
+      let(:has_nino) { 'no' }
+
+      it 'returns nil' do
+        expect(subject.nino).to be_nil
+      end
+    end
+
+    context 'when has_nino is `nil`' do
+      let(:has_nino) { nil }
+
+      it 'returns nil' do
+        expect(subject.nino).to be_nil
+      end
+    end
+  end
+
+  describe '#arc' do
+    before do
+      attributes.merge!(has_arc: has_arc, arc: 'ARC123')
+    end
+
+    context 'when has_arc is `yes`' do
+      let(:has_arc) { 'yes' }
+
+      it 'returns arc' do
+        expect(subject.arc).to eq('ARC123')
+      end
+    end
+
+    context 'when has_arc is `no`' do
+      let(:has_arc) { 'no' }
+
+      it 'returns nil' do
+        expect(subject.arc).to be_nil
+      end
+    end
+
+    context 'when has_arc is `nil`' do
+      let(:has_arc) { nil }
+
+      it 'returns nil' do
+        expect(subject.arc).to be_nil
+      end
+    end
+  end
 end

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -26,7 +26,9 @@ describe Summary::Sections::ClientDetails do
   end
 
   let(:nino) { '123456' }
+  let(:has_nino) { 'yes' }
   let(:arc) { nil }
+  let(:has_arc) { nil }
   let(:application_type) { ApplicationType::INITIAL }
   let(:pse?) { false }
   let(:has_partner) { 'no' }
@@ -37,6 +39,8 @@ describe Summary::Sections::ClientDetails do
       has_partner: has_partner,
       relationship_status: 'separated',
       separation_date: Date.new(2001, 10, 12),
+      has_nino: has_nino,
+      has_arc: has_arc
     )
 
     allow(crime_application).to receive_messages(
@@ -65,6 +69,7 @@ describe Summary::Sections::ClientDetails do
     end
   end
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#answers' do
     let(:answers) { subject.answers }
 
@@ -135,6 +140,7 @@ describe Summary::Sections::ClientDetails do
 
     context 'when an arc is provided' do
       let(:nino) { nil }
+      let(:has_arc) { 'yes' }
       let(:arc) { 'ABC12/345678/A' }
 
       it 'has the correct rows' do
@@ -161,4 +167,5 @@ describe Summary::Sections::ClientDetails do
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/presenters/summary/sections/partner_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_details_spec.rb
@@ -162,17 +162,12 @@ describe Summary::Sections::PartnerDetails do
       let(:has_arc) { 'yes' }
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(11)
+        expect(answers.count).to eq(10)
 
         expect(answers[5]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-        expect(answers[5].question).to eq(:nino)
+        expect(answers[5].question).to eq(:arc)
         expect(answers[5].change_path).to match('applications/12345/steps/partner/nino')
-        expect(answers[5].value).to be_nil
-
-        expect(answers[6]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-        expect(answers[6].question).to eq(:arc)
-        expect(answers[6].change_path).to match('applications/12345/steps/partner/nino')
-        expect(answers[6].value).to eq('ABC12/345678/A')
+        expect(answers[5].value).to eq('ABC12/345678/A')
       end
     end
   end

--- a/spec/presenters/summary/sections/partner_details_spec.rb
+++ b/spec/presenters/summary/sections/partner_details_spec.rb
@@ -33,7 +33,9 @@ describe Summary::Sections::PartnerDetails do
   end
 
   let(:nino) { '123456' }
+  let(:has_nino) { 'yes' }
   let(:arc) { nil }
+  let(:has_arc) { nil }
   let(:has_same_address_as_client) { 'no' }
   let(:home_address) do
     HomeAddress.new(
@@ -43,6 +45,13 @@ describe Summary::Sections::PartnerDetails do
       postcode: 'Postcode',
       city: 'City',
       country: 'Country',
+    )
+  end
+
+  before do
+    allow(partner).to receive_messages(
+      has_nino:,
+      has_arc:
     )
   end
 
@@ -150,6 +159,7 @@ describe Summary::Sections::PartnerDetails do
     context 'when an arc is provided' do
       let(:nino) { nil }
       let(:arc) { 'ABC12/345678/A' }
+      let(:has_arc) { 'yes' }
 
       it 'has the correct rows' do
         expect(answers.count).to eq(11)

--- a/spec/requests/dwp_benefit_checker_spec.rb
+++ b/spec/requests/dwp_benefit_checker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'DWP passporting sub journey', :authorized do
         crime_application: app,
         first_name: 'Jane', last_name: 'Doe',
         date_of_birth: Date.new(1990, 2, 1),
+        has_nino: 'yes',
         nino: 'AB123456A'
       )
     end

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -35,33 +35,33 @@ RSpec.describe Adapters::Structs::Applicant do
     end
   end
 
-  describe '#has_nino' do
-    context 'when nino present' do
-      it 'returns yes if nino is present' do
-        expect(subject.has_nino).to eq('yes')
-      end
-    end
-
-    context 'when arc is present' do
-      before do
-        allow(subject).to receive_messages(nino: nil, arc: '123')
-      end
-
-      it 'returns nil if arc is present' do
-        expect(subject.has_nino).to be_nil
-      end
-    end
-
-    context 'when neither nino or arc is present' do
-      before do
-        allow(subject).to receive_messages(nino: nil, arc: nil)
-      end
-
-      it 'returns no' do
-        expect(subject.has_nino).to eq('no')
-      end
-    end
-  end
+  # describe '#has_nino' do
+  #   context 'when nino present' do
+  #     it 'returns yes if nino is present' do
+  #       expect(subject.has_nino).to eq('yes')
+  #     end
+  #   end
+  #
+  #   context 'when arc is present' do
+  #     before do
+  #       allow(subject).to receive_messages(nino: nil, arc: '123')
+  #     end
+  #
+  #     it 'returns nil if arc is present' do
+  #       expect(subject.has_nino).to be_nil
+  #     end
+  #   end
+  #
+  #   context 'when neither nino or arc is present' do
+  #     before do
+  #       allow(subject).to receive_messages(nino: nil, arc: nil)
+  #     end
+  #
+  #     it 'returns no' do
+  #       expect(subject.has_nino).to eq('no')
+  #     end
+  #   end
+  # end
 
   describe '#serializable_hash' do
     it 'returns a serializable hash, including relationships' do

--- a/spec/services/adapters/structs/applicant_spec.rb
+++ b/spec/services/adapters/structs/applicant_spec.rb
@@ -35,34 +35,6 @@ RSpec.describe Adapters::Structs::Applicant do
     end
   end
 
-  # describe '#has_nino' do
-  #   context 'when nino present' do
-  #     it 'returns yes if nino is present' do
-  #       expect(subject.has_nino).to eq('yes')
-  #     end
-  #   end
-  #
-  #   context 'when arc is present' do
-  #     before do
-  #       allow(subject).to receive_messages(nino: nil, arc: '123')
-  #     end
-  #
-  #     it 'returns nil if arc is present' do
-  #       expect(subject.has_nino).to be_nil
-  #     end
-  #   end
-  #
-  #   context 'when neither nino or arc is present' do
-  #     before do
-  #       allow(subject).to receive_messages(nino: nil, arc: nil)
-  #     end
-  #
-  #     it 'returns no' do
-  #       expect(subject.has_nino).to eq('no')
-  #     end
-  #   end
-  # end
-
   describe '#serializable_hash' do
     it 'returns a serializable hash, including relationships' do
       expect(

--- a/spec/services/evidence/prompt_spec.rb
+++ b/spec/services/evidence/prompt_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Evidence::Prompt do
   include_context 'serializable application'
 
   before do
+    applicant.has_nino = 'yes'
     applicant.nino = 'QQ123456B'
     income.client_owns_property = 'yes'
     outgoings.housing_payment_type = 'mortgage'

--- a/spec/services/evidence/rules/20240425222456_benefits_recipient_spec.rb
+++ b/spec/services/evidence/rules/20240425222456_benefits_recipient_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Evidence::Rules::BenefitsRecipient do
       before do
         applicant.benefit_type = 'jsa'
         applicant.benefit_check_result = true
+        applicant.has_nino = 'yes'
         applicant.nino = 'QQ123456A'
       end
 
@@ -66,6 +67,7 @@ RSpec.describe Evidence::Rules::BenefitsRecipient do
         applicant.benefit_type = 'none'
         partner.benefit_type = 'jsa'
         partner.benefit_check_result = true
+        partner.has_nino = 'yes'
         partner.nino = 'QQ123456A'
       end
 


### PR DESCRIPTION
## Description of change
The review page shows both the NINO and the ARC number. This should not be possible, as validation on the NINO page restricts both values being recorded and displayed on the review application page 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1334

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
