### PR TITLE
CRIMAPP-1630 Show 'Refused - ineligible' for Crown Court Means Failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.5.4'
+    tag: 'v1.7.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3fcb1da6f13b61b8ae846c86978cd16dedc4b9a8
-  tag: v1.5.4
+  revision: 89dc95ece96f18fd9f4e766f833ce8bf10e9d1ac
+  tag: v1.7.0
   specs:
-    laa-criminal-legal-aid-schemas (1.5.4)
+    laa-criminal-legal-aid-schemas (1.7.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
@@ -179,7 +179,7 @@ GEM
       dry-types (>= 1.7, < 2)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.8.1)
+    dry-types (1.8.2)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)

--- a/app/presenters/summary/components/funding_decision.rb
+++ b/app/presenters/summary/components/funding_decision.rb
@@ -12,7 +12,7 @@ module Summary
             :funding_decision_case_number, funding_decision.case_id
           ),
           Components::ValueAnswer.new(
-            :funding_decision_court_type, funding_decision.court_type
+            :funding_decision_assessment_rules, funding_decision.assessment_rules
           ),
           Components::ValueAnswer.new(
             :funding_decision_ioj_result, funding_decision.interests_of_justice&.result

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -703,11 +703,14 @@ en:
         question: MAAT ID
       funding_decision_case_number:
         question: Case number
-      funding_decision_court_type:
+      funding_decision_assessment_rules:
         question: Means test
         answers:
-          crown: Crown Court
-          magistrates: Magistrates Court
+          appeal_to_crown_court: Appeal to Crown Court
+          committal_for_sentence: Committal for sentence
+          crown_court: Crown Court
+          magistrates_court: Magistrates Court
+          non_means: Non-means
       funding_decision_ioj_result:
         question: Interests of justice (IoJ) test result
         answers:
@@ -737,8 +740,9 @@ en:
           granted_failed_means: Granted - failed means
           refused: Refused
           refused_failed_ioj: Refused - failed IoJ
-          refused_failed_ioj_and_means: Refused - failed IoJ & means
+          refused_failed_ioj_and_means: Refused - failed IoJ and means
           refused_failed_means: Refused - failed means
+          refused_ineligible: Refused - ineligible
 
       funding_decision_further_info:
         question: Further information about the decision

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -14,7 +14,7 @@ describe Summary::Components::FundingDecision, type: :component do
       means: means,
       funding_decision: 'refused',
       overall_result: 'refused_failed_means',
-      court_type: 'crown',
+      assessment_rules: 'crown_court',
       comment: 'Decision comment'
     }
   end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -255,7 +255,7 @@ describe Summary::HtmlPresenter do
           'reference' => nil,
           'maat_id' => 6_060_001,
           'case_id' => 'NOL123-123123',
-          'court_type' => 'crown',
+          'assessment_rules' => 'crown_court',
           'interests_of_justice' => {
             'result' => 'passed',
             'details' => 'Loss of liberty',
@@ -268,7 +268,7 @@ describe Summary::HtmlPresenter do
             'assessed_on' => '2022-11-11'
           },
           'funding_decision' => 'refused',
-          'overall_result' => 'Refused',
+          'overall_result' => 'refused_ineligible',
         'comment' => 'Ineligible with current income'
         }
       ]


### PR DESCRIPTION
Also use `assessment_rules` instead of `court_type`

## Description of change

This PR supports displaying "Refused - ineligible" as the overall result for cases assessed under Crown Court Trial rules when the means test has failed.

Expands the types of "Means test" to include display of:
- Non-means
- Committal for sentence
- Appeal to Crown Court


## Link to relevant ticket

[CRIMAPP-1630](https://dsdmoj.atlassian.net/browse/CRIMAPP-1630)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1630]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ