### PR TITLE
[CRIMAPP-1516] Enable property ownership validation in prod

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,9 +4,9 @@ feature_flags:
     staging: true
     production: false
   property_ownership_validation:
-    local: false
+    local: true
     staging: true
-    production: false
+    production: true
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is


### PR DESCRIPTION
## Description of change
Enables the new property ownership validation questions in production.

## Link to relevant ticket
[CRIMAPP-1516](https://dsdmoj.atlassian.net/browse/CRIMAPP-1516)

[CRIMAPP-1516]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ