### PR TITLE
CRIMAPP-1499: Remove back link from completed application page

### DIFF
--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -1,6 +1,4 @@
 <% title t('.page_title') %>
-<% step_header(path: :back) %>
-
 <% content_for(:head) do %>
   <%= stylesheet_link_tag 'print', media: 'print' %>
 <% end %>


### PR DESCRIPTION
## Description of change

Remove back link from completed application page

## Link to relevant ticket

[CRIMAPP-1499](https://dsdmoj.atlassian.net/browse/CRIMAPP-1499)

## Notes for reviewer

Now that search requests use POST, it's better for users to rely on the browser's native back button to return to the search results page. This ensures the search form remains populated.

The GOV.UK Design System advises using back links for question pages and other pages within a multi-page transaction when appropriate. However, it does not apply in this case.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1499]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ