### PR TITLE
[CRIMAPP-1485] Fix under 18 and bypass dwp dev tools

### DIFF
--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -111,7 +111,6 @@ module DeveloperTools
 
     def find_or_create_partner_detail(overrides = {})
       PartnerDetail.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
-
         record.update(
           has_partner: overrides.fetch(:has_partner, 'no'),
           relationship_status: overrides.fetch(:relationship_status, 'single'),

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -80,8 +80,7 @@ module DeveloperTools
       @crime_application ||= current_crime_application || initialize_crime_application
     end
 
-    # rubocop:disable Metrics/MethodLength
-    def find_or_create_applicant(overrides = {})
+    def find_or_create_applicant(overrides = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       Applicant.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
         surname, details = DWP::MockBenefitCheckService::KNOWN.to_a.sample
 
@@ -103,7 +102,6 @@ module DeveloperTools
         )
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def find_or_create_case
       Case.find_or_initialize_by(crime_application_id: crime_application.id)

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -26,12 +26,18 @@ module DeveloperTools
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def bypass_dwp
       find_or_create_applicant
+      find_or_create_partner_detail
 
       crime_application.update(
         navigation_stack: [
-          edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
-          edit_steps_client_has_nino_path(crime_application),
+          edit_steps_client_is_means_tested_path(crime_application),
+          edit_steps_client_case_type_path(crime_application),
+          edit_steps_client_residence_type_path(crime_application),
+          edit_steps_client_contact_details_path(crime_application),
+          edit_steps_nino_path(crime_application, subject: 'client'),
+          edit_steps_client_has_partner_path(crime_application),
+          edit_steps_client_relationship_status_path(crime_application),
           edit_steps_dwp_benefit_type_path(crime_application),
           edit_steps_dwp_benefit_check_result_path(crime_application),
         ]
@@ -58,9 +64,8 @@ module DeveloperTools
 
       crime_application.update(
         navigation_stack: [
-          edit_steps_client_has_partner_path(crime_application),
           edit_steps_client_details_path(crime_application),
-          edit_steps_client_contact_details_path(crime_application),
+          edit_steps_client_is_means_tested_path(crime_application),
           edit_steps_client_case_type_path(crime_application),
         ]
       )
@@ -85,10 +90,16 @@ module DeveloperTools
           last_name: surname,
           other_names: '',
           date_of_birth: overrides.fetch(:dob, details[:dob]),
+          has_nino: overrides.fetch(:has_nino, 'yes'),
           nino: overrides.fetch(:nino, details[:nino]),
+          has_arc: overrides.fetch(:has_arc, 'no'),
+          arc: overrides.fetch(:nino, nil),
           benefit_type: overrides.fetch(:benefit_type, 'universal_credit'),
           last_jsa_appointment_date: overrides.fetch(:last_jsa_appointment_date, nil),
           benefit_check_result: overrides.fetch(:benefit_check_result, true),
+          residence_type: overrides.fetch(:residence_type, 'none'),
+          correspondence_address_type: CorrespondenceType::PROVIDERS_OFFICE_ADDRESS,
+          telephone_number: '123456789',
         )
       end
     end
@@ -96,6 +107,16 @@ module DeveloperTools
 
     def find_or_create_case
       Case.find_or_initialize_by(crime_application_id: crime_application.id)
+    end
+
+    def find_or_create_partner_detail(overrides = {})
+      PartnerDetail.find_or_initialize_by(crime_application_id: crime_application.id).tap do |record|
+
+        record.update(
+          has_partner: overrides.fetch(:has_partner, 'no'),
+          relationship_status: overrides.fetch(:relationship_status, 'single'),
+        )
+      end
     end
   end
 end

--- a/app/models/concerns/type_of_application.rb
+++ b/app/models/concerns/type_of_application.rb
@@ -35,7 +35,7 @@ module TypeOfApplication
   alias cifc? change_in_financial_circumstances?
 
   def appeal_no_changes?
-    return false unless kase&.appeal_original_app_submitted == 'yes'
+    return false unless kase.present? && kase.appeal_original_app_submitted == 'yes'
 
     kase.case_type == CaseType::APPEAL_TO_CROWN_COURT.to_s &&
       kase.appeal_financial_circumstances_changed == 'no'


### PR DESCRIPTION
## Description of change
Fixes the under 18 and bypass dwp dev tools which were broken since the application has been updated with new questions

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1485

## Notes for reviewer
These dev tool buttons may need rethinking as a whole as there may be new buttons we could implement that would be useful for testing purposes

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Start a new application. Go to the dev tools and select bypass dwp and check that the dwp result is confirmed. 
Then start another application, click the under 18 bypass and check that the applicant is under 18 as expected.  