### PR TITLE
CRIMAPP-1336 Apply can enter and save a hearing date beyond the permitted date range

### DIFF
--- a/app/forms/steps/case/hearing_details_form.rb
+++ b/app/forms/steps/case/hearing_details_form.rb
@@ -11,7 +11,9 @@ module Steps
       validates :hearing_court_name, presence: true
       # hearing_date must fall between 01/01/2010 - 31/12/2035 as per validation in MAAT; latest update LASB-3572
       validates :hearing_date, presence: true,
-                multiparam_date: { allow_future: true, earliest_year: 2010, latest_year: 2035 }
+                multiparam_date: { allow_future: true,
+                                   earliest_year: ::Case::EARLIEST_HEARING_DATE.year,
+                                   latest_year: ::Case::LATEST_HEARING_DATE.year }
 
       validates :is_first_court_hearing, inclusion: { in: :choices }
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -1,6 +1,9 @@
 class Case < ApplicationRecord
   belongs_to :crime_application
 
+  EARLIEST_HEARING_DATE = Date.parse('01-01-2010')
+  LATEST_HEARING_DATE = Date.parse('31-12-2035')
+
   has_one :ioj, dependent: :destroy
   has_many :codefendants, dependent: :destroy
   accepts_nested_attributes_for :codefendants, allow_destroy: true
@@ -22,6 +25,10 @@ class Case < ApplicationRecord
 
   def complete?
     valid?(:submission)
+  end
+
+  def hearing_date_within_range?
+    hearing_date.between?(EARLIEST_HEARING_DATE, LATEST_HEARING_DATE)
   end
 
   private

--- a/app/validators/case_details/answers_validator.rb
+++ b/app/validators/case_details/answers_validator.rb
@@ -75,7 +75,11 @@ module CaseDetails
     end
 
     def hearing_details_complete?
-      kase.values_at(:hearing_court_name, :hearing_date, :is_first_court_hearing).all?(&:present?)
+      kase.values_at(
+        :hearing_court_name,
+        :hearing_date,
+        :is_first_court_hearing
+      ).all?(&:present?) && kase.hearing_date_within_range?
     end
 
     def first_court_hearing_complete?

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe Case, type: :model do
   subject(:kase) { described_class.new(attributes) }
 
   let(:attributes) { {} }
+  let(:hearing_date) { Time.zone.today }
 
   let(:case_attributes) do
     {
       crime_application: CrimeApplication.new,
       hearing_court_name: 'court name',
-      hearing_date: Time.zone.today,
+      hearing_date: hearing_date,
       is_first_court_hearing: nil,
       first_court_hearing_name: nil,
       has_case_concluded: nil,
@@ -107,6 +108,26 @@ RSpec.describe Case, type: :model do
       let(:court_name) { '' }
 
       it { expect(subject.hearing_court).to be_nil }
+    end
+  end
+
+  describe '#hearing_date_within_range?' do
+    context 'when latest hearing date is out of range' do
+      let(:attributes) { { hearing_date: Date.parse('01-01-2036') } }
+
+      it { expect(kase).not_to be_hearing_date_within_range }
+    end
+
+    context 'when earliest hearing date is out of range' do
+      let(:attributes) { { hearing_date: Date.parse('31-12-2009') } }
+
+      it { expect(kase).not_to be_hearing_date_within_range }
+    end
+
+    context 'when hearing date is within the range' do
+      let(:attributes) { { hearing_date: Date.parse('01-01-2030') } }
+
+      it { expect(kase).to be_hearing_date_within_range }
     end
   end
 end

--- a/spec/validators/case_details/answers_validator_spec.rb
+++ b/spec/validators/case_details/answers_validator_spec.rb
@@ -10,9 +10,13 @@ RSpec.describe CaseDetails::AnswersValidator, type: :model do
   let(:errors) { double(:errors) }
   let(:non_means_tested) { false }
   let(:cifc?) { false }
+  let(:hearing_date_within_range?) { true }
 
   describe '#validate' do
-    before { allow(record).to receive_messages(**attributes) }
+    before {
+      allow(record).to receive_messages(**attributes)
+      allow(record).to receive(:hearing_date_within_range?).and_return(hearing_date_within_range?)
+    }
 
     context 'when all validations pass' do
       let(:errors) { double(empty?: true) }
@@ -263,7 +267,7 @@ RSpec.describe CaseDetails::AnswersValidator, type: :model do
       allow(record).to receive_messages(
         hearing_court_name:, hearing_date:, is_first_court_hearing:
       )
-
+      allow(record).to receive(:hearing_date_within_range?).and_return(hearing_date_within_range?)
       allow(record).to receive(:values_at).with(:hearing_court_name, :hearing_date, :is_first_court_hearing) {
         [hearing_court_name, hearing_date, is_first_court_hearing]
       }
@@ -286,6 +290,17 @@ RSpec.describe CaseDetails::AnswersValidator, type: :model do
     context 'when any hearing detail is missing' do
       let(:hearing_court_name) { 'Court Name' }
       let(:hearing_date) { nil }
+      let(:is_first_court_hearing) { true }
+
+      it 'returns false' do
+        expect(subject.hearing_details_complete?).to be(false)
+      end
+    end
+
+    context 'when any hearing date is out of range' do
+      let(:hearing_date_within_range?) { false }
+      let(:hearing_court_name) { 'Court Name' }
+      let(:hearing_date) { Date.parse('01-01-2036') }
       let(:is_first_court_hearing) { true }
 
       it 'returns false' do


### PR DESCRIPTION
## Description of change

Update case details answers_validator to add  `case.hearing_date` date range validation on review application page

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1336

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
