### PR TITLE
Override default nav colour

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -74,6 +74,10 @@ $colours: (
   display: none;
 }
 
+.govuk-service-navigation {
+  background-color: #f4f8fb;
+}
+
 @media (max-width: 52.25em) { // 836px
   .govuk-header__navigation-list {
     float: none;


### PR DESCRIPTION
## Description of change
The primary navigation default colour is #f3f2f1, it has now been updated to #f4f8fb

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1883?focusedCommentId=726313

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1002" height="241" alt="Screenshot 2026-02-17 at 10 00 26" src="https://github.com/user-attachments/assets/2148f93d-3f6a-4c4e-a0d4-cecf01d05223" />

### After changes:
<img width="1017" height="265" alt="Screenshot 2026-02-17 at 10 00 02" src="https://github.com/user-attachments/assets/287d4131-6ac2-4946-bc82-8679126bd9b5" />

## How to manually test the feature
