### PR TITLE
[CRIMAPP-1653] show review status tag and decision link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.7.0'
+    tag: 'v1.7.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 89dc95ece96f18fd9f4e766f833ce8bf10e9d1ac
-  tag: v1.7.0
+  revision: 033dce9a4bcad554fc4fde2f3296ce893f3feecd
+  tag: v1.7.1
   specs:
-    laa-criminal-legal-aid-schemas (1.7.0)
+    laa-criminal-legal-aid-schemas (1.7.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/components/task_list/section_component.rb
+++ b/app/components/task_list/section_component.rb
@@ -23,7 +23,7 @@ module TaskList
     end
 
     def header_content
-      tag.h2(class: 'govuk-heading-m') { section_title }
+      tag.h2(class: 'govuk-heading-m', id: name) { section_title }
     end
 
     def section_title

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title @crime_application.applicant.full_name %>
 <% content_for(:head) do %>
   <%= stylesheet_link_tag 'print', media: 'print' %>
 <% end %>
@@ -8,7 +8,24 @@
     <%= render partial: 'return_notification',
                locals: { return_details: @crime_application.return_details } if @crime_application.returned? %>
 
-             <h1 class="govuk-heading-xl"><%= t(".heading.#{@crime_application.application_type}") %></h1>
+    <div class="govuk-!-margin-bottom-6">
+      <% if @crime_application.review_status.present? %>
+        <%= govuk_tag(text: t(@crime_application.review_status, scope: 'review_status'), colour: 'blue') %>
+      <% end %>
+      <% if @crime_application.decisions.present? %>
+          <%= govuk_link_to(t('.view_funding_decision'), '#funding_decisions', no_visited_state: true, class: 'govuk-!-margin-left-2 govuk-body-m') %>
+      <% end %>
+    </div>
+
+    <p class="govuk-body-l govuk-!-margin-bottom-1">
+      <%= @crime_application.reference %>
+    </p>
+
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+      <%= @crime_application.applicant.full_name %>
+    </h1>
+
+    <h2 class="govuk-heading-l"><%= t(".heading.#{@crime_application.application_type}") %></h2>
 
     <% if @crime_application.can_be_withdrawn? %>
       <div class="govuk-inset-text">
@@ -23,7 +40,7 @@
       </div>
     <% end %>
 
-    <div class="govuk-!-margin-top-8 app-no-print">
+    <div class="govuk-!-margin-top-6 app-no-print">
       <%= link_button t('.print_application'), '#', data: { module: 'print' } %>
     </div>
   </div>

--- a/app/views/steps/submission/shared/_list_section.html.erb
+++ b/app/views/steps/submission/shared/_list_section.html.erb
@@ -1,7 +1,5 @@
 <% if list_section.heading %>
-  <h2 class="govuk-heading-l">
-    <%= t(list_section.heading, scope: 'summary.sections') %>
-  </h2>
+  <%= tag.h2(class: 'govuk-heading-l', id: list_section.heading) { t(list_section.heading, scope: 'summary.sections') } %>
 <% end %>
 
 <%= render list_section.answers, editable: list_section.editable? %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -68,7 +68,6 @@ en:
       page_title: Your applications
       no_records: There are no applications
     show:
-      page_title: Application representation order
       heading:
         initial: Application for a criminal legal aid representation order
         change_in_financial_circumstances: Change in financial circumstances
@@ -83,6 +82,7 @@ en:
         hours: 9am to 5pm, Monday to Friday (excluding bank holidays)
       action:
         create_pse: Upload supporting evidence
+      view_funding_decision: View funding decision
     return_notification:
       title: Important
       heading:

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Dashboard', :authorized do
     it 'renders the representation order page' do
       expect(response).to have_http_status(:success)
 
-      assert_select 'h1', 'Application for a criminal legal aid representation order'
+      assert_select 'h2', 'Application for a criminal legal aid representation order'
     end
 
     it 'has print buttons' do
@@ -148,6 +148,7 @@ RSpec.describe 'Dashboard', :authorized do
     let(:app_split_case) do
       LaaCrimeSchemas.fixture(1.0, name: 'application_returned') do |json|
         json.deep_merge(
+          'review_status' => 'returned_to_provider',
           'return_details' => {
             'reason' => 'split_case',
             'details' => 'Offence 1 reason requires more detail'
@@ -165,6 +166,8 @@ RSpec.describe 'Dashboard', :authorized do
 
     # rubocop:disable Layout/LineLength
     it 'has a notification banner with the return details' do
+      assert_select 'strong.govuk-tag.govuk-tag--blue', 'Returned'
+
       assert_select 'div.govuk-notification-banner' do
         assert_select 'h2', 'Important'
         assert_select 'div.govuk-notification-banner__content' do
@@ -194,7 +197,7 @@ RSpec.describe 'Dashboard', :authorized do
     it 'renders the representation order page' do
       expect(response).to have_http_status(:success)
 
-      assert_select 'h1', 'Application for a criminal legal aid representation order'
+      assert_select 'h2', 'Application for a criminal legal aid representation order'
     end
 
     it 'does not have a button to "Upload supporting evidence"' do


### PR DESCRIPTION
## Description of change

On completed applications page:
- Add application status tag
- Add link to "View funding decision" if decision present
- Add LAA reference heading
- Add applicant name heading

## Link to relevant ticket

[CRIMAPP-1653](https://dsdmoj.atlassian.net/browse/CRIMAPP-1653)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="980" alt="Screenshot 2025-02-20 at 16 52 42" src="https://github.com/user-attachments/assets/7c014db8-a1ce-430e-8152-3812ea6fd4e5" />


### After changes:
<img width="972" alt="Screenshot 2025-02-20 at 16 52 20" src="https://github.com/user-attachments/assets/dfb647f0-424e-4e0c-b615-606583798bad" />



## How to manually test the feature


[CRIMAPP-1653]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ