### PR TITLE
[CRIMAPP-1658] ensure declared file type and extension allowed

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -27,13 +27,9 @@ class FileUploadValidator < ActiveModel::Validator
 
   private
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Style/GuardClause
+  # rubocop:disable Style/GuardClause
   def perform_validations
-    unless record.content_type.in?(ALLOWED_CONTENT_TYPES)
-      record.errors.add(
-        :content_type, :invalid
-      )
-    end
+    record.errors.add(:content_type, :invalid) unless content_type_allowed?
 
     if record.file_size < MIN_FILE_SIZE.kilobytes
       record.errors.add(
@@ -47,5 +43,38 @@ class FileUploadValidator < ActiveModel::Validator
       )
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Style/GuardClause
+  # rubocop:enable Style/GuardClause
+
+  def content_type_allowed?
+    return false unless declared_content_type_allowed? && extension_type_allowed?
+    return true if detected_content_type_allowed?
+
+    content_type_undetermined? && declared_as_text_file?
+  end
+
+  def declared_content_type_allowed?
+    ALLOWED_CONTENT_TYPES.include?(record.declared_content_type)
+  end
+
+  def detected_content_type_allowed?
+    ALLOWED_CONTENT_TYPES.include?(record.content_type)
+  end
+
+  def content_type_undetermined?
+    record.content_type == 'application/octet-stream'
+  end
+
+  def declared_as_text_file?
+    %w[text/csv text/plain].include?(record.declared_content_type)
+  end
+
+  def extension_type_allowed?
+    return true if extension_type == 'application/octet-stream'
+
+    ALLOWED_CONTENT_TYPES.include?(extension_type)
+  end
+
+  def extension_type
+    Marcel::MimeType.for(name: record.filename)
+  end
 end

--- a/db/migrate/20250304140637_add_declared_content_type_to_documents.rb
+++ b/db/migrate/20250304140637_add_declared_content_type_to_documents.rb
@@ -1,0 +1,5 @@
+class AddDeclaredContentTypeToDocuments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :documents, :declared_content_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_17_084151) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_04_140637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_17_084151) do
     t.enum "scan_status", default: "awaiting", enum_type: "virus_scan_status"
     t.string "scan_output"
     t.datetime "scan_at"
+    t.string "declared_content_type"
     t.index ["crime_application_id"], name: "index_documents_on_crime_application_id"
   end
 

--- a/spec/controllers/steps/evidence/upload_controller_spec.rb
+++ b/spec/controllers/steps/evidence/upload_controller_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe Steps::Evidence::UploadController, type: :controller do
   it_behaves_like 'a generic step controller', Steps::Evidence::UploadForm, Decisions::EvidenceDecisionTree
   it_behaves_like 'a step that can be drafted', Steps::Evidence::UploadForm
 
-  describe 'additional CRUD actions' do
-    let(:crime_application) { CrimeApplication.create }
-    let(:document) { crime_application.documents.create({ filename: 'test.pdf' }) }
+  include_context('with an existing document')
 
+  describe 'additional CRUD actions' do
     before do
-      document
+      document.save!
     end
 
     context 'deleting a document' do

--- a/spec/support/matchers/error_message.rb
+++ b/spec/support/matchers/error_message.rb
@@ -33,6 +33,25 @@ RSpec::Matchers.define :have_step_error do |error|
   end
 end
 
+RSpec::Matchers.define :have_file_error do |filename, error|
+  match do |page|
+    document_row = page.find('span._uploaded_file__filename', text: filename)
+                       .ancestor('.govuk-table__cell', match: :first)
+
+    @actual_text = document_row.find('.govuk-error-message').text(:all)
+
+    @actual_text[error]
+  end
+
+  description do
+    "renders an error '#{error}' on file '#{filename}'"
+  end
+
+  failure_message do
+    "Expected error '#{error}' on file '#{filename}' got '#{@actual_text}'"
+  end
+end
+
 RSpec::Matchers.define :have_errors do |*question_errors|
   match do |page|
     question_errors.each_slice(2).each do |question, error|

--- a/spec/support/shared_contexts/with_an_existing_document.rb
+++ b/spec/support/shared_contexts/with_an_existing_document.rb
@@ -1,8 +1,14 @@
 RSpec.shared_context 'with an existing document' do
   let(:crime_application) { CrimeApplication.new(usn: 123) }
   let(:file) { fixture_file_upload('uploads/test.pdf', 'application/pdf') }
-  let(:content_type) { 'application/pdf' }
-  let(:attributes) { { crime_application:, content_type: } }
+  let(:content_type) { file.content_type }
+  let(:declared_content_type) { file.content_type }
+  let(:file_size) { file.tempfile.size }
+  let(:filename) { file.original_filename }
+
+  let(:attributes) do
+    { crime_application:, content_type:, declared_content_type:, file_size:, filename: }
+  end
 
   let(:document) do
     Document.new(attributes)

--- a/spec/system/applying/with_supporting_evidence_spec.rb
+++ b/spec/system/applying/with_supporting_evidence_spec.rb
@@ -91,19 +91,23 @@ RSpec.describe 'Supporting evidence' do
 
       # With a fake pdf file
       upload_evidence_file('not_really.pdf')
-      expect(page).to have_content(
+
+      expect(page).to have_file_error(
+        'not_really.pdf',
         'File could not be uploaded – file must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF'
       )
 
       # With a small file
       upload_evidence_file('small.txt')
-      expect(page).to have_content(
+      expect(page).to have_file_error(
+        'small.txt',
         'File could not be uploaded – file must be bigger than 3KB'
       )
 
       # With a pdf that fails the scan
       upload_evidence_file('fails_scan.pdf')
-      expect(page).to have_content(
+      expect(page).to have_file_error(
+        'fails_scan.pdf',
         'File could not be uploaded – try again'
       )
 


### PR DESCRIPTION
## Description of change

Prevent files with a permitted `content_type` but an incorrect or disallowed extension or `declared_content_type` from being uploaded.

## Link to relevant ticket

[CRIMAPP-1658](https://dsdmoj.atlassian.net/browse/CRIMAPP-1658)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1658]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ