### PR TITLE
[CRIMAPP-1721] Upgrade ModSec controller on staging

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -74,7 +74,7 @@ metadata:
         "id:1008,phase:2,pass,nolog,\
         ctl:ruleRemoveById=942230"
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   tls:
   - hosts:
     - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change
Updated the ModSec ingress controller on staging for testing purposes ahead of the wider roll out on 15th April.

## Link to relevant ticket
[CRIMAPP-1721](https://dsdmoj.atlassian.net/browse/CRIMAPP-1721)

[CRIMAPP-1721]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ