### PR TITLE
[CRIMAPP-1453] Fix error with incomplete records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    branch: 'CRIMAPP-1453-fix-sentry-bug'
+    tag: 'v1.4.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.4.0'
+    branch: 'CRIMAPP-1453-fix-sentry-bug'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b37d6353babee7a5daa1c8628fb96e6456283c9d
-  branch: CRIMAPP-1453-fix-sentry-bug
+  revision: 624d2b9518397e4380ce74c47cca390b30c61380
+  tag: v1.4.2
   specs:
     laa-criminal-legal-aid-schemas (1.4.2)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a2b69c10443a70370bd618a98a59379decf44f4c
-  tag: v1.4.0
+  revision: b37d6353babee7a5daa1c8628fb96e6456283c9d
+  branch: CRIMAPP-1453-fix-sentry-bug
   specs:
-    laa-criminal-legal-aid-schemas (1.4.0)
+    laa-criminal-legal-aid-schemas (1.4.2)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
@@ -146,8 +146,9 @@ GEM
     dry-configurable (1.2.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-core (1.0.1)
+    dry-core (1.0.2)
       concurrent-ruby (~> 1.0)
+      logger
       zeitwerk (~> 2.6)
     dry-inflector (1.1.0)
     dry-initializer (3.1.1)

--- a/app/models/concerns/person_capital_assets.rb
+++ b/app/models/concerns/person_capital_assets.rb
@@ -4,6 +4,8 @@ module PersonCapitalAssets
   %i[savings investments national_savings_certificates].each do |assets|
     define_method(:"client_#{assets}") do
       public_send(assets).select do |asset|
+        next if asset.ownership_type.blank?
+
         ownership_type = OwnershipType.new(asset.ownership_type)
         ownership_type.applicant? || ownership_type.applicant_and_partner?
       end
@@ -11,6 +13,8 @@ module PersonCapitalAssets
 
     define_method(:"partner_#{assets}") do
       public_send(assets).select do |asset|
+        next if asset.ownership_type.blank?
+
         ownership_type = OwnershipType.new(asset.ownership_type)
         ownership_type.partner? || ownership_type.applicant_and_partner?
       end


### PR DESCRIPTION
## Description of change
Fixes a couple of sentry errors linked in the ticket. 

Users are being thrown errors on the evidence upload and review page when there are incomplete employment, Investment, co-defendant, saving and national saving certificate records. This is because the application's data is used to recreate a draft version of the application based on the schema. For some attributes, nil values were not permitted and so errors were being thrown. This is fixed at the schema level and with some `nil` value handling

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1453

## Notes for reviewer
Note: this means there will be greater reliance on validation to catch incomplete records before an app is submitted

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Start an application and create incomplete employment, Investment, co-defendant, saving and national saving certificate records. Check that you can view the evidence upload and review screens and no error is presented
