### PR TITLE
[CRIMAPP-1754] Fix partner dwp check routing

### DIFF
--- a/app/controllers/steps/dwp/confirm_result_controller.rb
+++ b/app/controllers/steps/dwp/confirm_result_controller.rb
@@ -2,17 +2,13 @@ module Steps
   module DWP
     class ConfirmResultController < Steps::DWPStepController
       def edit
-        @form_object = form.build(
+        @form_object = ConfirmResultForm.build(
           current_crime_application
         )
       end
 
       def update
-        update_and_advance(form, as: :confirm_result)
-      end
-
-      def form
-        benefit_check_on_partner? ? ConfirmResultPartnerForm : ConfirmResultForm
+        update_and_advance(ConfirmResultForm, as: :confirm_result)
       end
     end
   end

--- a/app/controllers/steps/dwp/partner_confirm_result_controller.rb
+++ b/app/controllers/steps/dwp/partner_confirm_result_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module DWP
+    class PartnerConfirmResultController < Steps::DWPStepController
+      def edit
+        @form_object = PartnerConfirmResultForm.build(
+          current_crime_application
+        )
+      end
+
+      def update
+        update_and_advance(PartnerConfirmResultForm, as: :partner_confirm_result)
+      end
+    end
+  end
+end

--- a/app/forms/steps/dwp/partner_confirm_result_form.rb
+++ b/app/forms/steps/dwp/partner_confirm_result_form.rb
@@ -1,6 +1,6 @@
 module Steps
   module DWP
-    class ConfirmResultPartnerForm < Steps::DWP::ConfirmResultForm
+    class PartnerConfirmResultForm < Steps::DWP::ConfirmResultForm
       include Steps::HasOneAssociation
       has_one_association :partner
 

--- a/app/services/decisions/dwp_decision_tree.rb
+++ b/app/services/decisions/dwp_decision_tree.rb
@@ -20,6 +20,8 @@ module Decisions
         after_cannot_check_dwp_status
       when :confirm_result
         after_confirm_result
+      when :partner_confirm_result
+        after_partner_confirm_result
       when :confirm_details
         after_confirm_details
       else
@@ -31,6 +33,16 @@ module Decisions
     private
 
     def after_confirm_result
+      if form_object.confirm_dwp_result.yes?
+        return edit(:partner_benefit_type) if include_partner_in_means_assessment?
+
+        edit('steps/case/urn')
+      else
+        edit(:confirm_details)
+      end
+    end
+
+    def after_partner_confirm_result
       if form_object.confirm_dwp_result.yes?
         edit('steps/case/urn')
       else
@@ -106,6 +118,8 @@ module Decisions
       elsif person.benefit_check_result
         edit(:benefit_check_result)
       else
+        return edit(:partner_confirm_result) if person.type == 'Partner'
+
         edit(:confirm_result)
       end
     end

--- a/app/views/steps/dwp/partner_confirm_result/edit.html.erb
+++ b/app/views/steps/dwp/partner_confirm_result/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row app-inverted--card app-inverted-text govuk-!-margin-bottom-5">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l app-inverted-text govuk-!-margin-bottom-0" id="dwp-partner-confirm-result-desc">
+      <%= legend_t(:heading) %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :confirm_dwp_result, @form_object.choices, :value,
+                                           inline: false,
+                                           legend: { 'aria-describedby': 'dwp-partner-confirm-result-desc' } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -284,7 +284,7 @@ en:
           attributes:
             confirm_dwp_result:
               inclusion: Select yes if they do not receive a passporting benefit
-        steps/dwp/confirm_result_partner_form: *CONFIRM_RESULT_VALIDATION
+        steps/dwp/partner_confirm_result_form: *CONFIRM_RESULT_VALIDATION
         steps/address/lookup_form:
           attributes:
             postcode:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -115,7 +115,7 @@ en:
       steps_dwp_confirm_result_form: &CONFIRM_DWP_RESULT_HEADING
         heading: DWP records show that %{subject} does not receive a passporting benefit
         confirm_dwp_result: Are the DWP records correct?
-      steps_dwp_confirm_result_partner_form: *CONFIRM_DWP_RESULT_HEADING
+      steps_dwp_partner_confirm_result_form: *CONFIRM_DWP_RESULT_HEADING
       steps_dwp_confirm_details_form: &CONFIRM_DETAILS_LEGEND
         page_title: Confirm %{subject}’s details
         heading: Check %{subject}’s details
@@ -699,9 +699,8 @@ en:
       steps_dwp_confirm_result_form: &CONFIRM_DWP_RESULT_OPTIONS
         confirm_dwp_result_options:
           "yes": "Yes"
-          # TODO: Check with design
           "no": No, they receive a passporting benefit
-      steps_dwp_confirm_result_partner_form: *CONFIRM_DWP_RESULT_OPTIONS
+      steps_dwp_partner_confirm_result_form: *CONFIRM_DWP_RESULT_OPTIONS
       steps_dwp_confirm_details_form: &CONFIRM_DETAILS_OPTIONS
         confirm_details_options:
           "yes": "Yes"

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -126,10 +126,11 @@ en:
         edit:
           page_title: Sorry, we cannot check %{subject} information with DWP
           heading: Sorry, we cannot check %{subject} information with DWP
-      confirm_result:
+      confirm_result: &CONFIRM_RESULT_HEADING
         edit:
           heading: DWP records show that %{subject} does not receive a passporting benefit
           page_title: Benefit check result
+      partner_confirm_result: *CONFIRM_RESULT_HEADING
       confirm_details:
         edit:
           page_title: Confirm %{subject} details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,6 @@ def edit_step(name, opts = {}, &block)
            path_names: { edit: '' } do
     yield if block
   end
-  # temp underscored routes
-  # if name.to_s.include?('_') && !block_given?
-  #   get name, to: "#{opts.fetch(:alias, name)}#edit"
-  #   patch name, to: "#{opts.fetch(:alias, name)}#update"
-  #   put name, to: "#{opts.fetch(:alias, name)}#update"
-  # end
 end
 
 def crud_step(name, opts = {})
@@ -162,6 +156,7 @@ Rails.application.routes.draw do
         edit_step :has_benefit_evidence
         edit_step :cannot_check_dwp_status
         edit_step :confirm_result
+        edit_step :partner_confirm_result
         edit_step :confirm_details
       end
 

--- a/spec/controllers/steps/dwp/partner_confirm_result_controller_spec.rb
+++ b/spec/controllers/steps/dwp/partner_confirm_result_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::DWP::PartnerConfirmResultController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::DWP::PartnerConfirmResultForm, Decisions::DWPDecisionTree
+end

--- a/spec/forms/steps/dwp/partner_confirm_result_form_spec.rb
+++ b/spec/forms/steps/dwp/partner_confirm_result_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Steps::DWP::ConfirmResultPartnerForm do
+RSpec.describe Steps::DWP::PartnerConfirmResultForm do
   subject { described_class.new(arguments) }
 
   let(:arguments) do


### PR DESCRIPTION
## Description of change
Fixes a bug with the partner benefit check routing when a client has a partner and the client’s benefit check result is undetermined or no. When asked whether the dwp result is correct, if the user selects that the result is correct, the client’s passporting benefit is reset to none and the user is routed to the urn question. However, as the applicant has a partner who is part of the means assessment, the partner passporting benefit question should be asked. 

This was resulting in users reaching the end of the application and being shown an error message saying they have not answered all questions. For more detail, including the step by step to replicate the bug, see [the ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?selectedIssue=CRIMAPP-1754)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1754

## Notes for reviewer
I have separated the client and partner confirm dwp result screens to simplify the routing logic and prevent looping

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Follow the steps in the ticket and confirm that the routing is now working as expected 
