### PR TITLE
[CRIMAPP-1965] Adds missing welsh translation to income summary card

### DIFF
--- a/app/presenters/summary/sections/income_details.rb
+++ b/app/presenters/summary/sections/income_details.rb
@@ -33,7 +33,11 @@ module Summary
       private
 
       def income_above_threshold_prefix
-        include_partner_in_means_assessment? ? 'Joint annual income' : 'Income'
+        if include_partner_in_means_assessment?
+          I18n.t('summary.questions.income_above_threshold.joint_annual_income')
+        else
+          I18n.t('summary.questions.income_above_threshold.income')
+        end
       end
 
       def property_ownership_type

--- a/config/locales/cy/summary.yml
+++ b/config/locales/cy/summary.yml
@@ -473,6 +473,8 @@ cy:
       # BEGIN income details section
       income_above_threshold:
         question: "%{prefix} mwy na £12,475 y flwyddyn cyn treth?"
+        income: Incwm
+        joint_annual_income: Incwm blynyddol ar y cyd
         answers:
           <<: *YESNO
       has_frozen_income_or_assets:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -473,6 +473,8 @@ en:
       # BEGIN income details section
       income_above_threshold:
         question: "%{prefix} more than £12,475 a year before tax?"
+        income: Income
+        joint_annual_income: Joint annual income
         answers:
           <<: *YESNO
       has_frozen_income_or_assets:


### PR DESCRIPTION
## Description of change
Adds missing welsh translation to income summary card
See screenshot below of change

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1965 

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1080" height="260" alt="Screenshot 2025-10-16 at 08 43 15" src="https://github.com/user-attachments/assets/264bc80b-665a-45b7-a232-3c115871e61f" />

### After changes:
<img width="1080" height="260" alt="Screenshot 2025-10-16 at 08 42 59" src="https://github.com/user-attachments/assets/0c5bd6a3-e3ce-4a22-a4d3-c822372b415b" />

## How to manually test the feature
