### PR TITLE
[CRIMAPP-1508] Fix premium bonds content

### DIFF
--- a/app/presenters/summary/sections/partner_premium_bonds.rb
+++ b/app/presenters/summary/sections/partner_premium_bonds.rb
@@ -2,6 +2,8 @@ module Summary
   module Sections
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     class PartnerPremiumBonds < Sections::BaseSection
+      include HasDynamicSubject
+
       def show?
         show_partner_premium_bonds? && super
       end
@@ -38,6 +40,10 @@ module Summary
 
       def partner_have_premium_bonds?
         YesNoAnswer.new(capital.partner_has_premium_bonds).yes?
+      end
+
+      def subject_type
+        SubjectType.new(:partner)
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/app/presenters/summary/sections/premium_bonds.rb
+++ b/app/presenters/summary/sections/premium_bonds.rb
@@ -2,6 +2,8 @@ module Summary
   module Sections
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     class PremiumBonds < Sections::BaseSection
+      include HasDynamicSubject
+
       def show?
         shown_premium_bonds? && super
       end

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -113,8 +113,8 @@ en:
         national_savings_or_post_office: National Savings or Post Office account
         other: Other cash investment
       partner_employment_details: Employment
-      premium_bonds: "Premium Bonds: client"
-      partner_premium_bonds: "Premium Bonds: partner"
+      premium_bonds: Premium Bonds
+      partner_premium_bonds: Premium Bonds
       investments: Investments
       investment:
         bond: Investment bond


### PR DESCRIPTION
## Description of change
Updates to the 'Premium Bonds' summary card to align it with the other summary cards - ': client' is only shown when a partner is included in the application.

## Link to relevant ticket
[CRIMAPP-1508](https://dsdmoj.atlassian.net/browse/CRIMAPP-1508)
[Figma design](https://www.figma.com/design/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=19698-65906&t=Dl32HUvXFHf6vQOF-1)

## Screenshots of changes (if applicable)

### After changes:
![image](https://github.com/user-attachments/assets/e908bf16-6465-49e9-a3e7-baadec14dac3)


[CRIMAPP-1508]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ