### PR TITLE
Hide warning text when search enabled

### DIFF
--- a/app/views/application_searches/new.html.erb
+++ b/app/views/application_searches/new.html.erb
@@ -3,7 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-5"><%= t('search.heading') %></h1>
-    <%= govuk_warning_text text: 'This page is for test purposes only' %>
+    <% unless FeatureFlags.search.enabled? %>
+      <%= govuk_warning_text text: 'This page is for test purposes only' %>
+    <% end %>
     <p class="govuk-body"><%= t('search.subheading', current_office_code:) %></p>
     <%= render @filter %>
   </div>

--- a/app/views/application_searches/search.html.erb
+++ b/app/views/application_searches/search.html.erb
@@ -3,7 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-5"><%= t('search.heading') %></h1>
-    <%= govuk_warning_text text: 'This page is for test purposes only' %>
+    <% unless FeatureFlags.search.enabled? %>
+      <%= govuk_warning_text text: 'This page is for test purposes only' %>
+    <% end %>
     <p class="govuk-body"><%= t('search.subheading', current_office_code:) %></p>
     <%= render @search.filter %>
   </div>


### PR DESCRIPTION
## Description of change
Hides the warning text that was added for user research purposes. The text will not display when the feature flag is enabled. 

## Link to relevant ticket

## Notes for reviewer
When search is eventually enabled and deployed, we will need to remove the warning text (will add to a ticket)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
