### PR TITLE
CRIMAPP-1597 translate overall result

### DIFF
--- a/app/presenters/summary/components/funding_decision.rb
+++ b/app/presenters/summary/components/funding_decision.rb
@@ -35,7 +35,7 @@ module Summary
           Components::DateAnswer.new(
             :funding_decision_means_date, funding_decision.means&.assessed_on
           ),
-          Components::FreeTextAnswer.new(
+          Components::ValueAnswer.new(
             :funding_decision_overall_result, funding_decision.overall_result
           ),
           Components::FreeTextAnswer.new(

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -733,9 +733,12 @@ en:
         question: Overall result
         answers:
           granted: Granted
-          refused: Refused
-          granted_failed_means: Granted - failed means test
           granted_with_contribution: Granted - with contribution
+          granted_failed_means: Granted - failed means
+          refused: Refused
+          refused_failed_ioj: Refused - failed IoJ
+          refused_failed_ioj_and_means: Refused - failed IoJ & means
+          refused_failed_means: Refused - failed means
 
       funding_decision_further_info:
         question: Further information about the decision

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -13,7 +13,7 @@ describe Summary::Components::FundingDecision, type: :component do
       interests_of_justice: interests_of_justice,
       means: means,
       funding_decision: 'refused',
-      overall_result: 'Refused - failed means',
+      overall_result: 'refused_failed_means',
       court_type: 'crown',
       comment: 'Decision comment'
     }


### PR DESCRIPTION
## Description of change

Translate Types::OverallResult in strings

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1597
## Notes for reviewer

The previous plan was to store MAAT strings directly in the datastore overall_result, as MAAT is the source of truth for decisions and its logic is complex. However, testing has shown that these strings do not fully meet providers' needs and may cause confusion.

Instead, the datastore now stores a constant representing the overall result, which Crime Apply and Review translate into text as needed. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
