### PR TITLE
CRIMAPP-1581 prepare for outcome status user research

### DIFF
--- a/app/presenters/summary/components/funding_decision.rb
+++ b/app/presenters/summary/components/funding_decision.rb
@@ -12,6 +12,9 @@ module Summary
             :funding_decision_case_number, funding_decision.case_id
           ),
           Components::ValueAnswer.new(
+            :funding_decision_court_type, funding_decision.court_type
+          ),
+          Components::ValueAnswer.new(
             :funding_decision_ioj_result, funding_decision.interests_of_justice&.result
           ),
           Components::FreeTextAnswer.new(
@@ -32,8 +35,8 @@ module Summary
           Components::DateAnswer.new(
             :funding_decision_means_date, funding_decision.means&.assessed_on
           ),
-          Components::TagAnswer.new(
-            :funding_decision_overall_result, funding_decision.funding_decision
+          Components::ValueAnswer.new(
+            :funding_decision_overall_result, overall_result
           ),
           Components::FreeTextAnswer.new(
             :funding_decision_further_info, funding_decision.comment
@@ -47,6 +50,26 @@ module Summary
 
       def status_tag
         nil
+      end
+
+      # TODO: source from datastore once decision on simplified statuses resolved
+      def overall_result
+        return 'granted_failed_means' if granted? && failed_means?
+        return 'granted_with_contribution' if granted? && with_contribution?
+
+        record.funding_decision
+      end
+
+      def granted?
+        record.funding_decision == 'granted'
+      end
+
+      def failed_means?
+        record.means&.result == 'failed'
+      end
+
+      def with_contribution?
+        record.means&.result == 'passed_with_contribution'
       end
 
       def funding_decision

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -703,6 +703,11 @@ en:
         question: MAAT ID
       funding_decision_case_number:
         question: Case number
+      funding_decision_court_type:
+        question: Means test
+        answers:
+          crown: Crown Court
+          magistrates: Magistrates Court
       funding_decision_ioj_result:
         question: Interests of justice (IoJ) test result
         answers:
@@ -727,12 +732,11 @@ en:
       funding_decision_overall_result:
         question: Overall result
         answers:
-          granted:
-            value: Granted
-            colour: green
-          refused:
-            value: Refused
-            colour: red
+          granted: Granted
+          refused: Refused
+          granted_failed_means: Granted - failed means test
+          granted_with_contribution: Granted - with a contribution
+
       funding_decision_further_info:
         question: Further information about the decision
       # END funding decisions section

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -8,17 +8,16 @@ describe Summary::Components::FundingDecision, type: :component do
 
   let(:attributes) do
     {
-      case_id:,
-      maat_id:,
-      interests_of_justice:,
-      means:,
-      funding_decision:,
-      comment:
+      case_id: 'APP123',
+      maat_id: 'M123',
+      interests_of_justice: interests_of_justice,
+      means: means,
+      funding_decision: funding_decision,
+      court_type: 'crown',
+      comment: 'Decision comment'
     }
   end
 
-  let(:case_id) { 'APP123' }
-  let(:maat_id) { 'M123' }
   let(:interests_of_justice) do
     instance_double(
       LaaCrimeSchemas::Structs::TestResult,
@@ -28,17 +27,19 @@ describe Summary::Components::FundingDecision, type: :component do
       assessed_on: Date.new(2024, 10, 8),
     )
   end
+
   let(:means) do
     instance_double(
       LaaCrimeSchemas::Structs::TestResult,
-      result: 'failed',
+      result: means_result,
       details: 'Means details',
       assessed_by: 'Grace Nolan',
       assessed_on: Date.new(2024, 10, 9),
     )
   end
+
   let(:funding_decision) { 'refused' }
-  let(:comment) { 'Decision comment' }
+  let(:means_result) { 'failed' }
 
   before { component }
 
@@ -47,6 +48,7 @@ describe Summary::Components::FundingDecision, type: :component do
       expect(summary_card('Case')).to have_rows(
         'MAAT ID', 'M123',
         'Case number', 'APP123',
+        'Means test', 'Crown Court',
         'Interests of justice (IoJ) test result', 'Failed',
         'IoJ comment', 'IoJ details',
         'IoJ caseworker', 'Grace Nolan',
@@ -58,5 +60,25 @@ describe Summary::Components::FundingDecision, type: :component do
         'Further information about the decision', 'Decision comment'
       )
     end
+  end
+
+  context 'when funding decision is "granted" and means "passed"' do
+    let(:funding_decision) { 'granted' }
+    let(:means_result) { 'passed' }
+
+    it { is_expected.to have_text('Granted') }
+  end
+
+  context 'when funding decision is "granted" and means "passed_with_contribution"' do
+    let(:funding_decision) { 'granted' }
+    let(:means_result) { 'passed_with_contribution' }
+
+    it { is_expected.to have_text('Granted - with a contribution') }
+  end
+
+  context 'when funding decision is "granted" and means "failed"' do
+    let(:funding_decision) { 'granted' }
+
+    it { is_expected.to have_text('Granted - failed means test') }
   end
 end


### PR DESCRIPTION
## Description of change

- show simplified overall result
- remove colour tags from overall result
- show court_type (Means test)

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1581

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="924" alt="Screenshot 2025-01-20 at 16 03 28" src="https://github.com/user-attachments/assets/b7ee4889-ad6d-4087-a741-102eb110a4a7" />

### After changes:

### Showing Means test (Court Type)

<img width="931" alt="Screenshot 2025-01-20 at 16 03 59" src="https://github.com/user-attachments/assets/79de6278-e79a-4e65-8c27-c3cfa110c509" />

### Showing simplified overall result
<img width="966" alt="Screenshot 2025-01-20 at 16 03 08" src="https://github.com/user-attachments/assets/ccdeecd5-9863-4d41-8b58-a030050b7f50" />


## How to manually test the feature
