### PR TITLE
[CRIMAPP-1866] deny internal monitoring endpoints

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -33,6 +33,13 @@ spec:
                 name: service-staging
                 port:
                   number: 80
+          - path: /applications
+            pathType: Exact
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
           - path: /about
             pathType: Prefix
             backend:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -19,20 +19,6 @@ spec:
     - host: staging.apply-for-criminal-legal-aid.service.justice.gov.uk
       http:
         paths:
-          - path: /health
-            pathType: Exact
-            backend:
-              service:
-                name: service-staging
-                port:
-                  number: 80
-          - path: /datastore/health
-            pathType: Exact
-            backend:
-              service:
-                name: service-staging
-                port:
-                  number: 80
           - path: /
             pathType: Exact
             backend:
@@ -126,6 +112,9 @@ metadata:
       location = /.well-known/security.txt {
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
+      }
+      location ~* ^/(health|readyz|startupz|datastore/health) {
+        deny all;
       }
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/custom-http-errors: "423"


### PR DESCRIPTION
## Description of change

Make health endpoints internal on staging
Add /applications to public ingress to allow redirect from auth'd homepage

## Link to relevant ticket

[CRIMAPP-1865](https://dsdmoj.atlassian.net/browse/CRIMAPP-1865)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1865]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ