### PR TITLE
[CRIMAPP-1558] Apply error styling to autocomplete input field

### DIFF
--- a/app/assets/stylesheets/local/accessible-autocomplete.scss
+++ b/app/assets/stylesheets/local/accessible-autocomplete.scss
@@ -164,3 +164,10 @@
     line-height: 1.31579;
   }
 }
+
+/* Required to apply the govuk error message styling to the input field */
+.govuk-form-group--error {
+  .autocomplete__input {
+    border-color: govuk-colour("red");
+  }
+}


### PR DESCRIPTION
## Description of change
Fixes issue where the red outline was not appearing around the input field for accessible autocomplete components when there is an error message as per gov uk design conventions

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1558 

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="874" alt="Screenshot 2025-01-16 at 17 08 53" src="https://github.com/user-attachments/assets/47f346c2-fe61-4bf8-b216-1367a504aa58" />


### After changes:
<img width="874" alt="Screenshot 2025-01-16 at 16 51 21" src="https://github.com/user-attachments/assets/63c767c0-7681-4328-9ca7-4a15dbab3cc9" />
<img width="874" alt="Screenshot 2025-01-16 at 16 52 26" src="https://github.com/user-attachments/assets/4998a56a-ead9-4272-bb80-4875ddaa972f" />



## How to manually test the feature
