### PR TITLE
Ignore ModSec rules 942360 & 942140

### DIFF
--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -196,6 +196,12 @@ metadata:
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
         "id:1008,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
+      SecRule REQUEST_URI "@endsWith /steps/outgoings/are-outgoings-more-than-income" \
+        "id:1009,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942360"
+      SecRule REQUEST_URI "@rx /steps/income/client/employer-details/[a-f0-9-]+$" \
+        "id:1010,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942140"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -196,6 +196,12 @@ metadata:
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
         "id:1008,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
+      SecRule REQUEST_URI "@endsWith /steps/outgoings/are-outgoings-more-than-income" \
+        "id:1009,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942360"
+      SecRule REQUEST_URI "@rx /steps/income/client/employer-details/[a-f0-9-]+$" \
+        "id:1010,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942140"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -196,6 +196,12 @@ metadata:
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
         "id:1008,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
+      SecRule REQUEST_URI "@endsWith /steps/outgoings/are-outgoings-more-than-income" \
+        "id:1009,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942360"
+      SecRule REQUEST_URI "@rx /steps/income/client/employer-details/[a-f0-9-]+$" \
+        "id:1010,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=942140"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session


### PR DESCRIPTION
## Description of change
- ignores rule 942360 on path matching `/steps/outgoings/are-outgoings-more-than-income`
- ignores rule 942140 on path matching `/steps/income/client/employer-details/{id}`

This has been tested in staging.

## Link to relevant ticket
[Alert for 942360](https://mojdt.slack.com/archives/C056U956ESH/p1760353841786999)
[Alert for 942140](https://mojdt.slack.com/archives/C056U956ESH/p1760717771793899)