### PR TITLE
CRIMAPP-1782 only allow access to the staging service via VPN

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -1,9 +1,59 @@
+# staging public ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-staging-public
+  namespace: laa-apply-for-criminal-legal-aid-staging
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-public-laa-apply-for-criminal-legal-aid-staging-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_method !~ ^GET$) {
+        return 405;
+      }
+spec:
+  ingressClassName: modsec-non-prod
+  rules:
+    - host: staging.apply-for-criminal-legal-aid.service.justice.gov.uk
+      http:
+        paths:
+          - path: /ping
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+          - path: /health
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+          - path: /datastore/ping
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+          - path: /datastore/health
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+---
+# staging application ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-staging
   namespace: laa-apply-for-criminal-legal-aid-staging
   annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "165.1.170.106,165.1.170.107,134.231.143.70,134.231.143.71"
     external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-laa-apply-for-criminal-legal-aid-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |


### PR DESCRIPTION
## Description of change

Apply IP allowlist to the staging service

Creates a separate ingress for public staging to allow GET access to /health /ping etc from unspecified IP addresses. (This is also hoped will reduce the noise from bots in the ModSec logs)

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1782

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
