### PR TITLE
CRIMAPP-1597 show the overall result text from the datastore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.5.3'
+    tag: 'v1.5.4'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: cdfbb169d5949b3c3f813fb364ba9ebeb7a8af31
-  tag: v1.5.3
+  revision: 3fcb1da6f13b61b8ae846c86978cd16dedc4b9a8
+  tag: v1.5.4
   specs:
-    laa-criminal-legal-aid-schemas (1.5.3)
+    laa-criminal-legal-aid-schemas (1.5.4)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
@@ -179,7 +179,7 @@ GEM
       dry-types (>= 1.7, < 2)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.8.0)
+    dry-types (1.8.1)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)

--- a/app/presenters/summary/components/funding_decision.rb
+++ b/app/presenters/summary/components/funding_decision.rb
@@ -35,8 +35,8 @@ module Summary
           Components::DateAnswer.new(
             :funding_decision_means_date, funding_decision.means&.assessed_on
           ),
-          Components::ValueAnswer.new(
-            :funding_decision_overall_result, overall_result
+          Components::FreeTextAnswer.new(
+            :funding_decision_overall_result, funding_decision.overall_result
           ),
           Components::FreeTextAnswer.new(
             :funding_decision_further_info, funding_decision.comment
@@ -50,26 +50,6 @@ module Summary
 
       def status_tag
         nil
-      end
-
-      # TODO: source from datastore once decision on simplified statuses resolved
-      def overall_result
-        return 'granted_failed_means' if granted? && failed_means?
-        return 'granted_with_contribution' if granted? && with_contribution?
-
-        record.funding_decision
-      end
-
-      def granted?
-        record.funding_decision == 'granted'
-      end
-
-      def failed_means?
-        record.means&.result == 'failed'
-      end
-
-      def with_contribution?
-        record.means&.result == 'passed_with_contribution'
       end
 
       def funding_decision

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -12,7 +12,8 @@ describe Summary::Components::FundingDecision, type: :component do
       maat_id: 'M123',
       interests_of_justice: interests_of_justice,
       means: means,
-      funding_decision: funding_decision,
+      funding_decision: 'refused',
+      overall_result: 'Refused - failed means',
       court_type: 'crown',
       comment: 'Decision comment'
     }
@@ -21,7 +22,7 @@ describe Summary::Components::FundingDecision, type: :component do
   let(:interests_of_justice) do
     instance_double(
       LaaCrimeSchemas::Structs::TestResult,
-      result: 'failed',
+      result: 'passed',
       details: 'IoJ details',
       assessed_by: 'Grace Nolan',
       assessed_on: Date.new(2024, 10, 8),
@@ -31,15 +32,12 @@ describe Summary::Components::FundingDecision, type: :component do
   let(:means) do
     instance_double(
       LaaCrimeSchemas::Structs::TestResult,
-      result: means_result,
+      result: 'failed',
       details: 'Means details',
       assessed_by: 'Grace Nolan',
       assessed_on: Date.new(2024, 10, 9),
     )
   end
-
-  let(:funding_decision) { 'refused' }
-  let(:means_result) { 'failed' }
 
   before { component }
 
@@ -49,37 +47,16 @@ describe Summary::Components::FundingDecision, type: :component do
         'MAAT ID', 'M123',
         'Case number', 'APP123',
         'Means test', 'Crown Court',
-        'Interests of justice (IoJ) test result', 'Failed',
+        'Interests of justice (IoJ) test result', 'Passed',
         'IoJ comment', 'IoJ details',
         'IoJ caseworker', 'Grace Nolan',
         'IoJ test date', '8 October 2024',
         'Means test result', 'Failed',
         'Means test caseworker', 'Grace Nolan',
         'Means test date', '9 October 2024',
-        'Overall result', 'Refused',
+        'Overall result', 'Refused - failed means',
         'Further information about the decision', 'Decision comment'
       )
     end
-  end
-
-  context 'when funding decision is "granted" and means "passed"' do
-    let(:funding_decision) { 'granted' }
-    let(:means_result) { 'passed' }
-
-    it { is_expected.to have_text('Granted') }
-  end
-
-  context 'when funding decision is "granted" and means "passed_with_contribution"' do
-    let(:funding_decision) { 'granted' }
-    let(:means_result) { 'passed_with_contribution' }
-
-    it { is_expected.to have_text('Granted - with contribution') }
-    it { is_expected.to have_text('Passed - with contribution') }
-  end
-
-  context 'when funding decision is "granted" and means "failed"' do
-    let(:funding_decision) { 'granted' }
-
-    it { is_expected.to have_text('Granted - failed means test') }
   end
 end


### PR DESCRIPTION
## Description of change

Revert to using eForm's overall result text

## Link to relevant ticket
[CRIMAPP-1597](https://dsdmoj.atlassian.net/browse/CRIMAPP-1597)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1597]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ