### PR TITLE
Handle unsupported locale in param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,11 +41,14 @@ class ApplicationController < ActionController::Base
   end
 
   def switch_locale(&action)
-    locale = params[:locale] || I18n.default_locale
-    I18n.with_locale(locale, &action)
+    I18n.with_locale(locale_from_param || I18n.default_locale, &action)
   end
 
   private
+
+  def locale_from_param
+    I18n.available_locales.find { |l| l == params[:locale]&.to_sym }
+  end
 
   def initialize_crime_application(attributes = {}, &block)
     attributes[:office_code] = current_office_code

--- a/spec/controllers/switch_locale_spec.rb
+++ b/spec/controllers/switch_locale_spec.rb
@@ -32,5 +32,12 @@ RSpec.describe 'Locale switching', type: :controller do
         expect(response.body).to eq(I18n.default_locale.to_s)
       end
     end
+
+    context 'when locale param is not available' do
+      it 'defaults to I18n.default_locale' do
+        get :show_locale, params: { locale: 'cyg' }
+        expect(response.body).to eq(I18n.default_locale.to_s)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change

Fall back to the default locale for unsupported query‑string locales.

This prevents an exception that was causing Integer Overflow Error (30003) in ZAP scans.

## Link to relevant ticket

https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/issues/1655

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
