### PR TITLE
Update ModSec rules in staging

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -26,7 +26,53 @@ metadata:
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
-      SecRule REQUEST_URI "@endsWith /documents" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110"
+      SecRuleUpdateTargetById 932160 !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
+      SecRuleUpdateTargetById 942100 !ARGS:authenticity_token
+      SecRule REQUEST_URI "@endsWith /documents" \
+        "id:1000,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=920120"
+      SecRule REQUEST_URI "@endsWith /steps/case/ioj" \
+        "id:1001,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=932100,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=933210,\
+        ctl:ruleRemoveById=942100,\
+        ctl:ruleRemoveById=942230"
+      SecRule REQUEST_URI "@endsWith /steps/submission/more_information" \
+        "id:1002,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=932150,\
+        ctl:ruleRemoveById=942230"
+      SecRule REQUEST_URI "@endsWith /steps/circumstances/pre_cifc_reason" \
+        "id:1003,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115"
+      SecRule REQUEST_URI "@endsWith /steps/case/client/other_charge" \
+        "id:1004,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=942230"
+      SecRule REQUEST_URI "@endsWith /steps/case/partner/other_charge" \
+        "id:1005,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=942230"
+      SecRule REQUEST_URI "@rx .*/steps/capital/investments/[a-f0-9-]+$" \
+        "id:1006,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115"
+      SecRule REQUEST_URI "@rx .*/steps/case/charges/[a-f0-9-]+$" \
+        "id:1007,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=933210,\
+        ctl:ruleRemoveById=942100"
+      SecRule REQUEST_URI "@endsWith /steps/income/how_manage_with_no_income" \
+        "id:1008,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942230"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
Updated the ModSec rules in staging to prevent common false positives on select endpoints.

## How to manually test the feature
Test the endpoints with form input that normally triggers the rules.