### PR TITLE
[CRIMAPP-1837] ClamAV vulnerability fixes staging

### DIFF
--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -23,11 +23,12 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10000
+        runAsGroup: 10000
+        runAsNonRoot: true
       containers:
         - name: clamav
-          image: ghcr.io/ministryofjustice/clamav-docker/laa-clamav:latest
+          image: clamav/clamav-debian:stable
           imagePullPolicy: Always
           ports:
             - containerPort: 3310
@@ -35,11 +36,18 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/clamav
               name: clamav-signatures
+            - mountPath: /var/log/clamav
+              name: clamav-log
+            - mountPath: /etc/clamav/freshclam.conf
+              name: freshclam-config
+              subPath: freshclam.conf
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
           env:
             - name: FRESHCLAM_CHECKS
               value: "24"
-            - name: MIRROR_URL
-              value: https://laa-clamav-mirror-production.apps.live.cloud-platform.service.justice.gov.uk
+          command: ["/init-unprivileged"]
           resources:
             requests:
               cpu: 25m
@@ -68,6 +76,20 @@ spec:
                 - clamdscan --no-summary /tmp/starttest
             periodSeconds: 30
             failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: clamav-log
+          emptyDir: {}
+        - name: freshclam-config
+          configMap:
+            name: configmap-clamav-staging
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: clamav-signatures
@@ -77,6 +99,17 @@ spec:
         resources:
           requests:
             storage: 1Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clamav-configmap-staging
+  namespace: laa-apply-for-criminal-legal-aid-staging
+data:
+  freshclam.conf: |
+    PrivateMirror https://laa-clamav-mirror-production.apps.live.cloud-platform.service.justice.gov.uk
+    UpdateLogFile /var/log/clamav/freshclam.log
+    NotifyClamd /etc/clamav/clamd.conf
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description of change
This change updates the ClamAV deployment on staging by fixing the [security vulnerabilities found by the Snyk IaC scanner](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/security/code-scanning?query=is%3Aopen+branch%3Amain+rule%3ASNYK-CC-K8S-11%2CSNYK-CC-K8S-9%2CSNYK-CC-K8S-8%2CSNYK-CC-K8S-6).

The recommendations suggest restricting the root filesystem to be read-only and disabling privilege escalation. In order to make this work with [MoJ’s clamav-docker image](https://github.com/ministryofjustice/clamav-docker), we would have to modify its scripts to ensure it could write to `/etc/clamav/freshclam.conf` to add a private mirror, as well as use the `/init-unprivileged` script that comes with ClamAV and avoids making calls that assume root privileges. At the moment the entrypoint is hardcoded to `/init`, which is a modified version of ClamAV’s default `/init`, but it still makes calls that require write access to the root filesystem.

While the above scripts could be modified by making copies in a mounted volume (e.g. `/tmp`) and modifying them there with some inline scripting, the more practical solution may be to use the original ClamAV image that comes with the ready-made `/init-unprivileged` script. Or, if this solution proves to be useful and appropriate, perhaps the `clamav-docker` image itself could be updated to use these more restrictive settings.

The changes to `deployment-clamav.yml` include:
- Implementing all the security vulnerability fixes recommended by Snyk IaC that ensure no write access to the root filesystem and no privilege escalation.
- Using the original `clamav/clamav-debian:stable` image.
- Mounting a volume at `/var/log/clamav` so ClamAV can write logs to its default directory.
- Mounting a volume at `/etc/clamav/freshclam.conf` that uses our own `freshclam.conf`, defined as a `ConfigMap`. It uses the default settings and adds the private mirror.
- Mounting a volume at `/tmp` to allow `clamd` to create its default local socket at `/tmp/clamd.socket` and to allow the creation of `/tmp/starttest` used by the startup probe.
- Running `/init-unprivileged` as the entrypoint script.

## Link to relevant ticket
[CRIMAPP-1837](https://dsdmoj.atlassian.net/browse/CRIMAPP-1837)

## How to manually test the feature
Ensure virus scanning works as expected in staging.

[CRIMAPP-1837]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ