### PR TITLE
[CRIMAPP-1516] Property ownership validation

### DIFF
--- a/app/controllers/steps/capital/saving_type_controller.rb
+++ b/app/controllers/steps/capital/saving_type_controller.rb
@@ -20,7 +20,6 @@ module Steps
       end
 
       def require_no_savings
-        # pp current_crime_application.capital.savings
         return true if current_crime_application.capital.savings.empty?
 
         redirect_to edit_steps_capital_savings_summary_path(current_crime_application)

--- a/app/controllers/steps/capital/usual_property_details_controller.rb
+++ b/app/controllers/steps/capital/usual_property_details_controller.rb
@@ -1,0 +1,21 @@
+module Steps
+  module Capital
+    class UsualPropertyDetailsController < Steps::CapitalStepController
+      def edit
+        @form_object = UsualPropertyDetailsForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(UsualPropertyDetailsForm, as: :usual_property_details)
+      end
+
+      private
+
+      def additional_permitted_params
+        [:action]
+      end
+    end
+  end
+end

--- a/app/forms/steps/capital/usual_property_details_form.rb
+++ b/app/forms/steps/capital/usual_property_details_form.rb
@@ -1,0 +1,32 @@
+module Steps
+  module Capital
+    class UsualPropertyDetailsForm < Steps::BaseFormObject
+      attr_accessor :action
+
+      validates :action, presence: true
+      validates :action, inclusion: { in: :choices }
+
+      def choices
+        UsualPropertyDetailsAnswer.values
+      end
+
+      def home_address
+        crime_application.applicant.home_address.values_at(
+          *::Address::ADDRESS_ATTRIBUTES
+        ).compact_blank.join("\r\n")
+      end
+
+      def residence_ownership
+        crime_application.applicant.residence_type
+      end
+
+      private
+
+      # :nocov:
+      def persist!
+        true
+      end
+      # :nocov:
+    end
+  end
+end

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -71,6 +71,20 @@ class Capital < ApplicationRecord
     super if requires_full_capital?
   end
 
+  def usual_property_details_required?
+    return false unless FeatureFlags.property_ownership_validation.enabled?
+    return false unless requires_full_capital?
+
+    residence_type = ResidenceType.new(crime_application.applicant.residence_type)
+    if residence_type.owned?
+      return false if residence_type == ResidenceType::PARTNER_OWNED && !MeansStatus.include_partner?(crime_application)
+
+      return crime_application.properties.home_address.blank?
+    end
+
+    false
+  end
+
   private
 
   def confirmation_validator

--- a/app/validators/capital_assessment/answers_validator.rb
+++ b/app/validators/capital_assessment/answers_validator.rb
@@ -23,6 +23,7 @@ module CapitalAssessment
         errors.add :national_savings_certificates, :incomplete_records unless national_savings_certificates_complete?
         errors.add :investment_type, :blank unless investment_type_complete?
         errors.add :investments, :incomplete_records unless investments_complete?
+        errors.add :usual_property_details, :blank unless usual_property_details_complete?
       end
 
       errors.add :trust_fund, :blank unless trust_fund_complete?
@@ -110,6 +111,10 @@ module CapitalAssessment
 
     def frozen_income_savings_assets_complete?
       record.has_frozen_income_or_assets.present? || income&.has_frozen_income_or_assets.present?
+    end
+
+    def usual_property_details_complete?
+      !record.usual_property_details_required?
     end
   end
 end

--- a/app/value_objects/residence_type.rb
+++ b/app/value_objects/residence_type.rb
@@ -9,4 +9,12 @@ class ResidenceType < ValueObject
     SOMEONE_ELSE = new(:someone_else),
     NONE = new(:none),
   ].freeze
+
+  def owned?
+    [
+      APPLICANT_OWNED,
+      PARTNER_OWNED,
+      JOINT_OWNED
+    ].include?(self)
+  end
 end

--- a/app/value_objects/usual_property_details_answer.rb
+++ b/app/value_objects/usual_property_details_answer.rb
@@ -1,0 +1,6 @@
+class UsualPropertyDetailsAnswer < ValueObject
+  VALUES = [
+    PROVIDE_DETAILS = new(:provide_details),
+    CHANGE_ANSWER = new(:change_answer)
+  ].freeze
+end

--- a/app/views/steps/capital/usual_property_details/edit.html.erb
+++ b/app/views/steps/capital/usual_property_details/edit.html.erb
@@ -1,0 +1,22 @@
+<% title t('.heading', residence_ownership: t(".residence_ownership.#{@form_object.residence_ownership}")) %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+
+    <span class="govuk-caption-xl"><%= t('steps.capital.caption') %></span>
+
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading', residence_ownership: t(".residence_ownership.#{@form_object.residence_ownership}")) %>
+    </h1>
+
+    <p class="govuk-body"><%= t('.info', residence_ownership: t(".residence_ownership.#{@form_object.residence_ownership}")) %></p>
+    <%= simple_format(@form_object.home_address, class: 'govuk-body') %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :action, @form_object.choices, :value %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -858,6 +858,10 @@ en:
           attributes:
             property_type:
               blank: Select which assets %{subject} owns or part-owns inside or outside the UK, or select 'They do not own any of these assets'
+        steps/capital/usual_property_details_form:
+          attributes:
+            action:
+              blank: Select what you want to do next
         steps/capital/saving_type_form:
           attributes:
             saving_type:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -340,6 +340,8 @@ en:
         heading: You cannot submit this application yet, as we cannot check %{subject}'s benefit status without their National Insurance number
       steps_capital_property_type_form:
         property_type: Which assets does %{subject} own or part-own inside or outside the UK?
+      steps_capital_usual_property_details_form:
+        action: What do you want to do next?
       steps_capital_other_property_type_form:
         property_type: Which other assets does %{subject} own or part-own inside or outside the UK?
       steps_capital_saving_type_form:
@@ -1130,6 +1132,10 @@ en:
           none: They do not own any of these assets
       steps_capital_other_property_type_form:
         property_type_options: *PROPERTY_TYPE_OPTIONS
+      steps_capital_usual_property_details_form:
+        action_options:
+          provide_details: Provide the details of this property
+          change_answer: Change answer to where your client usually lives
       steps_capital_saving_type_form:
         saving_type_options: &SAVING_TYPE_OPTIONS
           bank: Bank accounts

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -664,6 +664,15 @@ en:
         edit:
           page_title: Check your answers - Your client's capital
           heading: Check your answers
+      
+      usual_property_details:
+        edit:
+          heading: You need to give the details about the property your client usually lives in and that %{residence_ownership}
+          info: "You told us your client usually lives in a property %{residence_ownership}:"
+          residence_ownership:
+            applicant_owned: they own
+            partner_owned: their partner owns
+            joint_owned: they and their partner own
 
     evidence:
       upload:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,9 @@ Rails.application.routes.draw do
 
       namespace :capital do
         edit_step :which_assets_owned, alias: :property_type
+        if FeatureFlags.property_ownership_validation.enabled?
+          edit_step :usual_property_details
+        end
         crud_step :residential_property, alias: :residential_property, param: :property_id
         crud_step :commercial_property, alias: :commercial_property, param: :property_id
         crud_step :land, alias: :land, param: :property_id

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  property_ownership_validation:
+    local: false
+    staging: true
+    production: false
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/spec/controllers/steps/capital/usual_property_details_controller_spec.rb
+++ b/spec/controllers/steps/capital/usual_property_details_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::UsualPropertyDetailsController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::Capital::UsualPropertyDetailsForm,
+                  Decisions::CapitalDecisionTree
+end

--- a/spec/forms/steps/capital/usual_property_details_form_spec.rb
+++ b/spec/forms/steps/capital/usual_property_details_form_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Capital::UsualPropertyDetailsForm do
+  subject(:form) { described_class.new(crime_application:) }
+
+  let(:applicant) { instance_double(Applicant, home_address:, residence_type:) }
+  let(:home_address) { nil }
+  let(:residence_type) { nil }
+  let(:capital) { instance_double(Capital) }
+  let(:crime_application) { instance_double(CrimeApplication, applicant:, capital:) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:action, :blank, 'Select what you want to do next') }
+
+    context 'when the action is an invalid option' do
+      before { form.action = 'invalid_option' }
+
+      it 'raises an inclusion error' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:action, :inclusion)).to be(true)
+      end
+    end
+  end
+
+  describe '#choices' do
+    it { expect(form.choices).to eq(UsualPropertyDetailsAnswer.values) }
+  end
+
+  describe '#home_address' do
+    let(:home_address) {
+      HomeAddress.new(address_line_one: '1 Test Road', city: 'London', postcode: 'SW1 1RT',
+                      country: 'United Kingdom')
+    }
+
+    it "returns client's formatted home address" do
+      expect(form.home_address).to eq("1 Test Road\r\nLondon\r\nSW1 1RT\r\nUnited Kingdom")
+    end
+  end
+
+  describe '#residence_ownership' do
+    context 'when the residence is owned by the client' do
+      let(:residence_type) { ResidenceType::APPLICANT_OWNED.to_s }
+
+      it { expect(form.residence_ownership).to eq(ResidenceType::APPLICANT_OWNED.to_s) }
+    end
+
+    context 'when the residence is owned by the partner' do
+      let(:residence_type) { ResidenceType::PARTNER_OWNED.to_s }
+
+      it { expect(form.residence_ownership).to eq(ResidenceType::PARTNER_OWNED.to_s) }
+    end
+
+    context 'when the residence is joint owned by the client and the partner' do
+      let(:residence_type) { ResidenceType::JOINT_OWNED.to_s }
+
+      it { expect(form.residence_ownership).to eq(ResidenceType::JOINT_OWNED.to_s) }
+    end
+  end
+end

--- a/spec/validators/capital_assessment/answers_validator_spec.rb
+++ b/spec/validators/capital_assessment/answers_validator_spec.rb
@@ -97,6 +97,10 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
         }
       end
 
+      before do
+        allow(record).to receive(:usual_property_details_required?).and_return(false)
+      end
+
       it 'does not add any errors' do
         subject.validate
       end
@@ -125,6 +129,7 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
 
       before do
         allow(income).to receive(:has_frozen_income_or_assets).and_return(nil)
+        allow(record).to receive(:usual_property_details_required?).and_return(true)
       end
 
       it 'adds errors for all failed validations' do # rubocop:disable RSpec/MultipleExpectations
@@ -138,6 +143,7 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
         expect(errors).to receive(:add).with(:has_national_savings_certificates, :blank)
         expect(errors).to receive(:add).with(:national_savings_certificates, :incomplete_records)
         expect(errors).to receive(:add).with(:investments, :incomplete_records)
+        expect(errors).to receive(:add).with(:usual_property_details, :blank)
         expect(errors).to receive(:add).with(:trust_fund, :blank)
         expect(errors).to receive(:add).with(:partner_trust_fund, :blank)
         expect(errors).to receive(:add).with(:frozen_income_savings_assets_capital, :blank)
@@ -541,6 +547,24 @@ RSpec.describe CapitalAssessment::AnswersValidator, type: :model do
 
         expect(subject.frozen_income_savings_assets_complete?).to be(false)
       end
+    end
+  end
+
+  describe '#usual_property_details_complete?' do
+    context 'when the usual property details are required' do
+      before do
+        allow(record).to receive(:usual_property_details_required?).and_return(true)
+      end
+
+      it { expect(subject.usual_property_details_complete?).to be(false) }
+    end
+
+    context 'when the usual property details are not required' do
+      before do
+        allow(record).to receive(:usual_property_details_required?).and_return(false)
+      end
+
+      it { expect(subject.usual_property_details_complete?).to be(true) }
     end
   end
 end

--- a/spec/value_objects/usual_property_details_answer_spec.rb
+++ b/spec/value_objects/usual_property_details_answer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe UsualPropertyDetailsAnswer do
+  subject { described_class.new(value) }
+
+  let(:value) { :foo }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w[provide_details change_answer])
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This changes adds validation in the capital section to check whether the client's usual residence is declared as a property. A new question is asked to allow the user to either add a new property with a matching home address or change where the client usually lives.

The changes are behind the feature flag `property_ownership_validation`.

## Link to relevant ticket
[CRIMAPP-1516](https://dsdmoj.atlassian.net/browse/CRIMAPP-1516)

## Screenshots of changes (if applicable)

### After changes:
![image](https://github.com/user-attachments/assets/8efdf4a3-580a-447f-97bc-c594e2c66dc2)

## How to manually test the feature
1. Create an application and when asked 'Where does your client usually live?' answer 'In a property they own', 'In a property their partner owns', or 'In a property they and their partner both own'.
2. At the capital section, when asked about which assets the client (and/or partner) owns, answer 'They do not own any of these assets'.
3. You should see the new question.

The new question should also be triggered after answering 'No' to 'Do you want to add another asset?' if there is no asset that matches the home address.
The new question (and validation) shouldn't be triggered if the client has a partner and they live in a property owned by the partner and there's a conflict of interest.

[CRIMAPP-1516]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ