### PR TITLE
Enable Dependabot checks for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Description of change
Added `dependabot.yml` to check GitHub Actions for updates. This will help us to keep our workflow actions updated as warnings about deprecated versions often go unnoticed.

## Link to relevant ticket
[CRIMAPP-1353](https://dsdmoj.atlassian.net/browse/CRIMAPP-1353)

[CRIMAPP-1353]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ