### PR TITLE
[CRIMAPP-2015] Preserve Welsh language when sorting applications table

### DIFF
--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -90,7 +90,7 @@ module DataTable
     end
 
     def locale_param
-      request.query_parameters.slice('locale') || {}
+      request.query_parameters.slice('locale')
     end
   end
 end


### PR DESCRIPTION
## Description of change
When sorting the columns on the Crime Application table, ensure that the locale is preserved.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="222" height="338" alt="Screenshot 2025-11-11 at 11 20 29" src="https://github.com/user-attachments/assets/6bc11f1b-e48b-421d-9d1b-00a545faf3e1" />

### After changes:
<img width="185" height="406" alt="Screenshot 2025-11-11 at 11 20 12" src="https://github.com/user-attachments/assets/00b4949c-e8d2-41eb-8341-0e66ba4ac829" />

## How to manually test the feature
Visit applications/, select the Welsh language, click on a table column header to sort the table values. The values should remain Welsh.
