### PR TITLE
[CRIMAPP-1599] Dynamic subject for asset question

### DIFF
--- a/app/presenters/summary/sections/properties.rb
+++ b/app/presenters/summary/sections/properties.rb
@@ -26,7 +26,7 @@ module Summary
       end
 
       def subject_type
-        if crime_application.has_partner?
+        if crime_application.partner.present?
           SubjectType.new(:applicant_and_partner)
         else
           SubjectType.new(:applicant)

--- a/app/presenters/summary/sections/properties.rb
+++ b/app/presenters/summary/sections/properties.rb
@@ -27,14 +27,14 @@ module Summary
 
       def subject_type
         if crime_application.partner.present?
-          SubjectType.new(:applicant_and_partner)
+          SubjectType.new(:applicant_or_partner)
         else
           SubjectType.new(:applicant)
         end
       end
 
       def i18n_opts
-        { count: subject_type.applicant_and_partner? ? 2 : 1 }
+        { count: subject_type.applicant_or_partner? ? 2 : 1 }
       end
 
       def has_records_answer

--- a/app/presenters/summary/sections/properties.rb
+++ b/app/presenters/summary/sections/properties.rb
@@ -9,8 +9,11 @@ module Summary
 
       def has_no_records_component
         Components::ValueAnswer.new(
-          :has_assets, has_records_answer,
-          change_path: edit_steps_capital_property_type_path
+          :has_assets,
+          has_records_answer,
+          change_path: edit_steps_capital_property_type_path,
+          subject_type: subject_type,
+          i18n_opts: i18n_opts
         )
       end
 
@@ -20,6 +23,18 @@ module Summary
 
       def records
         @records ||= capital.properties
+      end
+
+      def subject_type
+        if crime_application.has_partner?
+          SubjectType.new(:applicant_and_partner)
+        else
+          SubjectType.new(:applicant)
+        end
+      end
+
+      def i18n_opts
+        { count: subject_type.applicant_and_partner? ? 2 : 1 }
       end
 
       def has_records_answer

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -920,7 +920,9 @@ en:
         question: Percentage owner %{index} owns
         absence_answer: *absence_none
       has_assets:
-        question: Assets %{subject} owns
+        question:
+          one: Assets %{subject} owns
+          other: Assets %{subject} own or part own
         answers:
           <<: *YESNO
           none: *absence_none

--- a/spec/support/shared_examples/a_capital_records_section.rb
+++ b/spec/support/shared_examples/a_capital_records_section.rb
@@ -5,7 +5,9 @@ RSpec.shared_examples 'a capital records section' do |_options|
     instance_double(
       CrimeApplication,
       to_param: 12_345,
-      capital: capital, in_progress?: true
+      capital: capital,
+      in_progress?: true,
+      has_partner: nil
     )
   end
 

--- a/spec/support/shared_examples/a_capital_records_section.rb
+++ b/spec/support/shared_examples/a_capital_records_section.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'a capital records section' do |_options|
       to_param: 12_345,
       capital: capital,
       in_progress?: true,
-      has_partner: nil
+      partner: nil
     )
   end
 


### PR DESCRIPTION
## Description of change
When there are no capital assets, the section question should refer to "client" or "client or partner" dynamically. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?selectedIssue=CRIMAPP-1599

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1002" alt="Screenshot 2025-02-26 at 09 25 30" src="https://github.com/user-attachments/assets/239a3924-374a-42e8-91b5-d4aaad4e7f1e" />
<img width="1000" alt="Screenshot 2025-02-26 at 09 25 27" src="https://github.com/user-attachments/assets/6da8d4ae-1c6e-4c01-b2aa-050ce9f147fd" />


## How to manually test the feature
