### PR TITLE
[CRIMAPP-1866] use production modsec instead of non-prod

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -14,7 +14,7 @@ metadata:
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
 spec:
-  ingressClassName: modsec-non-prod
+  ingressClassName: modsec
   rules:
     - host: staging.apply-for-criminal-legal-aid.service.justice.gov.uk
       http:
@@ -84,7 +84,7 @@ metadata:
         return 405;
       }
 spec:
-  ingressClassName: modsec-non-prod
+  ingressClassName: modsec
   rules:
     - host: staging.apply-for-criminal-legal-aid.service.justice.gov.uk
       http:
@@ -228,7 +228,7 @@ metadata:
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-injection-php !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
 spec:
-  ingressClassName: modsec-non-prod
+  ingressClassName: modsec
   tls:
     - hosts:
         - laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change

Use production modsec instead of modsec-non-prod in staging.

## Link to relevant ticket
[CRIMAPP-1865](https://dsdmoj.atlassian.net/browse/CRIMAPP-1865)

## Notes for reviewer

To ensure staging is as production like as possible.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1865]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ