### PR TITLE
[CRIMAPP-1676] Disregard unrequired benefit check values when result has changed

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -39,4 +39,22 @@ class Applicant < Person
   def ownership_type
     OwnershipType::APPLICANT
   end
+
+  def confirm_details
+    return nil if benefit_check_result
+
+    super
+  end
+
+  def has_benefit_evidence
+    return nil if benefit_check_result
+
+    super
+  end
+
+  def confirm_dwp_result
+    return nil if benefit_check_result
+
+    super
+  end
 end

--- a/spec/fixtures/files/benefit_checker_responses/unsuccessful.xml
+++ b/spec/fixtures/files/benefit_checker_responses/unsuccessful.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <benefitCheckerResponse xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check">
+      <ns1:originalClientRef xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">5678</ns1:originalClientRef>
+      <ns2:benefitCheckerStatus xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">No</ns2:benefitCheckerStatus>
+      <ns3:confirmationRef xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1675786402666</ns3:confirmationRef>
+    </benefitCheckerResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -64,4 +64,42 @@ RSpec.describe Applicant, type: :model do
       expect(subject.separation_date).to eq Date.new(1991, 8, 7)
     end
   end
+
+  describe 'benefit check reset behaviour' do
+    before do
+      applicant.confirm_details = 'yes'
+      applicant.confirm_dwp_result = 'no'
+      applicant.has_benefit_evidence = 'yes'
+    end
+
+    context 'when the benefit check result is true' do
+      before do
+        applicant.benefit_check_result = true
+      end
+
+      it { expect(applicant.confirm_details).to be_nil }
+      it { expect(applicant.confirm_dwp_result).to be_nil }
+      it { expect(applicant.has_benefit_evidence).to be_nil }
+    end
+
+    context 'when the benefit check result is false' do
+      before do
+        applicant.benefit_check_result = false
+      end
+
+      it { expect(applicant.confirm_details).to eq 'yes' }
+      it { expect(applicant.confirm_dwp_result).to eq 'no' }
+      it { expect(applicant.has_benefit_evidence).to eq 'yes' }
+    end
+
+    context 'when the benefit check result is nil' do
+      before do
+        applicant.benefit_check_result = nil
+      end
+
+      it { expect(applicant.confirm_details).to eq 'yes' }
+      it { expect(applicant.confirm_dwp_result).to eq 'no' }
+      it { expect(applicant.has_benefit_evidence).to eq 'yes' }
+    end
+  end
 end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -196,4 +196,12 @@ module CapybaraHelpers # rubocop:disable Metrics/ModuleLength
 
     visit completed_crime_application_path(application_id)
   end
+
+  # mock_result format 'Yes' or 'No'
+  def mock_benefit_check(mock_result)
+    fixture_name = mock_result == 'Yes' ? 'successful.xml' : 'unsuccessful.xml'
+
+    stub_request(:post, 'http://benefit-checker/?wsdl')
+      .to_return(body: file_fixture("benefit_checker_responses/#{fixture_name}").read)
+  end
 end

--- a/spec/system/applying/benefit_check_retry_spec.rb
+++ b/spec/system/applying/benefit_check_retry_spec.rb
@@ -1,0 +1,205 @@
+require 'rails_helper'
+
+RSpec.describe 'Apply for Criminal Legal Aid when the benefit checker is re-ran' do
+  include_context 'when logged in'
+
+  describe 'Submitting an application where the benefit check result changes from undetermined to confirmed' do
+    before do
+      # applications
+      click_link('Start an application')
+      choose('New application')
+      save_and_continue
+
+      # edit (Task list)
+      click_link('Client details')
+
+      # steps/client/details
+      fill_in('First name', with: 'Jo')
+      fill_in('Last name', with: 'WALKER')
+      fill_date('What is their date of birth?', with: Date.new(1980, 0o1, 10))
+      save_and_continue
+
+      # steps/client/is-application-means-tested
+      save_and_continue
+
+      # steps/client/case-type
+      choose('Summary only')
+      save_and_continue
+
+      # steps/client/date-stamp
+      save_and_continue
+
+      # steps/client/residence_type
+      choose_answer(
+        'Where does your client usually live?',
+        'They do not have a fixed home address'
+      )
+      save_and_continue
+
+      # steps/client/contact_details
+      choose_answer('Where shall we send correspondence?', 'Provider’s office')
+      save_and_continue
+
+      # steps/client/nino
+      choose_answer('Does your client have a National Insurance number?', 'Yes')
+      fill_in('What is their National Insurance number?', with: 'JA293483A')
+      save_and_continue
+
+      # steps/client/does-client-have-partner
+      choose_answer('Does your client have a partner?', 'No')
+      save_and_continue
+
+      # steps/client/relationship-status
+      choose_answer("What is your client's relationship status?", 'Single')
+      save_and_continue
+
+      # steps/dwp/benefit-type
+      mock_benefit_check('No')
+      choose_answer('Does your client get one of these passporting benefits?', 'Universal Credit')
+      save_and_continue
+
+      # steps/dwp/confirm-result
+      choose_answer('Are the DWP records correct?', 'No, they receive a passporting benefit')
+      save_and_continue
+
+      # steps/dwp/confirm-details
+      choose_answer('Are these details correct?', 'Yes')
+      save_and_continue
+
+      # steps/dwp/has-benefit-evidence
+      choose_answer('Do you have evidence your client gets Universal Credit?', 'Yes')
+      save_and_continue
+
+      # steps/client/urn
+      save_and_continue
+
+      # steps/case/has-the-case-concluded
+      choose_answer('Has the case concluded?', 'No')
+      save_and_continue
+
+      # steps/case/has-court-remanded-client-in-custody
+      choose_answer('Has a court remanded your client in custody?', 'No')
+      save_and_continue
+
+      # steps/case/charges/#{charge_id}
+      fill_in('Offence', with: 'Theft from a shop (Over £100,000)')
+      fill_date('Start date 1', with: 1.month.ago.to_date)
+      save_and_continue
+
+      # steps/case/charges-summary
+      choose_answer('Do you want to add another offence?', 'No')
+      save_and_continue
+
+      # steps/case/has-codefendants
+      choose_answer('Does your client have any co-defendants in this case?', 'No')
+      save_and_continue
+
+      # steps/case/hearing-details
+      select('Derby Crown Court', from: 'What court is the hearing at?')
+      fill_date('When is the next hearing', with: 1.week.from_now.to_date)
+      choose_answer('Did this court also hear the first hearing?', 'Yes')
+      save_and_continue
+
+      # steps/case/ioj
+      choose_answers(
+        'Why should your client get legal aid?',
+        ['It is likely that they will lose their livelihood']
+      )
+      fill_in(
+        'steps-case-ioj-form-loss-of-livelihood-justification-field',
+        with: 'IoJ justification details'
+      )
+      save_and_continue
+
+      # steps/evidence/upload
+      # to bypass evidence validation requirements
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive_messages(validate: true,
+                                                                                      evidence_complete?: true)
+      save_and_continue
+
+      # steps/submission/more-information
+      choose_answer('Do you want to add any other information?', 'No')
+      save_and_continue
+
+      # steps/submission/review
+      expect(page).to have_content('Passporting benefit?Universal Credit')
+      expect(page).to have_content('Passporting benefit check outcomeNo match - check details are correct')
+      expect(page).to have_content('Confirmed details correct?Yes')
+      expect(page).to have_content('Evidence can be provided?Yes')
+
+      # Redo passporting benefit check to get confirmed result
+      within('.govuk-summary-card__title-wrapper', text: 'Passporting benefit check') do
+        click_link('Change')
+      end
+
+      # steps/dwp/benefit-type
+      mock_benefit_check('Yes')
+      save_and_continue
+
+      # steps/dwp/benefit-check-result
+      save_and_continue
+
+      # steps/case/urn
+      save_and_continue
+
+      # steps/case/has-the-case-concluded
+      save_and_continue
+
+      # steps/case/has-court-remanded-client-in-custody
+      save_and_continue
+
+      # steps/case/charges-summary
+      choose_answer('Do you want to add another offence?', 'No')
+      save_and_continue
+
+      # steps/case/has-codefendants
+      save_and_continue
+
+      # steps/case/hearing-details
+      save_and_continue
+
+      # steps/case/ioj
+      save_and_continue
+
+      # steps/evidence/upload
+      # to bypass evidence validation requirements
+      allow_any_instance_of(SupportingEvidence::AnswersValidator).to receive_messages(validate: true,
+                                                                                      evidence_complete?: true)
+      save_and_continue
+
+      # steps/submission/more-information
+      choose_answer('Do you want to add any other information?', 'No')
+      save_and_continue
+
+      # steps/submission/review
+      # Assert that benefit check result has changed
+      expect(page).to have_content('Passporting benefit?Universal Credit')
+      expect(page).to have_content('Passporting benefit check outcomeConfirmed')
+      expect(page).not_to have_content('Confirmed details correct?Yes')
+      expect(page).not_to have_content('Evidence can be provided?Yes')
+      save_and_continue
+
+      # steps/submission/declaration
+      fill_in('First name', with: 'Zoe')
+      fill_in('Last name', with: 'Bar')
+      fill_in('Telephone number', with: '07715339488')
+
+      stub_request(:post, 'http://datastore-webmock/api/v1/applications')
+      click_button 'Save and submit application'
+    end
+
+    it 'submits a valid application to the datastore' do
+      expect(
+        a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
+          body = JSON.parse(req.body)['application']
+          body['client_details']['applicant']['benefit_type'] == 'universal_credit' &&
+          body['client_details']['applicant']['confirm_details'].nil? &&
+          body['client_details']['applicant']['has_benefit_evidence'].nil? &&
+          body['client_details']['applicant']['confirm_dwp_result'].nil? &&
+          body['client_details']['applicant']['benefit_check_result'] == true &&
+          body['client_details']['applicant']['benefit_check_status'] == 'confirmed'
+        }
+      ).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Caseworkers in review reported an issue where they could not determine whether a benefit check had been performed for an application. This occurred as the application's passporting benefit check result had changed from undetermined to confirmed during the drafting of the application. However, the answers to the questions that were answered as part of the undetermined flow (e.g. has benefit evidence) were still being used to calculate the benefit check status on submission. This was resulting in a final benefit check status of `nil` which impacted the view of the passporting benefit check result on apply and review

This PR fixes this and ignores the values for these fields if a confirmed result is obtained when calculating the benefit check status to be presented in apply and review.  

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1676

## Notes for reviewer
I have added a helper method to mock the benefit check status result in the system specs. We could now add system specs for all of the benefit check routes
 
## Screenshots of changes (if applicable)

### Before changes:

(Note screenshot taken from ticket)
![image (14)](https://github.com/user-attachments/assets/57ee86c3-1020-486e-9418-fe367589a295)

### After changes:

<img width="1158" alt="Screenshot 2025-03-11 at 09 27 41" src="https://github.com/user-attachments/assets/a6c34f12-f22a-44aa-80df-3727d9e19d6a" />

## How to manually test the feature

The scenarios that need testing are: 
1. The benefit checker returned an undetermined result, the confirm dwp result, confirm client details and has benefit evidence question was answered and then the passporting benefit checker was re-ran later with a confirmed result. `Note: this will require updating the answers in the rails console`
2. The benefit checker was down, the has benefit evidence question was answered and then the passporting benefit checker was re-ran later with a confirmed result. `Note: this requires turning the mock benefit checker service off and then on via your local env.development.local file` 