### PR TITLE
Update session cookie ModSec rules

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -155,12 +155,6 @@ metadata:
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
         ctl:ruleRemoveById=942230"
-      SecRule REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session "@rx .+" \
-        "id:1009,phase:2,pass,nolog,\
-        ctl:ruleRemoveByTag=attack-rce,\
-        ctl:ruleRemoveByTag=attack-injection-php,\
-        ctl:ruleRemoveByTag=attack-xss,\
-        ctl:ruleRemoveByTag=attack-sqli"
       SecRule REQUEST_URI "@streq /providers/auth/saml/callback" \
         "id:1010,phase:2,pass,nolog,chain"
         SecRule REQUEST_METHOD "@streq POST" \
@@ -171,6 +165,10 @@ metadata:
           ctl:ruleRemoveById=932370,\
           ctl:ruleRemoveById=933150,\
           ctl:ruleRemoveById=941130"
+      SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag injection-php !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
 spec:
   ingressClassName: modsec-non-prod
   tls:


### PR DESCRIPTION
## Description of change

Update session cookie ModSec rules

Previously requests including the session cookie skipped certain rules this change updates to only skips the rules on the cookie itself.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
