### PR TITLE
[CRIMAPP-1840] Staging custom error page vulnerability fixes

### DIFF
--- a/config/kubernetes/staging/deployment-custom-errors.yml
+++ b/config/kubernetes/staging/deployment-custom-errors.yml
@@ -21,13 +21,29 @@ spec:
       containers:
         - name: nginx-error-server
           image: registry.k8s.io/ingress-nginx/nginx-errors:v20230505@sha256:3600dcd1bbd0d05959bb01af4b272714e94d22d24a64e91838e7183c80e53f7f
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           volumeMounts:
             - name: custom-error-pages
               mountPath: /www
           securityContext:
-            runAsUser: 1000
+            runAsUser: 10000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 25m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 3Gi
 
       volumes:
         - name: custom-error-pages


### PR DESCRIPTION
## Description of change
Fixes the vulnerabilities identified by the snyk IaC scan in the custom error page deployment configuration. This improves the security posture of the `nginx-error-server` container and configures explicit resource requests and limits.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1840

## Notes for reviewer
There is one vulnerability i haven't fixed in this pr which is the [container is running without liveness probe](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/security/code-scanning/11) issue

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
