### PR TITLE
Add missing service name to provider step pages

### DIFF
--- a/app/views/steps/provider_step/_header.html.erb
+++ b/app/views/steps/provider_step/_header.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_header(classes: "govuk-header-#{HostEnv.env_name}") do |header|
+<%= govuk_header(service_name: service_name, homepage_url: root_path, classes: "govuk-header-#{HostEnv.env_name}") do |header|
       header.with_navigation_item(
         text: current_provider.display_name,
         href: nil,


### PR DESCRIPTION
## Description of change
- add the service name to the header on the provider office pages

## Link to relevant ticket
[Slack thread](https://mojdt.slack.com/archives/C05N1RXEU2E/p1760608912181249)

## Screenshots of changes (if applicable)

### Before changes:
<img width="2116" height="980" alt="image" src="https://github.com/user-attachments/assets/5b53b895-bc38-4917-8c6b-7dcc81e8bc42" />

### After changes:
<img width="2080" height="1094" alt="image" src="https://github.com/user-attachments/assets/97437417-4bfa-4253-88be-733c1d9a630d" />