### PR TITLE
[CRIMAPP-1806] CSP update to allow EntraID

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data, 'https://*.google-analytics.com', 'https://*.googletagmanager.com'
     policy.connect_src :self, 'https://ga.jspm.io', 'https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com'
-    policy.form_action :self, 'https://*.legalservices.gov.uk/oamfed/idp/samlv20'
+    policy.form_action :self, 'https://*.legalservices.gov.uk/oamfed/idp/samlv20', 'https://login.microsoftonline.com'
     policy.object_src  :none
     policy.script_src  :self, :https
     policy.style_src   :self, :https


### PR DESCRIPTION
## Description of change
This change updates the content security policy to allow form actions to https://login.microsoftonline.com, enabling us to test EntraID.

## Link to relevant ticket
[CRIMAPP-1806](https://dsdmoj.atlassian.net/browse/CRIMAPP-1806)

[CRIMAPP-1806]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ