### PR TITLE
[CRIMAPP-1640] Descriptive error messages for blank values

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -977,11 +977,11 @@ en:
               greater_than_or_equal_to: *property_partner_percentage_error
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
-              blank: Select if the address of the property is the same as your client's home address
+              blank: Select yes if the address of the property is the same as your client's home address
               inclusion: Select yes if the address of the property is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
-              blank: Select if anyone else owns part of the property
+              blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
               invalid_when_other_owners: The property cannot be partly owned by someone else if percentage ownership totals 100%
         steps/capital/commercial_form:
@@ -1008,11 +1008,11 @@ en:
               greater_than_or_equal_to: *property_partner_percentage_error
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
-              blank: Select if the address of the property is the same as your client's home address
+              blank: Select yes if the address of the property is the same as your client's home address
               inclusion: Select yes if the address of the property is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
-              blank: Select if anyone else owns part of the property
+              blank: Select yes if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
               invalid_when_other_owners: The property cannot be partly owned by someone else if percentage ownership totals 100%
         steps/capital/land_form:
@@ -1042,11 +1042,11 @@ en:
               greater_than_or_equal_to: *land_partner_percentage_error
               less_than_or_equal_to: *land_partner_percentage_error
             is_home_address:
-              blank: Select if the address of the property is the same as your client's home address
+              blank: Select yes if the address of the property is the same as your client's home address
               inclusion: Select yes if the address of the land is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
-              blank: Select if anyone else owns part of the land
+              blank: Select yes if anyone else owns part of the land
               inclusion: Select yes if anyone else owns part of the land
               invalid_when_other_owners: The property cannot be partly owned by someone else if percentage ownership totals 100%
         steps/capital/property_address_form:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -977,9 +977,11 @@ en:
               greater_than_or_equal_to: *property_partner_percentage_error
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
+              blank: Select if the address of the property is the same as your client's home address
               inclusion: Select yes if the address of the property is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
+              blank: Select if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
               invalid_when_other_owners: The property cannot be partly owned by someone else if percentage ownership totals 100%
         steps/capital/commercial_form:
@@ -1006,9 +1008,11 @@ en:
               greater_than_or_equal_to: *property_partner_percentage_error
               less_than_or_equal_to: *property_partner_percentage_error
             is_home_address:
+              blank: Select if the address of the property is the same as your client's home address
               inclusion: Select yes if the address of the property is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
+              blank: Select if anyone else owns part of the property
               inclusion: Select yes if anyone else owns part of the property
               invalid_when_other_owners: The property cannot be partly owned by someone else if percentage ownership totals 100%
         steps/capital/land_form:
@@ -1038,9 +1042,11 @@ en:
               greater_than_or_equal_to: *land_partner_percentage_error
               less_than_or_equal_to: *land_partner_percentage_error
             is_home_address:
+              blank: Select if the address of the property is the same as your client's home address
               inclusion: Select yes if the address of the land is the same as your client's home address
               invalid: Client can only have 1 home address
             has_other_owners:
+              blank: Select if anyone else owns part of the land
               inclusion: Select yes if anyone else owns part of the land
               invalid_when_other_owners: The property cannot be partly owned by someone else if percentage ownership totals 100%
         steps/capital/property_address_form:


### PR DESCRIPTION
## Description of change
Provide a descriptive error message for the home address and other owners radio options

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1640

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/user-attachments/assets/b6cca135-cb13-4c16-8f6e-ef8b293a6071)


### After changes:
<img width="701" alt="Screenshot 2025-05-14 at 10 28 36" src="https://github.com/user-attachments/assets/4c57f047-681a-4165-a6d4-4c16768739b9" />


## How to manually test the feature
Leave blank values for the above options on this or similar pages - steps/capital/land/{id}