### PR TITLE
[CRIMAPP-1912] Allow deletion exemptions

### DIFF
--- a/db/migrate/20250827134435_add_exempt_from_deletion_to_crime_applications.rb
+++ b/db/migrate/20250827134435_add_exempt_from_deletion_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddExemptFromDeletionToCrimeApplications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :crime_applications, :exempt_from_deletion, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_18_101902) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_27_134435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -155,6 +155,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_18_101902) do
     t.string "pre_cifc_reason"
     t.jsonb "date_stamp_context"
     t.datetime "soft_deleted_at"
+    t.boolean "exempt_from_deletion", default: false
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["parent_id"], name: "index_crime_applications_on_parent_id", unique: true
     t.index ["usn"], name: "index_crime_applications_on_usn", unique: true

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -200,6 +200,18 @@ RSpec.describe CrimeApplication, type: :model do
         expect(described_class.to_be_soft_deleted.count).to eq(0)
       end
     end
+
+    context 'when application is exempt from deletion' do
+      let(:attributes) { { exempt_from_deletion: true, updated_at: retention_period - 1.day } }
+
+      before do
+        application.save!
+      end
+
+      it 'does not return application' do
+        expect(described_class.to_be_soft_deleted.count).to eq(0)
+      end
+    end
   end
 
   describe '#to_be_hard_deleted' do
@@ -238,6 +250,51 @@ RSpec.describe CrimeApplication, type: :model do
 
       it 'does not return application' do
         expect(described_class.to_be_hard_deleted.count).to eq(0)
+      end
+    end
+  end
+
+  describe '#exempt_from_deletion' do
+    it 'is false by default' do
+      expect(described_class.new.exempt_from_deletion).to be(false)
+    end
+  end
+
+  describe '#exempt_from_deletion!' do
+    let(:attributes) { { soft_deleted_at: Time.zone.now } }
+
+    before { application.save }
+
+    it 'clears soft_deleted_at' do
+      expect { application.exempt_from_deletion! }.to change(application, :soft_deleted_at).to(nil)
+    end
+
+    it 'sets exempt_from_deletion to true' do
+      expect { application.exempt_from_deletion! }.to change(application, :exempt_from_deletion).from(false).to(true)
+    end
+  end
+
+  describe 'Deleting an application' do
+    before { application.save }
+
+    context 'when the application is exempt from deletion' do
+      let(:attributes) { { exempt_from_deletion: true } }
+
+      it 'destroy raises an exception' do
+        expect {
+          application.destroy!
+        }.to raise_error(ActiveRecord::RecordNotDestroyed,
+                         'Application exempt from deletion').and(not_change(described_class, :count))
+      end
+    end
+
+    context 'when the application is not exempt from deletion' do
+      let(:attributes) { { exempt_from_deletion: false } }
+
+      it 'destroys the application' do
+        expect {
+          application.destroy!
+        }.to change(described_class, :count).from(1).to(0)
       end
     end
   end

--- a/spec/services/automated_deletion_spec.rb
+++ b/spec/services/automated_deletion_spec.rb
@@ -15,13 +15,15 @@ RSpec.describe AutomatedDeletion do
     # app to remain unaffected due to having a parent application
     CrimeApplication.create(reference: 700_000_5, parent_id: SecureRandom.uuid,
                             documents: [], updated_at: 2.years.ago)
+    # app to be remain unaffected due to exemption
+    CrimeApplication.create(reference: 700_000_6, documents: [], updated_at: 2.years.ago, exempt_from_deletion: true)
   end
 
   it 'deletes applications as required' do
     expect {
       described_class.call
     }.to change(CrimeApplication,
-                :count).from(5).to(4)
+                :count).from(6).to(5)
     expect(CrimeApplication.find_by(reference: 700_000_1)).to be_nil
   end
 
@@ -33,6 +35,12 @@ RSpec.describe AutomatedDeletion do
 
   it 'ignores an application if it has parent application' do
     exempt_app = CrimeApplication.find_by(reference: 700_000_5)
+
+    expect { described_class.call }.not_to(change { exempt_app.reload.soft_deleted_at })
+  end
+
+  it 'ignores an application if it is exempt' do
+    exempt_app = CrimeApplication.find_by(reference: 700_000_6)
 
     expect { described_class.call }.not_to(change { exempt_app.reload.soft_deleted_at })
   end


### PR DESCRIPTION
## Description of change
- added `exempt_from_deletion` attribute to `crime_applications`
- added `exempt_from_deletion` check to `to_be_soft_deleted` scope
- added `before_destroy` callback to `crime_applications` to prevent deletion of exempt applications

## Link to relevant ticket
[CRIMAPP-1912](https://dsdmoj.atlassian.net/browse/CRIMAPP-1912)

[CRIMAPP-1912]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ