### PR TITLE
[CRIMAPP-1300] Route to armed forces question unless client is self employed

### DIFF
--- a/app/models/concerns/employed_income.rb
+++ b/app/models/concerns/employed_income.rb
@@ -45,7 +45,7 @@ module EmployedIncome
     owners
   end
 
-  # employed income payement types relevant to a given application based on the
+  # employed income payment types relevant to a given application based on the
   # extent of means assessment
   def employed_income_payment_types
     if known_to_be_full_means?
@@ -60,7 +60,7 @@ module EmployedIncome
   end
 
   def require_partner_in_armed_forces?
-    partner_employed_only? && client_employed_only?
+    partner_employed_only? && employment_status.exclude?(EmploymentStatus::SELF_EMPLOYED.to_s)
   end
 
   def client_employed?

--- a/spec/models/concerns/employed_income_spec.rb
+++ b/spec/models/concerns/employed_income_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe EmployedIncome do
     context 'when the partner employment status is only `employed`' do
       let(:partner_employment_status) { [EmploymentStatus::EMPLOYED.to_s] }
 
-      context 'and the client employment status is only `employed`' do
+      context "and the client's employment status does not include `self employed`" do
         let(:employment_status) { [EmploymentStatus::EMPLOYED.to_s] }
 
         it { is_expected.to be true }
       end
 
-      context 'and the client employment status is more than `employed`' do
+      context "and the client's employment status includes `self employed`" do
         let(:employment_status) { [EmploymentStatus::EMPLOYED.to_s, EmploymentStatus::SELF_EMPLOYED.to_s] }
 
         it { is_expected.to be false }
@@ -50,6 +50,7 @@ RSpec.describe EmployedIncome do
     end
 
     context 'when the partner employment status is more than `employed`' do
+      let(:employment_status) { [EmploymentStatus::EMPLOYED.to_s] }
       let(:partner_employment_status) { [EmploymentStatus::EMPLOYED.to_s, EmploymentStatus::SELF_EMPLOYED.to_s] }
 
       it { is_expected.to be false }


### PR DESCRIPTION
## Description of change
Fixes a routing issue uncovered in qa. The partner armed forces question was not appearing when the partner is employed and the client is not working. This is due to an error in the logic in the ticket which said the client also needed to be employed. This has been changed to check whether the partner is employed and whether the client is self employed 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1300

## Notes for reviewer
As we are considering moving the partner employment status question we would need to amend the client armed forces logic to check if the partner is self employed. I have left as is for now. 
## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Check the armed forces question appears for the following scenario: 
- Summary only, Client Unemployed, Partner employed