### PR TITLE
Standardize default page size

### DIFF
--- a/app/models/pagination.rb
+++ b/app/models/pagination.rb
@@ -2,7 +2,7 @@ class Pagination
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  DEFAULT_LIMIT_VALUE = 50
+  DEFAULT_LIMIT_VALUE = Kaminari.config.default_per_page
   DEFAULT_CURRENT_PAGE = 1
 
   attribute :current_page, :integer, default: DEFAULT_CURRENT_PAGE

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 10
+  config.default_per_page = 20 
   config.outer_window = 1
   config.window = 1
 end

--- a/spec/models/pagination_spec.rb
+++ b/spec/models/pagination_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Pagination do
     end
 
     context 'when no attribute provided' do
-      it { is_expected.to be 50 }
+      it { is_expected.to be 20 }
     end
   end
 end


### PR DESCRIPTION
## Description of change

Change dashboard page size from 10 to 20 so that is consistent with the new search pagination.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
