### PR TITLE
Fix missing save and come back later button

### DIFF
--- a/app/views/steps/partner/details/edit.html.erb
+++ b/app/views/steps/partner/details/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.govuk_text_field :other_names, autocomplete: 'off', width: 'three-quarters', label: { size: 'm' } %>
       <%= f.govuk_date_field :date_of_birth, maxlength_enabled: true, legend: { size: 'm' } %>
-      <%= f.continue_button(secondary: false) %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Description of change
Client details has no 'Save and come back later' as the application record is not persisted before the data on that page is saved.

Partner details replicated that page, but should not be missing the save and come back later button as the user is now much 
 further into the form and that is not intentional feature
