### PR TITLE
[CRIMAPP-1606] Outcome playback content update

### DIFF
--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -745,7 +745,7 @@ en:
           refused_ineligible: Refused - ineligible
 
       funding_decision_further_info:
-        question: Further information about the decision
+        question: Comments
       # END funding decisions section
 
       # BEGIN declarations section

--- a/spec/presenters/summary/components/funding_decision_spec.rb
+++ b/spec/presenters/summary/components/funding_decision_spec.rb
@@ -55,7 +55,7 @@ describe Summary::Components::FundingDecision, type: :component do
         'Means test caseworker', 'Grace Nolan',
         'Means test date', '9 October 2024',
         'Overall result', 'Refused - failed means',
-        'Further information about the decision', 'Decision comment'
+        'Comments', 'Decision comment'
       )
     end
   end


### PR DESCRIPTION
## Description of change
Small content amend to the decision summary card: 
- in Apply Provider view of application: ‘Further information about the decision’ row label should be >> ‘Comments’

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1606

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1142" alt="Screenshot 2025-02-10 at 15 03 20" src="https://github.com/user-attachments/assets/25337ff8-9939-4aa6-95e8-c2d1d38b7f6c" />


## How to manually test the feature
