### PR TITLE
[LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-5F] redirect to submitted applications

### DIFF
--- a/app/controllers/completed_applications_controller.rb
+++ b/app/controllers/completed_applications_controller.rb
@@ -6,11 +6,9 @@ class CompletedApplicationsController < DashboardController
 
   layout 'application_dashboard', only: [:index]
 
-  # :nocov:
   def index
-    raise 'Define in sub-controller'
+    redirect_to submitted_applications_path
   end
-  # :nocov:
 
   def show
     @presenter = Summary::HtmlPresenter.new(

--- a/spec/system/dashboard/viewing_submitted_applications_spec.rb
+++ b/spec/system/dashboard/viewing_submitted_applications_spec.rb
@@ -41,4 +41,10 @@ RSpec.describe 'Viewing Submitted Criminal Legal Aid applications' do
   end
 
   it_behaves_like 'a datastore api results table'
+
+  it 'redirects back here when visiting the old completed applications path' do
+    visit('completed/applications')
+
+    expect(page).to have_current_path(submitted_applications_path)
+  end
 end


### PR DESCRIPTION
## Description of change

Redirect to the submitted applications tab from "/completed/applications"

## Link to relevant ticket
[LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-5F](https://ministryofjustice.sentry.io/issues/6327861807/)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
