### PR TITLE
[CRIMAPP-1356] Add missing decision row to summary

### DIFF
--- a/app/presenters/summary/components/funding_decision.rb
+++ b/app/presenters/summary/components/funding_decision.rb
@@ -34,6 +34,9 @@ module Summary
           ),
           Components::TagAnswer.new(
             :funding_decision_overall_result, funding_decision.funding_decision
+          ),
+          Components::FreeTextAnswer.new(
+            :funding_decision_further_info, funding_decision.comment
           )
         ].select(&:show?)
       end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -733,6 +733,14 @@ en:
           fail_on_ioj:
             value: Rejected
             colour: red
+          failmeans:
+            value: Failed on means
+            colour: red
+          failioj:
+            value: Rejected
+            colour: red
+      funding_decision_further_info:
+        question: Further information about the decision
       # END funding decisions section
 
       # BEGIN declarations section

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -62,6 +62,7 @@ describe Summary::Components::FundingDecision, type: :component do
       expect(page).to have_summary_row('Means test caseworker name', 'Grace Nolan')
       expect(page).to have_summary_row('Date of means test', '9 October 2024')
       expect(page).to have_summary_row('Overall result', 'Granted')
+      expect(page).to have_summary_row('Further information about the decision', 'Decision comment')
     end
   end
 end


### PR DESCRIPTION
## Description of change
- Added the missing "Further information about the decision" row to the funding decision summary component
- Added missing overall result answers

## Link to relevant ticket
[CRIMAPP-1356](https://dsdmoj.atlassian.net/browse/CRIMAPP-1356)

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/user-attachments/assets/cb337c29-7570-441f-9084-62ed73acb768)
### After changes:
![image](https://github.com/user-attachments/assets/a69325f6-8777-49fd-9516-90db6299bf13)

## How to manually test the feature
1. Create and submit an application on Apply
2. Assign it to yourself on Review and submit a funding decision with a comment
3. Back on Apply, view the submitted application, which should have the funding decision with the comment on the "Further information about the decision" row

[CRIMAPP-1356]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ