### PR TITLE
[CRIMAPP-1837] Fix ClamAV ConfigMap naming inconsistency

### DIFF
--- a/config/kubernetes/staging/deployment-clamav.yml
+++ b/config/kubernetes/staging/deployment-clamav.yml
@@ -87,7 +87,7 @@ spec:
           emptyDir: {}
         - name: freshclam-config
           configMap:
-            name: configmap-clamav-staging
+            name: clamav-configmap-staging
         - name: tmp
           emptyDir: {}
   volumeClaimTemplates:


### PR DESCRIPTION
## Description of change
This change fixes an issue in the ClamAV StatefulSet where the ConfigMap is referenced by the wrong name.

## Link to relevant ticket
[CRIMAPP-1837](https://dsdmoj.atlassian.net/browse/CRIMAPP-1837)


[CRIMAPP-1837]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ