### PR TITLE
[CRIMAPP-1733] Validate Welsh month names

### DIFF
--- a/app/attributes/type/multiparam_date.rb
+++ b/app/attributes/type/multiparam_date.rb
@@ -32,18 +32,23 @@ module Type
     private
 
     # Attempt to parse the month, which could be a digit or a month name
-    # Date::parse is quite tolerant of abbreviations of variable length and slight misspellings
     # Assumes value[2] to be the month value
     def normalize_month_of_date(value)
       normalized = value.dup
       month_value = value[2]
 
       begin
-        normalized[2] = month_value.to_i.nonzero? || Date.parse(month_value).month
+        normalized[2] = month_value.to_i.nonzero? || parse_month(month_value)
         normalized
       rescue StandardError
         value
       end
+    end
+
+    # Parse a full or abbreviated month name
+    # Relies on the correct locale being set when the value is non-English
+    def parse_month(month)
+      I18n.t('date.month_names').index(month.capitalize) || I18n.t('date.abbr_month_names').index(month.capitalize) || 0
     end
   end
 end

--- a/app/views/steps/case/is_preorder_work_claimed/edit.html.erb
+++ b/app/views/steps/case/is_preorder_work_claimed/edit.html.erb
@@ -11,7 +11,6 @@
             <%= f.govuk_radio_button :is_preorder_work_claimed, choice.value do %>
               <%= f.date_input :preorder_work_date, legend: { text: t('.preorder_work_date',), size: 's' } %>
               <%= f.govuk_text_area :preorder_work_details,
-                                    segment_names: f.segment_names,
                                     label: { hidden: true },
                                     'aria-live': 'polite',
                                     'aria-label': t('.preorder_work_details',) %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -52,6 +52,7 @@ cy:
       - Gwe
       - Sad
     abbr_month_names:
+      - ~
       - Ion
       - Chw
       - Maw
@@ -73,6 +74,7 @@ cy:
       - Dydd Gwener
       - Dydd Sadwrn
     month_names:
+      - ~
       - Ionawr
       - Chwefror
       - Mawrth

--- a/config/locales/cy/helpers.yml
+++ b/config/locales/cy/helpers.yml
@@ -420,12 +420,12 @@ cy:
         separation_date:
       steps_client_details_form:
         other_names: Mae hyn yn cynnwys enwau eraill neu lysenwau y gellir galw eich cleient.
-        date_of_birth: Er enghraifft, 27 3 2007.
+        date_of_birth: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_partner_details_form:
         other_names: Mae hyn yn cynnwys enwau eraill neu lysenwau y gellir eu galw.
-        date_of_birth: Er enghraifft, 27 3 2007.
+        date_of_birth: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_client_appeal_details_form:
-        appeal_lodged_date: Er enghraifft, 27 3 2007.
+        appeal_lodged_date: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
         appeal_original_app_submitted: Mae hyn yn wir am y canlyniad y mae eich cleient eisiau apelio yn ei erbyn.
       steps_client_appeal_reference_number_form:
         appeal_reference_number: Mae angen naill ai ID MAAT neu rif cyflwyno unigryw (USN) eich cleient.
@@ -464,20 +464,20 @@ cy:
       steps_case_urn_form:
         urn: Er enghraifft, ‘12 AB 3456789’.
       steps_case_has_case_concluded_form:
-        date_case_concluded: Er enghraifft, 27 3 2007.
+        date_case_concluded: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_case_is_preorder_work_claimed_form:
-        preorder_work_date: Er enghraifft, 27 3 2007.
+        preorder_work_date: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
         preorder_work_details: Rhowch fanylion am frys y gwaith
       steps_case_is_client_remanded_form:
-        date_client_remanded: Er enghraifft, 27 3 2007.
+        date_client_remanded: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_case_charges_form:
         offence_name: Dechreuwch deipio i ddewis trosedd, er enghraifft lladrad. Gallwch ychwanegu mwy yn nes ymlaen.
         offence_dates_attributes:
-          date_from: Er enghraifft, 27 3 2007.
+          date_from: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
           date_to: Gadewch yn wag os digwyddodd y trosedd ar un dyddiad
       steps_case_hearing_details_form:
         hearing_court_name: Dechreuwch deipio i ychwanegu llys. Er enghraifft, Llys y Goron Caerdydd.
-        hearing_date: Er enghraifft, 27 3 2024
+        hearing_date: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_case_first_court_hearing_form:
         first_court_hearing_name: Dechreuwch deipio i ychwanegu llys. Er enghraifft, Llys Ynadon Bryste
       steps_case_ioj_form:
@@ -518,7 +518,7 @@ cy:
         partner_self_assessment_tax_bill: Bydd hyn gan Gyllid a Thollau EF (CThEF).
         partner_self_assessment_tax_bill_amount: Rhowch '0' os nad oes dim.
       steps_income_lost_job_in_custody_form:
-        date_job_lost: Er enghraifft, 27 3 2007.
+        date_job_lost: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_income_income_payments_form:
         income_payments: Dewiswch bob un sy'n berthnasol.
         types_options:
@@ -548,7 +548,7 @@ cy:
       steps_income_business_type_form:
         business_type: Gallwch ychwanegu mwy yn nes ymlaen.
       steps_income_business_start_date_form:
-        trading_start_date: Er enghraifft, 27 3 2007.
+        trading_start_date: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_income_business_employees_form:
         has_employees: Nodwch a oes ganddyn nhw gyflogeion, heb gynnwys nhw eu hunain.
       steps_income_business_financials_form:

--- a/config/locales/cy/steps.yml
+++ b/config/locales/cy/steps.yml
@@ -263,7 +263,7 @@ cy:
           charge_label: Beth yw’r cyhuddiad? (dewisol)
           hearing_court_name_label: Pa lys sy'n gwrando'r achos? (dewisol)
           hearing_date_legend: Pryd mae'r gwrandawiad nesaf? (dewisol)
-          hearing_date_hint: Er enghraifft, 27 3 2007.
+          hearing_date_hint: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       hearing_details:
         edit:
           page_title: Manylion llys y gwrandawiad nesaf

--- a/spec/attributes/type/multiparam_date_spec.rb
+++ b/spec/attributes/type/multiparam_date_spec.rb
@@ -39,16 +39,36 @@ RSpec.describe Type::MultiparamDate do
         it { expect(coerced_value).to eq(date) }
       end
 
-      context 'and the month is a full month name' do
+      context 'and the month is a full month name in English' do
         let(:value) { { 3 => date.day, 2 => date.strftime('%B'), 1 => date.year } }
 
         it { expect(coerced_value).to eq(date) }
       end
 
-      context 'and the month is an abbreviated month name' do
+      context 'and the month is a full month name in Welsh' do
+        let(:value) { { 3 => date.day, 2 => I18n.t('date.month_names', locale: :cy)[date.month], 1 => date.year } }
+
+        it do
+          I18n.with_locale(:cy) do
+            expect(coerced_value).to eq(date)
+          end
+        end
+      end
+
+      context 'and the month is an abbreviated month name in English' do
         let(:value) { { 3 => date.day, 2 => date.strftime('%b'), 1 => date.year } }
 
         it { expect(coerced_value).to eq(date) }
+      end
+
+      context 'and the month is an abbreviated month name in Welsh' do
+        let(:value) { { 3 => date.day, 2 => I18n.t('date.abbr_month_names', locale: :cy)[date.month], 1 => date.year } }
+
+        it do
+          I18n.with_locale(:cy) do
+            expect(coerced_value).to eq(date)
+          end
+        end
       end
     end
 

--- a/spec/support/shared_examples/form_validation_shared_examples.rb
+++ b/spec/support/shared_examples/form_validation_shared_examples.rb
@@ -104,7 +104,7 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     end
   end
 
-  context 'when month is a full month name' do
+  context 'when month is a full month name in English' do
     let(:date) { { 3 => 25, 2 => 'december', 1 => 2020 } }
 
     it 'allows the month value' do
@@ -113,12 +113,34 @@ RSpec.shared_examples 'a multiparam date validation' do |options|
     end
   end
 
-  context 'when month is an abbreviated month name' do
+  context 'when month is a full month name in Welsh' do
+    let(:date) { { 3 => 25, 2 => 'rhagfyr', 1 => 2020 } }
+
+    it 'allows the month value' do
+      I18n.with_locale(:cy) do
+        subject.validate
+        expect(subject.errors.added?(attribute_name, :invalid_month)).to be(false)
+      end
+    end
+  end
+
+  context 'when month is an abbreviated month name in English' do
     let(:date) { { 3 => 25, 2 => 'dec', 1 => 2020 } }
 
     it 'allows the month value' do
       subject.validate
       expect(subject.errors.added?(attribute_name, :invalid_month)).to be(false)
+    end
+  end
+
+  context 'when month is an abbreviated month name in Welsh' do
+    let(:date) { { 3 => 25, 2 => 'rha', 1 => 2020 } }
+
+    it 'allows the month value' do
+      I18n.with_locale(:cy) do
+        subject.validate
+        expect(subject.errors.added?(attribute_name, :invalid_month)).to be(false)
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change
- update date parsing to allow the validation of Welsh month names
- add Welsh translations for date input hint text

## Link to relevant ticket
[CRIMAPP-1733](https://dsdmoj.atlassian.net/browse/CRIMAPP-1733)

[CRIMAPP-1733]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ