### PR TITLE
[CRIMAPP-1399] Change form to allow max 18 dependants

### DIFF
--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -1,6 +1,6 @@
 class Dependant < ApplicationRecord
   MAX_AGE = 18
-  MAX_TOTAL_DEPENDANTS = 50
+  MAX_TOTAL_DEPENDANTS = 18 # Maximum determined by MAAT
 
   belongs_to :crime_application
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -605,7 +605,7 @@ en:
         steps/income/dependants_form:
           attributes:
             dependants:
-              too_long: Must have 50 or fewer dependants
+              too_long: Must have 18 or fewer dependants
         steps/income/dependant_fieldset_form:
           summary:
             age:

--- a/spec/forms/steps/income/dependants_form_spec.rb
+++ b/spec/forms/steps/income/dependants_form_spec.rb
@@ -41,20 +41,20 @@ RSpec.describe Steps::Income::DependantsForm do
       end
     end
 
-    context 'when there are 50 dependants' do
+    context 'when there are 18 dependants' do
       let(:dependants_attributes) do
-        Array.new(50) { |i| [i.to_s, { 'age' => 5 }] }.to_h
+        Array.new(18) { |i| [i.to_s, { 'age' => 5 }] }.to_h
       end
 
       it 'is valid' do
-        expect(subject.crime_application.dependants.size).to eq 50
+        expect(subject.crime_application.dependants.size).to eq 18
         expect(subject).to be_valid
       end
     end
 
-    context 'when there are 51 or more dependants' do
+    context 'when there are 19 or more dependants' do
       let(:dependants_attributes) do
-        Array.new(51) { |i| [i.to_s, { 'age' => 5 }] }.to_h
+        Array.new(19) { |i| [i.to_s, { 'age' => 5 }] }.to_h
       end
 
       it 'is invalid' do


### PR DESCRIPTION
## Description of change
Limits number of dependants to 18 to comply with MAAT data format

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1399

## Notes for reviewer
Part of MAAT truncation work

## How to manually test the feature
Create new application, `Does your client get one of these passporting benefits?` should be NONE so that user must do full income assessment. In dependants form try and enter 18 dependants then 19 - should see an error for the 19th when you try to save it.