### PR TITLE
[CRIMAPP-2015] preserve locale when sorting

### DIFF
--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -62,17 +62,17 @@ module DataTable
     end
 
     def sorted_params
-      return sorting_params unless filter
-
-      { filter: filter.params }.merge(sorting_params)
+      {
+        locale: I18n.locale,
+        sorting: sorting_params,
+        filter: filter&.params
+      }.compact
     end
 
     def sorting_params
       {
-        sorting: {
-          sort_by: colname,
-          sort_direction: sorting.reverse_direction
-        }
+        sort_by: colname,
+        sort_direction: sorting.reverse_direction
       }
     end
 

--- a/spec/system/dashboard/viewing_in_progress_applications_spec.rb
+++ b/spec/system/dashboard/viewing_in_progress_applications_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe 'Viewing In Progress Criminal Legal Aid applications' do
       end
     end
 
+    it 'preserves the locale when sorting' do
+      click_link 'Cymraeg'
+      click_button 'Enw'
+      expect(find(:element, 'aria-sort': 'ascending')).to have_text 'Enw'
+    end
+
     context 'when there are more than 30 records' do
       let(:number_of_records) { Kaminari.config.default_per_page + 1 }
 


### PR DESCRIPTION
## Description of change

Ensure locale is preserved when sorting applications

## Link to relevant ticket

[CRIMAPP-2015](https://dsdmoj.atlassian.net/browse/CRIMAPP-2015)

[CRIMAPP-2015]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ