### PR TITLE
[CRIMAPP-2033] Simplify ModSec rules

### DIFF
--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -147,73 +147,31 @@ metadata:
       SecRuleUpdateTargetById 933150 !ARGS:authenticity_token
       SecRuleUpdateTargetById 932260 !ARGS:authenticity_token
       SecRuleUpdateTargetById 932230 !ARGS:authenticity_token
-      SecRule REQUEST_URI "@endsWith /documents" \
+      SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
         ctl:ruleRemoveById=920120,\
-        ctl:ruleRemoveById=933150"
-      SecRule REQUEST_URI "@rx /steps/(case/ioj|submission/more-information|circumstances/pre-cifc-reason|income/how-manage-with-no-income)" \
-        "id:1001,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=921110,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
         ctl:ruleRemoveById=932125,\
         ctl:ruleRemoveById=932235,\
         ctl:ruleRemoveById=932250,\
+        ctl:ruleRemoveById=932260,\
         ctl:ruleRemoveById=932370,\
         ctl:ruleRemoveById=932380,\
+        ctl:ruleRemoveById=933150,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
+        ctl:ruleRemoveById=942140,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360,\
-        ctl:ruleRemoveById=949110"
-      SecRule REQUEST_URI "@rx /steps/case/(client|partner)/other-charge" \
-        "id:1002,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932110,\
-        ctl:ruleRemoveById=932115,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932370,\
-        ctl:ruleRemoveById=942230,\
-        ctl:ruleRemoveById=942360"
-      SecRule REQUEST_URI "@rx .*/steps/capital/investments/[a-f0-9-]+$" \
-        "id:1003,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932110,\
-        ctl:ruleRemoveById=932115"
-      SecRule REQUEST_URI "@rx .*/steps/case/charges/[a-f0-9-]+$" \
-        "id:1004,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=933210,\
-        ctl:ruleRemoveById=942100"
-      SecRule REQUEST_URI "@rx /steps/income/client/deductions-from-pay/[a-f0-9-]+$" \
-        "id:1005,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932380,\
-        ctl:ruleRemoveById=932125,\
-        ctl:ruleRemoveById=932370"
-      SecRule REQUEST_URI "@rx /steps/income/client/nature-of-business/[a-f0-9-]+$" \
-        "id:1006,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932260"
-      SecRule REQUEST_URI "@endsWith /steps/client/nino" \
-        "id:1007,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932250"
+        ctl:ruleRemoveById=949110,chain"
+        SecRule REQUEST_METHOD "^POST$" "phase:2,t:none"
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
-        "id:1008,phase:1,pass,nolog,\
+        "id:1001,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
-      SecRule REQUEST_URI "@endsWith /steps/outgoings/are-outgoings-more-than-income" \
-        "id:1009,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=942360"
-      SecRule REQUEST_URI "@rx /steps/income/client/employer-details/[a-f0-9-]+$" \
-        "id:1010,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=942140"
-      SecRule REQUEST_URI "@rx /steps/income/client/employment-details/[a-f0-9-]+$" \
-        "id:1011,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932260"
-      SecRule REQUEST_URI "@endsWith /steps/client/financial-circumstances-changed" \
-        "id:1012,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -147,73 +147,31 @@ metadata:
       SecRuleUpdateTargetById 933150 !ARGS:authenticity_token
       SecRuleUpdateTargetById 932260 !ARGS:authenticity_token
       SecRuleUpdateTargetById 932230 !ARGS:authenticity_token
-      SecRule REQUEST_URI "@endsWith /documents" \
+      SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
         ctl:ruleRemoveById=920120,\
-        ctl:ruleRemoveById=933150"
-      SecRule REQUEST_URI "@rx /steps/(case/ioj|submission/more-information|circumstances/pre-cifc-reason|income/how-manage-with-no-income)" \
-        "id:1001,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=921110,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
         ctl:ruleRemoveById=932125,\
         ctl:ruleRemoveById=932235,\
         ctl:ruleRemoveById=932250,\
+        ctl:ruleRemoveById=932260,\
         ctl:ruleRemoveById=932370,\
         ctl:ruleRemoveById=932380,\
+        ctl:ruleRemoveById=933150,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
+        ctl:ruleRemoveById=942140,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360,\
-        ctl:ruleRemoveById=949110"
-      SecRule REQUEST_URI "@rx /steps/case/(client|partner)/other-charge" \
-        "id:1002,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932110,\
-        ctl:ruleRemoveById=932115,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932370,\
-        ctl:ruleRemoveById=942230,\
-        ctl:ruleRemoveById=942360"
-      SecRule REQUEST_URI "@rx .*/steps/capital/investments/[a-f0-9-]+$" \
-        "id:1003,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932110,\
-        ctl:ruleRemoveById=932115"
-      SecRule REQUEST_URI "@rx .*/steps/case/charges/[a-f0-9-]+$" \
-        "id:1004,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=933210,\
-        ctl:ruleRemoveById=942100"
-      SecRule REQUEST_URI "@rx /steps/income/client/deductions-from-pay/[a-f0-9-]+$" \
-        "id:1005,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932380,\
-        ctl:ruleRemoveById=932125,\
-        ctl:ruleRemoveById=932370"
-      SecRule REQUEST_URI "@rx /steps/income/client/nature-of-business/[a-f0-9-]+$" \
-        "id:1006,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932260"
-      SecRule REQUEST_URI "@endsWith /steps/client/nino" \
-        "id:1007,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932250"
+        ctl:ruleRemoveById=949110,chain"
+        SecRule REQUEST_METHOD "^POST$" "phase:2,t:none"
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
-        "id:1008,phase:1,pass,nolog,\
+        "id:1001,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
-      SecRule REQUEST_URI "@endsWith /steps/outgoings/are-outgoings-more-than-income" \
-        "id:1009,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=942360"
-      SecRule REQUEST_URI "@rx /steps/income/client/employer-details/[a-f0-9-]+$" \
-        "id:1010,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=942140"
-      SecRule REQUEST_URI "@rx /steps/income/client/employment-details/[a-f0-9-]+$" \
-        "id:1011,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932260"
-      SecRule REQUEST_URI "@endsWith /steps/client/financial-circumstances-changed" \
-        "id:1012,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -147,73 +147,31 @@ metadata:
       SecRuleUpdateTargetById 933150 !ARGS:authenticity_token
       SecRuleUpdateTargetById 932260 !ARGS:authenticity_token
       SecRuleUpdateTargetById 932230 !ARGS:authenticity_token
-      SecRule REQUEST_URI "@endsWith /documents" \
+      SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
         ctl:ruleRemoveById=920120,\
-        ctl:ruleRemoveById=933150"
-      SecRule REQUEST_URI "@rx /steps/(case/ioj|submission/more-information|circumstances/pre-cifc-reason|income/how-manage-with-no-income)" \
-        "id:1001,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=921110,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
         ctl:ruleRemoveById=932125,\
         ctl:ruleRemoveById=932235,\
         ctl:ruleRemoveById=932250,\
+        ctl:ruleRemoveById=932260,\
         ctl:ruleRemoveById=932370,\
         ctl:ruleRemoveById=932380,\
+        ctl:ruleRemoveById=933150,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=933210,\
         ctl:ruleRemoveById=942100,\
+        ctl:ruleRemoveById=942140,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360,\
-        ctl:ruleRemoveById=949110"
-      SecRule REQUEST_URI "@rx /steps/case/(client|partner)/other-charge" \
-        "id:1002,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932110,\
-        ctl:ruleRemoveById=932115,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932370,\
-        ctl:ruleRemoveById=942230,\
-        ctl:ruleRemoveById=942360"
-      SecRule REQUEST_URI "@rx .*/steps/capital/investments/[a-f0-9-]+$" \
-        "id:1003,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932110,\
-        ctl:ruleRemoveById=932115"
-      SecRule REQUEST_URI "@rx .*/steps/case/charges/[a-f0-9-]+$" \
-        "id:1004,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=933210,\
-        ctl:ruleRemoveById=942100"
-      SecRule REQUEST_URI "@rx /steps/income/client/deductions-from-pay/[a-f0-9-]+$" \
-        "id:1005,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932380,\
-        ctl:ruleRemoveById=932125,\
-        ctl:ruleRemoveById=932370"
-      SecRule REQUEST_URI "@rx /steps/income/client/nature-of-business/[a-f0-9-]+$" \
-        "id:1006,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932260"
-      SecRule REQUEST_URI "@endsWith /steps/client/nino" \
-        "id:1007,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235,\
-        ctl:ruleRemoveById=932250"
+        ctl:ruleRemoveById=949110,chain"
+        SecRule REQUEST_METHOD "^POST$" "phase:2,t:none"
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
-        "id:1008,phase:1,pass,nolog,\
+        "id:1001,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
-      SecRule REQUEST_URI "@endsWith /steps/outgoings/are-outgoings-more-than-income" \
-        "id:1009,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=942360"
-      SecRule REQUEST_URI "@rx /steps/income/client/employer-details/[a-f0-9-]+$" \
-        "id:1010,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=942140"
-      SecRule REQUEST_URI "@rx /steps/income/client/employment-details/[a-f0-9-]+$" \
-        "id:1011,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932260"
-      SecRule REQUEST_URI "@endsWith /steps/client/financial-circumstances-changed" \
-        "id:1012,phase:2,pass,nolog,\
-        ctl:ruleRemoveById=932235"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session


### PR DESCRIPTION
## Description of change
- reduces ModSec rule duplication by applying all existing rule exceptions to all URLs matching the pattern `'/steps/.+$'`
- this solves the issue where we had reached a limit on how much data `nginx.ingress.kubernetes.io/modsecurity-snippet` can support
- this is expected to reduce the number of false positives across all application step pages

## Link to relevant ticket
[CRIMAPP-2033](https://dsdmoj.atlassian.net/browse/CRIMAPP-2033)

## Notes for reviewer
The new rule has been tested in staging. I tested a few POST and GET requests on authenticated paths with suspicious payloads. As expected, those in POST requests did not trigger ModSec, but those in GET requests did.

[CRIMAPP-2033]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ