### PR TITLE
[CRIMAPP-1840] Ass liveness probe configuration

### DIFF
--- a/config/kubernetes/production/deployment-custom-errors.yml
+++ b/config/kubernetes/production/deployment-custom-errors.yml
@@ -44,6 +44,11 @@ spec:
             limits:
               cpu: 500m
               memory: 3Gi
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
 
       volumes:
         - name: custom-error-pages

--- a/config/kubernetes/staging/deployment-custom-errors.yml
+++ b/config/kubernetes/staging/deployment-custom-errors.yml
@@ -44,6 +44,11 @@ spec:
             limits:
               cpu: 500m
               memory: 3Gi
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
 
       volumes:
         - name: custom-error-pages


### PR DESCRIPTION
## Description of change
Adds liveness probe configuration to custom error page kubernetes configuration to address [vulnerability](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/security/code-scanning/11) identified by snyk code scanning 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1840

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
