### PR TITLE
[CRIMAPP-1652]  Make sure `Your applications` marked as current on submitted

### DIFF
--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -8,7 +8,7 @@
             <%= link_to 'Your applications',
                         crime_applications_path,
                         class: 'moj-primary-navigation__link',
-                        aria: { current: ('page' if current_page?(crime_applications_path) || current_page?(completed_crime_applications_path)) } %>
+                        aria: { current: ('page' if current_page?('/applications') || controller.is_a?(CompletedApplicationsController)) } %>
           </li>
 
           <li class="moj-primary-navigation__item">

--- a/spec/system/primary_navigation_spec.rb
+++ b/spec/system/primary_navigation_spec.rb
@@ -31,8 +31,35 @@ RSpec.describe 'Primary navigation' do
   context 'when on "Your applications"' do
     before { click_link('Your applications') }
 
-    it 'the search tab is not the current tab' do
+    it '`Your applications` is the current tab' do
       expect(search_tab_current?).to be false
+      expect(your_applications_tab_current?).to be true
+    end
+  end
+
+  context 'when on the Submitted applications page' do
+    include_context 'with stubbed search results'
+
+    before do
+      click_link('Submitted')
+    end
+
+    it '`Your applications` is the current tab' do
+      expect(search_tab_current?).to be false
+      expect(your_applications_tab_current?).to be true
+    end
+  end
+
+  context 'when on the Returned applications page' do
+    include_context 'with stubbed search results'
+
+    before do
+      click_link('Returned')
+    end
+
+    it '`Your applications` is the current tab' do
+      expect(search_tab_current?).to be false
+      expect(your_applications_tab_current?).to be true
     end
   end
 
@@ -60,5 +87,9 @@ RSpec.describe 'Primary navigation' do
 
   def search_tab_current?
     page.find('a.moj-primary-navigation__link', text: 'Search')['aria-current'] == 'page'
+  end
+
+  def your_applications_tab_current?
+    page.find('a.moj-primary-navigation__link', text: 'Your applications')['aria-current'] == 'page'
   end
 end


### PR DESCRIPTION
## Description of change

Make sure "Your applications" primary navigation tab marked as current when on Submitted, Returned, Decided etc

## Link to relevant ticket

[CRIMAPP-1652](https://dsdmoj.atlassian.net/browse/CRIMAPP-1652)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="512" alt="Screenshot 2025-02-21 at 07 27 25" src="https://github.com/user-attachments/assets/b33d9fbc-ef5c-475f-a5dd-15904a628b9c" />


### After changes:

<img width="563" alt="Screenshot 2025-02-21 at 07 27 08" src="https://github.com/user-attachments/assets/2417cd71-decd-421b-a347-81f077699fc0" />


## How to manually test the feature


[CRIMAPP-1652]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ