### PR TITLE
[CRIMAPP-1892] filter SILAS offices codes for active crime contracts

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -77,3 +77,6 @@ OMNIAUTH_ENTRA_CLIENT_ID=7d95f6ff-2ff5-4ba0-aaf3-06d8769557ef
 OMNIAUTH_ENTRA_TENANT_ID=8352c342-da15-413a-8b5b-d89545766f0c
 OMNIAUTH_ENTRA_REDIRECT_URI=http://localhost:3000/providers/auth/entra/callback
 OMNIAUTH_POST_LOGOUT_REDIRECT_URI=http://localhost:3000/providers/logout
+
+PROVIDER_DATA_API_URL=https://laa-provider-details-api-dev.apps.live.cloud-platform.service.justice.gov.uk
+PROVIDER_DATA_API_SECRET=setInEnvDevelopmentLocal

--- a/.env.test
+++ b/.env.test
@@ -19,3 +19,7 @@ OMNIAUTH_ENTRA_CLIENT_SECRET='TestEntraClientSecret'
 OMNIAUTH_ENTRA_TENANT_ID='TestEntraTenantID'
 OMNIAUTH_ENTRA_REDIRECT_URI='https://www.example.com/users/auth/entra/callback'
 OMNIAUTH_ENTRA_POST_LOGOUT_REDIRECT_URI='https://www.example.com/providers/logout'
+
+PROVIDER_DATA_API_URL=https://pda.example.com
+PROVIDER_DATA_API_SECRET=TestPDASecret
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read('.ruby-version').chomp
 
-gem 'faraday', '~> 2.7'
+gem 'faraday', '~> 2.13'
+gem 'faraday-retry'
 gem 'govuk-components'
 gem 'govuk_design_system_formbuilder'
 gem 'jbuilder', '~> 2.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,14 +200,16 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
-    faraday (2.12.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.3.0)
       net-http
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     govuk-components (5.7.1)
@@ -576,7 +578,8 @@ DEPENDENCIES
   devise
   dotenv-rails
   erb_lint
-  faraday (~> 2.7)
+  faraday (~> 2.13)
+  faraday-retry
   govuk-components
   govuk_design_system_formbuilder
   jbuilder (~> 2.13.0)

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -35,13 +35,18 @@ module Providers
     end
 
     def check_provider_is_enrolled
-      gatekeeper = Providers::Gatekeeper.new(auth_hash.info)
-      return if gatekeeper.provider_enrolled?
+      return if provider_enrolled?
 
       Rails.logger.warn 'Not enrolled provider access attempt. ' \
                         "UID: #{auth_hash.uid}, accounts: #{auth_hash.info.office_codes}"
 
       redirect_to not_enrolled_errors_path
+    end
+
+    def provider_enrolled?
+      return auth_hash.info.office_codes.any? if FeatureFlags.provider_data_api.enabled?
+
+      Providers::Gatekeeper.new(auth_hash.info).provider_enrolled?
     end
   end
 end

--- a/app/lib/provider_data_api.rb
+++ b/app/lib/provider_data_api.rb
@@ -1,0 +1,12 @@
+module ProviderDataApi
+  module Types
+    include Dry.Types()
+
+    AreaOfLaw = String.enum(
+      'MEDIATION',
+      'LEGAL HELP',
+      'CIVIL FUNDING',
+      'CRIME LOWER'
+    )
+  end
+end

--- a/app/lib/provider_data_api/active_office_codes_filter.rb
+++ b/app/lib/provider_data_api/active_office_codes_filter.rb
@@ -1,0 +1,41 @@
+module ProviderDataApi
+  class ActiveOfficeCodesFilter
+    def initialize(office_codes: [], area_of_law: nil, http_client: HttpClient.call)
+      @office_codes = office_codes
+      @area_of_law = Types::AreaOfLaw[area_of_law] if area_of_law
+      @http_client = http_client
+    end
+
+    def call
+      office_codes.filter do |office_code|
+        response = http_client.head(schedules_endpoint(office_code))
+
+        response.status == 200
+      rescue Faraday::ResourceNotFound
+        next
+      end
+    end
+
+    class << self
+      def call(office_codes, area_of_law: nil)
+        new(office_codes:, area_of_law:).call
+      end
+    end
+
+    private
+
+    attr_reader :office_codes, :http_client, :area_of_law
+
+    def schedules_endpoint(office_code)
+      path = "/provider-offices/#{office_code}/schedules"
+
+      URI::Generic.build(path:, query:)
+    end
+
+    def query
+      return unless area_of_law
+
+      URI.encode_www_form('areaOfLaw' => area_of_law)
+    end
+  end
+end

--- a/app/lib/provider_data_api/http_client.rb
+++ b/app/lib/provider_data_api/http_client.rb
@@ -1,0 +1,33 @@
+module ProviderDataApi
+  class HttpClient
+    def initialize(host: Rails.configuration.x.provider_data_api.url)
+      @host = host
+    end
+
+    def call
+      Faraday.new(host) do |f|
+        f.headers = { 'X-Authorization': Rails.configuration.x.provider_data_api.secret }
+        f.response :raise_error
+        f.request :retry, retry_options
+        f.request :json
+        f.response :json
+      end
+    end
+
+    class << self
+      delegate :call, to: :new
+    end
+
+    private
+
+    attr_reader :host
+
+    def retry_options
+      {
+        methods: [:get, :head],
+        retry_statuses: [409],
+        interval: 0.05
+      }
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -25,6 +25,8 @@ class Provider < ApplicationRecord
   end
 
   def office_codes
+    return super if FeatureFlags.provider_data_api.enabled?
+
     super & Providers::Gatekeeper.active_office_codes
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,5 +74,8 @@ module LaaApplyForCriminalLegalAid
     config.x.inactive_offices = config_for(
       :inactive_offices, env: ENV.fetch('ENV_NAME', 'localhost')
     )
+
+    config.x.provider_data_api.url = ENV.fetch('PROVIDER_DATA_API_URL', nil)
+    config.x.provider_data_api.secret = ENV.fetch('PROVIDER_DATA_API_SECRET', nil)
   end
 end

--- a/config/kubernetes/preprod/config_map.yml
+++ b/config/kubernetes/preprod/config_map.yml
@@ -18,11 +18,11 @@ data:
   DATASTORE_API_CONSUMER: crime-apply-preprod
   BC_WSDL_URL: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
   VIRUS_SCAN_TIMEOUT: "20"
-
   OMNIAUTH_ENTRA_CLIENT_ID: 7d95f6ff-2ff5-4ba0-aaf3-06d8769557ef
   OMNIAUTH_ENTRA_TENANT_ID: 8352c342-da15-413a-8b5b-d89545766f0c
   OMNIAUTH_ENTRA_REDIRECT_URI: https://preprod.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/auth/entra/callback
   OMNIAUTH_ENTRA_POST_LOGOUT_REDIRECT_URI: https://preprod.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/logout
+  PROVIDER_DATA_API_URL: https://laa-provider-details-api-preprod.apps.live.cloud-platform.service.justice.gov.uk
 
   # If this is uncommented, authentication will be mocked
   # OMNIAUTH_TEST_MODE: "true"

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -21,6 +21,7 @@ data:
   OMNIAUTH_ENTRA_TENANT_ID: ff260a8b-cb92-4cfe-8ae9-d48bb0fd9851
   OMNIAUTH_ENTRA_REDIRECT_URI: https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/auth/entra/callback
   OMNIAUTH_ENTRA_POST_LOGOUT_REDIRECT_URI: https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/logout
+  PROVIDER_DATA_API_URL: https://laa-provider-details-api-preprod.apps.live.cloud-platform.service.justice.gov.uk
 
   # If this is uncommented, authentication will be mocked
   # OMNIAUTH_TEST_MODE: "true"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,7 @@ feature_flags:
     local: true
     test: false
     staging: true
+    preprod: true
     production: false
 
 # NOTE: consider if the setting you are adding here

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,11 @@ feature_flags:
     local: true
     staging: false
     production: false
+  provider_data_api:
+    local: true
+    test: false
+    staging: true
+    production: false
 
 # NOTE: consider if the setting you are adding here
 # should belong in the k8s `config_map`, which is

--- a/spec/lib/lassie/oidc_strategy_spec.rb
+++ b/spec/lib/lassie/oidc_strategy_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe Lassie::OidcStrategy do
         )
       end
     end
+
+    context 'when the provider data API feature is enabled' do
+      before do
+        allow(FeatureFlags).to receive(:provider_data_api) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+        }
+
+        allow(ProviderDataApi::ActiveOfficeCodesFilter).to receive(:call).and_return(
+          %w[1A123B 3B345C]
+        )
+      end
+
+      it 'filters the office codes using the active office code filter' do
+        expect(strategy_instance.info[:office_codes]).to eq %w[1A123B 3B345C]
+
+        expect(ProviderDataApi::ActiveOfficeCodesFilter).to have_received(:call).with(
+          laa_accounts, area_of_law: ProviderDataApi::Types::AreaOfLaw['CRIME LOWER']
+        )
+      end
+    end
   end
 
   describe 'Devise OmniAuth strategy configuration' do

--- a/spec/lib/provider_data_api/active_office_codes_filter_spec.rb
+++ b/spec/lib/provider_data_api/active_office_codes_filter_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+describe ProviderDataApi::ActiveOfficeCodesFilter do
+  let(:office_codes) { %w[1A2B3C 2B3C4E] }
+
+  describe '.call' do
+    subject(:filtered_office_codes) { described_class.call(office_codes) }
+
+    before do
+      stub_request(:head, 'https://pda.example.com/provider-offices/2B3C4E/schedules')
+        .to_return(status: 200)
+      stub_request(:head, 'https://pda.example.com/provider-offices/1A2B3C/schedules')
+        .to_return(status:)
+    end
+
+    let(:status) { 200 }
+
+    describe 'when an office is active' do
+      let(:status) { 200 }
+
+      it 'keeps the office code in the list' do
+        expect(filtered_office_codes).to eq office_codes
+      end
+    end
+
+    describe 'when an office is inactive' do
+      let(:status) { 204 }
+
+      it 'office_code is filtered from the list' do
+        expect(filtered_office_codes).to eq ['2B3C4E']
+      end
+    end
+
+    describe 'when an office is not found' do
+      let(:status) { 404 }
+
+      it 'office_code is filtered from the list' do
+        expect(filtered_office_codes).to eq ['2B3C4E']
+      end
+    end
+
+    describe 'when the Provider Data API returns a server error' do
+      let(:status) { 500 }
+
+      it 'raises a ServerError' do
+        expect { filtered_office_codes }.to raise_error Faraday::ServerError
+      end
+    end
+
+    describe 'when the Provider Data API returns a ForbiddenError error' do
+      let(:status) { 403 }
+
+      it 'raises a ProviderDataApi::ForbiddenError' do
+        expect { filtered_office_codes }.to raise_error Faraday::ForbiddenError
+      end
+    end
+
+    describe 'when the Provider Data API returns a conflict error' do
+      let(:url) { 'https://pda.example.com/provider-offices/C1C83H/schedules' }
+      let(:office_codes) { super() << 'C1C83H' }
+
+      context 'when API responds successfully after two attempts' do
+        before do
+          stub_request(:head, url).to_return(
+            { status: 409 },
+            { status: 200 }
+          )
+        end
+
+        it 'keeps the office code in the list after retry' do
+          expect(filtered_office_codes).to eq %w[1A2B3C 2B3C4E C1C83H]
+
+          expect(WebMock).to have_requested(:head, url).times(2)
+        end
+      end
+
+      context 'when API does not respond successfully' do
+        before do
+          stub_request(:head, url).to_return(
+            { status: 409 },
+            { status: 409 },
+            { status: 409 }
+          )
+        end
+
+        it 'raise a conflict error' do
+          expect { filtered_office_codes }.to raise_error(Faraday::ConflictError)
+
+          expect(WebMock).to have_requested(:head, url).times(3)
+        end
+      end
+    end
+
+    describe 'when `area_of_law` is specified' do
+      it 'scopes PDA request by the area of law' do
+        stub_request(:head, 'https://pda.example.com/provider-offices/9B3C4E/schedules?areaOfLaw=CIVIL%20FUNDING')
+          .to_return(status: 200)
+
+        described_class.call(['9B3C4E'], area_of_law: 'CIVIL FUNDING')
+      end
+
+      it 'returns an error if not a ProviderDataApi::Types::AreaOfLaw' do
+        expect { described_class.call(['9B3C4E'], area_of_law: 'CIVIL BUNDING') }
+          .to raise_error Dry::Types::ConstraintError
+      end
+    end
+  end
+end

--- a/spec/lib/provider_data_api/http_client_spec.rb
+++ b/spec/lib/provider_data_api/http_client_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ProviderDataApi::HttpClient do
+  describe '.call' do
+    subject(:connection) { described_class.call }
+
+    let(:middleware) { connection.builder.handlers.map(&:klass) }
+
+    it { is_expected.to be_a Faraday::Connection }
+
+    it 'sets the authorisation header' do
+      expect(connection.headers['X-Authorization']).to eq 'TestPDASecret'
+    end
+
+    it 'uses the configured PDA host url' do
+      allow(Faraday).to receive(:new) { double }
+      connection
+      expect(Faraday).to have_received(:new).with('https://pda.example.com')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
- Checks the office codes provided by SILAS against the Provider Data API to ensure that each has an active crime contract.
- Only store active office codes for each provider.
- Retry twice on PDA 409
- Feature toggle between this and the gatekeeper

## Link to relevant ticket

[CRIMAPP-1892](https://dsdmoj.atlassian.net/browse/CRIMAPP-1892)

## Notes for reviewer

There is no optimisation for these office code requests. An exceptional large number of office codes would be 30--which have bearable impact on the authentication time.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1892]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ