### PR TITLE
Block access to Crime Apply Friday 10 October 2025

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -136,7 +136,7 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
-      SecRule TIME_WDAY "!@pm 1 2 3 4 5" \
+      SecRule TIME_WDAY "!@pm 1 2 3 4" \
         "id:997,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 06 07 08 09 10 11 12 13 14 15 16 17" \
         "id:998,phase:1,deny,status:503,tag:github_team=laa-crime-apply"


### PR DESCRIPTION
This is to block access to Crime Apply for providers. It will be reverted before Friday 17.