### PR TITLE
[CRIMAPP-1445] Add documentation for evidence prompt and virus scanning

### DIFF
--- a/docs/clam-av.md
+++ b/docs/clam-av.md
@@ -1,0 +1,105 @@
+# Clam AV
+Apply requires evidence files to be scanned for viruses. We use ClamAV CLI to do that.
+
+See the general README for setup guide.
+
+## Overview
+The Apply ClamAV setup relies on pre-existing work by HMPPS - specifically their ready-made ClamAV image:
+
+```
+docker pull ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+docker run -p 3310:3310 --name clamav-server ghcr.io/ministryofjustice/hmpps-clamav-freshclammed
+```
+
+## Troubleshooting
+
+### Testing clamdscan availability on the deployed server
+
+If you need to check whether the Clamdscan service is working as expected between Apply and the ClamAV containers:
+
+1. Open a shell in one of the application hosts
+
+2. Locate the appropriate Clamd environment configuration file (should be located in /config/clamd)
+
+3. Perform the scan via CLI. For example in the `staging` environment:
+
+```
+touch ./my-example-file.txt
+clamdscan -c config/clamd/clamd.staging.conf --stream --no-summary ./my-example-file.txt
+```
+
+### Setting up ClamAV locally
+
+1. Pull the HMPPS docker containter and start it:
+
+```
+docker pull ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+docker run -p 3310:3310 --name clamav-server ghcr.io/ministryofjustice/hmpps-clamav-freshclammed
+```
+
+2. Create a new Ruby project with the following structure:
+
+```
++--src
+   |__ Gemfile
+   |__ scan.rb
++--local-clam.conf
+
+```
+
+3. File contents:
+
+```
+# Gemfile
+source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby "3.2.2"
+
+gem 'clamby'
+gem 'shellwords'
+
+# scan.rb
+require 'clamby'
+require 'tempfile'
+require 'shellwords'
+
+Clamby.configure({
+  :check => false,
+  :daemonize => true,
+  :config_file => '/full/path/to/local-clam.conf',
+  :error_clamscan_missing => true,
+  :error_clamscan_client_error => false,
+  :error_file_missing => true,
+  :error_file_virus => false,
+  :fdpass => false,
+  :stream => true,
+  :reload => false,
+  :output_level => 'high', # one of 'off', 'low', 'medium', 'high'
+  :executable_path_clamscan => 'clamscan',
+  :executable_path_clamdscan => 'clamdscan',
+  :executable_path_freshclam => 'freshclam',
+})
+
+file_to_scan = Tempfile.new('check-file.txt')
+file_to_scan.write('HELLO CLAMAV!');
+file_to_scan.rewind
+
+begin
+  response = Clamby.safe?(file_to_scan.path)
+  puts "CLAMBY RESULT: #{response}"
+ensure
+  file_to_scan.close
+end
+
+
+# local-clam.conf
+TCPAddr localhost
+TCPSocket 3310
+```
+
+4. Run it
+
+```
+cd src && ruby scan.rb
+```

--- a/docs/evidence-prompt.md
+++ b/docs/evidence-prompt.md
@@ -1,0 +1,36 @@
+# Evidence Prompt
+
+Before application submission the provider must supply uploaded documentary evidence to support the answers given. Which documents to upload is governed by the Evidence Prompt.
+
+## Generating a new rule
+```
+rails g evidence:rule --key my_key_from_spreadsheet --class ApplicantLivesInOwnHouse2025
+```
+
+This will generate a Rule class and a corresponding RSpec test. The `key` should be copied from the source Evidence Triggers speadsheet (see below). The `class` name should be unique and ideally reflect the nature of the rule.
+
+
+## Validation
+At least 1 document should be uploaded if there was evidence required. No data verification is performed - this is the caseworker's job.
+
+## System design
+
+A `Prompt` is initialized with the `CrimeApplication` in its current state. Some 'pre-flight' checks are made as not all applications require evidence upload - for example if the applicant is under 18.
+
+After the pre-flight checks, a `Ruleset` is executed. For new/unsubmitted applications the Ruleset is `Latest`. For returned applications the ruleset is `Hydrated`.
+
+Each `Rule` corresponds to a `key`. Therefore a `key` can have many `Rule` implementations. This is to allow versioning of rules with newer rules taking precedence over older rules in the `Latest` Ruleset. In the `Hydrated` Ruleset, the Rule executed for a given key is persisted in the `CrimeApplication#evidence_prompts` field.
+
+The `key` also acts as a link between the implementation code and the first spreadsheet drawn up by the business analysts. The spreadsheet 'Evidence Triggers' can be found in Google Drive (and/or Confluence). This ensures the business understanding of a Rule and the corresponding code logic have a clear audit trail.
+
+When the `Prompt` is initialized, the `Ruleset` is determined and the individual `Rule` predicates are evaluated in order of `Runner::KEYS`. The order of `Runner::KEYS` determines output order for the result of each group of predicates.
+
+## Groups and Personas
+
+Each Rule can specify a `group` (one of :income, :outgoings, :capital, :none) and a `persona` (one of :client, :partner, :other).
+
+The `group` value controls in which output section/grouping the actual prompt wording will be displayed.
+
+Each persona has a corresponding `predicate`. The predicate must evaluate to `TrueClass` or `FalseClass` (i.e. ruby `true` or `false`). Any `nil` values will be treated as an exception. This is to force evaluation to always be `true` or `false` and not undetermined. That may change in future to allow flexibility.
+
+The output from each `predicate` will determine which `sentence` to show, using the `evidence.yml` translation file as the source for all output.


### PR DESCRIPTION
## Description of change
Adds some general info for evidence prompt and virus scanning

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1445

