### PR TITLE
Add system specs for partner means tested flows

### DIFF
--- a/app/views/steps/income/client/other_work_benefits/edit.html.erb
+++ b/app/views/steps/income/client/other_work_benefits/edit.html.erb
@@ -1,27 +1,28 @@
-<% title t('steps.income.caption') %>
+<% title t('.page_title') %>
 <% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
     <%= govuk_error_summary(@form_object) %>
-
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-    <p class="govuk-body">
-      <%= t('.page_text') %>
-    </p>
-    <ul class="govuk-body govuk-list--bullet govuk-!-margin-bottom-6">
-      <% t('.list').each_line do |line| %>
-        <li><%= line %></li>
-      <% end %>
-    </ul>
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :applicant_other_work_benefit_received, legend: { tag: 'h1', size: 'xl', hidden: true } do %>
+      <%= f.govuk_radio_buttons_fieldset :applicant_other_work_benefit_received,
+                                         legend: { text: t('.applicant_other_work_benefit_received'),
+                                                   tag: 'h1', size: 'xl' } do %>
+        <p class="govuk-body">
+          <%= t('.page_text') %>
+        </p>
+        <ul class="govuk-body govuk-list--bullet govuk-!-margin-bottom-6">
+          <% t('.list').each_line do |line| %>
+            <li><%= line %></li>
+          <% end %>
+        </ul>
+
         <%= f.govuk_radio_button :applicant_other_work_benefit_received, YesNoAnswer::YES do %>
           <%= f.govuk_number_field(:amount,
                                    prefix_text: '£',
                                    width: 'one-half') %>
-          <% end %>
+        <% end %>
         <%= f.govuk_radio_button :applicant_other_work_benefit_received, YesNoAnswer::NO %>
       <% end %>
       <%= f.continue_button %>

--- a/app/views/steps/income/client/self_assessment_tax_bill/edit.html.erb
+++ b/app/views/steps/income/client/self_assessment_tax_bill/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('steps.income.caption') %>
+<% title t('.page_title') %>
 <% step_header %>
 
 <div class="govuk-grid-row">

--- a/app/views/steps/income/partner/other_work_benefits/edit.html.erb
+++ b/app/views/steps/income/partner/other_work_benefits/edit.html.erb
@@ -1,22 +1,22 @@
-<% title t('steps.income.caption') %>
+<% title t('.page_title') %>
 <% step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= t('steps.income.caption') %></span>
     <%= govuk_error_summary(@form_object) %>
-
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-    <p class="govuk-body">
-      <%= t('.page_text') %>
-    </p>
-    <ul class="govuk-body govuk-list--bullet govuk-!-margin-bottom-6">
-      <% t('.list').each_line do |line| %>
-        <li><%= line %></li>
-      <% end %>
-    </ul>
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :partner_other_work_benefit_received, legend: { tag: 'h1', size: 'xl', hidden: true } do %>
+      <%= f.govuk_radio_buttons_fieldset :partner_other_work_benefit_received,
+                                         legend: { text: t('.partner_other_work_benefit_received'),
+                                                   tag: 'h1', size: 'xl' } do %>
+        <p class="govuk-body">
+          <%= t('.page_text') %>
+        </p>
+        <ul class="govuk-body govuk-list--bullet govuk-!-margin-bottom-6">
+          <% t('.list').each_line do |line| %>
+            <li><%= line %></li>
+          <% end %>
+        </ul>
         <%= f.govuk_radio_button :partner_other_work_benefit_received, YesNoAnswer::YES do %>
           <%= f.govuk_number_field(:amount,
                                    prefix_text: '£',

--- a/app/views/steps/income/partner/self_assessment_tax_bill/edit.html.erb
+++ b/app/views/steps/income/partner/self_assessment_tax_bill/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('steps.income.caption') %>
+<% title t('.page_title') %>
 <% step_header %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -180,7 +180,7 @@ en:
         applicant_self_assessment_tax_bill: Has your client received a Self Assessment tax calculation in the last 2 years?
         applicant_self_assessment_tax_bill_frequency: How often do they pay this amount?
       steps_income_partner_self_assessment_tax_bill_form:
-        partner_self_assessment_tax_bill: Has the partner received a Self Assessment tax bill calculation in the last 2 years?
+        partner_self_assessment_tax_bill: Has the partner received a Self Assessment tax calculation in the last 2 years?
         partner_self_assessment_tax_bill_frequency: How often do they pay this amount?
       steps_income_income_payments_form:
         income_payments: Which of these payments does your client get?

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -378,6 +378,7 @@ en:
         other_work_benefits:
           edit:
             page_title: Does your client receive any other benefits from work?
+            applicant_other_work_benefit_received: Does your client receive any other benefits from work?
             heading: Does your client receive any other benefits from work?
             page_text: 'These could be, for example:'
             list: |
@@ -419,7 +420,7 @@ en:
             page_text: You told us your client's partner is employed.
         self_assessment_tax_bill:
           edit:
-            page_title: Has the partner received a Self Assessment tax bill calculation in the last 2 years?
+            page_title: Has the partner received a Self Assessment tax calculation in the last 2 years?
         deductions:
           edit:
             page_title: Deductions from the partner’s pay
@@ -445,6 +446,7 @@ en:
         other_work_benefits:
           edit:
             page_title: Does the partner receive any other benefits from work?
+            partner_other_work_benefit_received: Does the partner receive any other benefits from work?
             heading: Does the partner receive any other benefits from work?
             page_text: 'These could be, for example:'
             list: |

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -22,6 +22,14 @@ module CapybaraHelpers
     end
   end
 
+  def choose_answer_all(question, choice)
+    all('legend', text: question).each do |legend|
+      within legend.sibling('div.govuk-radios') do
+        choose(choice)
+      end
+    end
+  end
+
   # check boxes
   def choose_answers(question, choices = [])
     q = find('legend', text: question).sibling('div.govuk-checkboxes')

--- a/spec/support/shared_contexts/means_tested_with_partner.rb
+++ b/spec/support/shared_contexts/means_tested_with_partner.rb
@@ -1,0 +1,125 @@
+RSpec.shared_context 'means tested with partner' do
+  let(:case_type) { 'Indictable' }
+
+  before do
+    visit root_path
+    click_button('Start now')
+
+    # steps/provider/select_office
+    choose('2A555X')
+    # prevent requests to the datastore for counters for tab headings on the next page
+    allow_any_instance_of(Datastore::ApplicationCounters).to receive_messages(returned_count: 0)
+    save_and_continue
+
+    # applications
+    click_link('Start an application')
+    choose('New application')
+    save_and_continue
+
+    # edit (Task list)
+    click_link('Client details')
+
+    # steps/client/details
+    fill_in('First name', with: 'Jo')
+    fill_in('Last name', with: 'Bloggs')
+    fill_date('Date of birth', with: 19.years.ago.to_date)
+    save_and_continue
+
+    # steps/client/is_application_means_tested
+    save_and_continue
+
+    # steps/client/case_type
+    choose(case_type)
+    save_and_continue
+
+    # steps/client/residence_type
+    choose_answer(
+      'Where does your client usually live?',
+      'They do not have a fixed home address'
+    )
+    save_and_continue
+
+    # steps/client/contact_details
+    choose_answer('Where shall we send correspondence?', 'Provider’s office')
+    save_and_continue
+
+    # steps/client/nino
+    choose_answer('Does your client have a National Insurance number?', 'No')
+    save_and_continue
+
+    # steps/client/does_client_have_partner
+    choose_answer('Does your client have a partner?', 'Yes')
+    save_and_continue
+
+    # steps/client/client_relationship_to_partner
+    choose_answer('What is the client’s relationship to their partner?', 'Living together')
+    save_and_continue
+
+    # steps/partner/partner_details
+    fill_in('First name', with: 'John')
+    fill_in('Last name', with: 'Huffman')
+    fill_date('Date of birth', with: 19.years.ago.to_date)
+    save_and_continue
+
+    # steps/partner/partner_involved_in_case
+    choose_answer('Is the partner involved in your client’s case?', 'No, the partner is not involved')
+    save_and_continue
+
+    # steps/partner/nino
+    choose_answer('Does the partner have a National Insurance number?', 'No')
+    save_and_continue
+
+    # steps/partner/do_client_and_partner_live_same_address
+    choose_answer('Do your client and their partner live at the same address?', 'Yes')
+    save_and_continue
+
+    # steps/dwp/benefit_type
+    choose_answer('Does your client get one of these passporting benefits?', 'None of these')
+    save_and_continue
+
+    # steps/dwp/partner_benefit_type
+    choose_answer('Does the partner get one of these passporting benefits?', 'None of these')
+    save_and_continue
+
+    # steps/client/urn
+    save_and_continue
+
+    # steps/case/has_the_case_concluded
+    choose_answer('Has the case concluded?', 'No')
+    save_and_continue
+
+    # steps/case/haas_court_remanded_client_in_custody
+    choose_answer('Has a court remanded your client in custody?', 'No')
+    save_and_continue
+
+    # steps/case/charges/#{charge_id}
+    fill_in('Offence', with: 'Theft from a shop (Over £100,000)')
+    fill_date('Start date 1', with: 1.month.ago.to_date)
+    save_and_continue
+
+    # steps/case/charges_summary
+    choose_answer('Do you want to add another offence?', 'No')
+    save_and_continue
+
+    # steps/case/has_codefendants
+    choose_answer('Does your client have any co-defendants in this case?', 'No')
+    save_and_continue
+
+    # steps/case/hearing_details
+    select('Derby Crown Court', from: 'Court name')
+    fill_date('Date of next hearing', with: 1.week.from_now.to_date)
+    choose_answer('Did this court also hear the first hearing?', 'Yes')
+    save_and_continue
+
+    # steps/case/ioj_passport
+    choose_answers(
+      'Why should your client get legal aid?',
+      ['It is likely that they will lose their livelihood']
+    )
+    fill_in(
+      'steps-case-ioj-form-loss-of-livelihood-justification-field',
+      with: 'IoJ justification details'
+    )
+    save_and_continue
+  end
+end

--- a/spec/system/applying/employed_with_partner_spec.rb
+++ b/spec/system/applying/employed_with_partner_spec.rb
@@ -1,0 +1,224 @@
+require 'rails_helper'
+
+RSpec.describe 'Apply for Criminal Legal Aid when Means Tested' do
+  describe 'Submitting a means tested application with an employed client and partner' do
+    include_context 'means tested with partner'
+
+    before do
+      # steps/income/what_is_clients_employment_status
+      choose_answers("What is your client's employment status?", ['Employed'])
+      save_and_continue
+
+      # steps/income/client/armed_forces
+      choose_answer('Is your client in the armed forces?', 'No')
+      save_and_continue
+
+      # steps/income/current_income_before_tax
+      choose_answer("Is your client and their partner's joint annual income more than £12,475 a year before tax?",
+                    'Yes')
+      save_and_continue
+
+      # steps/income/client/employer_details/:job_id
+      fill_in("Employer's name", with: 'Ministry of Justice')
+      fill_in('Address line 1', with: 'Test address line 1')
+      fill_in('Address line 2', with: 'Test address line 2')
+      fill_in('Town or city', with: 'Test town')
+      fill_in('Country', with: 'Test Country')
+      fill_in('Postcode', with: 'Test postcode')
+      save_and_continue
+
+      # steps/income/client/employment_details/:job_id
+      fill_in('What is your client’s job title?', with: 'Software Developer')
+      fill_in('What is their salary or wage?', with: 35_000)
+      choose_answer('Is this before or after tax?', 'Before tax')
+      choose_answer('How often do they get this payment?', 'Monthly')
+      save_and_continue
+
+      # steps/income/client/deductions_from_pay/:job_id
+      choose_answers('Deductions', ['The client does not have deductions taken from their pay'])
+      save_and_continue
+
+      # steps/income/client/add_employments
+      choose_answer('Do you want to add another job?', 'No')
+      save_and_continue
+
+      # steps/client/businesses_summary
+      choose_answer('Has your client received a Self Assessment tax calculation in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/client/other_work_benefits_client
+      choose_answer('Does your client receive any other benefits from work?', 'No')
+      save_and_continue
+
+      # steps/income/which_payments_client
+      choose_answers('Which of these payments does your client get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/which_benefits_client
+      choose_answers('Which of these benefits does your client get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # steps/income/does_client_have_dependants
+      choose_answer('Does your client have any dependants?', 'No')
+      save_and_continue
+
+      # steps/income/what_is_partners_employment_status
+      choose_answers("What is the partner's employment status?", ['Employed'])
+      save_and_continue
+
+      # steps/income/partner/armed_forces
+      choose_answer('Is the partner in the armed forces?', 'No')
+      save_and_continue
+
+      # steps/income/partner/employer_details/:job_id
+      fill_in("Employer's name", with: 'Ministry of Justice')
+      fill_in('Address line 1', with: 'Test address line 1')
+      fill_in('Address line 2', with: 'Test address line 2')
+      fill_in('Town or city', with: 'Test town')
+      fill_in('Country', with: 'Test Country')
+      fill_in('Postcode', with: 'Test postcode')
+      save_and_continue
+
+      # steps/income/partner/employment_details/:job_id
+      fill_in('What is their job title?', with: 'Software Developer')
+      fill_in('What is their salary or wage?', with: 35_000)
+      choose_answer('Is this before or after tax?', 'Before tax')
+      choose_answer('How often do they get this payment?', 'Monthly')
+      save_and_continue
+
+      # steps/income/partner/deductions_from_pay/:job_id
+      choose_answers('Deductions', ['The partner does not have deductions taken from their pay'])
+      save_and_continue
+
+      # steps/income/partner/add_employments
+      choose_answer('Do you want to add another job?', 'No')
+      save_and_continue
+
+      # steps/income/partner/self_assessment_partner
+      choose_answer('Has the partner received a Self Assessment tax calculation in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/income/partner/other_work_benefits_partner
+      choose_answer('Does the partner receive any other benefits from work?', 'No')
+      save_and_continue
+
+      # steps/income/partner/which_payments_partner
+      choose_answers('Which of these payments does the partner get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/partner/which_benefits_partner
+      choose_answers('Which of these benefits does the partner get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # income cya
+      save_and_continue
+
+      # steps/outgoings/housing_payments_where_lives
+      choose_answer('Which of these payments does your client or their partner make where they usually live?',
+                    'They do not make any of these payments')
+      save_and_continue
+
+      # steps/outgoings/pay_council_tax
+      choose_answer('Do your client and their partner pay Council Tax where they usually live?', 'No')
+      save_and_continue
+
+      # steps/outgoings/which_payments
+      choose_answers('Which of these payments do your client and their partner make?',
+                     ['They do not make any of these payments'])
+      save_and_continue
+
+      # steps/outgoings/client_paid_income_tax_rate
+      choose_answer('Has your client paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/partner_paid_income_tax_rate
+      choose_answer('Has the partner paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/are_outgoings_more_than_income
+      choose_answer("Are your client and their partner's outgoings more than their income?", 'No')
+      save_and_continue
+
+      # outgoings cya
+      save_and_continue
+
+      # steps/capital/which_assets_owned
+      choose_answer('Which assets does your client or their partner own or part-own inside or outside the UK?',
+                    'They do not own any of these assets')
+      save_and_continue
+
+      # steps/capital/which_savings
+      choose_answer('Which savings does your client or their partner have inside or outside the UK?',
+                    'They do not have any of these savings')
+      save_and_continue
+
+      # steps/capital/client_any_premium_bonds
+      choose_answer('Does your client have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/partner_any_premium_bonds
+      choose_answer('Does the partner have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/any_national_savings_certificates
+      choose_answer('Does your client or their partner have any National Savings Certificates?', 'No')
+      save_and_continue
+
+      # steps/capital/which_investments
+      choose_answer('Which investments does your client or their partner have inside or outside the UK?',
+                    'They do not have any of these investments')
+      save_and_continue
+
+      # steps/capital/client_benefit_from_trust_fund
+      choose_answer('Does your client stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/partner_benefit_from_trust_fund
+      choose_answer('Does the partner stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/income_savings_assets_under_restraint_freezing_order
+      choose_answer(
+        'Does your client or their partner have any income, savings or assets under a restraint or freezing order?',
+        'No'
+      )
+      save_and_continue
+
+      # capital cya
+      choose_answers('Confirm the following',
+                     ['Tick to confirm your client and their partner do not have any other assets or capital'])
+      save_and_continue
+
+      # steps/evidence/upload
+      save_and_continue
+
+      # steps/submission/more_information
+      choose_answer('Do you want to add any other information?', 'No')
+      save_and_continue
+
+      # steps/submission/review
+      save_and_continue
+
+      # steps/submission/declaration
+      choose_answer('Do you have a signed declaration from your client’s partner?', 'Yes')
+
+      fill_in('First name', with: 'Zoe')
+      fill_in('Last name', with: 'Bar')
+      fill_in('Telephone number', with: '07715339488')
+
+      stub_request(:post, 'http://datastore-webmock/api/v1/applications')
+      click_button 'Save and submit application'
+    end
+
+    it 'submits a valid application to the datastore' do
+      expect(
+        a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
+          body = JSON.parse(req.body)['application']
+          body['is_means_tested'] == 'yes' &&
+            body['means_details']['income_details']['partner_employment_type'] == ['employed'] &&
+            body['means_details']['income_details']['employment_type'] == ['employed']
+        }
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/system/applying/non_means_tested_spec.rb
+++ b/spec/system/applying/non_means_tested_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Apply for Criminal Leagal Aid when Non-Means Tested' do
+RSpec.describe 'Apply for Criminal Legal Aid when Non-Means Tested' do
   describe 'Submitting a completed application' do
     before do
       visit root_path

--- a/spec/system/applying/not_working_with_partner_spec.rb
+++ b/spec/system/applying/not_working_with_partner_spec.rb
@@ -1,0 +1,156 @@
+require 'rails_helper'
+
+RSpec.describe 'Apply for Criminal Legal Aid when Means Tested' do
+  describe 'Submitting a means tested application with a not working client and partner' do
+    include_context 'means tested with partner'
+
+    before do
+      # steps/income/what_is_clients_employment_status
+      choose_answers("What is your client's employment status?", ['Not working'])
+      choose_answer('Has your client ended employment in the last 3 months?', 'No')
+      save_and_continue
+
+      # steps/income/current_income_before_tax
+      choose_answer("Is your client and their partner's joint annual income more than £12,475 a year before tax", 'Yes')
+      save_and_continue
+
+      # steps/income/which_payments_client
+      choose_answers('Which of these payments does your client get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/which_benefits_client
+      choose_answers('Which of these benefits does your client get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # steps/income/does_client_have_dependants
+      choose_answer('Does your client have any dependants?', 'No')
+      save_and_continue
+
+      # steps/income/what_is_partners_employment_status
+      choose_answers("What is the partner's employment status?", ['Not working'])
+      save_and_continue
+
+      # steps/income/partner/which_payments_partner
+      choose_answers('Which of these payments does the partner get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/partner/which_benefits_partner
+      choose_answers('Which of these benefits does the partner get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # steps/income/how_manage_with_no_income
+      choose_answer('How do your client and their partner manage with no income?', 'They stay with family for free')
+      save_and_continue
+
+      # income cya
+      save_and_continue
+
+      # steps/outgoings/housing_payments_where_lives
+      choose_answer('Which of these payments does your client or their partner make where they usually live?',
+                    'They do not make any of these payments')
+      save_and_continue
+
+      # steps/outgoings/pay_council_tax
+      choose_answer('Do your client and their partner pay Council Tax where they usually live?', 'No')
+      save_and_continue
+
+      # steps/outgoings/which_payments
+      choose_answers('Which of these payments do your client and their partner make?',
+                     ['They do not make any of these payments'])
+      save_and_continue
+
+      # steps/outgoings/client_paid_income_tax_rate
+      choose_answer('Has your client paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/partner_paid_income_tax_rate
+      choose_answer('Has the partner paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/are_outgoings_more_than_income
+      choose_answer("Are your client and their partner's outgoings more than their income?", 'No')
+      save_and_continue
+
+      # outgoings cya
+      save_and_continue
+
+      # steps/capital/which_assets_owned
+      choose_answer('Which assets does your client or their partner own or part-own inside or outside the UK?',
+                    'They do not own any of these assets')
+      save_and_continue
+
+      # steps/capital/which_savings
+      choose_answer('Which savings does your client or their partner have inside or outside the UK?',
+                    'They do not have any of these savings')
+      save_and_continue
+
+      # steps/capital/client_any_premium_bonds
+      choose_answer('Does your client have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/partner_any_premium_bonds
+      choose_answer('Does the partner have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/any_national_savings_certificates
+      choose_answer('Does your client or their partner have any National Savings Certificates?', 'No')
+      save_and_continue
+
+      # steps/capital/which_investments
+      choose_answer('Which investments does your client or their partner have inside or outside the UK?',
+                    'They do not have any of these investments')
+      save_and_continue
+
+      # steps/capital/client_benefit_from_trust_fund
+      choose_answer('Does your client stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/partner_benefit_from_trust_fund
+      choose_answer('Does the partner stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/income_savings_assets_under_restraint_freezing_order
+      choose_answer(
+        'Does your client or their partner have any income, savings or assets under a restraint or freezing order?',
+        'No'
+      )
+      save_and_continue
+
+      # capital cya
+      choose_answers('Confirm the following',
+                     ['Tick to confirm your client and their partner do not have any other assets or capital'])
+      save_and_continue
+
+      # steps/evidence/upload
+      save_and_continue
+
+      # steps/submission/more_information
+      choose_answer('Do you want to add any other information?', 'No')
+      save_and_continue
+
+      # steps/submission/review
+      save_and_continue
+
+      # steps/submission/declaration
+      choose_answer('Do you have a signed declaration from your client’s partner?', 'Yes')
+
+      fill_in('First name', with: 'Zoe')
+      fill_in('Last name', with: 'Bar')
+      fill_in('Telephone number', with: '07715339488')
+
+      stub_request(:post, 'http://datastore-webmock/api/v1/applications')
+      click_button 'Save and submit application'
+    end
+
+    it 'submits a valid application to the datastore' do
+      expect(
+        a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
+          body = JSON.parse(req.body)['application']
+          body['is_means_tested'] == 'yes' &&
+            body['means_details']['income_details']['partner_employment_type'] == ['not_working'] &&
+            body['means_details']['income_details']['employment_type'] == ['not_working']
+        }
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/system/applying/passported_on_age_spec.rb
+++ b/spec/system/applying/passported_on_age_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Apply for Criminal Leagal Aid when under 18 years old' do
+RSpec.describe 'Apply for Criminal Legal Aid when under 18 years old' do
   describe 'Submitting a completed application' do
     before do
       visit root_path

--- a/spec/system/applying/self_employed_with_partner_spec.rb
+++ b/spec/system/applying/self_employed_with_partner_spec.rb
@@ -1,0 +1,249 @@
+require 'rails_helper'
+
+RSpec.describe 'Apply for Criminal Legal Aid when Means Tested' do
+  describe 'Submitting a means tested application with a self employed client and partner' do
+    include_context 'means tested with partner'
+
+    before do
+      # steps/income/what_is_clients_employment_status
+      choose_answers("What is your client's employment status?", ['Self-employed'])
+      save_and_continue
+
+      # steps/income/client/business_type
+      choose_answer('Which type of self-employed business do you want to add?', 'Self-employed business')
+      save_and_continue
+
+      # steps/income/client/businesses/:business_id
+      fill_in('Trading name of the business', with: 'Test business')
+      fill_in('Address line 1', with: 'Test address line 1')
+      fill_in('Address line 2', with: 'Test address line 2')
+      fill_in('Town or city', with: 'Test town')
+      fill_in('Country', with: 'Test Country')
+      fill_in('Postcode', with: 'Test postcode')
+      save_and_continue
+
+      # steps/income/client/nature_of_business/:business_id
+      fill_in('Give a brief description of what the business does', with: 'Dry cleaners')
+      save_and_continue
+
+      # steps/income/client/date_business_began_trading/:business_id
+      fill_date('When did the business begin trading?', with: 1.year.ago.to_date)
+      save_and_continue
+
+      # steps/income/client/in_business_with_anyone_else/:business_id
+      choose_answer('Is your client in business with anyone else?', 'No')
+      save_and_continue
+
+      # steps/income/client/employees/:business_id
+      choose_answer('Does your client employ anyone through the business?', 'No')
+      save_and_continue
+
+      # steps/income/client/financials_of_business/:business_id
+      fill_in('Total turnover', with: 10_000)
+      fill_in('Total drawings', with: 1_000)
+      fill_in('Total profit', with: 5_000)
+      choose_answer_all('How often was this?', 'Monthly')
+      choose_answer('Over what period was this?', 'Monthly')
+      save_and_continue
+
+      # steps/client/businesses_summary
+      choose_answer('Do you need to add another business?', 'No')
+      save_and_continue
+
+      # steps/client/businesses_summary
+      choose_answer('Has your client received a Self Assessment tax calculation in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/client/other_work_benefits_client
+      choose_answer('Does your client receive any other benefits from work?', 'No')
+      save_and_continue
+
+      # steps/income/which_payments_client
+      choose_answers('Which of these payments does your client get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/which_benefits_client
+      choose_answers('Which of these benefits does your client get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # steps/income/does_client_have_dependants
+      choose_answer('Does your client have any dependants?', 'No')
+      save_and_continue
+
+      # steps/income/what_is_partners_employment_status
+      choose_answers("What is the partner's employment status?", ['Self-employed'])
+      save_and_continue
+
+      # steps/income/partner/business_type
+      choose_answer('Which type of self-employed business do you want to add?', 'Self-employed business')
+      save_and_continue
+
+      # steps/income/partner/businesses/:business_id
+      fill_in('Trading name of the business', with: 'Test partner business')
+      fill_in('Address line 1', with: 'Test address line 1')
+      fill_in('Address line 2', with: 'Test address line 2')
+      fill_in('Town or city', with: 'Test town')
+      fill_in('Country', with: 'Test Country')
+      fill_in('Postcode', with: 'Test postcode')
+      save_and_continue
+
+      # steps/income/partner/nature_of_business/:business_id
+      fill_in('Give a brief description of what the business does', with: 'Dry cleaners')
+      save_and_continue
+
+      # steps/income/partner/date_business_began_trading/:business_id
+      fill_date('When did the business begin trading?', with: 1.year.ago.to_date)
+      save_and_continue
+
+      # steps/income/partner/in_business_with_anyone_else/:business_id
+      choose_answer('Is the partner in business with anyone else?', 'No')
+      save_and_continue
+
+      # steps/income/partner/employees/:business_id
+      choose_answer('Does the partner employ anyone through the business?', 'No')
+      save_and_continue
+
+      # steps/income/partner/financials_of_business/:business_id
+      fill_in('Total turnover', with: 10_000)
+      fill_in('Total drawings', with: 1_000)
+      fill_in('Total profit', with: 5_000)
+      choose_answer_all('How often was this?', 'Monthly')
+      choose_answer('Over what period was this?', 'Monthly')
+      save_and_continue
+
+      # steps/income/partner/businesses_summary
+      choose_answer('Do you need to add another business?', 'No')
+      save_and_continue
+
+      # steps/income/partner/self_assessment_partner
+      choose_answer('Has the partner received a Self Assessment tax calculation in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/income/partner/other_work_benefits_partner
+      choose_answer('Does the partner receive any other benefits from work?', 'No')
+      save_and_continue
+
+      # steps/income/partner/which_payments_partner
+      choose_answers('Which of these payments does the partner get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/partner/which_benefits_partner
+      choose_answers('Which of these benefits does the partner get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # steps/income/how_manage_with_no_income
+      choose_answer('How do your client and their partner manage with no income?', 'They stay with family for free')
+      save_and_continue
+
+      # income cya
+      save_and_continue
+
+      # steps/outgoings/housing_payments_where_lives
+      choose_answer('Which of these payments does your client or their partner make where they usually live?',
+                    'They do not make any of these payments')
+      save_and_continue
+
+      # steps/outgoings/pay_council_tax
+      choose_answer('Do your client and their partner pay Council Tax where they usually live?', 'No')
+      save_and_continue
+
+      # steps/outgoings/which_payments
+      choose_answers('Which of these payments do your client and their partner make?',
+                     ['They do not make any of these payments'])
+      save_and_continue
+
+      # steps/outgoings/client_paid_income_tax_rate
+      choose_answer('Has your client paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/partner_paid_income_tax_rate
+      choose_answer('Has the partner paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/are_outgoings_more_than_income
+      choose_answer("Are your client and their partner's outgoings more than their income?", 'No')
+      save_and_continue
+
+      # outgoings cya
+      save_and_continue
+
+      # steps/capital/which_assets_owned
+      choose_answer('Which assets does your client or their partner own or part-own inside or outside the UK?',
+                    'They do not own any of these assets')
+      save_and_continue
+
+      # steps/capital/which_savings
+      choose_answer('Which savings does your client or their partner have inside or outside the UK?',
+                    'They do not have any of these savings')
+      save_and_continue
+
+      # steps/capital/client_any_premium_bonds
+      choose_answer('Does your client have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/partner_any_premium_bonds
+      choose_answer('Does the partner have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/any_national_savings_certificates
+      choose_answer('Does your client or their partner have any National Savings Certificates?', 'No')
+      save_and_continue
+
+      # steps/capital/which_investments
+      choose_answer('Which investments does your client or their partner have inside or outside the UK?',
+                    'They do not have any of these investments')
+      save_and_continue
+
+      # steps/capital/client_benefit_from_trust_fund
+      choose_answer('Does your client stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/partner_benefit_from_trust_fund
+      choose_answer('Does the partner stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/income_savings_assets_under_restraint_freezing_order
+      choose_answer(
+        'Does your client or their partner have any income, savings or assets under a restraint or freezing order?',
+        'No'
+      )
+      save_and_continue
+
+      # capital cya
+      choose_answers('Confirm the following',
+                     ['Tick to confirm your client and their partner do not have any other assets or capital'])
+      save_and_continue
+
+      # steps/evidence/upload
+      save_and_continue
+
+      # steps/submission/more_information
+      choose_answer('Do you want to add any other information?', 'No')
+      save_and_continue
+
+      # steps/submission/review
+      save_and_continue
+
+      # steps/submission/declaration
+      choose_answer('Do you have a signed declaration from your client’s partner?', 'Yes')
+
+      fill_in('First name', with: 'Zoe')
+      fill_in('Last name', with: 'Bar')
+      fill_in('Telephone number', with: '07715339488')
+
+      stub_request(:post, 'http://datastore-webmock/api/v1/applications')
+      click_button 'Save and submit application'
+    end
+
+    it 'submits a valid application to the datastore' do
+      expect(
+        a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
+          body = JSON.parse(req.body)['application']
+          body['is_means_tested'] == 'yes' &&
+            body['means_details']['income_details']['partner_employment_type'] == ['self_employed'] &&
+            body['means_details']['income_details']['employment_type'] == ['self_employed']
+        }
+      ).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds system specs for three means tested routes with a partner (employed, not working, self employed)
For the time being, it verifies whether the submission is successful with some basic expected application information tested. We can look to test expectations in a subsequent pr like whether partner information is deleted when the partner answer has been updated

Also fixes a couple of small content/ux issues I noticed along the way

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1344

## Notes for reviewer
One thing to note is each test takes a couple of seconds (~3) which will add up in time. We should look into what options we have to ensure this doesn't slow down the pipeline too much as we add more specs 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
