### PR TITLE
Add hint text to self assessment tax bill question

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -462,8 +462,10 @@ en:
           other: For example, Student Loans, pensions or employee benefits
       steps_income_client_self_assessment_tax_bill_form:
         applicant_self_assessment_tax_bill: This will be from HM Revenue and Customs (HMRC).
+        applicant_self_assessment_tax_bill_amount: Enter '0' if none.
       steps_income_partner_self_assessment_tax_bill_form:
         partner_self_assessment_tax_bill: This will be from HM Revenue and Customs (HMRC).
+        partner_self_assessment_tax_bill_amount: Enter '0' if none.
       steps_income_lost_job_in_custody_form:
         date_job_lost: For example, 27 3 2007
       steps_income_income_payments_form:


### PR DESCRIPTION
## Description of change
Adds some missing hint text

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2024-09-25 at 14 50 19](https://github.com/user-attachments/assets/915566ef-3f45-4f0f-8b1d-26c1b77f4237)

### After changes:

<img width="1192" alt="Screenshot 2024-09-25 at 17 03 31" src="https://github.com/user-attachments/assets/bc0868db-0614-4f03-991f-4368ac9162b7">
<img width="1192" alt="Screenshot 2024-09-25 at 17 03 45" src="https://github.com/user-attachments/assets/c1842e38-9a1b-47d6-8fef-fa9485375244">


## How to manually test the feature
