### PR TITLE
[CRIMAPP-1557] Change hint to a caption

### DIFF
--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -8,7 +8,7 @@
     <%= govuk_error_summary(@form_object) %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-    <p class="govuk-hint govuk-!-margin-bottom-6"><%=t '.subheading' %></p>
+    <p class="govuk-caption-m govuk-!-margin-bottom-6"><%=t '.subheading' %></p>
 
     <%= step_form @form_object, data: { module: 'multi-action-form' } do |f| %>
       <% suggestions_id = f.field_id(:offence_name, :field, :suggestions).tr('_', '-') %>


### PR DESCRIPTION
## Description of change
The hint text on the charges screen was not associated with an input or interactive element. Changed to a caption as there is already a hint text associated with the input field 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1557

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
