### PR TITLE
[CRIMAPP-1670] Update session timeouts on staging

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -10,8 +10,8 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   RAILS_LOG_TO_STDOUT: enabled
   GA_TRACKING_ID: G-5V1GTJM5K7
-  SESSION_TIMEOUT_MINUTES: "1440"
-  REAUTHENTICATE_AFTER_MINUTES: "2880"
+  SESSION_TIMEOUT_MINUTES: "60"
+  REAUTHENTICATE_AFTER_MINUTES: "1440"
   ENABLE_PROMETHEUS_EXPORTER: "true"
   CLAMD_CONF_FILENAME: "clamd.staging.conf"
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local


### PR DESCRIPTION
## Description of change
This change updates the session and reauthentication timeouts to match those of production. This allows the AppSec team to perform their testing in an environment that's closer to production.

## Link to relevant ticket
[CRIMAPP-1670](https://dsdmoj.atlassian.net/browse/CRIMAPP-1670)


[CRIMAPP-1670]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ