### PR TITLE
[CRIMAPP-1806] Add Entra ID omniauth provider

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -14,6 +14,9 @@ DATASTORE_API_ROOT=http://localhost:3003
 # and the datastore has the same env value
 DATASTORE_API_AUTH_SECRET=foobar
 
+# Auth identity prodivder - 'saml' (Portal) or 'azure_ad'
+AUTH_IDP=saml
+
 # LAA Portal SAML authentication metadata endpoint
 # or path to a locally-stored metadata file, one or the other
 # LAA_PORTAL_IDP_METADATA_URL=https://portal.dev.legalservices.gov.uk/oamfed/idp/metadata

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'uk_postcode'
 
 # Authentication
 gem 'devise', '~> 4.8'
+gem 'omniauth_openid_connect', '0.8.0'
 gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-saml', '~> 2.1.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,11 +93,13 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aes_key_wrap (1.1.0)
     akami (1.3.3)
       base64
       gyoku (>= 0.4.0)
       nokogiri
     ast (2.4.3)
+    attr_required (1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -109,6 +111,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (3.1.9)
+    bindata (2.5.1)
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -186,6 +189,8 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
+    email_validator (2.2.4)
+      activemodel
     erb_lint (0.7.0)
       activesupport
       better_html (>= 2.0.1)
@@ -198,6 +203,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.4)
       json
       logger
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.3.0)
       net-http
     globalid (1.2.1)
@@ -237,6 +244,13 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.2)
+    json-jwt (1.16.7)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      base64
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     json-schema (4.0.0)
       addressable (>= 2.8)
     jwt (2.10.1)
@@ -309,6 +323,22 @@ GEM
     omniauth-saml (2.1.3)
       omniauth (~> 2.1)
       ruby-saml (~> 1.18)
+    omniauth_openid_connect (0.8.0)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.3.1)
+      activemodel
+      attr_required (>= 1.0.0)
+      email_validator
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      mail
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_url
+      webfinger (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (9.3.3)
@@ -339,6 +369,13 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-oauth2 (2.2.1)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -472,6 +509,11 @@ GEM
     smart_properties (1.17.0)
     stackprof (0.2.26)
     stringio (3.1.5)
+    swd (2.0.3)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     thor (1.3.2)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -482,6 +524,9 @@ GEM
     unicode-emoji (4.0.4)
     uri (0.13.2)
     useragent (0.16.11)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (3.20.0)
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
@@ -497,6 +542,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webfinger (2.1.3)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -538,6 +587,7 @@ DEPENDENCIES
   marcel
   omniauth-rails_csrf_protection
   omniauth-saml (~> 2.1.3)
+  omniauth_openid_connect (= 0.8.0)
   ostruct
   pg (~> 1.4)
   prometheus_exporter

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,8 @@ class ApplicationController < ActionController::Base
   include ErrorHandling
 
   helper StepsHelper,
-         AnalyticsHelper
+         AnalyticsHelper,
+         AuthHelper
 
   prepend_before_action :authenticate_provider!
 

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     skip_before_action :verify_authenticity_token
-    before_action :check_provider_is_enrolled, only: [:saml]
+    before_action :check_provider_is_enrolled, only: [:saml, :azure_ad]
 
     def saml
       provider = Provider.from_omniauth(auth_hash)
@@ -10,6 +10,12 @@ module Providers
         provider, event: :authentication
       )
     end
+
+    # :nocov:
+    def azure_ad
+      saml
+    end
+    # :nocov:
 
     def failure
       # Let the application generic error handling deal with the

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -1,0 +1,10 @@
+module AuthHelper
+  # :nocov:
+  def provider_omniauth_authorize_path
+    case ENV.fetch('AUTH_IDP', 'saml')
+    when 'saml' then provider_saml_omniauth_authorize_path
+    when 'azure_ad' then provider_azure_ad_omniauth_authorize_path
+    end
+  end
+  # :nocov:
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,6 +1,6 @@
 class Provider < ApplicationRecord
   devise :lockable, :timeoutable, :reauthable, :trackable,
-         :omniauthable, omniauth_providers: %i[saml]
+         :omniauthable
 
   store_accessor :settings,
                  :selected_office_code,
@@ -38,6 +38,10 @@ class Provider < ApplicationRecord
           office_codes: auth.info.office_codes
         )
       end
+    end
+
+    def omniauth_providers
+      [ENV.fetch('AUTH_IDP', 'saml').to_sym]
     end
   end
 end

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -6,7 +6,7 @@
 
     <h1 class="govuk-heading-xl"><%= service_name %></h1>
     <p class="govuk-body">Use this service to apply for criminal legal aid.</p>
-    <%= button_to provider_saml_omniauth_authorize_path, method: :post,
+    <%= button_to provider_omniauth_authorize_path, method: :post,
                   class: 'govuk-button govuk-button--start govuk-!-margin-top-4', form_class: 'app-button--start',
                   data: { module: 'govuk-button' }, role: 'button', draggable: false do %>
       <%= t('helpers.submit.start') %>

--- a/app/views/shared/_portal_sign_in_button.html.erb
+++ b/app/views/shared/_portal_sign_in_button.html.erb
@@ -1,3 +1,3 @@
-<%= button_to provider_saml_omniauth_authorize_path, method: :post,
+<%= button_to provider_omniauth_authorize_path, method: :post,
               class: 'govuk-button govuk-!-margin-top-2',
               data: { module: 'govuk-button' } do; t('helpers.submit.sign_in'); end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -65,4 +65,22 @@ Devise.setup do |config|
                   name: 'saml',
                   setup: LaaPortal::SamlSetup,
                   strategy_class: LaaPortal::SamlStrategy
+
+  config.omniauth(
+    :openid_connect,
+    {
+      name: :azure_ad,
+      scope: [:openid, :email],
+      response_type: :code,
+      client_options: {
+        identifier: ENV.fetch('OMNIAUTH_AZURE_CLIENT_ID', nil),
+        secret: ENV.fetch('OMNIAUTH_AZURE_CLIENT_SECRET', nil),
+        redirect_uri: ENV.fetch('OMNIAUTH_AZURE_REDIRECT_URI', nil)
+      },
+      discovery: true,
+      pkce: true,
+      issuer: "https://login.microsoftonline.com/#{ENV.fetch('OMNIAUTH_AZURE_TENANT_ID', nil)}/v2.0",
+      strategy_class: OmniAuth::Strategies::OpenIDConnect
+    }
+  )
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,7 @@ require 'laa_portal/saml_strategy'
 Rails.application.config.middleware.use OmniAuth::Builder do
   configure do |config|
     config.add_mock(:saml, LaaPortal::SamlStrategy.mock_auth)
+    config.add_mock(:azure_ad, LaaPortal::SamlStrategy.mock_auth)
     config.test_mode = Rails.env.test? || ENV.fetch('OMNIAUTH_TEST_MODE', 'false').inquiry.true?
   end
 end

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -18,3 +18,4 @@ data:
   BC_WSDL_URL: https://benefitchecker.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   LAA_PORTAL_IDP_METADATA_URL: https://portal.legalservices.gov.uk/oamfed/idp/metadata
   VIRUS_SCAN_TIMEOUT: '20'
+  AUTH_IDP: saml

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -17,6 +17,9 @@ data:
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   VIRUS_SCAN_TIMEOUT: '20'
+  OMNIAUTH_AZURE_CLIENT_ID: 7d95f6ff-2ff5-4ba0-aaf3-06d8769557ef
+  OMNIAUTH_AZURE_TENANT_ID: 8352c342-da15-413a-8b5b-d89545766f0c
+  OMNIAUTH_AZURE_REDIRECT_URI: https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/auth/azure_ad/callback
 
   # If this is uncommented, authentication will be mocked
   # OMNIAUTH_TEST_MODE: "true"
@@ -28,3 +31,5 @@ data:
   # corresponding certificates, if required (in `deployment.tpl` file)
   #
   LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/staging.xml
+  # Auth identity prodivder - 'saml' (Portal) or 'azure_ad'
+  AUTH_IDP: azure_ad


### PR DESCRIPTION
## Description of change
This is a first attempt at integrating with Entra ID as a new identity provider.

The environment variable `AUTH_IDP` allows us to switch between the existing Portal configuration and the new Entra ID one.

While the app registration already exists in the External tenant, we don't expect this to work straight away as there is ongoing work to add the necessary claims to Entra ID (such as office codes) that we rely on for proper authentication and authorization.

## Link to relevant ticket
[CRIMAPP-1806](https://dsdmoj.atlassian.net/browse/CRIMAPP-1806)

[CRIMAPP-1806]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ