### PR TITLE
Apply base modsec for health and ping

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -7,6 +7,12 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-public-laa-apply-for-criminal-legal-aid-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($request_method !~ ^GET$) {
         return 405;


### PR DESCRIPTION
## Description of change
Ensure that Modsec base rules are applied for `/ping` `/health` `/datastore/ping` `/datastore/health` endpoints

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
You can run a terminal command to check for cross site scripting XSS `curl "https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk/ping?param=<script>alert(1)</script>"`. Or paste into URL.