### PR TITLE
[CRIMAPP-1335] Supporting evidence summary card update

### DIFF
--- a/app/presenters/summary/sections/supporting_evidence.rb
+++ b/app/presenters/summary/sections/supporting_evidence.rb
@@ -6,16 +6,24 @@ module Summary
       end
 
       def answers
-        [
-          documents.map do |document|
-            next if document.s3_object_key.nil?
+        if submitted_documents?
+          [
+            documents.map do |document|
+              next if document.s3_object_key.nil?
 
+              Components::FreeTextAnswer.new(
+                :supporting_evidence, document.filename,
+                change_path: edit_steps_evidence_upload_path(crime_application)
+              )
+            end
+          ].flatten.compact.select(&:show?)
+        else
+          [
             Components::FreeTextAnswer.new(
-              :supporting_evidence, document.filename,
-              change_path: edit_steps_evidence_upload_path(crime_application)
+              :no_supporting_evidence, nil
             )
-          end
-        ].flatten.compact.select(&:show?)
+          ]
+        end
       end
 
       def change_path
@@ -36,6 +44,10 @@ module Summary
 
       def documents
         @documents ||= crime_application.documents
+      end
+
+      def submitted_documents?
+        documents.any?
       end
     end
   end

--- a/app/presenters/summary/sections/supporting_evidence.rb
+++ b/app/presenters/summary/sections/supporting_evidence.rb
@@ -7,22 +7,9 @@ module Summary
 
       def answers
         if submitted_documents?
-          [
-            documents.map do |document|
-              next if document.s3_object_key.nil?
-
-              Components::FreeTextAnswer.new(
-                :supporting_evidence, document.filename,
-                change_path: edit_steps_evidence_upload_path(crime_application)
-              )
-            end
-          ].flatten.compact.select(&:show?)
+          evidence_card
         else
-          [
-            Components::FreeTextAnswer.new(
-              :no_supporting_evidence, nil
-            )
-          ]
+          no_evidence_card
         end
       end
 
@@ -38,6 +25,27 @@ module Summary
 
       def name
         :files
+      end
+
+      def no_evidence_card
+        [
+          Components::FreeTextAnswer.new(
+            :no_supporting_evidence, nil
+          )
+        ]
+      end
+
+      def evidence_card
+        [
+          documents.map do |document|
+            next if document.s3_object_key.nil?
+
+            Components::FreeTextAnswer.new(
+              :supporting_evidence, document.filename,
+              change_path: edit_steps_evidence_upload_path(crime_application)
+            )
+          end
+        ].flatten.compact.select(&:show?)
       end
 
       private

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -760,6 +760,9 @@ en:
       # BEGIN supporting evidence section
       supporting_evidence:
         question: File name
+      no_supporting_evidence:
+        question: No files were uploaded
+        absence_answer: ''
       additional_information:
         question: Any additional information?
         absence_answer: *absence_none

--- a/spec/presenters/summary/sections/supporting_evidence_spec.rb
+++ b/spec/presenters/summary/sections/supporting_evidence_spec.rb
@@ -60,7 +60,9 @@ describe Summary::Sections::SupportingEvidence do
       let(:documents) { [] }
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(0)
+        expect(answers.count).to eq(1)
+        expect(answers[0]).to be_an_instance_of(Summary::Components::FreeTextAnswer)
+        expect(answers[0].question).to eq(:no_supporting_evidence)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Updates supporting evidence summary card to display card when no files have been uploaded

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1335

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1057" alt="Screenshot 2024-10-22 at 14 42 08" src="https://github.com/user-attachments/assets/1b39cc46-ff07-4fb3-a1ae-711c25ddb9a0">
<img width="1057" alt="Screenshot 2024-10-22 at 14 47 10" src="https://github.com/user-attachments/assets/b7ad8700-6cb9-41e7-b540-c67c66e6b5df">


## How to manually test the feature
