### PR TITLE
[CRIMAPP-1733] Allow months names in date input

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -157,3 +157,8 @@ form.search {
     width: 8em;
   }
 }
+
+// Make the month input wider to accommodate month names
+.govuk-date-input__item input[id$="2"] {
+  @extend .govuk-input--width-5;
+}

--- a/app/attributes/type/multiparam_date.rb
+++ b/app/attributes/type/multiparam_date.rb
@@ -8,9 +8,9 @@ module Type
     def cast(value)
       return value if value.blank? || value.is_a?(Date)
 
-      # `value` is a hash in the format: {3=>31, 2=>12, 1=>2000}
-      # where `3` is the day, `2` is the month and `1` is the year.
-      value_args = value.values_at(1, 2, 3)
+      # `value` is a hash in the format: {3=>31, 2=>'12', 1=>2000}
+      # where `3` is the day, `2` is the month (digit or month name) and `1` is the year.
+      value_args = normalize_month_of_date(value).values_at(1, 2, 3)
 
       if Date.valid_date?(*value_args)
         Date.new(*value_args)
@@ -27,6 +27,23 @@ module Type
     # Leave the sanity check to the `#cast` method.
     def value_from_multiparameter_assignment(value)
       value
+    end
+
+    private
+
+    # Attempt to parse the month, which could be a digit or a month name
+    # Date::parse is quite tolerant of abbreviations of variable length and slight misspellings
+    # Assumes value[2] to be the month value
+    def normalize_month_of_date(value)
+      normalized = value.dup
+      month_value = value[2]
+
+      begin
+        normalized[2] = month_value.to_i.nonzero? || Date.parse(month_value).month
+        normalized
+      rescue StandardError
+        value
+      end
     end
   end
 end

--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -10,13 +10,23 @@ module FormBuilderHelper
     end
   end
 
-  def segment_names
-    { day: I18n.t('date.day'), month: I18n.t('date.month'), year: I18n.t('date.year') }
+  def date_input(attribute_name, opts = {}, &block)
+    govuk_date_field(attribute_name, segments:, segment_names:, **opts, &block)
   end
 
   private
 
   def submit_button(i18n_key, opts = {}, &block)
     govuk_submit I18n.t("helpers.submit.#{i18n_key}"), **opts, &block
+  end
+
+  def segment_names
+    { day: I18n.t('date.day'), month: I18n.t('date.month'), year: I18n.t('date.year') }
+  end
+
+  # This ensures that the month segment is not automatically cast to integer by the form class,
+  # allowing month names to be entered.
+  def segments
+    { day: '3i', month: '2', year: '1i' }
   end
 end

--- a/app/views/steps/case/charges/edit.html.erb
+++ b/app/views/steps/case/charges/edit.html.erb
@@ -28,19 +28,9 @@
         <%= f.fields_for :offence_dates do |od| %>
           <% index = od.index + 1 %>
 
-          <%= od.govuk_date_field :date_from, maxlength_enabled: true,
-                                  segment_names: f.segment_names,
-                                  legend: {
-                                    text: t("helpers.legend.#{f.object_name}.date_from", index:),
-                                    size: 's'
-                                  } %>
+          <%= od.date_input :date_from, legend: { text: t("helpers.legend.#{f.object_name}.date_from", index:), size: 's' } %>
 
-          <%= od.govuk_date_field :date_to, maxlength_enabled: true,
-                                  segment_names: f.segment_names,
-                                  legend: {
-                                    text: t("helpers.legend.#{f.object_name}.date_to", index:),
-                                    size: 's'
-                                  } %>
+          <%= od.date_input :date_to, legend: { text: t("helpers.legend.#{f.object_name}.date_to", index:), size: 's' } %>
 
           <%= od.button t('.remove_button', index:), type: :submit, value: '1', name: od.field_name(:_destroy, index: od.id),
                         class: %w[govuk-button govuk-button--warning],

--- a/app/views/steps/case/has_case_concluded/edit.html.erb
+++ b/app/views/steps/case/has_case_concluded/edit.html.erb
@@ -9,12 +9,7 @@
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice == YesNoAnswer::YES %>
             <%= f.govuk_radio_button :has_case_concluded, choice.value do %>
-              <%= f.govuk_date_field :date_case_concluded, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                     legend: {
-                                       text: t('.date_case_concluded',),
-                                       size: 's'
-                                     } %>
+              <%= f.date_input :date_case_concluded, legend: { text: t('.date_case_concluded',), size: 's' } %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :has_case_concluded, choice.value, link_errors: index.zero? %>

--- a/app/views/steps/case/hearing_details/edit.html.erb
+++ b/app/views/steps/case/hearing_details/edit.html.erb
@@ -12,7 +12,7 @@
                                     data: { module: 'accessible-autocomplete' },
                                     options: { include_blank: true }, label: { tag: 'h2', size: 'm' } %>
 
-      <%= f.govuk_date_field :hearing_date, maxlength_enabled: true, legend: { tag: 'h2', size: 'm' }, segment_names: f.segment_names %>
+      <%= f.date_input :hearing_date, legend: { tag: 'h2', size: 'm' } %>
 
       <%= f.govuk_collection_radio_buttons :is_first_court_hearing, @form_object.choices, :value, legend: { tag: 'h2', size: 'm' } %>
 

--- a/app/views/steps/case/is_client_remanded/edit.html.erb
+++ b/app/views/steps/case/is_client_remanded/edit.html.erb
@@ -9,12 +9,7 @@
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice == YesNoAnswer::YES %>
             <%= f.govuk_radio_button :is_client_remanded, choice.value do %>
-              <%= f.govuk_date_field :date_client_remanded, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                     legend: {
-                                       text: t('.date_client_remanded',),
-                                       size: 's'
-                                     } %>
+              <%= f.date_input :date_client_remanded, legend: { text: t('.date_client_remanded',), size: 's' } %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :is_client_remanded, choice.value, link_errors: index.zero? %>

--- a/app/views/steps/case/is_preorder_work_claimed/edit.html.erb
+++ b/app/views/steps/case/is_preorder_work_claimed/edit.html.erb
@@ -9,12 +9,7 @@
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice == YesNoAnswer::YES %>
             <%= f.govuk_radio_button :is_preorder_work_claimed, choice.value do %>
-              <%= f.govuk_date_field :preorder_work_date, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                     legend: {
-                                       text: t('.preorder_work_date',),
-                                       size: 's'
-                                     } %>
+              <%= f.date_input :preorder_work_date, legend: { text: t('.preorder_work_date',), size: 's' } %>
               <%= f.govuk_text_area :preorder_work_details,
                                     segment_names: f.segment_names,
                                     label: { hidden: true },

--- a/app/views/steps/case/other_charge/edit.html.erb
+++ b/app/views/steps/case/other_charge/edit.html.erb
@@ -9,11 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_area :charge, label: { text: t('.charge_label'), size: 'm' }  %>
       <%= f.govuk_text_field :hearing_court_name, label: { text: t('.hearing_court_name_label'), size: 'm' }, autocomplete: 'off' %>
-      <%= f.govuk_date_field :next_hearing_date,
-                             segment_names: f.segment_names,
-                             maxlength_enabled: true,
-                             legend: { text: t('.hearing_date_legend') },
-                             hint: { text: t('.hearing_date_hint') } %>
+      <%= f.date_input :next_hearing_date, legend: { text: t('.hearing_date_legend') }, hint: { text: t('.hearing_date_hint') } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/client/appeal_details/edit.en.html.erb
+++ b/app/views/steps/client/appeal_details/edit.en.html.erb
@@ -8,7 +8,7 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :appeal_lodged_date, maxlength_enabled: true, legend: { size: 's' }, segment_names: f.segment_names %>
+      <%= f.date_input :appeal_lodged_date, legend: { size: 's' } %>
 
       <%= f.govuk_radio_buttons_fieldset :appeal_original_app_submitted, legend: { tag: 'h2', size: 's' } do %>
         <% @form_object.yes_no_choices.each_with_index do |option, index| %>

--- a/app/views/steps/client/details/edit.html.erb
+++ b/app/views/steps/client/details/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.govuk_text_field :other_names, autocomplete: 'off', width: 'three-quarters', label: { size: 'm' } %>
 
-      <%= f.govuk_date_field :date_of_birth, maxlength_enabled: true, legend: { size: 'm' }, segment_names: f.segment_names %>
+      <%= f.date_input :date_of_birth, legend: { size: 'm' } %>
 
       <%= f.continue_button(secondary: false) %>
     <% end %>

--- a/app/views/steps/client/relationship_status/edit.html.erb
+++ b/app/views/steps/client/relationship_status/edit.html.erb
@@ -12,12 +12,7 @@
 
           <% if choice == ClientRelationshipStatusType::SEPARATED %>
             <%= f.govuk_radio_button :relationship_status, choice.value do %>
-              <%= f.govuk_date_field :separation_date, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                      legend: {
-                                        text: t('.separation_date'),
-                                        size: 's', class: 'govuk-!-font-weight-regular'
-                                      } %>
+              <%= f.date_input :separation_date, legend: { text: t('.separation_date'), size: 's', class: 'govuk-!-font-weight-regular' } %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :relationship_status, choice.value, link_errors: index.zero? %>

--- a/app/views/steps/dwp/benefit_type/edit.html.erb
+++ b/app/views/steps/dwp/benefit_type/edit.html.erb
@@ -11,12 +11,7 @@
 
         <% if option.jsa? %>
             <%= f.govuk_radio_button :benefit_type, option.value do %>
-              <%= f.govuk_date_field :last_jsa_appointment_date, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                      legend: {
-                                        text: t('.last_jsa_appointment_date'),
-                                        size: 's', class: 'govuk-!-font-weight-regular'
-                                      } %>
+              <%= f.date_input :last_jsa_appointment_date, legend: { text: t('.last_jsa_appointment_date'), size: 's', class: 'govuk-!-font-weight-regular' } %>
             <% end %>
           <% elsif option.none? %>
             <%= f.govuk_radio_divider I18n.t('divider_text') %>

--- a/app/views/steps/dwp/partner_benefit_type/edit.html.erb
+++ b/app/views/steps/dwp/partner_benefit_type/edit.html.erb
@@ -11,12 +11,7 @@
 
         <% if option.jsa? %>
             <%= f.govuk_radio_button :benefit_type, option.value do %>
-              <%= f.govuk_date_field :last_jsa_appointment_date, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                      legend: {
-                                        text: t('.last_jsa_appointment_date'),
-                                        size: 's', class: 'govuk-!-font-weight-regular'
-                                      } %>
+              <%= f.date_input :last_jsa_appointment_date, legend: { text: t('.last_jsa_appointment_date'), size: 's', class: 'govuk-!-font-weight-regular' } %>
             <% end %>
           <% elsif option.none? %>
             <%= f.govuk_radio_divider I18n.t('divider_text') %>

--- a/app/views/steps/income/business_start_date/edit.html.erb
+++ b/app/views/steps/income/business_start_date/edit.html.erb
@@ -7,11 +7,7 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :trading_start_date, maxlength_enabled: true,
-                             segment_names: f.segment_names,
-                              legend: {
-                                size: 'xl'
-                              } %>
+      <%= f.date_input :trading_start_date, legend: { size: 'xl' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/income/lost_job_in_custody/edit.html.erb
+++ b/app/views/steps/income/lost_job_in_custody/edit.html.erb
@@ -12,12 +12,7 @@
         <% @form_object.choices.each_with_index do |choice, index| %>
           <% if choice.yes? %>
             <%= f.govuk_radio_button :lost_job_in_custody, choice.value do %>
-              <%= f.govuk_date_field :date_job_lost, maxlength_enabled: true,
-                                     segment_names: f.segment_names,
-                                      legend: {
-                                        text: t('.date_job_lost'),
-                                        size: 's', class: 'govuk-!-font-weight-regular'
-                                      } %>
+              <%= f.date_input :date_job_lost, legend: { text: t('.date_job_lost'), size: 's', class: 'govuk-!-font-weight-regular' } %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_button :lost_job_in_custody, choice.value, link_errors: index.zero? %>

--- a/app/views/steps/partner/details/edit.html.erb
+++ b/app/views/steps/partner/details/edit.html.erb
@@ -14,7 +14,7 @@
       <% end %>
 
       <%= f.govuk_text_field :other_names, autocomplete: 'off', width: 'three-quarters', label: { size: 'm' } %>
-      <%= f.govuk_date_field :date_of_birth, maxlength_enabled: true, legend: { size: 'm' }, segment_names: f.segment_names %>
+      <%= f.date_input :date_of_birth, legend: { size: 'm' } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -419,12 +419,12 @@ en:
         separation_date:
       steps_client_details_form:
         other_names: This includes aliases, nicknames or other names your client may be known as.
-        date_of_birth: For example, 27 3 2007.
+        date_of_birth: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_partner_details_form:
         other_names: This includes aliases, nicknames or other names they may be known as.
-        date_of_birth: For example, 27 3 2007.
+        date_of_birth: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_client_appeal_details_form:
-        appeal_lodged_date: For example, 27 3 2007.
+        appeal_lodged_date: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
         appeal_original_app_submitted: This is the case with the outcome your client wants to appeal.
       steps_client_appeal_reference_number_form:
         appeal_reference_number: We need either your client's MAAT ID or unique submission number (USN).
@@ -461,20 +461,20 @@ en:
       steps_case_urn_form:
         urn: For example, ‘12 AB 3456789’.
       steps_case_has_case_concluded_form:
-        date_case_concluded: For example, 27 3 2007.
+        date_case_concluded: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_case_is_preorder_work_claimed_form:
-        preorder_work_date: For example, 27 3 2007.
+        preorder_work_date: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
         preorder_work_details: Enter details about the urgency of the work
       steps_case_is_client_remanded_form:
-        date_client_remanded: For example, 27 3 2007.
+        date_client_remanded: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_case_charges_form:
         offence_name: Start typing to select an offence, for example, robbery. You can add more later.
         offence_dates_attributes:
-          date_from: For example, 27 3 2007.
+          date_from: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
           date_to: Leave blank if the offence happened on a single date
       steps_case_hearing_details_form:
         hearing_court_name: Start typing to add a court. For example, Cardiff Crown Court.
-        hearing_date: For example, 27 3 2024
+        hearing_date: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_case_first_court_hearing_form:
         first_court_hearing_name: Start typing to add a court. For example, Bristol Magistrates Court
       steps_client_contact_details_form:
@@ -517,7 +517,7 @@ en:
         partner_self_assessment_tax_bill: This will be from HM Revenue and Customs (HMRC).
         partner_self_assessment_tax_bill_amount: Enter '0' if none.
       steps_income_lost_job_in_custody_form:
-        date_job_lost: For example, 27 3 2007.
+        date_job_lost: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_income_income_payments_form:
         income_payments: Select all that apply.
         types_options:
@@ -547,7 +547,7 @@ en:
       steps_income_business_type_form:
         business_type: You can add more later.
       steps_income_business_start_date_form:
-        trading_start_date: For example, 27 3 2007.
+        trading_start_date: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_income_business_employees_form:
         has_employees: Enter if they have employees, not including themself.
       steps_income_business_financials_form:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -263,7 +263,7 @@ en:
           charge_label: What is the charge? (optional)
           hearing_court_name_label: Which court is hearing the case? (optional)
           hearing_date_legend: When is the next hearing? (optional)
-          hearing_date_hint: For example, 27 3 2007.
+          hearing_date_hint: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       hearing_details:
         edit:
           page_title: Next hearing court details

--- a/spec/attributes/type/multiparam_date_spec.rb
+++ b/spec/attributes/type/multiparam_date_spec.rb
@@ -33,9 +33,23 @@ RSpec.describe Type::MultiparamDate do
     let(:date) { Date.new(2008, 11, 22) }
 
     context 'and contains all needed parts' do
-      let(:value) { { 3 => date.day, 2 => date.month, 1 => date.year } }
+      context 'and the month is a digit' do
+        let(:value) { { 3 => date.day, 2 => date.month, 1 => date.year } }
 
-      it { expect(coerced_value).to eq(date) }
+        it { expect(coerced_value).to eq(date) }
+      end
+
+      context 'and the month is a full month name' do
+        let(:value) { { 3 => date.day, 2 => date.strftime('%B'), 1 => date.year } }
+
+        it { expect(coerced_value).to eq(date) }
+      end
+
+      context 'and the month is an abbreviated month name' do
+        let(:value) { { 3 => date.day, 2 => date.strftime('%b'), 1 => date.year } }
+
+        it { expect(coerced_value).to eq(date) }
+      end
     end
 
     context 'the parts do not represent a valid date (invalid month)' do

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -104,6 +104,24 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     end
   end
 
+  context 'when month is a full month name' do
+    let(:date) { { 3 => 25, 2 => 'december', 1 => 2020 } }
+
+    it 'allows the month value' do
+      subject.validate
+      expect(subject.errors.added?(attribute_name, :invalid_month)).to be(false)
+    end
+  end
+
+  context 'when month is an abbreviated month name' do
+    let(:date) { { 3 => 25, 2 => 'dec', 1 => 2020 } }
+
+    it 'allows the month value' do
+      subject.validate
+      expect(subject.errors.added?(attribute_name, :invalid_month)).to be(false)
+    end
+  end
+
   context 'when year is invalid (too old)' do
     let(:date) { { 3 => 25, 2 => 12, 1 => earliest_year - 1 } }
 


### PR DESCRIPTION
## Description of change
- allow date inputs to accept string values in the month field, enabling users to enter the month name
- update the hint text of date inputs as per design

## Link to relevant ticket
[CRIMAPP-1733](https://dsdmoj.atlassian.net/browse/CRIMAPP-1733)

## Screenshots of changes (if applicable)

### Before changes:
<img width="674" height="320" alt="image" src="https://github.com/user-attachments/assets/5a8117a4-d335-4d77-875f-9712f2762dfc" />

### After changes:
<img width="1102" height="370" alt="image" src="https://github.com/user-attachments/assets/453728ee-6565-414c-912f-47dcb6c3ff55" />



[CRIMAPP-1733]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ