### PR TITLE
CRIMAPP-1712 add startup probe to clamav

### DIFF
--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -47,16 +47,27 @@ spec:
             limits:
               cpu: 500m
               memory: 3Gi
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - echo "started" > /tmp/starttest && clamdscan --no-summary /tmp/starttest
+            failureThreshold: 60
+            periodSeconds: 5
           readinessProbe:
             tcpSocket:
               port: 3310
-            initialDelaySeconds: 300
-            periodSeconds: 120
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
-            tcpSocket:
-              port: 3310
-            initialDelaySeconds: 300
-            periodSeconds: 120
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - clamdscan --no-summary /tmp/starttest
+            periodSeconds: 30
+            failureThreshold: 3
   volumeClaimTemplates:
     - metadata:
         name: clamav-signatures


### PR DESCRIPTION
## Description of change

- Add a startup probe
- Use clamscan to determine readyness rather than TCP

## Link to relevant ticket

## Notes for reviewer

I've confirmed that this config works on well and significantly reduces restart time and avoids liveness probe restart loops of the clamav pod.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
