### PR TITLE
CRIMAPP-1712 only check clamav on startup probe

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -5,6 +5,12 @@ class HealthcheckController < BareApplicationController
 
   def readiness
     return head :service_unavailable unless database_connected?
+
+    head :ok
+  end
+
+  def startup
+    return head :service_unavailable unless database_connected?
     return head :service_unavailable unless virus_scan_ready?
 
     head :ok

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -58,7 +58,7 @@ spec:
           periodSeconds: 10
         startupProbe:
           httpGet:
-            path: /ping
+            path: /startupz
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   get :health, to: 'healthcheck#show'
   get :ping, to: 'healthcheck#ping'
   get :readyz, to: 'healthcheck#readiness'
+  get :startupz, to: 'healthcheck#startup'
 
   root 'home#index'
 


### PR DESCRIPTION
## Description of change

- Web app only checks clamav working on startupProbe.
- Remove clamav from readynesProbe

## Link to relevant ticket

## Notes for reviewer

Moving to startup probe to ensure requests continue to the app if clamav down and web app has already started.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
