### PR TITLE
[CRIMAPP-1829] Fix error messaging on other charges screen

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -449,16 +449,7 @@ en:
               inclusion: Select yes if there is a criminal case or charge against the %{subject} in progress
         steps/case/other_charge_form:
           attributes:
-            next_hearing_date:
-              invalid: Enter a valid date
-              invalid_day: Enter a valid day
-              invalid_month: Enter a valid month
-              invalid_year: Enter a valid year
-        steps/case/hearing_details_form:
-          attributes:
-            hearing_court_name:
-              blank: Select a court name
-            hearing_date:
+            next_hearing_date: &hearing_date_errors
               blank: The next hearing cannot be blank
               blank_day: The next hearing must include a day
               blank_month: The next hearing must include a month
@@ -472,6 +463,11 @@ en:
               invalid_year: Enter a valid year for the next hearing date
               year_too_late: The next hearing is too far in the future
               year_too_early: The next hearing is too far in the past
+        steps/case/hearing_details_form:
+          attributes:
+            hearing_court_name:
+              blank: Select a court name
+            hearing_date: *hearing_date_errors
             is_first_court_hearing:
               inclusion: Select yes if this court also heard the first hearing
         steps/case/first_court_hearing_form:


### PR DESCRIPTION
## Description of change
Adds missing error messaging for next hearing date filed on other charges screen 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1829

## Notes for reviewer
Error messaging was approved by content designer

## Screenshots of changes (if applicable)

### Before changes:
<img width="647" alt="Screenshot 2025-06-24 at 15 19 23-20250624-141929" src="https://github.com/user-attachments/assets/32d2673f-9adf-4610-9380-067f35935005" />

### After changes:
<img width="834" alt="Screenshot 2025-06-26 at 17 13 53" src="https://github.com/user-attachments/assets/effd9d08-0210-4c0a-b539-b937a90770e2" />


## How to manually test the feature
