### PR TITLE
[CRIMAPP-1686] use type of application for page title

### DIFF
--- a/app/views/completed_applications/show.html.erb
+++ b/app/views/completed_applications/show.html.erb
@@ -1,4 +1,5 @@
-<% title @crime_application.applicant.full_name %>
+<% title t(".heading.#{@crime_application.application_type}") %>
+
 <% content_for(:head) do %>
   <%= stylesheet_link_tag 'print', media: 'print' %>
 <% end %>


### PR DESCRIPTION
## Description of change

Use application type for completed applications page title

## Link to relevant ticket

[CRIMAPP-1686](https://dsdmoj.atlassian.net/browse/CRIMAPP-1686)

## Notes for reviewer

Although accessibility guidelines recommend using a page's `h1` as the page title, this should not be done if the `h1` contains PII. Page titles can be logged by browsers, search engines, third-party analytics, and referrer headers.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
