### PR TITLE
[CRIMAPP-1860] Fix snyk vuln

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -69,7 +69,7 @@ class DocumentsController < ApplicationController
   def error_for(document)
     return nil if document.errors.empty?
 
-    document.errors.first.full_message.html_safe # rubocop:disable Rails/OutputSafety
+    document.errors.first.full_message
   end
 
   # TODO: unify if possible the submission params

--- a/app/validators/scan_validator.rb
+++ b/app/validators/scan_validator.rb
@@ -12,7 +12,7 @@ class ScanValidator < ActiveModel::Validator
   # rubocop:disable Style/GuardClause, Style/IfUnlessModifier
   def perform_validations
     if Datastore::Documents::Scan.inconclusive?(record)
-      record.errors.add(:scan_status, :inconclusive, support_email: Settings.support_email)
+      record.errors.add(:scan_status, :inconclusive)
     end
 
     if Datastore::Documents::Scan.flagged?(record)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -41,7 +41,7 @@ en:
               blank: File could not be uploaded – try again
             scan_status:
               flagged: File may have a virus - please check the file is safe before trying again
-              inconclusive: File scanning service failed - please contact <a href="mailto:%{support_email}">%{support_email}</a>
+              inconclusive: There may be a problem with the selected file. Try uploading again or upload a different document.
 
         amount_and_frequency:
           attributes:


### PR DESCRIPTION
## Description of change
Removes usage of `html_safe` which has been flagged by snyk
 
> Unsanitized input from an HTTP parameter flows into unescaped HTML ("html_safe"), where it is used to directly output to a view. This may result in a Cross-Site Scripting attack (XSS).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1860

## Notes for reviewer
Updated content has been agreed with design 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
