### PR TITLE
ModSec rule regression fix

### DIFF
--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -172,6 +172,11 @@ metadata:
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
         "id:1001,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
+      SecRule REQUEST_URI "@endsWith /documents" \
+        "id:1002,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=920120,\
+        ctl:ruleRemoveById=933150"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -172,6 +172,11 @@ metadata:
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
         "id:1001,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
+      SecRule REQUEST_URI "@endsWith /documents" \
+        "id:1002,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=920120,\
+        ctl:ruleRemoveById=933150"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -172,6 +172,11 @@ metadata:
       SecRule REQUEST_URI "@beginsWith /providers/auth/entra/callback" \
         "id:1001,phase:1,pass,nolog,\
         ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
+      SecRule REQUEST_URI "@endsWith /documents" \
+        "id:1002,phase:2,pass,nolog,\
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=920120,\
+        ctl:ruleRemoveById=933150"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_apply_for_criminal_legal_aid_session


### PR DESCRIPTION
## Description of change
- fix a regression introduced in https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/1597 that has caused the `/applications/{id}/documents` path to no longer ignore rules causing false +ves.