### PR TITLE
[CRIMAPP-1921] Only same-origin resources are allowed.

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,20 +8,21 @@ require 'feature_flags'
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.default_src :self, :https
+    policy.default_src :self
     policy.base_uri    :none
     policy.style_src   :self
-    policy.font_src    :self, :https, :data
+    policy.font_src    :self
+
     if FeatureFlags.google_analytics.enabled?
       policy.connect_src :self, 'https://ga.jspm.io', 'https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com'
-      policy.img_src :self, :https, :data, 'https://*.google-analytics.com', 'https://*.googletagmanager.com'
+      policy.img_src :self, 'https://*.google-analytics.com', 'https://*.googletagmanager.com'
     else
-      policy.img_src :self, :https, :data
+      policy.img_src :self
     end
-    policy.form_action :self, 'https://*.legalservices.gov.uk/oamfed/idp/samlv20', 'https://login.microsoftonline.com'
+
     policy.object_src  :none
-    policy.script_src  :self, :https
-    policy.style_src   :self, :https
+    policy.script_src  :self
+    policy.style_src   :self
 
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
@@ -29,8 +30,6 @@ Rails.application.configure do
 
   # Generate session nonces for permitted importmap and inline scripts
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
-
-  # config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w(script-src style-src)
 
   # Report violations without enforcing the policy.


### PR DESCRIPTION
## Description of change

Updated Content Security Policy to prevent external scripts/styles
Removes saml rule

## Link to relevant ticket

[CRIMAPP-1921](https://dsdmoj.atlassian.net/browse/CRIMAPP-1921)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
```
default-src 'self' https:; base-uri 'none'; style-src 'self' https: 'nonce-W7sxS5Q1hEFK9MlHkns5pQ=='; font-src 'self' https: data:; img-src 'self' https: data:; form-action 'self' https://*.legalservices.gov.uk/oamfed/idp/samlv20 https://login.microsoftonline.com; object-src 'none'; script-src 'self' https: 'nonce-W7sxS5Q1hEFK9MlHkns5pQ=='
```

### After changes:
```
default-src 'self'; base-uri 'none'; style-src 'self' 'nonce-RfgNv/9WJHwECpr980prtA=='; font-src 'self'; img-src 'self'; object-src 'none'; script-src 'self' 'nonce-RfgNv/9WJHwECpr980prtA=='
```

## How to manually test the feature


[CRIMAPP-1921]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ