### PR TITLE
[CRIMAPP-1912] Exclude submitted and PSE applications from automated deletion

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -88,7 +88,10 @@ class CrimeApplication < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   scope :with_applicant, -> { joins(:people).includes(:applicant).merge(Applicant.with_name) }
 
-  scope :to_be_soft_deleted, -> { active.where(updated_at: ..Rails.configuration.x.retention_period.ago) }
+  scope :to_be_soft_deleted, lambda {
+    active.where.not(application_type: ApplicationType::POST_SUBMISSION_EVIDENCE.to_s)
+          .where(parent_id: nil, updated_at: ..Rails.configuration.x.retention_period.ago)
+  }
 
   scope :to_be_hard_deleted, lambda {
     where(soft_deleted_at: ..Rails.configuration.x.soft_deletion_period.ago)

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -174,6 +174,32 @@ RSpec.describe CrimeApplication, type: :model do
         expect(described_class.to_be_soft_deleted.count).to eq(0)
       end
     end
+
+    context 'when application is PSE' do
+      let(:attributes) {
+        { application_type: ApplicationType::POST_SUBMISSION_EVIDENCE.to_s, updated_at: retention_period - 1.day }
+      }
+
+      before do
+        application.save!
+      end
+
+      it 'does not return application' do
+        expect(described_class.to_be_soft_deleted.count).to eq(0)
+      end
+    end
+
+    context 'when application is submitted' do
+      let(:attributes) { { parent_id: SecureRandom.uuid, updated_at: retention_period - 1.day } }
+
+      before do
+        application.save!
+      end
+
+      it 'does not return application' do
+        expect(described_class.to_be_soft_deleted.count).to eq(0)
+      end
+    end
   end
 
   describe '#to_be_hard_deleted' do

--- a/spec/services/automated_deletion_spec.rb
+++ b/spec/services/automated_deletion_spec.rb
@@ -9,14 +9,32 @@ RSpec.describe AutomatedDeletion do
     CrimeApplication.create(reference: 700_000_2, documents: [], updated_at: 2.years.ago)
     # app to remain unaffected
     CrimeApplication.create(reference: 700_000_3, documents: [])
+    # app to remain unaffected due to being PSE
+    CrimeApplication.create(reference: 700_000_4, application_type: ApplicationType::POST_SUBMISSION_EVIDENCE.to_s,
+                            documents: [], updated_at: 2.years.ago)
+    # app to remain unaffected due to being submitted
+    CrimeApplication.create(reference: 700_000_5, parent_id: SecureRandom.uuid,
+                            documents: [], updated_at: 2.years.ago)
   end
 
   it 'deletes applications as required' do
     expect {
       described_class.call
     }.to change(CrimeApplication,
-                :count).from(3).to(2)
+                :count).from(5).to(4)
     expect(CrimeApplication.find_by(reference: 700_000_1)).to be_nil
+  end
+
+  it 'ignores an application if it is PSE' do
+    exempt_app = CrimeApplication.find_by(reference: 700_000_4)
+
+    expect { described_class.call }.not_to(change { exempt_app.reload.soft_deleted_at })
+  end
+
+  it 'ignores an application if it is submitted' do
+    exempt_app = CrimeApplication.find_by(reference: 700_000_5)
+
+    expect { described_class.call }.not_to(change { exempt_app.reload.soft_deleted_at })
   end
 
   it 'adds a deletion entry for the deleted application' do


### PR DESCRIPTION
## Description of change
- updated the `to_be_soft_deleted` scope to exclude PSE and submitted applications

## Link to relevant ticket
[CRIMAPP-1912](https://dsdmoj.atlassian.net/browse/CRIMAPP-1912)