### PR TITLE
CRIMAPP-2190 only show and submit relevant details on crown court appeals

### DIFF
--- a/app/forms/steps/client/case_type_form.rb
+++ b/app/forms/steps/client/case_type_form.rb
@@ -25,20 +25,9 @@ module Steps
       end
 
       def persist!
-        return true unless changed?
+        return unless changed?
 
-        kase.update(
-          attributes.merge(
-            # The following are dependent attributes that need to be reset
-            appeal_lodged_date: nil,
-            appeal_with_changes_details: nil,
-            appeal_original_app_submitted: nil,
-            appeal_financial_circumstances_changed: nil,
-            appeal_reference_number: nil,
-            appeal_maat_id: nil,
-            appeal_usn: nil
-          )
-        )
+        kase.update(attributes.merge)
       end
     end
   end

--- a/app/forms/steps/client/case_type_form.rb
+++ b/app/forms/steps/client/case_type_form.rb
@@ -25,7 +25,7 @@ module Steps
       end
 
       def persist!
-        return unless changed?
+        return true unless changed?
 
         kase.update(attributes.merge)
       end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -29,10 +29,15 @@ class Applicant < Person
   end
 
   def relationship_status
+    return if has_partner == 'no'
+
     partner_detail&.relationship_status
   end
 
   def separation_date
+    return if has_partner == 'no'
+    return unless relationship_status == ClientRelationshipStatusType::SEPARATED.to_s
+
     partner_detail&.separation_date
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -46,15 +46,29 @@ class Case < ApplicationRecord
   end
 
   def appeal_financial_circumstances_changed
-    super if appeal_case_type?
+    super if appeal_original_app_submitted?
   end
 
   def appeal_maat_id
-    super if appeal_original_app_submitted?
+    super if original_application_reference_required?
   end
 
   def appeal_usn
-    super if appeal_original_app_submitted?
+    super if original_application_reference_required?
+  end
+
+  def appeal_case_type?
+    return false unless case_type
+
+    CaseType.new(case_type).appeal?
+  end
+
+  def appeal_original_app_submitted?
+    appeal_original_app_submitted == 'yes'
+  end
+
+  def appeal_financial_circumstances_changed?
+    appeal_financial_circumstances_changed == 'yes'
   end
 
   def hearing_date_within_range?
@@ -67,13 +81,7 @@ class Case < ApplicationRecord
     charge.offence_dates.first_or_initialize
   end
 
-  def appeal_original_app_submitted?
-    appeal_original_app_submitted == 'yes'
-  end
-
-  def appeal_case_type?
-    return false unless case_type
-
-    CaseType.new(case_type).appeal?
+  def original_application_reference_required?
+    appeal_financial_circumstances_changed == 'no'
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -29,6 +29,34 @@ class Case < ApplicationRecord
     valid?(:submission)
   end
 
+  def appeal_lodged_date
+    super if appeal_case_type?
+  end
+
+  def appeal_with_changes_details
+    super if appeal_case_type?
+  end
+
+  def appeal_original_app_submitted
+    super if appeal_case_type?
+  end
+
+  def appeal_reference_number
+    super if appeal_case_type?
+  end
+
+  def appeal_financial_circumstances_changed
+    super if appeal_case_type?
+  end
+
+  def appeal_maat_id
+    super if appeal_original_app_submitted?
+  end
+
+  def appeal_usn
+    super if appeal_original_app_submitted?
+  end
+
   def hearing_date_within_range?
     hearing_date.between?(EARLIEST_HEARING_DATE, LATEST_HEARING_DATE)
   end
@@ -37,5 +65,15 @@ class Case < ApplicationRecord
 
   def initialise_dates(charge)
     charge.offence_dates.first_or_initialize
+  end
+
+  def appeal_original_app_submitted?
+    appeal_original_app_submitted == 'yes'
+  end
+
+  def appeal_case_type?
+    return false unless case_type
+
+    CaseType.new(case_type).appeal?
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -21,15 +21,24 @@ class Person < ApplicationRecord
 
   def nino
     return unless has_nino == YesNoAnswer::YES.to_s
+    return if ignore_nino_and_arc?
 
     super
   end
 
   def arc
     return unless has_arc == YesNoAnswer::YES.to_s
+    return if ignore_nino_and_arc?
 
     super
   end
 
   delegate :capital, :income, to: :crime_application
+
+  private
+
+  def ignore_nino_and_arc?
+    crime_application.pse? || crime_application.appeal_no_changes? ||
+      crime_application.age_passported?
+  end
 end

--- a/app/presenters/summary/sections/case_details.rb
+++ b/app/presenters/summary/sections/case_details.rb
@@ -24,33 +24,32 @@ module Summary
           # START: Appeal to crown court case type questions
           Components::DateAnswer.new(
             :appeal_lodged_date, kase.appeal_lodged_date,
-            show: appeal_case_type?,
             change_path: edit_steps_client_appeal_details_path
           ),
 
           Components::ValueAnswer.new(
             :appeal_original_app_submitted, kase.appeal_original_app_submitted,
-            show: appeal_case_type?,
             change_path: edit_steps_client_appeal_details_path
           ),
 
           Components::ValueAnswer.new(
             :appeal_financial_circumstances_changed, kase.appeal_financial_circumstances_changed,
-            show: original_app_submitted? && !crime_application.cifc?,
             change_path: edit_steps_client_appeal_financial_circumstances_path
           ),
 
           Components::FreeTextAnswer.new(
             :appeal_with_changes_details, kase.appeal_with_changes_details,
-            show: financial_circumstances_changed? && !crime_application.cifc?,
             change_path: edit_steps_client_appeal_financial_circumstances_path
           ),
 
           Components::FreeTextAnswer.new(
-            :appeal_maat_id_or_usn, appeal_reference_value,
-            show: kase.appeal_reference_number.present?,
-            change_path: edit_steps_client_appeal_reference_number_path,
-            i18n_opts: { ref_type: appeal_reference_name }
+            :appeal_maat_id, kase.appeal_maat_id,
+            change_path: edit_steps_client_appeal_reference_number_path
+          ),
+
+          Components::FreeTextAnswer.new(
+            :appeal_usn, kase.appeal_usn,
+            change_path: edit_steps_client_appeal_reference_number_path
           ),
           # END: Appeal to crown court case type questions
 
@@ -110,18 +109,6 @@ module Summary
 
       def financial_circumstances_changed?
         kase.appeal_financial_circumstances_changed == 'yes'
-      end
-
-      def appeal_reference_name
-        return '' if kase.appeal_reference_number.nil?
-
-        kase.appeal_maat_id.present? ? 'MAAT ID' : 'USN'
-      end
-
-      def appeal_reference_value
-        return '' if kase.appeal_reference_number.nil?
-
-        kase.appeal_maat_id.presence || kase.appeal_usn.presence
       end
 
       def original_app_submitted?

--- a/app/presenters/summary/sections/client_details.rb
+++ b/app/presenters/summary/sections/client_details.rb
@@ -7,70 +7,50 @@ module Summary
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
-        answers = [
+        [
           Components::FreeTextAnswer.new(
             :first_name, applicant.first_name,
             change_path: edit_steps_client_details_path
           ),
-
           Components::FreeTextAnswer.new(
             :last_name, applicant.last_name,
             change_path: edit_steps_client_details_path
           ),
-
           Components::FreeTextAnswer.new(
             :other_names, applicant.other_names,
-            change_path: edit_steps_client_details_path, show: true
+            change_path: edit_steps_client_details_path,
+            show: true
           ),
-
           Components::DateAnswer.new(
             :date_of_birth, applicant.date_of_birth,
             change_path: edit_steps_client_details_path,
             i18n_opts: { format: :dob }
           ),
-        ]
-
-        unless nino_not_required?
-          answers.push(Components::FreeTextAnswer.new(
-                         :nino, applicant.nino,
-                         change_path: edit_steps_nino_path(subject: 'client'),
-                         show: true
-                       ))
-
-          answers.push(Components::FreeTextAnswer.new(
-                         :arc, applicant.arc,
-                         change_path: edit_steps_nino_path(subject: 'client'),
-                       ))
-        end
-
-        answers.push(
+          Components::FreeTextAnswer.new(
+            :nino, applicant.nino,
+            change_path: edit_steps_nino_path(subject: 'client'),
+            show: !nino_not_required?
+          ),
+          Components::FreeTextAnswer.new(
+            :arc, applicant.arc,
+            change_path: edit_steps_nino_path(subject: 'client'),
+          ),
           Components::ValueAnswer.new(
             :has_partner,
-            crime_application.applicant.has_partner,
+            applicant.has_partner,
             change_path: edit_steps_client_has_partner_path
+          ),
+          Components::ValueAnswer.new(
+            :relationship_status,
+            applicant.relationship_status,
+            change_path: edit_steps_client_relationship_status_path,
+          ),
+          Components::DateAnswer.new(
+            :separation_date,
+            applicant.separation_date,
+            change_path: edit_steps_client_relationship_status_path
           )
-        )
-
-        if no_partner?
-          answers.push(
-            Components::ValueAnswer.new(
-              :relationship_status,
-              crime_application.applicant.relationship_status,
-              change_path: edit_steps_client_relationship_status_path,
-            )
-          )
-
-          answers.push(
-            Components::DateAnswer.new(
-              :separation_date,
-              crime_application.applicant.separation_date,
-              change_path: edit_steps_client_relationship_status_path,
-              show: client_separated?,
-            )
-          )
-        end
-
-        answers.select(&:show?)
+        ].select(&:show?)
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
@@ -82,14 +62,6 @@ module Summary
 
       def applicant
         @applicant ||= crime_application.applicant
-      end
-
-      def no_partner?
-        crime_application.applicant.has_partner == 'no'
-      end
-
-      def client_separated?
-        crime_application.applicant.relationship_status == ClientRelationshipStatusType::SEPARATED.to_s
       end
 
       def nino_not_required?

--- a/app/validators/appeal_details/answers_validator.rb
+++ b/app/validators/appeal_details/answers_validator.rb
@@ -19,18 +19,18 @@ module AppealDetails
 
     def complete?
       return false unless general_details_complete?
-      return true if kase.appeal_original_app_submitted == 'no'
+      return true unless kase.appeal_original_app_submitted?
       return true if record.cifc?
 
       return true if kase.appeal_financial_circumstances_changed == 'yes' && kase.appeal_with_changes_details.present?
 
-      record.appeal_no_changes?
+      kase.appeal_maat_id.present? || kase.appeal_usn.present?
     end
 
     def applicable?
       return false if record.non_means_tested?
 
-      kase&.case_type.present? && CaseType.new(kase.case_type).appeal?
+      kase&.appeal_case_type?
     end
 
     private

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -335,8 +335,10 @@ en:
           <<: *YESNO
       appeal_with_changes_details:
         question: Changes details
-      appeal_maat_id_or_usn:
-        question: "Original application %{ref_type}"
+      appeal_maat_id:
+        question: "Original application MAAT ID"
+      appeal_usn:
+        question: "Original application USN"
       has_case_concluded:
         question: Case concluded?
         answers:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 feature_flags:
   developer_tools:
-    local: true
+    development: true
+    test: false
     staging: false
     production: false
   google_analytics:

--- a/docs/architectural-decisions/0003-use-draft-submission-json-for-review-page.md
+++ b/docs/architectural-decisions/0003-use-draft-submission-json-for-review-page.md
@@ -1,0 +1,58 @@
+# 3. Use draft submission JSON for the application review page
+
+Date: 2026-05-01
+
+## Status
+
+Accepted
+
+## Context
+
+Before submitting an application, providers are shown a review page where they can check all the information entered before confirming and sending. This page needs to present a complete summary of the application.
+
+The earlier approach rendered this page directly from the ActiveRecord model objects — the same models used by the individual form steps throughout the journey. While this was straightforward to implement initially, it created several problems:
+
+- **Logic divergence** — the review page and the submitted application could show different data. The serializer that produced the submission JSON applied its own rules about which fields to include, but the review page applied different rules through its presenters. Over time these could diverge, meaning a user might confirm information on the review page that did not match what was actually submitted.
+- **Duplicated rendering logic** — viewing a submitted application (fetched back from the datastore) required a separate rendering path from the review page, even though both were showing the same conceptual thing.
+- **Complexity in presenters** — presenters had to replicate decisions about which fields were relevant in a given application state, decisions that were also made in the serializer.
+
+## Decision
+
+The review page will render from the **draft submission**, not from the ActiveRecord models directly.
+
+`CrimeApplication#draft_submission` serializes the application to JSON using `SubmissionSerializer::Application` (the same serializer used to produce the payload sent to the datastore), then deserializes it into an `Adapters::Structs::CrimeApplication` struct. The review page presenter (`Summary::HtmlPresenter`) receives this struct, not the ActiveRecord record.
+
+```ruby
+# ReviewController
+def set_presenter
+  @presenter = Summary::HtmlPresenter.new(
+    crime_application: current_crime_application.draft_submission
+  )
+end
+
+# CrimeApplication model
+def draft_submission
+  Adapters::Structs::CrimeApplication.new(draft_submission_as_json)
+end
+
+def draft_submission_as_json
+  draft = SubmissionSerializer::Application.new(self).to_builder
+  draft.set!('status', ApplicationStatus::IN_PROGRESS.to_s)
+  draft.attributes!.as_json
+end
+```
+
+The same `HtmlPresenter` and summary section components are also used to display completed applications fetched from the datastore, since those are already struct-based representations of the submitted JSON.
+
+## Consequences
+
+**Benefits:**
+
+- **What you see is what gets submitted** — the review page shows exactly the data that will be sent to the datastore. Providers confirm based on the actual submission payload, not an approximation of it.
+- **Single rendering path** — draft applications on the review page and completed applications in the dashboard are rendered by the same presenter operating on the same struct interface. Changes to the presentation logic apply consistently to both.
+- **Serializer as single source of truth** — decisions about which fields are included in a submission live in one place (the serializer). The review page inherits those decisions automatically rather than having to replicate them.
+- **Presenters stay simple** — because the struct already reflects only the fields that are relevant for submission (nil or absent values are excluded), presenters do not need their own conditional logic to decide what to display. This is complementary to the dynamic relevance pattern described in [ADR 0004](0004-dynamic-relevance-for-attribute-visibility.md), where model methods return nil for irrelevant attributes — the serializer naturally omits those nil values, and the presenter simply renders what is present.
+
+**Trade-offs:**
+
+- **Serialization on every page load** — the review page triggers a full serialization of the application on each request.

--- a/docs/architectural-decisions/0004-dynamic-relevance-for-attribute-visibility.md
+++ b/docs/architectural-decisions/0004-dynamic-relevance-for-attribute-visibility.md
@@ -1,0 +1,74 @@
+# 4. Dynamic relevance for attribute visibility
+
+Date: 2026-05-01
+
+## Status
+
+Accepted
+
+## Context
+
+Crime Apply is a multi-step form where earlier answers determine which later questions are asked. This creates a class of attributes that may become irrelevant if a user changes a prior answer — for example, switching case type away from "Appeal to Crown Court" makes all appeal-specific fields irrelevant.
+
+Before this pattern was established, irrelevant data was handled in two main ways:
+
+1. **Form-driven resets** — forms would explicitly nil out dependent fields when a controlling answer changed (e.g. `CaseTypeForm` clearing all appeal fields on case type change).
+2. **Presenter/validator conditionals** — the logic for deciding whether an attribute was relevant was duplicated across presenters, serializers, validators, and external service adapters.
+
+Both approaches had significant drawbacks:
+
+- **Data loss** — resetting fields means a user who changes their mind and reverses an earlier answer must re-enter all dependent information.
+- **Scattered responsibility** — the rules about which data matters in which state lived in multiple places and could easily diverge.
+- **Increased coupling** — adding a new conditional field required changes in forms, presenters, validators, and serializers simultaneously.
+
+## Decision
+
+We will centralise attribute relevance logic in the **model layer**. Each model method for a conditionally relevant attribute guards the call to `super` (the database value) behind a state predicate. When the attribute is not relevant to the current application state, the method returns `nil`; when relevant, it returns the actual persisted value.
+
+```ruby
+class Case < ApplicationRecord
+  def appeal_lodged_date
+    super if appeal_case_type?
+  end
+
+  def appeal_financial_circumstances_changed
+    super if appeal_original_app_submitted?
+  end
+
+  def appeal_maat_id
+    super if original_application_reference_required?
+  end
+
+  private
+
+  def appeal_case_type?
+    return false unless case_type
+    CaseType.new(case_type).appeal?
+  end
+
+  def appeal_original_app_submitted?
+    appeal_original_app_submitted == 'yes'
+  end
+
+  def original_application_reference_required?
+    appeal_financial_circumstances_changed == 'no'
+  end
+end
+```
+
+The database value is preserved at all times. Downstream consumers (presenters, serializers, validators, external service adapters) treat a `nil` return as "this field is not present" without needing to know why.
+
+## Consequences
+
+**Benefits:**
+
+- **No data loss** — users can change earlier answers and reverse them without re-entering dependent information.
+- **Single source of truth** — the rules for what data is relevant in a given state live exclusively in the model. Changing the rules requires updating one place.
+- **Simpler consumers** — presenters, serializers, and validators can treat model output uniformly without conditional logic. A `nil` value simply means "not applicable right now".
+- **Safer form handling** — forms no longer need to manage cascading nil-resets, reducing the risk of accidentally clearing data that should be preserved.
+
+**Trade-offs:**
+
+- **Invisible data** — database columns may contain values that are not surfaced through the model. This can be surprising when querying the database directly or writing migrations. The pattern must be understood by developers working on the codebase, however this problem goes once the draft is submitted.
+- **Model complexity** — models accrue more methods as more attributes adopt this pattern. Predicate method naming and grouping must be kept clear.
+- **Test strategy** — tests should focus on state combination scenarios (e.g. "when case type is appeal and original app was submitted and circumstances changed: no") rather than testing individual predicate methods in isolation, to ensure the full chain of relevance logic is covered.reference

--- a/spec/forms/steps/client/case_type_form_spec.rb
+++ b/spec/forms/steps/client/case_type_form_spec.rb
@@ -60,14 +60,7 @@ RSpec.describe Steps::Client::CaseTypeForm do
       it_behaves_like 'a has-one-association form',
                       association_name: :case,
                       expected_attributes: {
-                        'case_type' => CaseType::INDICTABLE,
-                        :appeal_lodged_date => nil,
-                        :appeal_original_app_submitted => nil,
-                        :appeal_financial_circumstances_changed => nil,
-                        :appeal_with_changes_details => nil,
-                        :appeal_reference_number => nil,
-                        :appeal_maat_id => nil,
-                        :appeal_usn => nil,
+                        'case_type' => CaseType::INDICTABLE
                       }
     end
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -130,4 +130,121 @@ RSpec.describe Case, type: :model do
       it { expect(kase).to be_hearing_date_within_range }
     end
   end
+
+  # Appeal-specific logic tests - State combination scenarios
+  describe 'appeal conditional logic' do
+    describe 'Appeal with changes scenario' do
+      let(:attributes) do
+        {
+          case_type: CaseType::APPEAL_TO_CROWN_COURT.to_s,
+          appeal_original_app_submitted: 'yes',
+          appeal_financial_circumstances_changed: 'yes',
+          appeal_lodged_date: Date.parse('2024-01-15'),
+          appeal_with_changes_details: 'Income increased by 10%'
+        }
+      end
+
+      it 'includes appeal_lodged_date' do
+        expect(kase.appeal_lodged_date).to eq(Date.parse('2024-01-15'))
+      end
+
+      it 'includes appeal_original_app_submitted' do
+        expect(kase.appeal_original_app_submitted).to eq('yes')
+      end
+
+      it 'includes appeal_financial_circumstances_changed' do
+        expect(kase.appeal_financial_circumstances_changed).to eq('yes')
+      end
+
+      it 'includes appeal_with_changes_details' do
+        expect(kase.appeal_with_changes_details).to eq('Income increased by 10%')
+      end
+
+      it 'excludes reference numbers (not required when changes exist)' do
+        expect(kase.appeal_maat_id).to be_nil
+        expect(kase.appeal_usn).to be_nil
+      end
+    end
+
+    describe 'Appeal without changes scenario (reference numbers required)' do
+      let(:attributes) do
+        {
+          case_type: CaseType::APPEAL_TO_CROWN_COURT.to_s,
+          appeal_original_app_submitted: 'yes',
+          appeal_financial_circumstances_changed: 'no',
+          appeal_lodged_date: Date.parse('2024-01-15'),
+          appeal_maat_id: '1234567',
+          appeal_usn: '87654321'
+        }
+      end
+
+      it 'includes appeal_lodged_date' do
+        expect(kase.appeal_lodged_date).to eq(Date.parse('2024-01-15'))
+      end
+
+      it 'includes appeal_original_app_submitted' do
+        expect(kase.appeal_original_app_submitted).to eq('yes')
+      end
+
+      it 'includes appeal_financial_circumstances_changed as no' do
+        expect(kase.appeal_financial_circumstances_changed).to eq('no')
+      end
+
+      it 'includes reference numbers when changes did not happen' do
+        expect(kase.appeal_maat_id).to eq('1234567')
+        expect(kase.appeal_usn).to eq('87654321')
+      end
+    end
+
+    describe 'Appeal with original app not submitted' do
+      let(:attributes) do
+        {
+          case_type: CaseType::APPEAL_TO_CROWN_COURT.to_s,
+          appeal_original_app_submitted: 'no',
+          appeal_lodged_date: Date.parse('2024-01-15'),
+          appeal_maat_id: '1234567'
+        }
+      end
+
+      it 'includes appeal_lodged_date' do
+        expect(kase.appeal_lodged_date).to eq(Date.parse('2024-01-15'))
+      end
+
+      it 'includes appeal_original_app_submitted as no' do
+        expect(kase.appeal_original_app_submitted).to eq('no')
+      end
+
+      it 'excludes financial circumstances details when original app not submitted' do
+        expect(kase.appeal_financial_circumstances_changed).to be_nil
+      end
+
+      it 'excludes reference numbers' do
+        expect(kase.appeal_maat_id).to be_nil
+        expect(kase.appeal_usn).to be_nil
+      end
+    end
+
+    describe 'Non-appeal case' do
+      let(:attributes) do
+        {
+          case_type: CaseType::INDICTABLE.to_s,
+          appeal_original_app_submitted: 'yes',
+          appeal_financial_circumstances_changed: 'yes',
+          appeal_lodged_date: Date.parse('2024-01-15'),
+          appeal_with_changes_details: 'Some details',
+          appeal_maat_id: '1234567'
+        }
+      end
+
+      it 'excludes all appeal fields' do
+        expect(kase.appeal_lodged_date).to be_nil
+        expect(kase.appeal_original_app_submitted).to be_nil
+        expect(kase.appeal_financial_circumstances_changed).to be_nil
+        expect(kase.appeal_with_changes_details).to be_nil
+        expect(kase.appeal_maat_id).to be_nil
+        expect(kase.appeal_usn).to be_nil
+        expect(kase.appeal_reference_number).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/concerns/type_of_application_spec.rb
+++ b/spec/models/concerns/type_of_application_spec.rb
@@ -84,14 +84,7 @@ RSpec.describe TypeOfApplication do
     let(:appeal_original_app_submitted) { 'yes' }
     let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
     let(:appeal_financial_circumstances_changed) { 'no' }
-
-    before do
-      allow(crime_application).to receive(:kase).and_return(
-        instance_double(
-          Case, appeal_original_app_submitted:, case_type:, appeal_financial_circumstances_changed:
-        )
-      )
-    end
+    let(:kase) { Case.new(appeal_original_app_submitted:, case_type:, appeal_financial_circumstances_changed:) }
 
     context 'with no financial changes since the original application' do
       it { is_expected.to be true }

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe Person, type: :model do
     {
       first_name: 'Joe',
       last_name: 'Bloggs',
+      crime_application: crime_application
     }
   end
 
   let(:address_line_one) { '1 North Pole' }
+
+  let(:crime_application) { CrimeApplication.new }
 
   describe '#home_address?' do
     let(:mock_address) do
@@ -97,6 +100,36 @@ RSpec.describe Person, type: :model do
       it 'returns nino' do
         expect(subject.nino).to eq('AB123456A')
       end
+
+      context 'when pse' do
+        before do
+          allow(crime_application).to receive(:pse?).and_return(true)
+        end
+
+        it 'returns nil' do
+          expect(subject.nino).to be_nil
+        end
+      end
+
+      context 'when appeal no changes' do
+        before do
+          allow(crime_application).to receive(:appeal_no_changes?).and_return(true)
+        end
+
+        it 'returns nil' do
+          expect(subject.nino).to be_nil
+        end
+      end
+
+      context 'when passported on age' do
+        before do
+          allow(crime_application).to receive(:age_passported?).and_return(true)
+        end
+
+        it 'returns nil' do
+          expect(subject.nino).to be_nil
+        end
+      end
     end
 
     context 'when has_nino is `no`' do
@@ -126,6 +159,36 @@ RSpec.describe Person, type: :model do
 
       it 'returns arc' do
         expect(subject.arc).to eq('ARC123')
+      end
+
+      context 'when pse' do
+        before do
+          allow(crime_application).to receive(:pse?).and_return(true)
+        end
+
+        it 'returns nil' do
+          expect(subject.arc).to be_nil
+        end
+      end
+
+      context 'when appeal no changes' do
+        before do
+          allow(crime_application).to receive(:appeal_no_changes?).and_return(true)
+        end
+
+        it 'returns nil' do
+          expect(subject.arc).to be_nil
+        end
+      end
+
+      context 'when passported on age' do
+        before do
+          allow(crime_application).to receive(:age_passported?).and_return(true)
+        end
+
+        it 'returns nil' do
+          expect(subject.arc).to be_nil
+        end
       end
     end
 

--- a/spec/presenters/summary/sections/case_details_spec.rb
+++ b/spec/presenters/summary/sections/case_details_spec.rb
@@ -313,7 +313,7 @@ describe Summary::Sections::CaseDetails do
 
             answer = answers[5]
             expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-            expect(answer.question).to eq(:appeal_maat_id_or_usn)
+            expect(answer.question).to eq(:appeal_maat_id)
             expect(answer.change_path).to match('applications/12345/steps/client/appeal-reference-number')
             expect(answer.value).to eq(appeal_maat_id)
           end
@@ -328,7 +328,7 @@ describe Summary::Sections::CaseDetails do
 
             answer = answers[5]
             expect(answer).to be_an_instance_of(Summary::Components::FreeTextAnswer)
-            expect(answer.question).to eq(:appeal_maat_id_or_usn)
+            expect(answer.question).to eq(:appeal_usn)
             expect(answer.change_path).to match('applications/12345/steps/client/appeal-reference-number')
             expect(answer.value).to eq(appeal_usn)
           end

--- a/spec/presenters/summary/sections/client_details_spec.rb
+++ b/spec/presenters/summary/sections/client_details_spec.rb
@@ -122,27 +122,6 @@ describe Summary::Sections::ClientDetails do
       expect(answers[7].value).to eq(Date.new(2001, 10, 12))
     end
 
-    context 'when there is a partner' do
-      let(:has_partner) { 'yes' }
-
-      it 'has the correct rows' do
-        expect(answers.count).to eq(6)
-
-        expect(answers[5]).to be_an_instance_of(Summary::Components::ValueAnswer)
-        expect(answers[5].question).to eq(:has_partner)
-        expect(answers[5].change_path).to match('applications/12345/steps/client/does-client-have-partner')
-        expect(answers[5].value).to eq('yes')
-      end
-    end
-
-    context 'when there is no `benefit_type` value' do
-      let(:benefit_type) { nil }
-
-      it 'has the correct rows' do
-        expect(answers.count).to eq(8)
-      end
-    end
-
     context 'when an arc is provided' do
       let(:nino) { nil }
       let(:has_arc) { 'yes' }
@@ -160,37 +139,6 @@ describe Summary::Sections::ClientDetails do
         expect(answers[5].question).to eq(:arc)
         expect(answers[5].change_path).to match('applications/12345/steps/client/nino')
         expect(answers[5].value).to eq('ABC12/345678/A')
-      end
-    end
-
-    context 'when application is a post submission evidence application' do
-      let(:application_type) { ApplicationType::POST_SUBMISSION_EVIDENCE }
-      let(:pse?) { true }
-
-      it 'has the correct rows' do
-        expect(answers.count).to eq(7)
-        expect(question_labels).to eq([:first_name, :last_name, :other_names, :date_of_birth,
-                                       :has_partner, :relationship_status, :separation_date])
-      end
-    end
-
-    context 'when application is a appeal no changes application' do
-      let(:appeal_no_changes?) { true }
-      let(:has_partner) { nil }
-
-      it 'has the correct rows' do
-        expect(answers.count).to eq(4)
-        expect(question_labels).to eq([:first_name, :last_name, :other_names, :date_of_birth])
-      end
-    end
-
-    context 'when application is an under 18 application' do
-      let(:means_passport) { ['on_age_under18'] }
-      let(:has_partner) { nil }
-
-      it 'has the correct rows' do
-        expect(answers.count).to eq(4)
-        expect(question_labels).to eq([:first_name, :last_name, :other_names, :date_of_birth])
       end
     end
   end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -54,6 +54,17 @@ module CapybaraHelpers # rubocop:disable Metrics/ModuleLength
     title.ancestor('div.govuk-summary-card')
   end
 
+  def task_list_item(task_name)
+    find('li.govuk-task-list__item', text: task_name)
+  end
+
+  def task_list_item_status(task_name)
+    task_list_item(task_name)
+      .find('.govuk-task-list__status')
+      .text
+      .strip
+  end
+
   def within_card(card_title, &block)
     within(summary_card(card_title), &block)
   end

--- a/spec/support/matchers/summary_card.rb
+++ b/spec/support/matchers/summary_card.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :have_summary_row do |question, answer|
   match do |page|
     key = page.find('dt', text: question, match: :prefer_exact)
-    @value = key.sibling('dd').text(normalize_ws: true)
+    @value = key.sibling('dd', class: 'govuk-summary-list__value').text(normalize_ws: true)
     @value == answer
   end
 

--- a/spec/system/applying/appeal_to_crown_court_spec.rb
+++ b/spec/system/applying/appeal_to_crown_court_spec.rb
@@ -95,8 +95,10 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
       save_and_continue
 
       # steps/submission/review
-      save_and_continue
+    end
 
+    it 'submits a valid application to the datastore' do
+      save_and_continue
       # steps/submission/declaration
       fill_in('First name', with: 'Zoe')
       fill_in('Last name', with: 'Bar')
@@ -104,9 +106,6 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
 
       stub_request(:post, 'http://datastore-webmock/api/v1/applications')
       click_button 'Save and submit application'
-    end
-
-    it 'submits a valid application to the datastore' do
       expect(
         a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
           body = JSON.parse(req.body)['application']
@@ -117,6 +116,86 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
           body['case_details']['appeal_maat_id'] == '1234567'
         }
       ).to have_been_made.once
+    end
+
+    # INC4196794 - Means details missing from Review
+    context 'when the original case answer changed to no' do
+      it 'requires client and means details and hides original application details' do # rubocop:disable RSpec/ExampleLength
+        expect(summary_card('Case details')).to have_rows(
+          'Case type', 'Appeal to Crown Court',
+          'Legal aid application for original case?', 'Yes',
+          'Original application MAAT ID', '1234567'
+        )
+
+        within(summary_card('Case details')) do
+          click_link('Change Legal aid application for original case?', match: :first)
+        end
+        choose_answer('Was a legal aid application submitted for the original case?', 'No')
+        click_button 'Save and come back later'
+
+        # confirm that the task list show client details as in progres
+        expect(task_list_item_status('Client details')).to have_text('In progress')
+
+        # return to the original case details having checked the task item status
+        visit(crime_application_path(CrimeApplication.last))
+        within(summary_card('Case details')) do
+          click_link('Change Legal aid application for original case?', match: :first)
+        end
+        save_and_continue
+
+        # because the original application no longer exists, client address and means
+        # details are required
+        expect(page).to have_content('Where does your client usually live?')
+        save_and_continue
+        save_and_continue
+        save_and_continue
+        # steps/client/residence_type
+        choose_answer(
+          'Where does your client usually live?',
+          'They do not have a fixed home address'
+        )
+        save_and_continue
+
+        # steps/client/contact_details
+        choose_answer('Where shall we send correspondence?', 'Provider’s office')
+        save_and_continue
+
+        # steps/client/nino
+        choose_answer('Does your client have a National Insurance number?', 'Yes')
+        fill_in('What is their National Insurance number?', with: 'JA293483A')
+        save_and_continue
+
+        # steps/client/does-client-have-partner
+        choose_answer('Does your client have a partner?', 'No')
+        save_and_continue
+
+        # steps/client/relationship-status
+        choose_answer("What is your client's relationship status?", 'Single')
+        save_and_continue
+
+        # steps/dwp/benefit-type
+        mock_benefit_check('Yes')
+        choose_answer('Does your client get one of these passporting benefits?', 'Universal Credit')
+        save_and_continue
+
+        # steps/dwp/benefit-check-result
+        save_and_continue
+
+        # steps/client/urn
+        save_and_continue
+        click_button 'Save and come back later'
+        expect(task_list_item_status('Client details')).to have_text('Completed')
+
+        within(task_list_item('Review the application')) do
+          click_link
+        end
+
+        expect(summary_card('Case details')).to have_rows(
+          'Case type', 'Appeal to Crown Court',
+          'Legal aid application for original case?', 'No'
+        )
+        expect(page).not_to have_content('Original application')
+      end
     end
   end
 end

--- a/spec/system/applying/appeal_to_crown_court_spec.rb
+++ b/spec/system/applying/appeal_to_crown_court_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
     end
 
     # INC4196794 - Means details missing from Review
-    context 'when the original case answer changed to no' do
+    context 'when the original case answer changed to no from yes' do
       it 'requires client and means details and hides original application details' do # rubocop:disable RSpec/ExampleLength
         expect(summary_card('Case details')).to have_rows(
           'Case type', 'Appeal to Crown Court',

--- a/spec/system/applying/appeal_to_crown_court_with_changes_spec.rb
+++ b/spec/system/applying/appeal_to_crown_court_with_changes_spec.rb
@@ -187,6 +187,9 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
       save_and_continue
 
       # steps/submission/review
+    end
+
+    it 'submits a valid application to the datastore' do
       save_and_continue
 
       # steps/submission/declaration
@@ -196,9 +199,6 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
 
       stub_request(:post, 'http://datastore-webmock/api/v1/applications')
       click_button 'Save and submit application'
-    end
-
-    it 'submits a valid application to the datastore' do
       expect(
         a_request(:post, 'http://datastore-webmock/api/v1/applications').with { |req|
           body = JSON.parse(req.body)['application']
@@ -208,6 +208,70 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
           body['case_details']['appeal_with_changes_details'] == 'Redundancy'
         }
       ).to have_been_made.once
+    end
+
+    context "when the client's financial circumstances answer changed from yes to no" do
+      it 'hides means and contact details' do # rubocop:disable RSpec/ExampleLength
+        expect(summary_card('Case details')).to have_rows(
+          'Case type', 'Appeal to Crown Court',
+          'Legal aid application for original case?', 'Yes',
+          'Changes to financial circumstances since original application?', 'Yes'
+        )
+
+        with_changes_cards = [
+          'Client contact details',
+          'Employment',
+          'Income'
+        ]
+
+        with_changes_cards.each do |name|
+          expect(summary_card(name)).not_to be_nil
+        end
+
+        within(summary_card('Case details')) do
+          click_link('Change Legal aid application for original case?', match: :first)
+        end
+
+        save_and_continue
+        choose_answer("Have your client's financial circumstances changed since the initial application?", 'No')
+        save_and_continue
+
+        click_button 'Save and come back later'
+
+        # confirm that the task list show client details as in progres--because original
+        # application reference is now required
+        expect(task_list_item_status('Client details')).to have_text('In progress')
+
+        # return to the original case details having checked the task item status
+        visit(crime_application_path(CrimeApplication.last))
+        within(summary_card('Case details')) do
+          click_link('Change Legal aid application for original case?', match: :first)
+        end
+        save_and_continue
+        save_and_continue
+
+        # steps/client/appeal_reference_number
+        choose_answer('What is the reference number of the original application?', 'USN')
+        fill_in('USN', with: 12_341_234)
+        click_button 'Save and come back later'
+
+        expect(task_list_item_status('Client details')).to have_text('Completed')
+
+        click_link('Review the application')
+
+        expect(summary_card('Case details')).to have_rows(
+          'Case type', 'Appeal to Crown Court',
+          'Legal aid application for original case?', 'Yes',
+          'Changes to financial circumstances since original application?', 'No',
+          'Original application USN', '12341234',
+          'Legal aid application for original case?', 'Yes'
+        )
+
+        # confirm cards are no longer shown now there are no changes
+        with_changes_cards.each do |name|
+          expect(page).not_to have_content(name)
+        end
+      end
     end
   end
 end

--- a/spec/validators/appeal_details/answers_validator_spec.rb
+++ b/spec/validators/appeal_details/answers_validator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AppealDetails::AnswersValidator, type: :model do
   end
 
   let(:errors) { double(:errors, empty?: false) }
-  let(:kase) { instance_double(Case, case_type:) }
+  let(:kase) { Case.new(case_type:) }
   let(:case_type) { nil }
   let(:cifc?) { false }
 
@@ -49,71 +49,80 @@ RSpec.describe AppealDetails::AnswersValidator, type: :model do
   describe '#complete?' do
     subject(:complete?) { validator.complete? }
 
-    before do
-      allow(record).to receive(:appeal_no_changes?).and_return(appeal_no_changes?)
-      allow(kase).to receive_messages(
-        appeal_lodged_date:,
-        appeal_original_app_submitted:
-      )
-    end
+    let(:case_type) { CaseType::APPEAL_TO_CROWN_COURT.to_s }
 
-    let(:appeal_lodged_date) { '2023-11-11' }
-    let(:appeal_original_app_submitted) { 'yes' }
-    let(:appeal_no_changes?) { false }
-
-    context 'when a general details is missing' do
-      let(:appeal_lodged_date) { nil }
-      let(:appeal_original_app_submitted) { 'no' }
+    context 'when appeal_lodged_date is missing' do
+      before do
+        kase.appeal_lodged_date = nil
+        kase.appeal_original_app_submitted = 'no'
+      end
 
       it { is_expected.to be false }
     end
 
-    context 'when legal aid application was not submitted for the original case' do
+    context 'when appeal original app submitted not answered' do
       before do
-        allow(kase).to receive(:appeal_original_app_submitted).and_return('no')
+        kase.appeal_original_app_submitted = nil
+        kase.appeal_lodged_date = '2023-11-11'
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when appeal lodged date and app submitted answered' do
+      before do
+        kase.appeal_original_app_submitted = 'no'
+        kase.appeal_lodged_date = '2023-11-11'
       end
 
       it { is_expected.to be true }
     end
 
-    context 'when legal aid application was submitted for the original case' do
-      let(:appeal_original_app_submitted) { 'yes' }
-      let(:appeal_reference) { [nil, nil] }
-
+    context 'when legal aid app was submitted for the original case' do
       before do
-        allow(kase).to receive(:values_at).with(:appeal_maat_id, :appeal_usn).and_return(appeal_reference)
+        kase.appeal_lodged_date = '2023-11-11'
+        kase.appeal_original_app_submitted = 'yes'
       end
 
       context 'when financial circumstances changed' do
         before do
-          allow(kase).to receive(:appeal_financial_circumstances_changed).and_return('yes')
+          kase.appeal_financial_circumstances_changed = 'yes'
         end
 
         it 'returns true when details given' do
-          allow(kase).to receive(:appeal_with_changes_details).and_return('Details about changes')
+          kase.appeal_with_changes_details = 'Details about changes'
+
           expect(subject).to be true
         end
 
-        it 'returns false when details not given' do
-          allow(kase).to receive(:appeal_with_changes_details).and_return(nil)
-
+        it 'returns false when details are not given' do
           expect(subject).to be false
         end
       end
 
       context 'when financial circumstances have not changed' do
         before do
-          allow(kase).to receive(:appeal_financial_circumstances_changed).and_return('no')
+          kase.appeal_financial_circumstances_changed = 'no'
         end
 
-        context 'appeal no changes' do
-          let(:appeal_no_changes?) { true }
+        context 'and an appeal reference is not given' do
+          it { is_expected.to be false }
+        end
+
+        context 'and an appeal MAAT ID is given' do
+          before do
+            kase.appeal_maat_id = '123456'
+          end
 
           it { is_expected.to be true }
         end
 
-        context 'and appeal reference is not given' do
-          it { is_expected.to be false }
+        context 'and an appeal USN is given' do
+          before do
+            kase.appeal_usn = 123_456
+          end
+
+          it { is_expected.to be true }
         end
       end
     end


### PR DESCRIPTION
## Description of change

Appeal to Crown Court--fix redundant data appearing on Crime Review and CYA screens

When an Appeal to Crown Court application was returned to a provider and they changed a key earlier answer (e.g. "was there a previous application?"), redundant data from the previous journey continued to appear on the Check Your Answers and Review Application screens. This affected several scenarios where the case type, passporting status, or means assessment path had effectively changed on return.

Responsibility for deciding which fields were relevant was spread across forms, presenters, Crime Review and validators. Forms would reset dependent fields on save, but only for the specific step being edited--if a provider changed an earlier answer without re-visiting downstream steps, stale data remained visible and was included in the submission.

Attribute relevance logic has been centralised in the model layer. Conditionally relevant attributes now return nil when their controlling condition is not met, regardless of what is stored in the database. This means the CYA and review screens, the submission serializer, and validators all see a consistent view of the application state without each needing to replicate the relevance rules. This approach has been used elsewhere, and whilst not perfect is an improvement on resetting attributes or having logic in the view layer.

This approach is documented in ADR 0004.

## Link to relevant ticket

[CRIMAPP-2190](https://dsdmoj.atlassian.net/browse/CRIMAPP-2190)

## Notes for reviewer

Once deployed, the conditional display logic in the review service that caused the original bug can be removed (see laa-review-criminal-legal-aid#1021).

[CRIMAPP-2190]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ