### PR TITLE
[CRIMAPP-2073] Translatable incomplete tag

### DIFF
--- a/app/presenters/summary/components/base_record.rb
+++ b/app/presenters/summary/components/base_record.rb
@@ -111,7 +111,7 @@ module Summary
         return if record.complete?
 
         GovukComponent::TagComponent.new(
-          text: :incomplete,
+          text: I18n.t('summary.dictionary.incomplete'),
           colour: 'red'
         ).call
       end

--- a/config/locales/cy/summary.yml
+++ b/config/locales/cy/summary.yml
@@ -44,6 +44,7 @@ cy:
       change: Newid
       edit: Dileu
       remove: Golygu
+      incomplete: Anghyflawn
 
     change_link_html: Newid <span class="govuk-visually-hidden">%{a11y_question}</span>
 

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -44,6 +44,7 @@ en:
       change: Change
       edit: Edit
       remove: Remove
+      incomplete: Incomplete
 
     change_link_html: Change <span class="govuk-visually-hidden">%{a11y_question}</span>
 

--- a/spec/presenters/summary/components/base_record_spec.rb
+++ b/spec/presenters/summary/components/base_record_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Summary::Components::BaseRecord do
 
       it 'includes the incomplete status in the title' do
         expect(title).to match(
-          '<strong class=\"govuk-tag govuk-tag--red\">incomplete</strong> Record human name'
+          '<strong class=\"govuk-tag govuk-tag--red\">Incomplete</strong> Record human name'
         )
       end
     end


### PR DESCRIPTION
## Description of change
- make the "Incomplete" tag in summary card titles translatable 

## Link to relevant ticket
[CRIMAPP-2073](https://dsdmoj.atlassian.net/browse/CRIMAPP-2073)