### PR TITLE
[CRIMAPP-1675] Fully sanitize HTML

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,9 @@ module LaaApplyForCriminalLegalAid
       g.orm :active_record, primary_key_type: :uuid
     end
 
+    # Prohibit all HTML tags
+    config.action_view.sanitized_allowed_tags = []
+
     config.x.analytics.ga_tracking_id = ENV['GA_TRACKING_ID']
     config.x.analytics.cookies_consent_name = 'crime_apply_cookies_consent'.freeze
     config.x.analytics.cookies_consent_expiration = 6.months


### PR DESCRIPTION
## Description of change
This addresses the issue discovered by the latest AppSec test where the HTML tags allowed by `Rails::HTML5::SafeListSanitizer` may be used in our text boxes to alter the HTML of user input when it is rendered, for example in our summary cards.

## Link to relevant ticket
[CRIMAPP-1675](https://dsdmoj.atlassian.net/browse/CRIMAPP-1675)

## Notes for reviewer
All free-text answers rendered using `Summary::Components::FreeTextAnswer` already call `simple_format`, which sanitizes input by default. The config change ensures that no HTML tags are allowed.

## Screenshots of changes

### Before changes:
![image](https://github.com/user-attachments/assets/458d3627-e452-4906-b463-46c336da7a60)

### After changes:
![image](https://github.com/user-attachments/assets/882f8202-71ae-42c2-ad04-376efca978cc)

[CRIMAPP-1675]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ