### PR TITLE
CRIMAPP-1712: Use dedicated readiness endpoint in staging

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -3,6 +3,13 @@ class HealthcheckController < BareApplicationController
     render json: { healthcheck: healthcheck_result }, status: http_status
   end
 
+  def readiness
+    return head :service_unavailable unless database_connected?
+    return head :service_unavailable unless virus_scan_ready?
+
+    head :ok
+  end
+
   def ping
     render json: build_args, status: :ok
   end
@@ -20,7 +27,7 @@ class HealthcheckController < BareApplicationController
   def green?
     # add more checks as needed:
     # database_connected? && redis_connected etc...
-    database_connected? && virus_scan_ready?
+    database_connected?
   end
 
   def database_connected?

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -36,7 +36,7 @@ spec:
             memory: 3Gi
         readinessProbe:
           httpGet:
-            path: /health
+            path: /readyz
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,8 @@ Rails.application.routes.draw do
   mount DatastoreApi::HealthEngine::Engine => '/datastore'
 
   get :health, to: 'healthcheck#show'
-  get :ping,   to: 'healthcheck#ping'
+  get :ping, to: 'healthcheck#ping'
+  get :readyz, to: 'healthcheck#readiness'
 
   root 'home#index'
 


### PR DESCRIPTION
## Description of change

 Use dedicated readiness endpoint in staging.

## Link to relevant ticket

## Notes for reviewer

This PR is intended to allow main to be deployed to production should it need to whilst staging uses the updated readyness probe assessment.

Previously, the health endpoint was used for both readiness and liveness checks. #1395 added clamav check to the health endpoint. This commit reverts that change to the health endpoint and adds a dedicated readyz endpoint to determine if clamav is available to the web app. This allows production continues to function as it did before #1395 and also prevents the staging service from being taken down due to transient issues with clamav after deployment.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
