### PR TITLE
Remove attack-lfi rule from session cookie

### DIFF
--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -218,16 +218,7 @@ metadata:
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
         ctl:ruleRemoveById=942230"
-      SecRule REQUEST_URI "@streq /providers/auth/saml/callback" \
-        "id:1010,phase:2,pass,nolog,chain"
-        SecRule REQUEST_METHOD "@streq POST" \
-          "ctl:ruleRemoveById=921110,\
-          ctl:ruleRemoveById=932235,\
-          ctl:ruleRemoveById=932250,\
-          ctl:ruleRemoveById=932260,\
-          ctl:ruleRemoveById=932370,\
-          ctl:ruleRemoveById=933150,\
-          ctl:ruleRemoveById=941130"
+      SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -218,16 +218,7 @@ metadata:
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
         ctl:ruleRemoveById=942230"
-      SecRule REQUEST_URI "@streq /providers/auth/saml/callback" \
-        "id:1010,phase:2,pass,nolog,chain"
-        SecRule REQUEST_METHOD "@streq POST" \
-          "ctl:ruleRemoveById=921110,\
-          ctl:ruleRemoveById=932235,\
-          ctl:ruleRemoveById=932250,\
-          ctl:ruleRemoveById=932260,\
-          ctl:ruleRemoveById=932370,\
-          ctl:ruleRemoveById=933150,\
-          ctl:ruleRemoveById=941130"
+      SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -218,16 +218,7 @@ metadata:
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
         ctl:ruleRemoveById=942230"
-      SecRule REQUEST_URI "@streq /providers/auth/saml/callback" \
-        "id:1010,phase:2,pass,nolog,chain"
-        SecRule REQUEST_METHOD "@streq POST" \
-          "ctl:ruleRemoveById=921110,\
-          ctl:ruleRemoveById=932235,\
-          ctl:ruleRemoveById=932250,\
-          ctl:ruleRemoveById=932260,\
-          ctl:ruleRemoveById=932370,\
-          ctl:ruleRemoveById=933150,\
-          ctl:ruleRemoveById=941130"
+      SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session


### PR DESCRIPTION
## Description of change
- Remove attack-lfi rule from session cookie
- Removes redundant SAML rule

## Notes for reviewer

These rules could not be use to exploit the rails session cookie but they are causing false positives. Fixes observed false positive blocking users.