### PR TITLE
CRIMAPP-1552 make task list page title same as h1

### DIFF
--- a/app/views/crime_applications/edit.html.erb
+++ b/app/views/crime_applications/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title t(@crime_application.application_type, scope: %i[tasklist heading_text]) %>
 <% step_header(path: :back) %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Description of change

Make task list page title same as h1

## Link to relevant ticket
[CRIMAPP-1552](https://dsdmoj.atlassian.net/browse/CRIMAPP-1552)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1552]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ