### PR TITLE
[CRIMAPP-1952] return OK status on CL error

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -11,7 +11,7 @@ module ErrorHandling
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path
       when Errors::ContingentLiability
-        render '/errors/contingent_liability', status: :forbidden
+        render '/errors/contingent_liability'
       when Errors::NotFound
         redirect_to not_found_errors_path
       # NOTE: Add more custom errors as they are needed, for instance:

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -36,7 +36,7 @@ class ErrorsController < UnauthenticatedController
   end
 
   def contingent_liability
-    respond_with_status(:forbidden)
+    respond_with_status(:ok)
   end
 
   private

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Error pages' do
   context 'contingent_liability' do
     it 'renders the expected page and has expected status code' do
       get '/errors/contingent-liability'
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/system/dashboard/contingent_liability_spec.rb
+++ b/spec/system/dashboard/contingent_liability_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe 'Viewing dashboard with Contingent Liability Criminal Legal Aid a
       within('.govuk-error-summary') do |error|
         expect(error).to have_content('You cannot start, change or submit applications using this account')
       end
-
-      expect(page).to have_http_status :forbidden
     end
 
     it 'shows error message when trying delete a draft application' do


### PR DESCRIPTION
## Description of change
Return OK http status on Contingent Liability error page
Previously :forbidden was used, however this resulted in the standard 403 error page being shown when deployed to Cloud Platform

## Link to relevant ticket
[CRIMAPP-1952](https://dsdmoj.atlassian.net/browse/CRIMAPP-1952)

[CRIMAPP-1952]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ