### PR TITLE
CRIMAPP-2143 set language attribute

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -1,6 +1,6 @@
 <%= yield :top_of_page %>
 <!DOCTYPE html>
-<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : 'en' %>" class="govuk-template">
+<html lang="<%= I18n.locale %>" class="govuk-template">
 
 <head>
   <title><%= yield(:page_title) %></title>


### PR DESCRIPTION
## Description of change

Set the HTML lang attribute based on what it actually is. Previously the text on the page would change as the user switched between language but the attribute didn't, leading to issues with screen readers

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2143

## Notes for reviewer

Use the language link on each page to switch the 

## Screenshots of changes (if applicable)

<img width="430" height="69" alt="image" src="https://github.com/user-attachments/assets/674f9c6d-ef97-42f9-be5e-c2d042f3ea84" />

### Before changes:

Regardless of language set was always:

<img width="580" height="155" alt="image" src="https://github.com/user-attachments/assets/db77436b-7032-4ef1-bc82-53a7aa311c7d" />


### After changes:

## How to manually test the feature

* Load an apply page.
* Open console to display the page HTML
* Switch between languages using the language select to the top right - notice the lang attribute changing in the HTML to match the language.
