### PR TITLE
[CRIMAPP-249] Add DateStampContext output

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -8,6 +8,7 @@ module Summary
       initial: %i[
         overview
         client_details
+        date_stamp_context
         contact_details
         partner_details
         passporting_benefit_check
@@ -60,6 +61,7 @@ module Summary
       change_in_financial_circumstances: %i[
         overview
         client_details
+        date_stamp_context
         contact_details
         partner_details
         passporting_benefit_check

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -25,7 +25,8 @@ module Summary
 
           Components::DateAnswer.new(
             :date_of_birth, applicant.date_of_birth,
-            change_path: edit_steps_client_details_path
+            change_path: edit_steps_client_details_path,
+            i18n_opts: { format: :dob }
           ),
         ]
 

--- a/app/presenters/summary/sections/date_stamp_context.rb
+++ b/app/presenters/summary/sections/date_stamp_context.rb
@@ -1,0 +1,60 @@
+module Summary
+  module Sections
+    class DateStampContext < Sections::BaseSection
+      def show?
+        date_stampable_values_changed? && super
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def answers
+        [
+          Components::DateAnswer.new(
+            :date_stamp, date_stamp_context.date_stamp,
+            i18n_opts: { format: :datestamp },
+          ),
+          Components::FreeTextAnswer.new(
+            :first_name, date_stamp_context.first_name,
+            change_path: nil
+          ),
+          Components::FreeTextAnswer.new(
+            :last_name, date_stamp_context.last_name,
+            change_path: nil
+          ),
+          Components::DateAnswer.new(
+            :date_of_birth, date_stamp_context.date_of_birth,
+            i18n_opts: { format: :dob },
+          ),
+        ]
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def date_stampable_values_changed?
+        return false if applicant.blank? || date_stamp_context.blank?
+
+        first_name_changed? || last_name_changed? || date_of_birth_changed?
+      end
+
+      def applicant
+        @applicant ||= crime_application.applicant
+      end
+
+      def date_stamp_context
+        @date_stamp_context ||= crime_application.date_stamp_context
+      end
+
+      def first_name_changed?
+        applicant.first_name != date_stamp_context.first_name
+      end
+
+      def last_name_changed?
+        applicant.last_name != date_stamp_context.last_name
+      end
+
+      def date_of_birth_changed?
+        applicant.date_of_birth != date_stamp_context.date_of_birth
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
       default: '%-d %B %Y'  # 3 January 2019
       compact: '%d/%m/%Y'   # 03/01/2019
       datetime: '%-d %B %Y %-l:%M%P'  # 3 January 2019 2:45pm
+      datestamp: '%d/%m/%Y %H:%M%P' # 03/01/2019 15:29pm
+      dob: '%-d %B %Y' # 1 January 1990
     subjects:
       applicant: 'your client'
       applicant_and_partner: 'your client and their partner'

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -72,6 +72,7 @@ en:
       client_other_charge: "Other charges"
       client_other_charge_explicit: "Other charges: client"
       partner_other_charge: "Other charges: partner"
+      date_stamp_context: Details entered for date stamp
       details: Details
       dependants: Dependants
       files: Files
@@ -375,7 +376,7 @@ en:
         question: Court
       client_other_charge_next_hearing_date: &other_charge_next_hearing_date
         question: Next hearing
-      
+
       partner_other_charge_in_progress: *other_charge_in_progress
       partner_other_charge_charge: *other_charge_charge
       partner_other_charge_hearing_court_name: *other_charge_hearing_court_name

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 # This spec is just a high level, smoke test of the sections.
 # It is not intended to test conditionality or complex rules,
 # as that is tested individually in each of the sections specs.
-#
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 describe Summary::HtmlPresenter do
   subject(:presenter) { described_class.new(crime_application:) }
 
   # rubocop:disable Layout/LineLength
   let(:database_application) do
     instance_double(
-      CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes'),
+      CrimeApplication, applicant: (double benefit_type: 'universal_credit', has_partner: 'yes', first_name: 'Arnold', last_name: 'Slit', date_of_birth: Date.new(1990, 1, 1)),
       partner: double(first_name: 'Test first name', arc: nil), partner_detail: double(PartnerDetail, involvement_in_case: 'none'),
       kase: kase, ioj: double, status: :in_progress,
       income: income,
@@ -20,6 +21,7 @@ describe Summary::HtmlPresenter do
       savings: [double], investments: [double], national_savings_certificates: [double], properties: [double],
       is_means_tested: 'yes',
       non_means_tested?: false,
+      date_stamp_context: date_stamp_context,
       cifc?: cifc?,
     )
   end
@@ -90,6 +92,10 @@ describe Summary::HtmlPresenter do
   let(:manage_without_income) { nil }
 
   let(:cifc?) { false }
+
+  let(:date_stamp_context) do
+    double(DateStampContext, first_name: 'Arnold', last_name: 'Slit', date_of_birth: Date.new(1990, 1, 1))
+  end
 
   let(:datastore_application) do
     extra = {
@@ -259,7 +265,7 @@ describe Summary::HtmlPresenter do
     context 'when an initial application' do
       let(:application_type) { 'initial' }
 
-      context 'for an "in progress" database application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'for an "in progress" database application' do
         let(:crime_application) { database_application }
 
         let(:expected_sections) do
@@ -310,13 +316,24 @@ describe Summary::HtmlPresenter do
         it { is_expected.to match_array(expected_sections) }
       end
 
-      context 'for a "submitted" datastore application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'with changed attributes in date stamp context' do
+        let(:date_stamp_context) do
+          double(DateStampContext, first_name: 'Arnie', last_name: 'Slight', date_of_birth: Date.new(1990, 1, 1))
+        end
+
+        let(:crime_application) { database_application }
+
+        it { is_expected.to include('DateStampContext') }
+      end
+
+      context 'for a "submitted" datastore application' do
         let(:crime_application) { datastore_application }
 
         let(:expected_sections) do
           %w[
             Overview
             ClientDetails
+            DateStampContext
             ContactDetails
             PartnerDetails
             PassportingBenefitCheck
@@ -371,7 +388,7 @@ describe Summary::HtmlPresenter do
       let(:application_type) { 'change_in_financial_circumstances' }
       let(:cifc?) { true }
 
-      context 'for an "in progress" database application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'for an "in progress" database application' do
         let(:crime_application) { database_application }
 
         let(:expected_sections) do
@@ -421,13 +438,14 @@ describe Summary::HtmlPresenter do
         it { is_expected.to match_array(expected_sections) }
       end
 
-      context 'for a "submitted" datastore application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'for a "submitted" datastore application' do
         let(:crime_application) { datastore_application }
 
         let(:expected_sections) do
           %w[
             Overview
             ClientDetails
+            DateStampContext
             ContactDetails
             PartnerDetails
             PassportingBenefitCheck
@@ -480,7 +498,7 @@ describe Summary::HtmlPresenter do
     context 'when a PSE application' do
       let(:application_type) { 'post_submission_evidence' }
 
-      context 'for an "in progress" database application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'for an "in progress" database application' do
         let(:crime_application) { database_application }
 
         let(:expected_sections) do
@@ -495,7 +513,7 @@ describe Summary::HtmlPresenter do
         it { is_expected.to match_array(expected_sections) }
       end
 
-      context 'for a "submitted" datastore application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'for a "submitted" datastore application' do
         let(:crime_application) { datastore_application }
 
         let(:expected_sections) do
@@ -654,3 +672,4 @@ describe Summary::HtmlPresenter do
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## Description of change
Displays the 'Details entered for datestamp' if the first_name/last_name/date_of_birth are altered

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-249

## Notes for reviewer
- Does not show the red 'changed after date stamp' tag as shown in figma as that requires alteration of the summary output mechanism. Subsequent PR #1200  will do that.

## Screenshots of changes (if applicable)

![Screenshot 2024-10-01 at 15 34 06](https://github.com/user-attachments/assets/b787aac4-7e6c-44c1-ac56-ce94c09f7c9c)


## How to manually test the feature
Create an application, change first name, go to the 'Review the application' page at the URL such as:

https://staging.apply.gov.uk/applications/<id>/steps/submission/review