### PR TITLE
[CRIMAPP-1641] has_no_properties not updated in property validation flow

### DIFF
--- a/app/forms/steps/capital/usual_property_details_form.rb
+++ b/app/forms/steps/capital/usual_property_details_form.rb
@@ -3,6 +3,8 @@ module Steps
     class UsualPropertyDetailsForm < Steps::BaseFormObject
       include UsualPropertyDetails
 
+      attr_reader :residential_property
+
       def choices
         UsualPropertyDetailsCapitalAnswer.values
       end
@@ -11,6 +13,17 @@ module Steps
         return if @action.nil?
 
         UsualPropertyDetailsCapitalAnswer.new(@action)
+      end
+
+      private
+
+      def persist!
+        return true unless action == UsualPropertyDetailsCapitalAnswer::PROVIDE_DETAILS
+
+        ::CrimeApplication.transaction do
+          crime_application.capital.update(has_no_properties: nil)
+          @residential_property = crime_application.properties.create!(property_type: PropertyType::RESIDENTIAL.to_s)
+        end
       end
     end
   end

--- a/app/forms/steps/capital/usual_property_details_form.rb
+++ b/app/forms/steps/capital/usual_property_details_form.rb
@@ -20,10 +20,7 @@ module Steps
       def persist!
         return true unless action == UsualPropertyDetailsCapitalAnswer::PROVIDE_DETAILS
 
-        ::CrimeApplication.transaction do
-          crime_application.capital.update(has_no_properties: nil)
-          @residential_property = crime_application.properties.create!(property_type: PropertyType::RESIDENTIAL.to_s)
-        end
+        @residential_property = crime_application.properties.create!(property_type: PropertyType::RESIDENTIAL.to_s)
       end
     end
   end

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -71,9 +71,10 @@ class Capital < ApplicationRecord
     super if requires_full_capital?
   end
 
-  def usual_property_details_required?
+  def usual_property_details_required? # rubocop:disable Metrics/AbcSize
     return false unless FeatureFlags.property_ownership_validation.enabled?
     return false unless requires_full_capital?
+    return false if crime_application.applicant.residence_type.blank?
 
     residence_type = ResidenceType.new(crime_application.applicant.residence_type)
     if residence_type.owned?

--- a/app/models/capital.rb
+++ b/app/models/capital.rb
@@ -52,7 +52,10 @@ class Capital < ApplicationRecord
   end
 
   def has_no_properties
-    super if requires_full_capital?
+    return unless requires_full_capital?
+    return unless properties.empty?
+
+    super
   end
 
   def has_no_savings

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -142,7 +142,7 @@ module Decisions
       end
 
       edit(:residential_property,
-           property_id: crime_application.properties.create!(property_type: PropertyType::RESIDENTIAL.to_s))
+           property_id: form_object.residential_property)
     end
 
     # TODO: : Fix nested conditions

--- a/app/services/decisions/capital_decision_tree.rb
+++ b/app/services/decisions/capital_decision_tree.rb
@@ -141,8 +141,7 @@ module Decisions
         return edit('/steps/client/residence_type')
       end
 
-      edit(:residential_property,
-           property_id: form_object.residential_property)
+      edit(:residential_property, property_id: form_object.residential_property)
     end
 
     # TODO: : Fix nested conditions

--- a/spec/forms/steps/capital/usual_property_details_form_spec.rb
+++ b/spec/forms/steps/capital/usual_property_details_form_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Steps::Capital::UsualPropertyDetailsForm do
     let(:residential_property) { instance_double(Property, property_type: PropertyType::RESIDENTIAL.to_s) }
 
     before do
-      allow(capital).to receive(:update).with(has_no_properties: nil).and_return(true)
       allow(properties).to receive(:create!)
         .with(property_type: PropertyType::RESIDENTIAL.to_s).and_return(residential_property)
     end
@@ -73,7 +72,6 @@ RSpec.describe Steps::Capital::UsualPropertyDetailsForm do
         form.save
       end
 
-      it { expect(capital).not_to have_received(:update) }
       it { expect(properties).not_to have_received(:create!) }
       it { expect(form.residential_property).to be_nil }
     end
@@ -84,7 +82,6 @@ RSpec.describe Steps::Capital::UsualPropertyDetailsForm do
         form.save
       end
 
-      it { expect(capital).to have_received(:update).with(has_no_properties: nil) }
       it { expect(properties).to have_received(:create!).with(property_type: PropertyType::RESIDENTIAL.to_s) }
       it { expect(form.residential_property).to eq(residential_property) }
     end

--- a/spec/models/capital_spec.rb
+++ b/spec/models/capital_spec.rb
@@ -212,7 +212,6 @@ RSpec.describe Capital, type: :model do
     let(:attribute_names) do
       %i[
         has_national_savings_certificates
-        has_no_properties
         has_no_savings
         has_no_investments
         has_premium_bonds
@@ -331,6 +330,42 @@ RSpec.describe Capital, type: :model do
         end
       end
       # rubocop:enable RSpec/NestedGroups
+    end
+  end
+
+  describe '#has_no_properties' do
+    subject(:has_no_properties) { capital.has_no_properties }
+
+    let(:crime_application) { CrimeApplication.new(properties:) }
+    let(:capital) { described_class.new(crime_application:) }
+    let(:properties) { [] }
+
+    before { capital.has_no_properties = 'yes' }
+
+    context 'when a full capital assessment is not required' do
+      before do
+        allow(MeansStatus).to receive(:full_capital_required?).and_return(false)
+      end
+
+      it { expect(has_no_properties).to be_nil }
+    end
+
+    context 'when a full capital assessment is required' do
+      before do
+        allow(MeansStatus).to receive(:full_capital_required?).and_return(true)
+      end
+
+      context 'and properties have been added' do
+        let(:properties) { [Property.new(property_type: 'land')] }
+
+        it { expect(has_no_properties).to be_nil }
+      end
+
+      context 'and no properties have been added' do
+        let(:properties) { [] }
+
+        it { expect(has_no_properties).to eq('yes') }
+      end
     end
   end
 

--- a/spec/services/decisions/capital_decision_tree_spec.rb
+++ b/spec/services/decisions/capital_decision_tree_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Decisions::CapitalDecisionTree do
       capital: capital,
       partner_detail: partner_detail,
       partner: nil,
-      non_means_tested?: false,
-      properties: properties
+      non_means_tested?: false
     )
   end
 
@@ -23,7 +22,6 @@ RSpec.describe Decisions::CapitalDecisionTree do
   let(:partner_detail) { instance_double(PartnerDetail, involvement_in_case:, conflict_of_interest:) }
   let(:involvement_in_case) { nil }
   let(:conflict_of_interest) { nil }
-  let(:properties) { Property.none }
 
   before do
     allow(form_object).to receive_messages(crime_application:)
@@ -411,14 +409,15 @@ RSpec.describe Decisions::CapitalDecisionTree do
 
     context 'and they want to provide the details of the property' do
       let(:action) { UsualPropertyDetailsCapitalAnswer::PROVIDE_DETAILS }
-      let(:property) { instance_double(Property, property_type: 'residential') }
+      let(:residential_property) { instance_double(Property, property_type: 'residential') }
 
       before do
-        allow(properties).to receive(:create!).and_return(property)
+        allow(form_object).to receive(:residential_property).and_return(residential_property)
       end
 
       it 'redirects to `residential_property`' do
-        expect(subject).to have_destination(:residential_property, :edit, id: crime_application, property_id: property)
+        expect(subject).to have_destination(:residential_property, :edit, id: crime_application,
+property_id: residential_property)
       end
     end
 

--- a/spec/system/applying/property_ownership_validation_spec.rb
+++ b/spec/system/applying/property_ownership_validation_spec.rb
@@ -1,0 +1,301 @@
+require 'rails_helper'
+
+RSpec.describe 'Apply for Criminal Legal Aid with cross-question property ownership validation' do
+  describe 'Submitting a means tested application with an employed client who owns a property' do
+    include_context 'when logged in'
+
+    before do
+      # applications
+      click_link('Start an application')
+      choose('New application')
+      save_and_continue
+
+      # edit (Task list)
+      click_link('Client details')
+
+      # steps/client/details
+      fill_in('First name', with: 'Jo')
+      fill_in('Last name', with: 'Bloggs')
+      fill_date('What is their date of birth?', with: 30.years.ago.to_date)
+      save_and_continue
+
+      # steps/client/is-application-means-tested
+      save_and_continue
+
+      # steps/client/case-type
+      choose('Either way')
+      save_and_continue
+
+      # steps/client/date-stamp
+      save_and_continue
+
+      # steps/client/residence-type
+      choose_answer(
+        'Where does your client usually live?',
+        'In a property they own'
+      )
+      save_and_continue
+
+      # steps/address/lookup/{address_id}
+      click_link('Enter address manually')
+
+      # steps/address/details/{address_id}
+      fill_in('Address line 1', with: '1 Test Road')
+      fill_in('Town or city', with: 'London')
+      fill_in('Country', with: 'United Kingdom')
+      fill_in('Postcode', with: 'SW1 1RT')
+      save_and_continue
+
+      # steps/client/contact-details
+      choose_answer('Where shall we send correspondence?', 'Same as usual home address')
+      save_and_continue
+
+      # steps/client/nino
+      choose_answer('Does your client have a National Insurance number?', 'No')
+      save_and_continue
+
+      # steps/client/does-client-have-partner
+      choose_answer('Does your client have a partner?', 'No')
+      save_and_continue
+
+      # steps/client/relationship-status
+      choose_answer("What is your client's relationship status?", 'Single')
+      save_and_continue
+
+      # steps/dwp/benefit-type
+      choose_answer('Does your client get one of these passporting benefits?', 'None of these')
+      save_and_continue
+
+      # steps/client/urn
+      save_and_continue
+
+      # steps/case/has-the-case-concluded
+      choose_answer('Has the case concluded?', 'No')
+      save_and_continue
+
+      # steps/case/has-court-remanded-client-in-custody
+      choose_answer('Has a court remanded your client in custody?', 'No')
+      save_and_continue
+
+      # steps/case/charges/#{charge_id}
+      fill_in('Offence', with: 'Theft from a shop (Over £100,000)')
+      fill_date('Start date 1', with: 1.month.ago.to_date)
+      save_and_continue
+
+      # steps/case/charges-summary
+      choose_answer('Do you want to add another offence?', 'No')
+      save_and_continue
+
+      # steps/case/has-codefendants
+      choose_answer('Does your client have any co-defendants in this case?', 'No')
+      save_and_continue
+
+      # steps/case/client/other-charge-in-progress
+      choose_answer('Is any other criminal case or charge against your client in progress?', 'No')
+      save_and_continue
+
+      # steps/case/hearing-details
+      select('Derby Crown Court', from: 'What court is the hearing at?')
+      fill_date('When is the next hearing', with: 1.week.from_now.to_date)
+      choose_answer('Did this court also hear the first hearing?', 'Yes')
+      save_and_continue
+
+      # steps/case/ioj
+      choose_answers(
+        'Why should your client get legal aid?',
+        ['It is likely that they will lose their livelihood']
+      )
+      fill_in(
+        'steps-case-ioj-form-loss-of-livelihood-justification-field',
+        with: 'IoJ justification details'
+      )
+      save_and_continue
+
+      # steps/income/what-is-clients-employment-status
+      choose_answers("What is your client's employment status?", ['Employed'])
+      save_and_continue
+
+      # steps/income/client/armed-forces
+      choose_answer('Is your client in the armed forces?', 'No')
+      save_and_continue
+
+      # steps/income/current-income-before-tax
+      choose_answer("Is your client's annual income currently more than £12,475 a year before tax?",
+                    'No')
+      save_and_continue
+
+      # steps/income/income-savings-assets-under-restraint-freezing-order
+      choose_answer(
+        'Does your client have any income, savings or assets under a restraint or freezing order?',
+        'No'
+      )
+      save_and_continue
+
+      # steps/income/own-home-land-property
+      choose_answer('Does your client own their home, or any other land or property?', 'No')
+      save_and_continue
+
+      # steps/income/usual-property-details
+      choose_answer('Select the question you want to change the answer to:',
+                    'Whether your client owns their home, land or other property')
+      save_and_continue
+
+      # steps/income/own-home-land-property
+      choose_answer('Does your client own their home, or any other land or property?', 'Yes')
+      save_and_continue
+
+      # steps/income/client/employer-details/#{employment_id}
+      fill_in("Employer's name", with: 'Test Employer')
+      fill_in('Address line 1', with: '98 Test Street')
+      fill_in('Town or city', with: 'London')
+      fill_in('Country', with: 'United Kingdom')
+      fill_in('Postcode', with: 'SW1 1RT')
+      save_and_continue
+
+      # steps/income/client/employment-details/#{employment_id}
+      fill_in('What is your client’s job title?', with: 'Worker')
+      fill_in('What is their salary or wage?', with: '11000')
+      choose_answer('Is this before or after tax?', 'Before tax')
+      choose_answer('How often do they get this payment?', 'Yearly')
+      save_and_continue
+
+      # steps/income/client/deductions-from-pay/#{employment_id}
+      choose_answers('Deductions', ['The client does not have deductions taken from their pay'])
+      save_and_continue
+
+      # steps/income/client/add-employments
+      choose_answer('Do you want to add another job?', 'No')
+      save_and_continue
+
+      # steps/income/client/self-assessment-client
+      choose_answer('Has your client received a Self Assessment tax calculation in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/income/client/other-work-benefits-client
+      choose_answer('Does your client receive any other benefits from work?', 'No')
+      save_and_continue
+
+      # steps/income/which-payments-client
+      choose_answers('Which of these payments does your client get?', ['They do not get any of these payments'])
+      save_and_continue
+
+      # steps/income/which-benefits-client
+      choose_answers('Which of these benefits does your client get?', ['They do not get any of these benefits'])
+      save_and_continue
+
+      # steps/income/does-client-have-dependants
+      choose_answer('Does your client have any dependants?', 'No')
+      save_and_continue
+
+      # steps/income/check-your-answers-income
+      save_and_continue
+
+      # steps/outgoings/housing-payments-where-lives
+      choose_answer('Which of these payments does your client make where they usually live?',
+                    'They do not make any of these payments')
+      save_and_continue
+
+      # steps/outgoings/pay-council-tax
+      choose_answer('Does your client pay Council Tax where they usually live?', 'No')
+      save_and_continue
+
+      # steps/outgoings/which-payments
+      choose_answers('Which of these payments does your client make?',
+                     ['They do not make any of these payments'])
+      save_and_continue
+
+      # steps/outgoings/client-paid-income-tax-rate
+      choose_answer('Has your client paid the 40% income tax rate in the last 2 years?', 'No')
+      save_and_continue
+
+      # steps/outgoings/are-outgoings-more-than-income
+      choose_answer("Are your client's outgoings more than their income?", 'No')
+      save_and_continue
+
+      # steps/outgoings/check-your-answers-outgoings
+      save_and_continue
+
+      # steps/capital/which-assets-owned
+      choose_answer('Which assets does your client own or part-own inside or outside the UK?',
+                    'They do not own any of these assets')
+      save_and_continue
+
+      # steps/capital/usual-property-details
+      choose_answer('What do you want to do next?', 'Provide the details of this property')
+      save_and_continue
+
+      # steps/capital/residential-property/{property_id}
+      choose_answer('Which type of property is it?', 'Terraced')
+      fill_in('How many bedrooms are there?', with: '2')
+      fill_in('How much is the property worth?', with: '540000')
+      fill_in('How much is left to pay on the mortgage?', with: '100000')
+      fill_in('What percentage of the property does your client own?', with: '100')
+      choose_answer('Is the address of the property the same as your client’s home address?', 'Yes')
+      choose_answer('Does anyone else own part of the property?', 'No')
+      save_and_continue
+
+      # steps/capital/add-assets
+      choose_answer('Do you want to add another asset?', 'No')
+      save_and_continue
+
+      # steps/capital/which-savings
+      choose_answer('Which savings do your client have inside or outside the UK?',
+                    'They do not have any of these savings')
+      save_and_continue
+
+      # steps/capital/client-any-premium-bonds
+      choose_answer('Does your client have any Premium Bonds?', 'No')
+      save_and_continue
+
+      # steps/capital/any-national-savings-certificates
+      choose_answer('Does your client have any National Savings Certificates?', 'No')
+      save_and_continue
+
+      # steps/capital/which-investments
+      choose_answer('Which investments does your client have inside or outside the UK?',
+                    'They do not have any of these investments')
+      save_and_continue
+
+      # steps/capital/client-benefit-from-trust-fund
+      choose_answer('Does your client stand to benefit from a trust fund?', 'No')
+      save_and_continue
+
+      # steps/capital/check-your-answers-capital
+      choose_answers('Confirm the following',
+                     ['Tick to confirm your client does not have any other assets or capital'])
+      save_and_continue
+
+      # steps/evidence/upload
+      Document.create_from_file(file: fixture_file_upload('uploads/test.pdf', 'application/pdf'),
+                                crime_application: CrimeApplication.first).update(
+                                  s3_object_key: '123/abcdef1234'
+                                )
+      save_and_continue
+
+      # steps/submission/more-information
+      choose_answer('Do you want to add any other information?', 'No')
+      save_and_continue
+
+      # steps/submission/review
+      save_and_continue
+
+      # steps/submission/declaration
+      fill_in('First name', with: 'Zoe')
+      fill_in('Last name', with: 'Bar')
+      fill_in('Telephone number', with: '07715339488')
+
+      stub_request(:post, 'http://datastore-webmock/api/v1/applications')
+      click_button 'Save and submit application'
+    end
+
+    it 'submits a valid application to the datastore' do
+      expect(
+        a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
+          body = JSON.parse(req.body)['application']
+          body['means_details']['capital_details']['properties'].first['is_home_address'] == 'yes' &&
+          body['means_details']['capital_details']['has_no_properties'].nil?
+        }
+      ).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This fixes an issue where `capital_details.has_no_properties` is not updated if the user chooses to create a residential property as a result of a failed property ownership validation. This causes their assets to not show on Review, where `has_no_properties` is used to determine whether to show their assets.

## Link to relevant ticket
[CRIMAPP-1641](https://dsdmoj.atlassian.net/browse/CRIMAPP-1641)

[CRIMAPP-1641]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ