### PR TITLE
Parallelize CI tests across 8 nodes

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -11,13 +11,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+
+      - name: Install Yarn 4.7
+        run: |
+          corepack enable
+          corepack prepare yarn@4.7 --activate
+
+      - name: Install Yarn dependencies
+        run: yarn install --immutable
+
+      - name: Precompile assets
+        run: bin/rails assets:precompile
+
+      - name: Run linters
+        run: bundle exec rake brakeman rubocop erblint
+
+  test-matrix:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [8]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
 
     env:
       RACK_ENV: test
       RAILS_ENV: test
+      CI: true
       DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1/laa-apply-for-criminal-legal-aid-test"
+      CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+      CI_NODE_INDEX: ${{ matrix.ci_node_index }}
 
     services:
       postgres:
@@ -56,19 +94,91 @@ jobs:
       - name: Setup test database
         run: bin/rails db:prepare
 
-      - name: Run linters and tests
-        run: bundle exec rake
+      - name: Run tests
+        run: |
+          bundle exec rspec --format progress \
+            $(COVERAGE=false bundle exec rspec --dry-run --format json spec 2>/dev/null | \
+              ruby -rjson -e '
+                raw = STDIN.read
+                json_str = raw[0..raw.rindex("}")]
+                examples = JSON.parse(json_str)["examples"].sort_by { |e| e["id"] }
+                total = ENV["CI_NODE_TOTAL"].to_i
+                index = ENV["CI_NODE_INDEX"].to_i
+                group = examples.select.with_index { |_, i| i % total == index }
+                example_ids = group.map { |e| e["id"] }
+                puts example_ids.join(" ")
+              ')
 
-      - name: Upload rspec coverage (if failure)
-        if: failure()
+      - name: Upload coverage results for merging
+        if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: rspec-coverage
-          path: coverage/*
+          name: coverage-${{ matrix.ci_node_index }}
+          path: coverage/.resultset.json
+          include-hidden-files: true
+          if-no-files-found: error
+
+  test:
+    runs-on: ubuntu-latest
+    needs: test-matrix
+    if: always()
+    steps:
+      - run: |
+          if [ "${{ needs.test-matrix.result }}" = "success" ]; then
+            echo "All test matrix jobs passed"
+          else
+            echo "One or more test matrix jobs failed"
+            exit 1
+          fi
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: test-matrix
+    if: success() || failure()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+
+      - name: Merge coverage results
+        run: |
+          mkdir -p coverage
+
+          for dir in coverage-artifacts/coverage-*; do
+            if [ -d "$dir" ] && [ -f "$dir/.resultset.json" ]; then
+              node=$(basename "$dir")
+              cp "$dir/.resultset.json" "coverage/.resultset-${node}.json"
+              echo "Copied $dir/.resultset.json"
+            fi
+          done
+
+          echo ""
+          echo "Files to merge:"
+          ls -la coverage/
+
+          bundle exec rake coverage:merge_reports
+
+      - name: Upload merged coverage
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: merged-coverage-report
+          path: coverage/
 
   build:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [lint, test, coverage]
     if: github.ref == 'refs/heads/main'
 
     permissions:

--- a/lib/tasks/coverage.rake
+++ b/lib/tasks/coverage.rake
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+namespace :coverage do
+  desc 'Merge SimpleCov coverage reports from parallel CI runs'
+  task :merge_reports do
+    require 'simplecov'
+    require 'simplecov_json_formatter'
+
+    SimpleCov.collate Dir['coverage/.resultset-*.json'] do
+      add_filter 'app/mailers/application_mailer.rb'
+      add_filter 'app/jobs/application_job.rb'
+      add_filter 'config/initializers'
+      add_filter 'config/routes.rb'
+      add_filter 'lib/rubocop/'
+      add_filter 'spec/'
+
+      track_files '{app,lib}/**/*.rb'
+
+      minimum_coverage 100
+
+      formatter SimpleCov::Formatter::MultiFormatter.new([
+        SimpleCov::Formatter::SimpleFormatter,
+        SimpleCov::Formatter::HTMLFormatter,
+        SimpleCov::Formatter::JSONFormatter
+      ])
+    end
+
+    # Report files with less than 100% coverage
+    coverage_data = JSON.parse(File.read('coverage/coverage.json'))
+    files_with_gaps = []
+
+    coverage_data['coverage'].each do |file, data|
+      lines = data['lines']
+      next unless lines
+
+      relevant = lines.compact.reject { |hits| hits.is_a?(String) }
+      covered = relevant.count { |hits| hits > 0 }
+      total = relevant.size
+
+      if covered < total
+        files_with_gaps << {
+          file: file.sub("#{Dir.pwd}/", ''),
+          covered: covered,
+          total: total,
+          percent: (covered.to_f / total * 100).round(2)
+        }
+      end
+    end
+
+    if files_with_gaps.any?
+      puts "\n#{'=' * 80}"
+      puts "Files with less than 100% coverage (#{files_with_gaps.size} files):"
+      puts '=' * 80
+      files_with_gaps.sort_by { |f| f[:percent] }.each do |f|
+        puts "  #{f[:percent]}% - #{f[:file]} (#{f[:covered]}/#{f[:total]} lines)"
+      end
+      puts '=' * 80
+    else
+      puts "\n✓ All files have 100% coverage!"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,33 @@
 ENV['RAILS_ENV'] ||= 'test'
 
-require 'simplecov'
+unless ENV['COVERAGE'] == 'false'
+  require 'simplecov'
 
-SimpleCov.minimum_coverage 100
+  SimpleCov.start 'rails' do
+    minimum_coverage 100 unless ENV['CI_NODE_INDEX']
 
-SimpleCov.start 'rails' do
-  add_filter 'app/mailers/application_mailer.rb'
-  add_filter 'app/jobs/application_job.rb'
-  add_filter 'config/initializers'
-  add_filter 'config/routes.rb'
-  add_filter 'lib/rubocop/'
-  add_filter 'spec/'
+    add_filter 'app/mailers/application_mailer.rb'
+    add_filter 'app/jobs/application_job.rb'
+    add_filter 'config/initializers'
+    add_filter 'config/routes.rb'
+    add_filter 'lib/rubocop/'
+    add_filter 'spec/'
+
+    # Track all application files to ensure consistent coverage across parallel runs
+    track_files '{app,lib}/**/*.rb'
+
+    # Support for parallel CI runs - each runner saves results with unique ID
+    command_name "Job #{ENV['GITHUB_JOB']}-#{ENV['CI_NODE_INDEX']}" if ENV['GITHUB_JOB'] && ENV['CI_NODE_INDEX']
+
+    if ENV['CI']
+      formatter SimpleCov::Formatter::SimpleFormatter
+    else
+      formatter SimpleCov::Formatter::MultiFormatter.new([
+                                                           SimpleCov::Formatter::SimpleFormatter,
+                                                           SimpleCov::Formatter::HTMLFormatter
+                                                         ])
+    end
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Description of change
- Split test job into lint + test (8-node matrix) + coverage merge
- Sort examples by ID before slicing for deterministic splitting (rspec --dry-run output is non-deterministic between runs)
- SimpleCov configured with track_files, enable_coverage_for_eval, and unique command_name per node
- Coverage merge rake task collates results and enforces 100% minimum
- Handle 'ignored' string values in coverage JSON parsing
- Build job now depends on lint + test + coverage

Based on https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/988 but includes additional work to ensure that the type of spec is shared across the nodes--to avoid single node with all the system specs.