### PR TITLE
Do not pre-compile in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Once all the above is done, you should be able to run the application as follows
 a) `bin/dev` - will run foreman, spawning a rails server, `yarn build --watch`, and `yarn build:css --watch` to process javascript and SCSS files and watch for any changes.
 b) `rails server` - will only run the rails server, usually fine if you are not making changes to the CSS.
 
-You can also compile assets manually with `rails assets:precompile` at any time, and just run the rails server, without foreman.
-
-If you ever feel something is not right with the CSS or JS, run `rails assets:clobber` to purge the local cache.
+In development, Rails is configured to bypass asset caching. This means that when you modify assets (e.g., CSS, JavaScript),
+Rails will serve the most up-to-date version directly from the file system. If you have run `rails assets:precompile` locally
+you will need to remove the compiled assets from public/assets for this to work.
 
 **Note about the datastore service**
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,12 +24,8 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
-
-  # We are pre-compiling assets, so on production these will always be present, however
-  # for this to work this flag needs to be `true`. Seems like a Rails bug to me.
-  config.assets.compile = true
+  # Cache assets for far-future expiry since they are all digest stamped.
+  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## Description of change

Legacy configuration in production was causing 500 errors to be raised on "missing" assets in production. `config.assets.compile = true` .

This PR removes the config to fix that. Adds longer caching on assets and updates the README to remove outdated recommendation to precompile assets in development.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
