### PR TITLE
[CRIMAPP-1634] Ensure income payment completness

### DIFF
--- a/app/forms/steps/income/client/employment_income_form.rb
+++ b/app/forms/steps/income/client/employment_income_form.rb
@@ -22,7 +22,7 @@ module Steps
 
           if payment
             form.amount = payment.amount
-            form.before_or_after_tax = payment.before_or_after_tax['value']
+            form.before_or_after_tax = payment.before_or_after_tax&.dig('value')
             form.frequency = payment.frequency
           end
 

--- a/app/forms/steps/income/partner/employment_income_form.rb
+++ b/app/forms/steps/income/partner/employment_income_form.rb
@@ -22,7 +22,7 @@ module Steps
 
           if payment
             form.amount = payment.amount
-            form.before_or_after_tax = payment.before_or_after_tax['value']
+            form.before_or_after_tax = payment.before_or_after_tax&.dig('value')
             form.frequency = payment.frequency
           end
 

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -31,6 +31,7 @@ class Income < ApplicationRecord
     # disregard payments for people not included in means assessemnt
     # as well as obsolete payment types
     scope = crime_application.income_payments
+                             .completed
                              .owned_by(ownership_types)
                              .not_of_type(obsolete_employed_income_payment_types)
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -12,6 +12,7 @@ class Payment < ApplicationRecord
 
   scope :for_client, -> { where(ownership_type: OwnershipType::APPLICANT.to_s) }
   scope :for_partner, -> { where(ownership_type: OwnershipType::PARTNER.to_s) }
+  scope :completed, -> { where.not(payment_type: '').where.not(frequency: '') }
 
   def complete?
     values_at(:amount, :payment_type, :frequency).all?(&:present?)

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -1,7 +1,7 @@
 class ValueObject
   attr_reader :value
 
-  delegate :to_s, :to_sym, to: :value
+  delegate :to_s, :to_sym, :present?, :blank?, :empty?, to: :value
 
   def initialize(raw_value)
     raise ArgumentError, 'Raw value must be symbol or implicitly convertible' unless raw_value.respond_to?(:to_sym)

--- a/spec/forms/steps/income/client/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/client/employment_income_form_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe Steps::Income::Client::EmploymentIncomeForm do
       expect(form.before_or_after_tax).to eq(BeforeOrAfterTax::AFTER)
       expect(form.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
     end
+
+    context 'when the model metadata is incomplete' do
+      let(:existing_employment_income_payment) {
+        IncomePayment.new(crime_application: crime_application,
+                          payment_type: IncomePaymentType::EMPLOYMENT.to_s,
+                          amount: 455,
+                          frequency: nil,
+                          ownership_type: 'applicant',
+                          metadata: {})
+      }
+
+      it 'successfully sets the form attributes' do
+        expect(form.amount).to eq Money.new(455)
+        expect(form.before_or_after_tax).to be_nil
+        expect(form.frequency).to be_nil
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/forms/steps/income/partner/employment_income_form_spec.rb
+++ b/spec/forms/steps/income/partner/employment_income_form_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe Steps::Income::Partner::EmploymentIncomeForm do
       expect(form.before_or_after_tax).to eq(BeforeOrAfterTax::AFTER)
       expect(form.frequency).to eq(PaymentFrequencyType::FOUR_WEEKLY)
     end
+
+    context 'when the model metadata is incomplete' do
+      let(:existing_employment_income_payment) {
+        IncomePayment.new(crime_application: crime_application,
+                          payment_type: IncomePaymentType::EMPLOYMENT.to_s,
+                          amount: 655,
+                          frequency: nil,
+                          ownership_type: 'applicant',
+                          metadata: {})
+      }
+
+      it 'successfully sets the form attributes' do
+        expect(form.amount).to eq Money.new(655)
+        expect(form.before_or_after_tax).to be_nil
+        expect(form.frequency).to be_nil
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/lib/employment_income_payments_calculator_spec.rb
+++ b/spec/lib/employment_income_payments_calculator_spec.rb
@@ -166,7 +166,8 @@ describe EmploymentIncomePaymentsCalculator do
     income_payment = IncomePayment.new(amount: 100,
                                        frequency: 'week',
                                        ownership_type: ownership_type,
-                                       payment_type: 'employment')
+                                       payment_type: 'employment',
+                                       before_or_after_tax: 'after_tax')
 
     crime_application.income_payments << income_payment
   end


### PR DESCRIPTION
## Description of change
This change fixes an issue where the user may leave the employment income question in an incomplete state and then face errors when attempting to revisit the question or access the evidence upload page.

Incomplete `IncomePayment` records will now be excluded from calculations and will not be serialized, which causes an exception when accessing the evidence upload page.

## Link to relevant ticket
[CRIMAPP-1634](https://dsdmoj.atlassian.net/browse/CRIMAPP-1634)

[CRIMAPP-1634]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ