### PR TITLE
[CRIMAPP-1918] Add category to Snyk's SARIF uploads

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -57,3 +57,4 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: snyk.sarif
+        category: snyk-container-check

--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -47,3 +47,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
+          category: snyk-infrastructure-check


### PR DESCRIPTION
## Description of change
- provide a category argument to `upload-sarif@v3` when uploading Snyk's scan results

## Link to relevant ticket
[CRIMAPP-1918](https://dsdmoj.atlassian.net/browse/CRIMAPP-1918)

[CRIMAPP-1918]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ