### PR TITLE
Add entra to form_action CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
     policy.script_src      :self
     policy.style_src       :self
     policy.frame_ancestors :none
-    policy.form_action     :self
+    policy.form_action     :self, 'https://login.microsoftonline.com'
 
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"


### PR DESCRIPTION
## Description of change

Add 'https://login.microsoftonline.com' to the form_action CSP

## Notes for reviewer

The OmniAuth PKCE flow redirects to Microsoft's login page via a form, which recent changes to CSP's form-action 'self' blocks. Adding 'https://login.microsoftonline.com' to the form_action directive allows the auth redirect to proceed.