### PR TITLE
CRIMAPP-1586 hide decisions in production

### DIFF
--- a/app/presenters/summary/sections/funding_decisions.rb
+++ b/app/presenters/summary/sections/funding_decisions.rb
@@ -6,6 +6,8 @@ module Summary
       end
 
       def show?
+        return false unless FeatureFlags.show_funding_decisions.enabled?
+
         crime_application.status == ApplicationStatus::SUBMITTED && funding_decisions.any? && super
       end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,11 @@ feature_flags:
     local: true
     staging: true
     production: true
+  show_funding_decisions:
+    test: true
+    local: true
+    staging: true
+    production: false
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/spec/presenters/summary/sections/funding_decisions_spec.rb
+++ b/spec/presenters/summary/sections/funding_decisions_spec.rb
@@ -48,6 +48,18 @@ describe Summary::Sections::FundingDecisions do
       end
     end
 
+    context 'when the funding decision feature flag is disabled' do
+      before do
+        allow(FeatureFlags).to receive(:show_funding_decisions) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+      end
+
+      it 'does not show this section' do
+        expect(subject.show?).to be(false)
+      end
+    end
+
     context 'when there are no funding decisions' do
       let(:decisions) { [] }
 


### PR DESCRIPTION
## Description of change
Hide decisions added to Crime Review via a Feature Flag

## Link to relevant ticket

[CRIMAPP-1586](https://dsdmoj.atlassian.net/browse/CRIMAPP-1586)

## Notes for reviewer

Before Outcome Playback is released to providers, there will be a trial period where caseworkers can add funding decisions to Crime Review without those decisions being immediately visible to providers on Crime Apply. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1586]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ