### PR TITLE
CRIMAPP-1263 Disable JS

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,16 +1,14 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 
-// https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
-import { initAll } from 'govuk-frontend'
-try {
-  initAll()
-} catch(e) {
+// Detect whether the user is on an iPad, if so then disable JS
+// to avoid the (unresolved) issue of conditionally revealed fields not displaying on old iPads
+if ((('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)) && (navigator.userAgent.match(/Safari/i))) {
   document.body.className += ' no-js'
 }
 
-if (navigator.userAgent.match(/iPad/i)) {
-  document.body.className += ' no-js'
-}
+// https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
+import { initAll } from 'govuk-frontend'
+initAll()
 
 // Cookie banner -- Script name is obfuscated to avoid browsers blocking it
 // https://design-system.service.gov.uk/components/cookie-banner/

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,7 +2,15 @@
 
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
 import { initAll } from 'govuk-frontend'
-initAll()
+try {
+  initAll()
+} catch(e) {
+  document.body.className += ' no-js'
+}
+
+if (navigator.userAgent.match(/iPad/i)) {
+  document.body.className += ' no-js'
+}
 
 // Cookie banner -- Script name is obfuscated to avoid browsers blocking it
 // https://design-system.service.gov.uk/components/cookie-banner/

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -25,7 +25,9 @@
 
 <body class="govuk-template__body app-body <%= ['app-body', HostEnv.env_name].join('--') %>">
 <%= javascript_tag nonce: true do %>
-  document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
+  if (!document.body.className.includes('no-js')) {
+    document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
+  }
 <% end %>
 
 <%= yield(:cookie_banner) unless controller_name == 'cookies' %>


### PR DESCRIPTION
## Description of change

Try a new method of detecting whether the user is on an iPad - check for touch screen attributes and Safari - if so then disable JS 
**This will also disable JS on iPhones**

## Link to relevant ticket

[CRIMAPP-1263](https://dsdmoj.atlassian.net/browse/CRIMAPP-1263)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1263]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ