### PR TITLE
[CRIMAPP-1948] DraftCreated task

### DIFF
--- a/lib/tasks/submit_draft_created_events.rake
+++ b/lib/tasks/submit_draft_created_events.rake
@@ -1,0 +1,26 @@
+desc 'Submit DraftCreated events for all drafts'
+task submit_draft_created_events: [:environment] do
+  require 'csv'
+
+  failed_events = []
+  CrimeApplication.order(created_at: :asc).find_each do |crime_application|
+    begin
+      Datastore::Events::DraftCreated.new(
+        entity_id: crime_application.id,
+        entity_type: crime_application.application_type,
+        business_reference: crime_application.reference,
+        created_at: crime_application.created_at
+      ).call
+    rescue StandardError => e
+      failed_events << crime_application.id
+      puts "Failed #{crime_application.id}: #{e.message}"
+      next
+    end
+  end
+
+  CSV.open('/tmp/failed_draft_created_events.csv', 'w', write_headers: true, headers: ['id']) do |csv|
+    failed_events.each { |id| csv << [id] }
+  end
+
+  puts 'Done'
+end


### PR DESCRIPTION
## Description of change
- add a `submit_draft_created_events` rake task to generate DraftCreated events for all existing drafts

The estimated number of drafts in production is 46,750.
The estimated number of drafts in staging is 223.

## Link to relevant ticket
[CRIMAPP-1948](https://dsdmoj.atlassian.net/browse/CRIMAPP-1948)

[CRIMAPP-1948]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ