### PR TITLE
[CRIMAPP-1567] show notice if funding decision missing

### DIFF
--- a/app/models/concerns/type_of_application.rb
+++ b/app/models/concerns/type_of_application.rb
@@ -12,12 +12,23 @@ module TypeOfApplication
     reviewed?
   end
 
+  def funding_decision_missing?
+    return false unless decided?
+    return false if pse?
+
+    decisions.empty?
+  end
+
   def initial?
     application_type_eql?(:initial)
   end
 
   def returned?
     returned_at.present?
+  end
+
+  def decided?
+    review_status == Types::ReviewApplicationStatus['assessment_completed']
   end
 
   def resubmission?

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,4 +1,4 @@
-class CrimeApplication < ApplicationRecord
+class CrimeApplication < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include TypeOfApplication
   include Passportable
   include MeansOwnershipScope
@@ -135,5 +135,9 @@ class CrimeApplication < ApplicationRecord
     draft.set!('status', ApplicationStatus::IN_PROGRESS.to_s)
 
     Adapters::Structs::CrimeApplication.new(draft.attributes!.as_json)
+  end
+
+  def review_status
+    nil
   end
 end

--- a/app/views/completed_applications/_funding_decision_notification.html.erb
+++ b/app/views/completed_applications/_funding_decision_notification.html.erb
@@ -1,0 +1,7 @@
+<% return unless application.funding_decision_missing? %>
+
+<%= govuk_notification_banner(title_text: t('.title')) do |nb| %>
+  <% nb.with_heading(text: t('.heading')) %>
+  <p><%= t '.processed_on', on: l(application.reviewed_at) %></p>
+  <p><%= t '.explanation' %></p>
+<% end %>

--- a/app/views/completed_applications/_return_notification.html.erb
+++ b/app/views/completed_applications/_return_notification.html.erb
@@ -1,3 +1,5 @@
+<% return unless return_details %>
+
 <div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title"
      data-module="govuk-notification-banner">
   <div class="govuk-notification-banner__header">

--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -5,8 +5,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'return_notification',
-               locals: { return_details: @crime_application.return_details } if @crime_application.returned? %>
+    <%= render(
+          partial: 'return_notification',
+          locals: { return_details: @crime_application.return_details }
+        ) %>
+
+    <%= render(
+          partial: 'funding_decision_notification',
+          locals: { application: @crime_application }
+        ) %>
 
     <div class="govuk-!-margin-bottom-6">
       <% if @crime_application.review_status.present? %>

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -64,6 +64,11 @@ en:
     destroy:
       success_flash: "%{applicant_name}’s application has been deleted"
   completed_applications:
+    funding_decision_notification:
+      title: Important
+      heading: Outcome decided
+      processed_on: This application was processed on %{on}.
+      explanation: Funding decisions made after 12 midday 13 February 2025 will appear in this service.
     index:
       page_title: Your applications
       no_records: There are no applications

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -129,4 +129,10 @@ RSpec.describe CrimeApplication, type: :model do
   end
 
   it_behaves_like 'it has a means ownership scope'
+
+  describe '#decided?' do
+    it 'returns false' do
+      expect(subject.decided?).to be false
+    end
+  end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -60,11 +60,24 @@ RSpec.describe 'Dashboard', :authorized do
 
     context 'when the application has been reviewed' do
       let(:application_fixture) do
-        LaaCrimeSchemas.fixture(1.0) { |data| data.merge('reviewed_at' => 1.day.ago) }.to_json
+        LaaCrimeSchemas.fixture(1.0) do |data|
+          data.merge(reviewed_at: '2025-02-01', review_status: 'assessment_completed').to_json
+        end
       end
 
       it 'has a button to "Upload supporting evidence"' do
         assert_select 'button.govuk-button', count: 1, text: 'Upload supporting evidence'
+      end
+
+      it 'shows funding decision notification if decisions are empty' do
+        assert_select 'strong.govuk-tag.govuk-tag--blue', 'Decided'
+
+        assert_select 'div.govuk-notification-banner' do
+          assert_select 'h2', 'Important'
+          assert_select 'p.govuk-notification-banner__heading', 'Outcome decided'
+          assert_select 'p', 'This application was processed on 1 February 2025.'
+          assert_select 'p', 'Funding decisions made after 12 midday 13 February 2025 will appear in this service.'
+        end
       end
 
       it 'creates a new PSE application' do

--- a/spec/services/adapters/structs/crime_application_spec.rb
+++ b/spec/services/adapters/structs/crime_application_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Adapters::Structs::CrimeApplication do
-  subject { build_struct_application }
+  subject(:application) {
+    Adapters::JsonApplication.new(attributes)
+  }
+
+  let(:attributes) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
 
   describe '#applicant' do
     it 'returns the applicant struct' do
@@ -63,6 +67,62 @@ RSpec.describe Adapters::Structs::CrimeApplication do
   describe '#partner' do
     it 'returns the partner struct' do
       expect(subject.partner).to be_a(Adapters::Structs::Partner)
+    end
+  end
+
+  describe '#decided?' do
+    subject(:decided) { application.decided? }
+
+    context 'when application is `assessment_completed`' do
+      let(:attributes) { super().merge(review_status: Types::ReviewApplicationStatus['assessment_completed']) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when application is `returned_to_provider`' do
+      let(:attributes) { super().merge(review_status: Types::ReviewApplicationStatus['returned_to_provider']) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when application is `application_received`' do
+      let(:attributes) { super().merge(review_status: Types::ReviewApplicationStatus['application_received']) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when application is `ready_for_assessment`' do
+      let(:attributes) { super().merge(review_status: Types::ReviewApplicationStatus['ready_for_assessment']) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#funding_decision_missing?' do
+    subject(:funding_decision_missing) { application.funding_decision_missing? }
+
+    context 'when application is `assessment_completed`' do
+      let(:attributes) { super().merge(review_status: Types::ReviewApplicationStatus['assessment_completed']) }
+
+      context 'when there are no decisions' do
+        it { is_expected.to be true }
+      end
+
+      context 'when there are no decisions and the application is PSE' do
+        let(:attributes) do
+          super().merge(application_type: Types::ApplicationType['post_submission_evidence'])
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when there are decisions' do
+        let(:attributes) do
+          super().merge(decisions: [LaaCrimeSchemas::Structs::Decision.new])
+        end
+
+        it { is_expected.to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change

Add notification if Funding decision is expected but not present (likely because Funding decision completed before OP released)

## Link to relevant ticket

[CRIMAPP-1567](https://dsdmoj.atlassian.net/browse/CRIMAPP-1567)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1002" alt="Screenshot 2025-02-21 at 14 06 20" src="https://github.com/user-attachments/assets/223fc24e-d7c4-401f-8a22-44dabb5d2142" />


### After changes:

<img width="1020" alt="Screenshot 2025-02-21 at 14 06 03" src="https://github.com/user-attachments/assets/3f1ecb0b-8582-4d11-92ad-d32bbf3771ff" />


## How to manually test the feature


[CRIMAPP-1567]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ