### PR TITLE
[CRIMAPP-1387] Fix partner address validation

### DIFF
--- a/app/validators/partner_details/answers_validator.rb
+++ b/app/validators/partner_details/answers_validator.rb
@@ -51,14 +51,10 @@ module PartnerDetails
     end
 
     def address?
-      return true unless include_partner_in_means_assessment?
-
-      record.has_same_address_as_client == 'no' ? crime_application.partner&.home_address.present? : true
+      record.has_same_address_as_client == 'no' ? crime_application.partner&.home_address? : true
     end
 
     def same_address?
-      return true unless include_partner_in_means_assessment?
-
       record.has_same_address_as_client.present?
     end
 

--- a/spec/validators/partner_details/answers_validator_spec.rb
+++ b/spec/validators/partner_details/answers_validator_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
     )
   end
 
-  let(:home_address) { instance_double(Address, type: 'HomeAddress', person: partner, postcode: 'SW1A 2AA') }
+  let(:home_address) do
+    instance_double(Address, type: 'HomeAddress', person: partner,
+                                       address_line_one: 'Test Address Line 1')
+  end
   let(:has_partner) { nil }
 
   before do
@@ -76,12 +79,20 @@ RSpec.describe PartnerDetails::AnswersValidator, type: :model do
         it { is_expected.to be true }
       end
 
-      context 'without address when living apart' do
+      context 'when living apart' do
         before { partner_detail.has_same_address_as_client = 'no' }
 
-        let(:home_address) { nil }
+        context 'without address' do
+          let(:home_address) { nil }
 
-        it { is_expected.to be false }
+          it { is_expected.to be false }
+        end
+
+        context 'when partner address incomplete' do
+          let(:home_address) { instance_double(Address, type: 'HomeAddress', person: partner, address_line_one: nil) }
+
+          it { is_expected.to be false }
+        end
       end
 
       context 'without address when living together' do


### PR DESCRIPTION
## Description of change
Fixes bug with partner address validation where the partner answer validation fails to pick up on an incomplete home address when a user clicks save and come back later on the partner address screen

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1387
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1208" alt="Screenshot 2024-10-09 at 08 32 04" src="https://github.com/user-attachments/assets/9a75ba39-ee23-45ad-a246-262f33cc984a">

### After changes:
<img width="1208" alt="Screenshot 2024-10-09 at 10 53 54" src="https://github.com/user-attachments/assets/0fb5d49b-e0b7-462d-a104-fdbe4cf27350">
<img width="1208" alt="Screenshot 2024-10-09 at 10 54 04" src="https://github.com/user-attachments/assets/f5b780bc-a88a-4c92-9586-6481fd0dcaeb">

## How to manually test the feature
Start an application with a partner. Get to the partner home address screen and select save and come back later rather than entering the home address. Verify that the partner details task list still says in progress rather than completed. 