### PR TITLE
[CRIMAPP-1369] Datastore unavailable content

### DIFF
--- a/app/views/completed_applications/_datastore_unavailable.html.erb
+++ b/app/views/completed_applications/_datastore_unavailable.html.erb
@@ -2,10 +2,8 @@
   <%= t('shared.errors.datastore.unavailable.heading') %>
 </h2>
 
-<p class="govuk-body">
-  <%= t('shared.errors.datastore.unavailable.explanation') %>
-</p>
-
-<p class="govuk-body">
-  <%= t('shared.errors.datastore.unavailable.contact_helpline_html', helpline_url: about_contact_path) %>
-</p>
+<% t('shared.errors.datastore.unavailable.body_html', helpline_url: about_contact_path).each do |paragraph| %>
+  <p class="govuk-body">
+    <%= paragraph %>
+  </p>
+<% end %>

--- a/app/views/steps/submission/failure/edit.html.erb
+++ b/app/views/steps/submission/failure/edit.html.erb
@@ -7,15 +7,11 @@
       <%= t('.heading')%>
     </h1>
 
-    <p class="govuk-body">
-      <%= t('.lead_text') %>
-    </p>
-    <p class="govuk-body">
-      <%= t('.info_text') %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-6">
-      <%= t('.contact_helpline_html', helpline_url: about_contact_path) %>
-    </p>
+    <% t('.body_html', helpline_url: about_contact_path).each do |paragraph| %>
+      <p class="govuk-body">
+        <%= paragraph %>
+      </p>
+    <% end %>
 
     <%= step_form @form_object do |f| %>
       <%= f.continue_button(primary: :try_again, secondary: nil) %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -120,8 +120,9 @@ en:
       datastore:
         unavailable:
           heading: Sorry, there is a problem with the service
-          explanation: We cannot connect to our database. This means that you cannot view submitted or returned applications.
-          contact_helpline_html: Try reloading the page or <a href="%{helpline_url}">contact the criminal applications helpline</a> if you need to get an update on submitted applications.
+          body_html:
+            - Try reloading the page or return to your applications list.
+            - For an update on a submitted application, <a class="govuk-link govuk-link--no-visited-state" href="%{helpline_url}">contact the criminal applications helpline</a>.
       no_records:
         in_progress: There are no applications in progress
         submitted: There are no submitted applications

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -760,8 +760,9 @@ en:
 
       failure:
         edit:
-          page_title: Application submission failed
+          page_title: Sorry, the service is unavailable
           heading: Sorry, there is a problem with the service
-          lead_text: We cannot connect to our database. This means you cannot submit applications in progress, or view returned and submitted applications.
-          info_text: We have saved your latest application in progress.
-          contact_helpline_html: <a href="%{helpline_url}">Contact the criminal applications helpline</a> if you need to get an update on submitted applications.
+          body_html:
+            - Try reloading the page.
+            - To continue editing another application, return to your applications list.
+            - If you're having problems submitting an application, <a class="govuk-link govuk-link--no-visited-state" href="%{helpline_url}">contact the technical support team</a>.


### PR DESCRIPTION
## Description of change
Updates to the content shown when Apply can't connect to the datastore.

## Link to relevant ticket
[CRIMAPP-1369](https://dsdmoj.atlassian.net/browse/CRIMAPP-1369)

## Screenshots of changes (if applicable)
### After changes:
![image](https://github.com/user-attachments/assets/59a2fa8f-acb0-4f40-ab73-ad814a9877ca)
![image](https://github.com/user-attachments/assets/1ccb8d26-eaac-4e05-a040-4928c48ffb47)

[CRIMAPP-1369]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ