### PR TITLE
[CRIMAPP-1841] Update courts and offences hint text

### DIFF
--- a/config/locales/cy/helpers.yml
+++ b/config/locales/cy/helpers.yml
@@ -471,15 +471,15 @@ cy:
       steps_case_is_client_remanded_form:
         date_client_remanded: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_case_charges_form:
-        offence_name: Dechreuwch deipio i ddewis trosedd, er enghraifft lladrad. Gallwch ychwanegu mwy yn nes ymlaen.
+        offence_name: Dechreuwch deipio i ddewis trosedd o'r rhestr yn y gwymplen neu parhewch i deipio i nodi â llaw.
         offence_dates_attributes:
           date_from: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
           date_to: Gadewch yn wag os digwyddodd y trosedd ar un dyddiad
       steps_case_hearing_details_form:
-        hearing_court_name: Dechreuwch deipio i ychwanegu llys. Er enghraifft, Llys y Goron Caerdydd.
+        hearing_court_name: Dechreuwch deipio i ddewis llys o'r rhestr yn y gwymplen neu parhewch i deipio i nodi â llaw.
         hearing_date: Er enghraifft, 12 11 2007, 12 Tach 2007 neu 12 Tachwedd 2007.
       steps_case_first_court_hearing_form:
-        first_court_hearing_name: Dechreuwch deipio i ychwanegu llys. Er enghraifft, Llys Ynadon Bryste
+        first_court_hearing_name: Dechreuwch deipio i ddewis llys o'r rhestr yn y gwymplen neu parhewch i deipio i nodi â llaw.
       steps_case_ioj_form:
         loss_of_liberty_justification: *ioj_justification_hint
         suspended_sentence_justification: *ioj_justification_hint

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -468,15 +468,15 @@ en:
       steps_case_is_client_remanded_form:
         date_client_remanded: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_case_charges_form:
-        offence_name: Start typing to select an offence, for example, robbery. You can add more later.
+        offence_name: Start typing to select an offence from the dropdown list or continue typing to enter manually.
         offence_dates_attributes:
           date_from: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
           date_to: Leave blank if the offence happened on a single date
       steps_case_hearing_details_form:
-        hearing_court_name: Start typing to add a court. For example, Cardiff Crown Court.
+        hearing_court_name: Start typing to select a court from the dropdown list or continue typing to enter manually.
         hearing_date: For example, 12 11 2007, 12 Nov 2007 or 12 November 2007.
       steps_case_first_court_hearing_form:
-        first_court_hearing_name: Start typing to add a court. For example, Bristol Magistrates Court
+        first_court_hearing_name: Start typing to select a court from the dropdown list or continue typing to enter manually.
       steps_client_contact_details_form:
         requested_welsh_correspondence: It will also be sent in English. Under the Welsh Language Act, some correspondence will be automatically sent in Welsh if the hearing is at certain Welsh courts.
       steps_case_ioj_form:


### PR DESCRIPTION
## Description of change
Updates the courts and offences hint texts based on feedback that the hints for the court and offences dropdowns may be misleading as it included examples of offences and courts in Welsh but the user can only use English to search courts and offences

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1841

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1872" height="438" alt="Screenshot 2025-12-09 at 15 05 27" src="https://github.com/user-attachments/assets/35551c8f-738d-4c94-b2cd-ee206d9357b2" />

<img width="871" height="167" alt="Screenshot 2025-12-11 at 08 46 47" src="https://github.com/user-attachments/assets/fbbcaea4-a659-4e95-98bc-bd2eeca8aeac" />


### After changes:

<img width="1087" height="468" alt="Screenshot 2025-12-11 at 08 24 57" src="https://github.com/user-attachments/assets/1b05acf1-ce0d-4863-a87b-34da20850293" />
<img width="1087" height="573" alt="Screenshot 2025-12-11 at 08 25 08" src="https://github.com/user-attachments/assets/92004fdf-f40a-4628-aa33-a4f745ea40f9" />
<img width="871" height="196" alt="Screenshot 2025-12-11 at 08 25 36" src="https://github.com/user-attachments/assets/096c48d9-9b26-4988-8118-fefbffaa701a" />
<img width="871" height="196" alt="Screenshot 2025-12-11 at 08 25 47" src="https://github.com/user-attachments/assets/fdd25471-ff80-480c-80b0-ddd700a0316c" />
<img width="871" height="285" alt="Screenshot 2025-12-11 at 08 26 09" src="https://github.com/user-attachments/assets/66abb704-91cf-4d77-bb9f-6f7985cba35c" />
<img width="871" height="204" alt="Screenshot 2025-12-11 at 08 26 17" src="https://github.com/user-attachments/assets/adefe988-b3bb-44f1-9f0d-897206306659" />


## How to manually test the feature
