### PR TITLE
[CRIMAPP-1671] use regular font-weight on "name" column

### DIFF
--- a/app/views/application_searches/search.html.erb
+++ b/app/views/application_searches/search.html.erb
@@ -34,9 +34,8 @@
         <tbody class="govuk-table__body">
           <% @search.results.each do |result| %>
             <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                <%= link_to result.applicant_name, completed_crime_application_path(result),
-                            class: 'govuk-link--no-visited-state govuk-!-font-weight-regular' %>
+              <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
+                <%= govuk_link_to result.applicant_name, completed_crime_application_path(result), no_visited_state: true %>
               </th>
               <td class="govuk-table__cell">
                 <%= l(result.submitted_at) %>

--- a/app/views/completed_applications/index.html.erb
+++ b/app/views/completed_applications/index.html.erb
@@ -21,9 +21,8 @@
         <tbody class="govuk-table__body">
           <% @search.results.each do |result| %>
             <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                <%= link_to result.applicant_name, completed_crime_application_path(result),
-                            class: 'govuk-link--no-visited-state govuk-!-font-weight-regular' %>
+              <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
+                <%= govuk_link_to result.applicant_name, completed_crime_application_path(result), no_visited_state: true %>
               </th>
               <td class="govuk-table__cell">
                 <%= l(result.submitted_at) %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -25,9 +25,8 @@
         <tbody class="govuk-table__body">
           <% @applications.present_each(CrimeApplicationPresenter) do |app| %>
             <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                <%= link_to app.applicant_name, edit_crime_application_path(app),
-                            class: 'govuk-link--no-visited-state' %>
+              <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
+                <%= govuk_link_to app.applicant_name, edit_crime_application_path(app), no_visited_state: true %>
               </th>
               <td class="govuk-table__cell">
                 <%= l(app.created_at) %>


### PR DESCRIPTION
## Description of change
Correct discrepancy in the font-weight of the “name” column of the “In progress” table compared to the other tables.

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?assignee=6320938929083bbe8cc35869&selectedIssue=CRIMAPP-1671

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1010" alt="Screenshot 2025-03-05 at 15 13 00" src="https://github.com/user-attachments/assets/70bf595a-bba3-4dc1-b289-52cee4b3aaa1" />


### After changes:

<img width="998" alt="Screenshot 2025-03-05 at 16 37 51" src="https://github.com/user-attachments/assets/632ac063-4b3d-4100-b032-cc33d0adf108" />




## How to manually test the feature
