### PR TITLE
Switch back to Portal auth on staging

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -32,4 +32,4 @@ data:
   #
   LAA_PORTAL_IDP_METADATA_FILE: config/laa_portal/metadata/staging.xml
   # Auth identity prodivder - 'saml' (Portal) or 'azure_ad'
-  AUTH_IDP: azure_ad
+  AUTH_IDP: saml


### PR DESCRIPTION
## Description of change
This change switches our identity provider back to LAA Portal. Work on the new IDAM solution is ongoing and right now there is no way to access staging using Entra ID.