### PR TITLE
[CRIMAPP-1865] use rails cookie instead of ip range for likely users

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -108,8 +108,8 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
-      SecRule REMOTE_ADDR "!@ipMatch 165.1.170.106,165.1.170.107,134.231.143.70,134.231.143.71,51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,128.77.75.64/26,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32" \
-        "id:999,deny,status:403,tag:github_team=laa-crime-apply"
+      SecRule &REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session "@eq 0" \
+        "id:999,phase:1,deny,status:403,tag:github_team=laa-crime-apply"
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,status:423"
       SecRuleUpdateTargetById 942100 !ARGS:authenticity_token
       SecRule REQUEST_URI "@endsWith /documents" \

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -37,6 +37,34 @@ spec:
                 name: service-staging
                 port:
                   number: 80
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+          - path: /cookies
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+          - path: /about
+            pathType: Prefix
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+          - path: /errors
+            pathType: Prefix
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
 ---
 # pingdom ingress
 apiVersion: networking.k8s.io/v1

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -13,10 +13,6 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_method !~ ^GET$) {
-        return 405;
-      }
 spec:
   ingressClassName: modsec-non-prod
   rules:


### PR DESCRIPTION
## Description of change

Use presence of rails cookie to determine if a user is a likely an authenticated user for deciding which error message to show. Previously IP range.

## Link to relevant ticket

[CRIMAPP-1865](https://dsdmoj.atlassian.net/browse/CRIMAPP-1865)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

See ticket


[CRIMAPP-1865]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ