### PR TITLE
[CRIMAPP-2057] offline December and January bank holidays

### DIFF
--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: 'shared/flash_banner' %>
 
     <h1 class="govuk-heading-xl"><%= service_name %></h1>
-    <p class="govuk-body">This service is available from 7am until 9:30pm.</p>
+    <p class="govuk-body">This service is available from 7am until 9:30pm. It is not available on bank holidays.</p>
     <%= button_to provider_entra_omniauth_authorize_path, method: :post,
                   class: 'govuk-button govuk-button--start govuk-!-margin-top-4', form_class: 'app-button--start',
                   data: { module: 'govuk-button' }, role: 'button', draggable: false do %>

--- a/config/kubernetes/preprod/custom-error-page.yml
+++ b/config/kubernetes/preprod/custom-error-page.yml
@@ -159,7 +159,7 @@ data:
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-                    <p class="govuk-body">You can use this service from 7am until 9:30pm.</p>
+                    <p class="govuk-body">You can use this service from 7am until 9:30pm. It is not available on bank holidays.</p>
                     <p class="govuk-body">We saved your answers up to the last time you selected 'Save', before the service became unavailable.</p>
                     
                     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/config/kubernetes/preprod/ingress.yml
+++ b/config/kubernetes/preprod/ingress.yml
@@ -136,6 +136,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "@eq 21" "id:997,phase:1,deny,status:503,chain"
         SecRule TIME_MIN "@gt 29" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \

--- a/config/kubernetes/production/custom-error-page.yml
+++ b/config/kubernetes/production/custom-error-page.yml
@@ -159,7 +159,7 @@ data:
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-                    <p class="govuk-body">You can use this service from 7am until 9:30pm.</p>
+                    <p class="govuk-body">You can use this service from 7am until 9:30pm. It is not available on bank holidays.</p>
                     <p class="govuk-body">We saved your answers up to the last time you selected 'Save', before the service became unavailable.</p>
                     
                     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -136,6 +136,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "@eq 21" "id:997,phase:1,deny,status:503,chain"
         SecRule TIME_MIN "@gt 29" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \

--- a/config/kubernetes/staging/custom-error-page.yml
+++ b/config/kubernetes/staging/custom-error-page.yml
@@ -159,7 +159,7 @@ data:
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-                    <p class="govuk-body">You can use this service from 7am until 9:30pm.</p>
+                    <p class="govuk-body">You can use this service from 7am until 9:30pm. It is not available on bank holidays.</p>
                     <p class="govuk-body">We saved your answers up to the last time you selected 'Save', before the service became unavailable.</p>
                     
                     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -136,6 +136,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 15728640
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "@eq 21" "id:997,phase:1,deny,status:503,chain"
         SecRule TIME_MIN "@gt 29" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \


### PR DESCRIPTION
## Description of change

1. Add ModSecurity ingress rules to keep the service offline (return 503) on UK bank holidays for:
    - Christmas Day (25 December)
    - Boxing Day (26 December)
    - New Year’s Day (1 January) 
4. Update service availability content

These rules are applied consistently across staging, preprod, and production ingress configurations.

## Notes for reviewer
- TIME_MON uses 0 for January and 11 for December, so these match 1 January and 25/26 December respectively.
- This only covers Christmas bank holidays, as separate ticket to review in the New Year is here: [CRIMAPP-2058](https://dsdmoj.atlassian.net/browse/CRIMAPP-2058)

## Link to relevant ticket

[CRIMAPP-2057](https://dsdmoj.atlassian.net/browse/CRIMAPP-2057)


[CRIMAPP-2058]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-2057]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ