### PR TITLE
CRIMAPP-1921 configure service hours

### DIFF
--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -133,6 +133,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_WDAY "!@pm 1 2 3 4 5" \
+        "id:997,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
+      SecRule TIME_HOUR "!@pm 06 07 08 09 10 11 12 13 14 15 16 17" \
+        "id:998,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
       SecRule &REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session "@eq 0" \
         "id:999,phase:1,deny,status:403,tag:github_team=laa-crime-apply"
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,status:423"

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -134,6 +134,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_WDAY "!@pm 1 2 3 4 5" \
+        "id:997,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
+      SecRule TIME_HOUR "!@pm 06 07 08 09 10 11 12 13 14 15 16 17" \
+        "id:998,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
       SecRule &REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session "@eq 0" \
         "id:999,phase:1,deny,status:403,tag:github_team=laa-crime-apply"
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,status:423"

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -133,6 +133,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_WDAY "!@pm 1 2 3" \
+        "id:997,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
+      SecRule TIME_HOUR "!@pm 09 10 11 12 13 14 15" \
+        "id:998,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
       SecRule &REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session "@eq 0" \
         "id:999,phase:1,deny,status:403,tag:github_team=laa-crime-apply"
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,status:423"


### PR DESCRIPTION
## Description of change

Return 503 when provider service is accessed outside of office hours
- Staging is only available 10am to 4pm Monday-Wednesday (for testing)
- Preprod and Production 7am to 7pm Monday-Friday

## Link to relevant ticket

[CRIMAPP-1929](https://dsdmoj.atlassian.net/browse/CRIMAPP-1929)

## Notes for reviewer

I've used @pm (pattern match) instead of @within because it allows easier testing of access control logic--particularly when simulating access during office hours without changing the rule structure.

I haven't yet verified whether values like 09, 08, etc., match correctly due to potential issues with leading zeros in numeric comparisons. If needed, I can adjust those to 9, 8, etc.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
