### PR TITLE
Revert modsec-non-prod on staging

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -74,7 +74,7 @@ metadata:
         "id:1008,phase:2,pass,nolog,\
         ctl:ruleRemoveById=942230"
 spec:
-  ingressClassName: modsec-non-prod
+  ingressClassName: modsec
   tls:
   - hosts:
     - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change
This reverts https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/1386. The upgrade breaks staging at the moment. I will continue testing it by applying the ingress config from my local machine, but I don't want the config to be redeployed each time in case it keeps breaking.

## Link to relevant ticket
[CRIMAPP-1721](https://dsdmoj.atlassian.net/browse/CRIMAPP-1721)

[CRIMAPP-1721]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ