### PR TITLE
announce table label and result count

### DIFF
--- a/app/views/application_searches/search.html.erb
+++ b/app/views/application_searches/search.html.erb
@@ -21,7 +21,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full app-table-container">
-      <table class="govuk-table app-table" aria-roledescription="." aria-label="<%= t('search.label') %> <%= t('search.total', count: @search.total) %>">
+      <table class="govuk-table app-table" aria-roledescription="." aria-label="<%= t('search.table_label') %> <%= t('search.total', count: @search.total) %>">
         <%= render DataTable::HeadComponent.new(sorting: @search.sorting, filter: @search.filter) do |head|
               head.with_row do |row|
                 row.with_cell(colname: 'applicant_name')

--- a/app/views/application_searches/search.html.erb
+++ b/app/views/application_searches/search.html.erb
@@ -21,7 +21,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full app-table-container">
-      <table class="govuk-table app-table">
+      <table class="govuk-table app-table" aria-roledescription="." aria-label="<%= t('search.label') %> <%= t('search.total', count: @search.total) %>">
         <%= render DataTable::HeadComponent.new(sorting: @search.sorting, filter: @search.filter) do |head|
               head.with_row do |row|
                 row.with_cell(colname: 'applicant_name')

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -1,6 +1,7 @@
 ---
 en:
   search:
+    label: Application search results table,
     total:
       one: 1 search result
       other: "%{count} search results"

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -1,7 +1,7 @@
 ---
 en:
   search:
-    label: Application search results table,
+    table_label: Application search results table,
     total:
       one: 1 search result
       other: "%{count} search results"


### PR DESCRIPTION
## Description of change
When entering the table, the screenreader should announce this and how many search results there are.

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?selectedIssue=CRIMAPP-1532

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1097" alt="Screenshot 2025-03-11 at 08 58 37" src="https://github.com/user-attachments/assets/ce3005ef-dcc3-4acc-9a38-a1717ce24aa4" />

### After changes:
<img width="1042" alt="Screenshot 2025-03-11 at 08 56 20" src="https://github.com/user-attachments/assets/00f73885-39e0-46f7-8d4e-fea9fb3957c8" />


## How to manually test the feature
Activate MacOS Voiceover using CMD + Fn + F5
You can tab into the "copy reference number" link then press CTRL + OPT + SPACE (MacOs)