### PR TITLE
[CRIMAPP-1952] add missing category of law

### DIFF
--- a/app/lib/provider_data_api.rb
+++ b/app/lib/provider_data_api.rb
@@ -13,6 +13,7 @@ module ProviderDataApi
 
     CategoryOfLaw = String.enum(
       'ALL',
+      'AAP',
       'APPEALS',
       'INVEST',
       'PRISON'


### PR DESCRIPTION
'AAP' was missing from CategoryOfLaw type