### PR TITLE
Keep service offline December and January bank holidays

### DIFF
--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -136,6 +136,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "@eq 21" "id:997,phase:1,deny,status:503,chain"
         SecRule TIME_MIN "@gt 29" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -136,6 +136,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "@eq 21" "id:997,phase:1,deny,status:503,chain"
         SecRule TIME_MIN "@gt 29" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -136,6 +136,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "@eq 21" "id:997,phase:1,deny,status:503,chain"
         SecRule TIME_MIN "@gt 29" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \


### PR DESCRIPTION
## Description of change

Add ModSecurity ingress rules to keep the service offline (return 503) on UK bank holidays for:
- Christmas Day (25 December)
- Boxing Day (26 December)
- New Year’s Day (1 January)

These rules are applied consistently across staging, preprod, and production ingress configurations.

## Note!
- TIME_MON uses 0 for January and 11 for December, so these match 1 January and 25/26 December respectively.
- These rules complement the existing out-of-hours rules already in place.