### PR TITLE
[FIX] Retain date stamp on resubmitted non-means applications

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -115,7 +115,8 @@ class CrimeApplication < ApplicationRecord
 
   # Ignore any stored date_stamp if the application is not date_stampable
   def date_stamp
-    return if not_means_tested? || kase&.case_type.blank?
+    return super if not_means_tested?
+    return if kase&.case_type.blank?
     return unless CaseType.new(kase.case_type).date_stampable?
 
     super


### PR DESCRIPTION
## Description of change
Retain date stamp on resubmitted non-means applications

A regression meant that a break clause (to protect against case type being missing when determining whether to retain a date stamp) cleared the date stamp on non-means tested application incorrectly 

## How to manually test the feature

1. Submit a non-means tested application
2. Return it to provider from Review
3. Resubmit it, check that the date stamp is retained from the initial submission, not overwritten with the submitted_at date of the resubmission