### PR TITLE
[CRIMAPP-1742] Move from nginx to ModSec for IP filtering

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -59,7 +59,6 @@ metadata:
   name: ingress-staging
   namespace: laa-apply-for-criminal-legal-aid-staging
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "165.1.170.106,165.1.170.107,134.231.143.70,134.231.143.71,51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,128.77.75.64/26,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32"
     external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-laa-apply-for-criminal-legal-aid-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -79,6 +78,8 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule REMOTE_ADDR "!@ipMatch 165.1.170.106,165.1.170.107,134.231.143.70,134.231.143.71,51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,128.77.75.64/26,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32" \
+        "id:999,deny,status:403,tag:github_team=laa-crime-apply"
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetById 942100 !ARGS:authenticity_token
       SecRule REQUEST_URI "@endsWith /documents" \


### PR DESCRIPTION
## Description of change

This enables a custom error status to be used for ModSec errors on requests on the IP allow list.

Prior to change:

Allowed IP + ModSec violation -> 423
Disallowed IP + ModSec violation -> 423
Disallowed IP + no ModSec violation -> 403 (from NGINX allowlist) After change:

Allowed IP + ModSec violation -> 423
Disallowed IP + ModSec violation -> 403
Disallowed IP + no ModSec violation -> 403 (from ModSec rule 999)

## Link to relevant ticket

[CRIMAPP-1742](https://dsdmoj.atlassian.net/browse/CRIMAPP-1742)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1742]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ