### PR TITLE
[CRIMAPP-1712] update ClamAV image and use MoJ mirror in production

### DIFF
--- a/config/kubernetes/production/deployment-clamav.yml
+++ b/config/kubernetes/production/deployment-clamav.yml
@@ -4,7 +4,7 @@ metadata:
   name: clamav-production
   namespace: laa-apply-for-criminal-legal-aid-production
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 2
   minReadySeconds: 15
   serviceName: clamav
@@ -26,42 +26,57 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       containers:
-      - name: clamav
-        image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
-        imagePullPolicy: Always
-        command: ['/bin/sh', '-c', 'freshclam && clamd && touch startup.txt && clamdscan startup.txt']
-        ports:
-          - containerPort: 3310
-            protocol: TCP
-        volumeMounts:
-          - mountPath: /var/lib/clamav
-            name: clamav-signatures
+        - name: clamav
+          image: ghcr.io/ministryofjustice/clamav-docker/laa-clamav:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3310
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/clamav
+              name: clamav-signatures
+          env:
+            - name: FRESHCLAM_CHECKS
+              value: "24"
+            - name: MIRROR_URL
+              value: https://laa-clamav-mirror-production.apps.live.cloud-platform.service.justice.gov.uk
+          resources:
+            requests:
+              cpu: 25m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 3Gi
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - echo "started" > /tmp/starttest && clamdscan --no-summary /tmp/starttest
+            failureThreshold: 60
+            periodSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 3310
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - clamdscan --no-summary /tmp/starttest
+            periodSeconds: 30
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: clamav-signatures
+      spec:
+        accessModes:
+          - ReadWriteOnce
         resources:
           requests:
-            cpu: 25m
-            memory: 1Gi
-          limits:
-            cpu: 500m
-            memory: 3Gi
-        readinessProbe:
-          tcpSocket:
-            port: 3310
-          initialDelaySeconds: 300
-          periodSeconds: 120
-        livenessProbe:
-          tcpSocket:
-            port: 3310
-          initialDelaySeconds: 300
-          periodSeconds: 120
-  volumeClaimTemplates:
-  - metadata:
-      name: clamav-signatures
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -72,8 +87,8 @@ metadata:
     app: apply-for-criminal-legal-aid-clamav-production
 spec:
   ports:
-  - port: 3310
-    name: clamav
-    targetPort: 3310
+    - port: 3310
+      name: clamav
+      targetPort: 3310
   selector:
     app: apply-for-criminal-legal-aid-clamav-production

--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -36,7 +36,7 @@ spec:
             memory: 3Gi
         readinessProbe:
           httpGet:
-            path: /health
+            path: /readyz
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
@@ -58,7 +58,7 @@ spec:
           periodSeconds: 10
         startupProbe:
           httpGet:
-            path: /ping
+            path: /startupz
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto

--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -4,7 +4,7 @@ metadata:
   name: clamav-staging
   namespace: laa-apply-for-criminal-legal-aid-staging
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 2
   minReadySeconds: 15
   serviceName: clamav

--- a/docs/clam-av.md
+++ b/docs/clam-av.md
@@ -6,14 +6,7 @@ See the general README for setup guide.
 
 ## Overview
 
-The Apply ClamAV setup in the live services relies on pre-existing work by HMPPS - specifically their ready-made ClamAV image:
-
-```
-docker pull ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
-docker run -p 3310:3310 --name clamav-server ghcr.io/ministryofjustice/hmpps-clamav-freshclammed
-```
-
-On staging and locally we're testing <https://github.com/ministryofjustice/clamav-mirror> and <https://github.com/ministryofjustice/clamav-docker>
+The Apply ClamAV setup uses <https://github.com/ministryofjustice/clamav-mirror> and <https://github.com/ministryofjustice/clamav-docker>
 
 ## Troubleshooting
 
@@ -30,80 +23,4 @@ If you need to check whether the Clamdscan service is working as expected betwee
 ```
 touch ./my-example-file.txt
 clamdscan -c config/clamd/clamd.staging.conf --stream --no-summary ./my-example-file.txt
-```
-
-### Setting up ClamAV locally
-
-1. Pull the HMPPS docker containter and start it:
-
-```
-docker pull ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
-docker run -p 3310:3310 --name clamav-server ghcr.io/ministryofjustice/hmpps-clamav-freshclammed
-```
-
-2. Create a new Ruby project with the following structure:
-
-```
-+--src
-   |__ Gemfile
-   |__ scan.rb
-+--local-clam.conf
-
-```
-
-3. File contents:
-
-```
-# Gemfile
-source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
-ruby "3.2.2"
-
-gem 'clamby'
-gem 'shellwords'
-
-# scan.rb
-require 'clamby'
-require 'tempfile'
-require 'shellwords'
-
-Clamby.configure({
-  :check => false,
-  :daemonize => true,
-  :config_file => '/full/path/to/local-clam.conf',
-  :error_clamscan_missing => true,
-  :error_clamscan_client_error => false,
-  :error_file_missing => true,
-  :error_file_virus => false,
-  :fdpass => false,
-  :stream => true,
-  :reload => false,
-  :output_level => 'high', # one of 'off', 'low', 'medium', 'high'
-  :executable_path_clamscan => 'clamscan',
-  :executable_path_clamdscan => 'clamdscan',
-  :executable_path_freshclam => 'freshclam',
-})
-
-file_to_scan = Tempfile.new('check-file.txt')
-file_to_scan.write('HELLO CLAMAV!');
-file_to_scan.rewind
-
-begin
-  response = Clamby.safe?(file_to_scan.path)
-  puts "CLAMBY RESULT: #{response}"
-ensure
-  file_to_scan.close
-end
-
-
-# local-clam.conf
-TCPAddr localhost
-TCPSocket 3310
-```
-
-4. Run it
-
-```
-cd src && ruby scan.rb
 ```


### PR DESCRIPTION
## Description of change

This update updates the CLAMAV image for live to use ministryofjustice/clamav-docker instead of the HMPPS image. It also utilises the new MOJ CLAMAV mirror.

## Link to relevant ticket

[CRIMAPP-1712](https://dsdmoj.atlassian.net/browse/CRIMAPP-1712)

## Notes for reviewer

This configuration has been tested and confirmed to work and maintain up to date virus database on staging.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1712]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ