### PR TITLE
Fix Sentry event data filtering

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -15,7 +15,16 @@ Rails.application.config.to_prepare do
       Rails.application.config.filter_parameters
     )
     config.before_send = lambda do |event, _hint|
-      params_filter.filter(event.to_hash)
+      if event.request
+        event.request.data = params_filter.filter(event.request.data) if event.request.data
+        event.request.cookies = params_filter.filter(event.request.cookies) if event.request.cookies
+      end
+
+      if event.user
+        event.user = params_filter.filter(event.user)
+      end
+
+      event
     end
   end
 end

--- a/spec/initializers/sentry_spec.rb
+++ b/spec/initializers/sentry_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/DescribeClass
+  subject(:result) { Sentry.configuration.before_send.call(event, {}) }
+
+  let(:event) do
+    Sentry::ErrorEvent.new(configuration: Sentry.configuration).tap do |e|
+      e.user = { 'email' => 'user@example.com', 'first_name' => 'John', 'id' => 'safe-id' }
+    end
+  end
+
+  it 'returns a Sentry::ErrorEvent' do
+    expect(result).to be_a(Sentry::ErrorEvent)
+  end
+
+  describe 'user field filtering' do
+    it 'filters sensitive user fields' do
+      expect(result.user['email']).to eq('[FILTERED]')
+      expect(result.user['first_name']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive user fields' do
+      expect(result.user['id']).to eq('safe-id')
+    end
+  end
+
+  describe 'request data filtering' do
+    let(:request_interface) do
+      Sentry::RequestInterface.new(
+        env: Rack::MockRequest.env_for('/test'),
+        send_default_pii: false,
+        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
+      ).tap do |r|
+        r.data    = { 'nino' => 'AB123456C', 'action' => 'submit' }
+        r.cookies = { 'token' => 'abc123', '_ga' => 'safe-ga-value' }
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'filters sensitive fields in request data' do
+      expect(result.request.data['nino']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive fields in request data' do
+      expect(result.request.data['action']).to eq('submit')
+    end
+
+    it 'filters sensitive fields in cookies' do
+      expect(result.request.cookies['token']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive cookie values' do
+      expect(result.request.cookies['_ga']).to eq('safe-ga-value')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This attempts to fix an issue where Sentry is no longer receiving alerts from the application due to an exception caused by code in the `before_send` callback in the Sentry initializer (`sentry.rb`). This code is meant to filter out sensitive data from the error event as defined in `filter_parameter_logging.rb`.

The breaking changes were introduced with `sentry-ruby v6.0.0`:
> - Migrate from to_hash to to_h (https://github.com/getsentry/sentry-ruby/pull/2351)
> - Returning a hash from before_send and before_send_transaction is no longer supported and will drop the event.

[Full release log](https://github.com/getsentry/sentry-ruby/releases/tag/6.0.0).

Examples of silent exceptions in our logs: [here](https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log),isDirty:!t,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1M,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-criminal-legal-aid-production),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-apply-for-criminal-legal-aid-production)))),query:(language:kuery,query:'%22sentry:%20exception%20happened%20in%20background%20worker:%20undefined%20method%20!'to_hash!'%20for%20an%20instance%20of%20Sentry::ErrorEvent%22'))).

Relevant Sentry docs:
https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/#using-before-send
https://develop.sentry.dev/sdk/foundations/transport/event-payloads/request/

## How to manually test the feature
In a Rails console on staging, run the following to raise an exception that should be picked up by Sentry and create an alert in our alerts channel:
```ruby
begin
  raise 'Sentry connectivity test'
rescue => e
  Rails.error.report(e, handled: false)
end
``` 