### PR TITLE
[CRIMAPP-2069] add draft PSE and resubmissions to automatic deletion

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -94,10 +94,8 @@ class CrimeApplication < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   scope :to_be_soft_deleted, lambda {
     active
-      .where.not(application_type: ApplicationType::POST_SUBMISSION_EVIDENCE.to_s)
       .where(
         exempt_from_deletion: false,
-        parent_id: nil,
         submission_updated_at: ..Rails.configuration.x.retention_period.ago
       )
   }

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -151,16 +151,6 @@ RSpec.describe CrimeApplication, type: :model do
         expect(described_class.to_be_soft_deleted.count).to eq(1)
       end
 
-      context 'when application is PSE' do
-        let(:attributes) {
-          { application_type: ApplicationType::POST_SUBMISSION_EVIDENCE.to_s, updated_at: retention_period - 1.day }
-        }
-
-        it 'does not return application' do
-          expect(described_class.to_be_soft_deleted.count).to eq(0)
-        end
-      end
-
       context 'when submission_updated_at has not been set' do
         it 'does not return application' do
           application.update_column(:submission_updated_at, nil) # rubocop:disable Rails/SkipsModelValidations
@@ -179,18 +169,6 @@ RSpec.describe CrimeApplication, type: :model do
 
     context 'when application is younger than the retention period' do
       let(:submission_updated_at) { retention_period.ago + 1.day }
-
-      it 'does not return application' do
-        expect(described_class.to_be_soft_deleted.count).to eq(0)
-      end
-    end
-
-    context 'when application has parent application' do
-      let(:attributes) { { parent_id: SecureRandom.uuid, updated_at: retention_period - 1.day } }
-
-      before do
-        application.save!
-      end
 
       it 'does not return application' do
         expect(described_class.to_be_soft_deleted.count).to eq(0)

--- a/spec/services/automated_deletion_spec.rb
+++ b/spec/services/automated_deletion_spec.rb
@@ -10,11 +10,9 @@ RSpec.describe AutomatedDeletion do
     end
 
     travel_to 2.years.ago do
-      # app to be soft deleted
+      # apps to be soft deleted
       CrimeApplication.create(reference: 700_000_2)
-      # app to remain unaffected due to being PSE
       CrimeApplication.create(reference: 700_000_4, application_type: ApplicationType::POST_SUBMISSION_EVIDENCE.to_s)
-      # app to remain unaffected due to having a parent application
       CrimeApplication.create(reference: 700_000_5, parent_id: SecureRandom.uuid)
       # app to be remain unaffected due to exemption
       CrimeApplication.create(reference: 700_000_6, exempt_from_deletion: true)
@@ -30,18 +28,6 @@ RSpec.describe AutomatedDeletion do
     }.to change(CrimeApplication,
                 :count).from(6).to(5)
     expect(CrimeApplication.find_by(reference: 700_000_1)).to be_nil
-  end
-
-  it 'ignores an application if it is PSE' do
-    exempt_app = CrimeApplication.find_by(reference: 700_000_4)
-
-    expect { described_class.call }.not_to(change { exempt_app.reload.soft_deleted_at })
-  end
-
-  it 'ignores an application if it has parent application' do
-    exempt_app = CrimeApplication.find_by(reference: 700_000_5)
-
-    expect { described_class.call }.not_to(change { exempt_app.reload.soft_deleted_at })
   end
 
   it 'ignores an application if it is exempt' do


### PR DESCRIPTION
## Description of change

Delete draft PSE and draft resubmissions two years after last action 

## Link to relevant ticket

[CRIMAPP-2069](https://dsdmoj.atlassian.net/browse/CRIMAPP-2069)

[CRIMAPP-2069]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ