### PR TITLE
[CRIMAPP-801] Hide home address question when home address known

### DIFF
--- a/app/forms/steps/capital/property_form.rb
+++ b/app/forms/steps/capital/property_form.rb
@@ -33,9 +33,7 @@ module Steps
       validates_with CapitalAssessment::PropertyOwnershipValidator
 
       def persist!
-        is_home_address_attr = display_home_address_question? ? is_home_address : YesNoAnswer::NO
-
-        record.update(attributes.merge(is_home_address: is_home_address_attr))
+        record.update(attributes)
       end
 
       def before_save

--- a/app/views/steps/capital/commercial_property/edit.html.erb
+++ b/app/views/steps/capital/commercial_property/edit.html.erb
@@ -19,7 +19,7 @@
       <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' if f.object.include_partner_in_means_assessment? %>
-      <% if f.object.person_has_home_address? %>
+      <% if f.object.display_home_address_question? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>

--- a/app/views/steps/capital/land/edit.html.erb
+++ b/app/views/steps/capital/land/edit.html.erb
@@ -20,7 +20,7 @@
       <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' if f.object.include_partner_in_means_assessment? %>
-      <% if f.object.person_has_home_address? %>
+      <% if f.object.display_home_address_question? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>

--- a/app/views/steps/capital/residential_property/edit.html.erb
+++ b/app/views/steps/capital/residential_property/edit.html.erb
@@ -29,7 +29,7 @@
       <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' %>
       <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third' if f.object.include_partner_in_means_assessment? %>
-      <% if f.object.person_has_home_address? %>
+      <% if f.object.display_home_address_question? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>
       <% end %>
       <%= f.govuk_collection_radio_buttons :has_other_owners, YesNoAnswer.values, :value, inline: true, legend: { size: 's' } %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -939,6 +939,7 @@ en:
               inclusion: Select yes if the address of the property is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
+              blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
         steps/capital/commercial_form:
           attributes:
@@ -969,6 +970,7 @@ en:
               inclusion: Select yes if the address of the property is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
+              blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
         steps/capital/land_form:
           attributes:
@@ -1002,6 +1004,7 @@ en:
               inclusion: Select yes if the address of the land is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
+              blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the land
         steps/capital/property_address_form:
           attributes:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -937,7 +937,6 @@ en:
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
               inclusion: Select yes if the address of the property is the same as your client's home address
-              invalid: Client can only have 1 home address
             has_other_owners:
               blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
@@ -968,7 +967,6 @@ en:
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
               inclusion: Select yes if the address of the property is the same as your client's home address
-              invalid: Client can only have 1 home address
             has_other_owners:
               blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
@@ -1002,7 +1000,6 @@ en:
               less_than_or_equal_to: *land_partner_percentage_error
             is_home_address:
               inclusion: Select yes if the address of the land is the same as your client's home address
-              invalid: Client can only have 1 home address
             has_other_owners:
               blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the land

--- a/spec/forms/steps/capital/residential_form_spec.rb
+++ b/spec/forms/steps/capital/residential_form_spec.rb
@@ -154,47 +154,6 @@ RSpec.describe Steps::Capital::ResidentialForm do
           end
         end
       end
-
-      # context 'home address validation' do
-      #   let(:attributes) { required_attributes }
-      #
-      #   context 'when home address has already been set' do
-      #     before do
-      #       allow(record).to receive(:id).and_return('123')
-      #     end
-      #
-      #     context 'and the current property is not the home address' do # rubocop:disable RSpec/NestedGroups
-      #       let(:home_address) { [instance_double(Property, id: '456')] }
-      #
-      #       it 'adds an error' do
-      #         expect(subject.save).to be(false)
-      #         expect(subject.errors.of_kind?(:is_home_address, :invalid)).to be(true)
-      #       end
-      #     end
-      #
-      #     context 'and the current property is the home address' do # rubocop:disable RSpec/NestedGroups
-      #       let(:home_address) { [instance_double(Property, id: '123')] }
-      #
-      #       it 'updates the record' do
-      #         expect(record).to receive(:update).and_return(true)
-      #         expect(subject.save).to be(true)
-      #       end
-      #     end
-      #   end
-      #
-      #   context 'when home address has not been set' do
-      #     let(:home_address) { [] }
-      #
-      #     before do
-      #       allow(record).to receive(:id).and_return('123')
-      #     end
-      #
-      #     it 'updates the record' do
-      #       expect(record).to receive(:update).and_return(true)
-      #       expect(subject.save).to be(true)
-      #     end
-      #   end
-      # end
     end
 
     context 'when client has a partner' do

--- a/spec/forms/steps/capital/residential_form_spec.rb
+++ b/spec/forms/steps/capital/residential_form_spec.rb
@@ -59,16 +59,31 @@ RSpec.describe Steps::Capital::ResidentialForm do
     end
 
     describe '#is_home_address' do
-      context 'when applicant home address is present' do
-        let(:home_address?) { true }
-
-        it { is_expected.to validate_is_a(:is_home_address, YesNoAnswer) }
+      before do
+        allow(record).to receive(:id).and_return('123')
       end
 
-      context 'when applicant home address is not present' do
-        let(:home_address?) { false }
+      context 'when the home address question is displayed' do
+        context 'when the applicant has a home address and home address property is unknown' do
+          let(:home_address?) { true }
+          let(:home_address) { [] }
 
-        it { is_expected.not_to validate_is_a(:is_home_address, YesNoAnswer) }
+          it { is_expected.to validate_is_a(:is_home_address, YesNoAnswer) }
+        end
+
+        context 'when the current property is the home address' do
+          let(:home_address) { [instance_double(Property, id: '123')] }
+
+          it { is_expected.to validate_is_a(:is_home_address, YesNoAnswer) }
+        end
+      end
+
+      context 'when the home address question is not displayed' do
+        context 'when the current property is not the home address' do
+          let(:home_address) { [instance_double(Property, id: '456')] }
+
+          it { is_expected.not_to validate_is_a(:is_home_address, YesNoAnswer) }
+        end
       end
     end
   end
@@ -140,46 +155,46 @@ RSpec.describe Steps::Capital::ResidentialForm do
         end
       end
 
-      context 'home address validation' do
-        let(:attributes) { required_attributes }
-
-        context 'when home address has already been set' do
-          before do
-            allow(record).to receive(:id).and_return('123')
-          end
-
-          context 'and the current property is not the home address' do # rubocop:disable RSpec/NestedGroups
-            let(:home_address) { [instance_double(Property, id: '456')] }
-
-            it 'adds an error' do
-              expect(subject.save).to be(false)
-              expect(subject.errors.of_kind?(:is_home_address, :invalid)).to be(true)
-            end
-          end
-
-          context 'and the current property is the home address' do # rubocop:disable RSpec/NestedGroups
-            let(:home_address) { [instance_double(Property, id: '123')] }
-
-            it 'updates the record' do
-              expect(record).to receive(:update).and_return(true)
-              expect(subject.save).to be(true)
-            end
-          end
-        end
-
-        context 'when home address has not been set' do
-          let(:home_address) { [] }
-
-          before do
-            allow(record).to receive(:id).and_return('123')
-          end
-
-          it 'updates the record' do
-            expect(record).to receive(:update).and_return(true)
-            expect(subject.save).to be(true)
-          end
-        end
-      end
+      # context 'home address validation' do
+      #   let(:attributes) { required_attributes }
+      #
+      #   context 'when home address has already been set' do
+      #     before do
+      #       allow(record).to receive(:id).and_return('123')
+      #     end
+      #
+      #     context 'and the current property is not the home address' do # rubocop:disable RSpec/NestedGroups
+      #       let(:home_address) { [instance_double(Property, id: '456')] }
+      #
+      #       it 'adds an error' do
+      #         expect(subject.save).to be(false)
+      #         expect(subject.errors.of_kind?(:is_home_address, :invalid)).to be(true)
+      #       end
+      #     end
+      #
+      #     context 'and the current property is the home address' do # rubocop:disable RSpec/NestedGroups
+      #       let(:home_address) { [instance_double(Property, id: '123')] }
+      #
+      #       it 'updates the record' do
+      #         expect(record).to receive(:update).and_return(true)
+      #         expect(subject.save).to be(true)
+      #       end
+      #     end
+      #   end
+      #
+      #   context 'when home address has not been set' do
+      #     let(:home_address) { [] }
+      #
+      #     before do
+      #       allow(record).to receive(:id).and_return('123')
+      #     end
+      #
+      #     it 'updates the record' do
+      #       expect(record).to receive(:update).and_return(true)
+      #       expect(subject.save).to be(true)
+      #     end
+      #   end
+      # end
     end
 
     context 'when client has a partner' do


### PR DESCRIPTION
## Description of change
PR to hide home address question in the property form when the home address has already been set for a property as requested by design. This fixes a qa issue where users would be able to save more than one property as the client's home address via the save and come back later button.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-801

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**When adding a property and a home address has not been set yet**

<img width="1469" alt="Screenshot 2024-09-18 at 13 25 39" src="https://github.com/user-attachments/assets/ff80cc61-008f-43aa-b8e1-481b53ace4c9">

**When adding a property and a home address has been set yet**

<img width="1469" alt="Screenshot 2024-09-18 at 13 26 04" src="https://github.com/user-attachments/assets/52f43d10-765b-48dd-8716-715e93c59d3b">

**When editing a property that is has been set as the home address already**

<img width="1469" alt="Screenshot 2024-09-18 at 13 25 21" src="https://github.com/user-attachments/assets/8c570fa5-aac8-47b5-ab4f-75fbaac4e7a7">


## How to manually test the feature
