### PR TITLE
[CRIMAPP-1356] Show funding decisions

### DIFF
--- a/app/presenters/summary/components/funding_decision.rb
+++ b/app/presenters/summary/components/funding_decision.rb
@@ -1,0 +1,54 @@
+module Summary
+  module Components
+    class FundingDecision < BaseRecord
+      private
+
+      def answers # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
+        [
+          Components::FreeTextAnswer.new(
+            :funding_decision_maat_id, funding_decision.maat_id
+          ),
+          Components::FreeTextAnswer.new(
+            :funding_decision_case_number, funding_decision.reference
+          ),
+          Components::ValueAnswer.new(
+            :funding_decision_ioj_result, funding_decision.interests_of_justice&.result
+          ),
+          Components::FreeTextAnswer.new(
+            :funding_decision_ioj_reason, funding_decision.interests_of_justice&.details
+          ),
+          Components::FreeTextAnswer.new(
+            :funding_decision_ioj_caseworker, funding_decision.interests_of_justice&.assessed_by
+          ),
+          Components::DateAnswer.new(
+            :funding_decision_ioj_date, funding_decision.interests_of_justice&.assessed_on
+          ),
+          Components::ValueAnswer.new(
+            :funding_decision_means_result, funding_decision.means&.result
+          ),
+          Components::FreeTextAnswer.new(
+            :funding_decision_means_caseworker, funding_decision.means&.assessed_by
+          ),
+          Components::DateAnswer.new(
+            :funding_decision_means_date, funding_decision.means&.assessed_on
+          ),
+          Components::TagAnswer.new(
+            :funding_decision_overall_result, funding_decision.funding_decision
+          )
+        ].select(&:show?)
+      end
+
+      def name
+        I18n.t('summary.sections.case')
+      end
+
+      def status_tag
+        nil
+      end
+
+      def funding_decision
+        @funding_decision ||= record
+      end
+    end
+  end
+end

--- a/app/presenters/summary/components/tag_answer.rb
+++ b/app/presenters/summary/components/tag_answer.rb
@@ -1,0 +1,13 @@
+module Summary
+  module Components
+    class TagAnswer < BaseAnswer
+      def answer_text
+        answer = I18n.t("summary.questions.#{question}.answers.#{value}")
+        GovukComponent::TagComponent.new(
+          text: answer[:value],
+          colour: answer[:colour]
+        ).call
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -56,6 +56,7 @@ module Summary
         supporting_evidence
         more_information
         declarations
+        funding_decisions
         legal_representative_details
       ],
       change_in_financial_circumstances: %i[

--- a/app/presenters/summary/sections/funding_decisions.rb
+++ b/app/presenters/summary/sections/funding_decisions.rb
@@ -1,0 +1,27 @@
+module Summary
+  module Sections
+    class FundingDecisions < Sections::BaseSection
+      def heading
+        :funding_decisions
+      end
+
+      def show?
+        crime_application.status == ApplicationStatus::SUBMITTED && funding_decisions.any? && super
+      end
+
+      def answers
+        Summary::Components::FundingDecision.with_collection(funding_decisions, show_actions: false)
+      end
+
+      def list?
+        true
+      end
+
+      private
+
+      def funding_decisions
+        @funding_decisions ||= crime_application.decisions
+      end
+    end
+  end
+end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -8,6 +8,9 @@ en:
       YESNO: &YESNO
         'yes': 'Yes'
         'no': 'No'
+      PASSFAIL: &PASSFAIL
+        pass: Passed
+        fail: Failed
       OWNERSHIP_TYPE: &OWNERSHIP_TYPE
         applicant: 'Client'
         applicant_and_partner: 'Client and partner'
@@ -148,6 +151,8 @@ en:
       partner_work_benefits: Other work benefits
       employment_income: Pay from employment
       partner_employment_income: Pay from employment
+      funding_decisions: Funding decisions
+      case: Case
 
     questions:
       # BEGIN overview section
@@ -692,6 +697,43 @@ en:
       how_manage:
         question: How they cover outgoings that are more than income
       # END other outgoings details section
+
+      # BEGIN funding decisions section
+      funding_decision_maat_id:
+        question: MAAT ID
+      funding_decision_case_number:
+        question: Case number
+      funding_decision_ioj_result:
+        question: Interests of justice test result
+        answers:
+          <<: *PASSFAIL
+      funding_decision_ioj_reason:
+        question: Interests of justice reason
+      funding_decision_ioj_caseworker:
+        question: Interests of justice test caseworker name
+      funding_decision_ioj_date:
+        question: Date of interests of justice test
+      funding_decision_means_result:
+        question: Means test result
+        answers:
+          <<: *PASSFAIL
+      funding_decision_means_caseworker:
+        question: Means test caseworker name
+      funding_decision_means_date:
+        question: Date of means test
+      funding_decision_overall_result:
+        question: Overall result
+        answers:
+          granted:
+            value: Granted
+            colour: green
+          granted_on_ioj:
+            value: Granted
+            colour: green
+          fail_on_ioj:
+            value: Rejected
+            colour: red
+      # END funding decisions section
 
       # BEGIN declarations section
       legal_rep_has_client_declaration:

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Summary::Components::FundingDecision, type: :component do
+  subject(:component) { render_summary_component(described_class.new(record: record, show_actions: false)) }
+
+  let(:record) { instance_double(LaaCrimeSchemas::Structs::Decision, **attributes) }
+  let(:crime_application) { instance_double(CrimeApplication, id: 'APP123') }
+
+  let(:attributes) do
+    {
+      reference:,
+      maat_id:,
+      interests_of_justice:,
+      means:,
+      funding_decision:,
+      comment:
+    }
+  end
+
+  let(:reference) { 'APP123' }
+  let(:maat_id) { 'M123' }
+  let(:interests_of_justice) do
+    instance_double(
+      LaaCrimeSchemas::Structs::TestResult,
+      result: 'pass',
+      details: 'IoJ details',
+      assessed_by: 'Grace Nolan',
+      assessed_on: Date.new(2024, 10, 8),
+    )
+  end
+  let(:means) do
+    instance_double(
+      LaaCrimeSchemas::Structs::TestResult,
+      result: 'fail',
+      details: 'Means details',
+      assessed_by: 'Grace Nolan',
+      assessed_on: Date.new(2024, 10, 9),
+    )
+  end
+  let(:funding_decision) { 'granted_on_ioj' }
+  let(:comment) { 'Decision comment' }
+
+  before { component }
+
+  describe 'card heading' do
+    subject(:heading) do
+      page.first('h2.govuk-summary-card__title').text
+    end
+
+    it { is_expected.to eq('Case') }
+  end
+
+  describe 'answers' do
+    it 'renders as summary list' do # rubocop:disable RSpec/MultipleExpectations
+      expect(page).to have_summary_row('MAAT ID', 'M123')
+      expect(page).to have_summary_row('Case number', 'APP123')
+      expect(page).to have_summary_row('Interests of justice test result', 'Passed')
+      expect(page).to have_summary_row('Interests of justice reason', 'IoJ details')
+      expect(page).to have_summary_row('Interests of justice test caseworker name', 'Grace Nolan')
+      expect(page).to have_summary_row('Date of interests of justice test', '8 October 2024')
+      expect(page).to have_summary_row('Means test result', 'Failed')
+      expect(page).to have_summary_row('Means test caseworker name', 'Grace Nolan')
+      expect(page).to have_summary_row('Date of means test', '9 October 2024')
+      expect(page).to have_summary_row('Overall result', 'Granted')
+    end
+  end
+end

--- a/spec/presenters/summary/components/tag_answer_spec.rb
+++ b/spec/presenters/summary/components/tag_answer_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Summary::Components::TagAnswer do
+  subject(:component) { described_class.new(question, value) }
+
+  let(:question) { :question }
+  let(:value) { :answer }
+
+  before do
+    allow(I18n).to receive(:t).with('summary.questions.question.answers.answer').and_return({ value: 'Answer',
+colour: 'green' })
+  end
+
+  describe '#answer_text' do
+    it 'returns a tag with the correct answer and colour' do
+      expect(component.answer_text).to eq('<strong class="govuk-tag govuk-tag--green">Answer</strong>')
+    end
+  end
+end

--- a/spec/presenters/summary/sections/funding_decisions_spec.rb
+++ b/spec/presenters/summary/sections/funding_decisions_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Summary::Sections::FundingDecisions do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) do
+    instance_double(
+      LaaCrimeSchemas::Structs::CrimeApplication,
+      status:,
+      decisions:,
+    )
+  end
+
+  let(:status) { ApplicationStatus::SUBMITTED }
+
+  let(:decisions) do
+    [
+      {
+        reference: nil,
+        maat_id: nil,
+        interests_of_justice: {
+          result: 'pass',
+          details: 'Details',
+          assessed_by: 'Grace Nolan',
+          assessed_on: Date.new(2024, 10, 8)
+        },
+        means: nil,
+        funding_decision: 'granted_on_ioj',
+        comment: ''
+      }
+    ]
+  end
+
+  describe '#heading' do
+    it { expect(subject.heading).to eq(:funding_decisions) }
+  end
+
+  describe '#show?' do
+    it 'shows this section' do
+      expect(subject.show?).to be(true)
+    end
+
+    context 'when the application is not submitted' do
+      let(:status) { ApplicationStatus::IN_PROGRESS }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+
+    context 'when there are no funding decisions' do
+      let(:decisions) { [] }
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:component) { instance_double(Summary::Components::FundingDecision) }
+
+    before do
+      allow(Summary::Components::FundingDecision).to receive(:with_collection) { component }
+    end
+
+    it 'returns the component without actions' do
+      expect(subject.answers).to be component
+
+      expect(Summary::Components::FundingDecision).to have_received(:with_collection).with(
+        decisions, show_actions: false
+      )
+    end
+  end
+
+  describe '#list?' do
+    it { expect(subject.list?).to be(true) }
+  end
+end


### PR DESCRIPTION
## Description of change
Show funding decisions on submitted applications.

## Link to relevant ticket
[CRIMAPP-1356](https://dsdmoj.atlassian.net/browse/CRIMAPP-1356)

## Notes for reviewer

## Screenshots of changes (if applicable)
![image](https://github.com/user-attachments/assets/4b63cf7a-f7e2-494c-b42f-fbacd088c18f)

## How to manually test the feature
1. Submit a non-means application
2. On Review, assign the application to yourself, add a funding decision and submit it
3. Back on Apply, view the application under Submitted applications and you should see the funding decision

[CRIMAPP-1356]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ