### PR TITLE
[CRIMAPP-2190] hide 'change details' rather than resetting data

### DIFF
--- a/app/forms/steps/client/appeal_financial_circumstances_form.rb
+++ b/app/forms/steps/client/appeal_financial_circumstances_form.rb
@@ -24,23 +24,7 @@ module Steps
       def persist!
         return true unless changed?
 
-        self.case.update(
-          attributes.merge(attributes_to_reset)
-        )
-      end
-
-      def attributes_to_reset
-        if financial_circumstances_changed?
-          return {
-            'appeal_maat_id' => nil,
-            'appeal_usn' => nil,
-            'appeal_reference_number' => nil
-          }
-        end
-
-        {
-          'appeal_with_changes_details' => nil
-        }
+        self.case.update(attributes)
       end
     end
   end

--- a/app/forms/steps/client/appeal_reference_number_form.rb
+++ b/app/forms/steps/client/appeal_reference_number_form.rb
@@ -29,40 +29,12 @@ module Steps
       end
 
       def persist!
-        reset_home_address
-        reset_correspondence_address
-        crime_application.applicant.update(applicant_attributes_to_reset)
-
-        self.case.update(
-          attributes
-        )
+        self.case.update(attributes)
       end
 
       def before_save
         self.appeal_maat_id = nil unless maat_id_selected?
         self.appeal_usn = nil unless usn_selected?
-      end
-
-      def applicant_attributes_to_reset
-        {
-          'residence_type' => nil, 'correspondence_address_type' => nil, 'telephone_number' => nil, 'has_nino' => nil,
-          'nino' => nil, 'has_arc' => nil, 'arc' => nil, 'will_enter_nino' => nil, 'benefit_type' => nil,
-          'last_jsa_appointment_date' => nil, 'benefit_check_result' => nil, 'has_benefit_evidence' => nil,
-          'dwp_response' => nil
-        }
-      end
-
-      # TODO: Duplicate of method in residence type form, is there somewhere this could live?
-      def reset_home_address
-        return unless crime_application.applicant.home_address?
-
-        crime_application.applicant.home_address.destroy!
-      end
-
-      def reset_correspondence_address
-        return unless crime_application.applicant.correspondence_address?
-
-        crime_application.applicant.correspondence_address.destroy!
       end
     end
   end

--- a/app/forms/steps/client/relationship_status_form.rb
+++ b/app/forms/steps/client/relationship_status_form.rb
@@ -22,17 +22,7 @@ module Steps
       private
 
       def persist!
-        partner_detail.update(
-          attributes.merge(attributes_to_reset)
-        )
-      end
-
-      def attributes_to_reset
-        return {} if separated?
-
-        {
-          'separation_date' => nil,
-        }
+        partner_detail.update(attributes)
       end
     end
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -34,7 +34,7 @@ class Case < ApplicationRecord
   end
 
   def appeal_with_changes_details
-    super if appeal_case_type?
+    super if appeal_financial_circumstances_changed?
   end
 
   def appeal_original_app_submitted

--- a/spec/forms/steps/client/appeal_financial_circumstances_form_spec.rb
+++ b/spec/forms/steps/client/appeal_financial_circumstances_form_spec.rb
@@ -52,10 +52,7 @@ RSpec.describe Steps::Client::AppealFinancialCircumstancesForm do
           expect(case_record).to receive(:update).with(
             {
               'appeal_financial_circumstances_changed' => appeal_financial_circumstances_changed,
-              'appeal_with_changes_details' => appeal_with_changes_details,
-              'appeal_maat_id' => nil,
-              'appeal_usn' => nil,
-              'appeal_reference_number' => nil
+              'appeal_with_changes_details' => appeal_with_changes_details
             }
           ).and_return(true)
 

--- a/spec/forms/steps/client/appeal_reference_number_form_spec.rb
+++ b/spec/forms/steps/client/appeal_reference_number_form_spec.rb
@@ -29,24 +29,6 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
   let(:home_address) { instance_double(HomeAddress, destroy!: true) }
   let(:correspondence_address) { instance_double(CorrespondenceAddress, destroy!: true) }
 
-  let(:applicant_attributes_to_reset) {
-    {
-      'residence_type' => nil,
-      'correspondence_address_type' => nil,
-      'telephone_number' => nil,
-      'has_nino' => nil,
-      'nino' => nil,
-      'has_arc' => nil,
-      'arc' => nil,
-      'will_enter_nino' => nil,
-      'benefit_type' => nil,
-      'last_jsa_appointment_date' => nil,
-      'benefit_check_result' => nil,
-      'has_benefit_evidence' => nil,
-      'dwp_response' => nil
-    }
-  }
-
   describe 'validations' do
     it { is_expected.to validate_presence_of(:appeal_reference_number) }
 
@@ -106,8 +88,6 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
           }
         ).and_return(true)
 
-        expect(applicant_record).to receive(:update).with(applicant_attributes_to_reset).and_return(true)
-
         expect(subject.save).to be(true)
       end
     end
@@ -124,8 +104,6 @@ RSpec.describe Steps::Client::AppealReferenceNumberForm do
             'appeal_usn' => appeal_usn
           }
         ).and_return(true)
-
-        expect(applicant_record).to receive(:update).with(applicant_attributes_to_reset).and_return(true)
 
         expect(subject.save).to be(true)
       end

--- a/spec/system/applying/appeal_to_crown_court_with_changes_spec.rb
+++ b/spec/system/applying/appeal_to_crown_court_with_changes_spec.rb
@@ -1,8 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Apply for Criminal Legal Aid' do
+  # rubocop:disable RSpec/ExampleLength
   describe 'Submitting an appeal to Crown Court (with changes) application' do
     include_context 'when logged in'
+
+    # details only required if changes or no original application submitted
+    let(:with_changes_cards) do
+      [
+        'Client contact details',
+        'Employment',
+        'Income'
+      ]
+    end
 
     before do
       # applications
@@ -189,7 +199,18 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
       # steps/submission/review
     end
 
-    it 'submits a valid application to the datastore' do
+    it 'shows correct details and submits a valid application to the datastore' do
+      expect(summary_card('Case details')).to have_rows(
+        'Case type', 'Appeal to Crown Court',
+        'Legal aid application for original case?', 'Yes',
+        'Changes to financial circumstances since original application?', 'Yes',
+        'Changes details', 'Redundancy'
+      )
+
+      with_changes_cards.each do |name|
+        expect(summary_card(name)).not_to be_nil
+      end
+
       save_and_continue
 
       # steps/submission/declaration
@@ -211,23 +232,7 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
     end
 
     context "when the client's financial circumstances answer changed from yes to no" do
-      it 'hides means and contact details' do # rubocop:disable RSpec/ExampleLength
-        expect(summary_card('Case details')).to have_rows(
-          'Case type', 'Appeal to Crown Court',
-          'Legal aid application for original case?', 'Yes',
-          'Changes to financial circumstances since original application?', 'Yes'
-        )
-
-        with_changes_cards = [
-          'Client contact details',
-          'Employment',
-          'Income'
-        ]
-
-        with_changes_cards.each do |name|
-          expect(summary_card(name)).not_to be_nil
-        end
-
+      it 'hides means and contact details' do
         within(summary_card('Case details')) do
           click_link('Change Legal aid application for original case?', match: :first)
         end
@@ -267,11 +272,53 @@ RSpec.describe 'Apply for Criminal Legal Aid' do
           'Legal aid application for original case?', 'Yes'
         )
 
+        expect(page).not_to have_content 'Changes details'
+
         # confirm cards are no longer shown now there are no changes
         with_changes_cards.each do |name|
           expect(page).not_to have_content(name)
         end
       end
     end
+
+    context 'when application changed to one where legal aid was not origionally submitted' do
+      it 'hides original application and CIFC details' do
+        %w[
+          appeal_financial_circumstances_changed
+          appeal_with_changes_details
+        ].each { |question| expect(page).to have_content I18n.t("summary.questions.#{question}.question") }
+
+        within(summary_card('Case details')) do
+          click_link('Legal aid application for original case?', match: :first)
+        end
+        choose_answer('Was a legal aid application submitted for the original case?', 'No')
+        save_and_continue
+        click_button 'Save and come back later'
+
+        # confirm that the task list show client details as in progres--because original
+        # application reference is now required
+        expect(task_list_item_status('Client details')).to have_text('Completed')
+
+        click_link('Review the application')
+
+        expect(summary_card('Case details')).to have_rows(
+          'Case type', 'Appeal to Crown Court',
+          'Legal aid application for original case?', 'No',
+        )
+
+        %w[
+          appeal_financial_circumstances_changed
+          appeal_usn
+          appeal_with_changes_details
+        ].each { |question| expect(page).not_to have_content I18n.t("summary.questions.#{question}.question") }
+
+        # confirm with change cards are there
+        with_changes_cards.each do |name|
+          expect(page).to have_content(name)
+        end
+      end
+    end
   end
+
+  # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
## Description of change

- Fix bug where change details were being shown when application changed to one without a previous submission.
- Also removes now redundant reseting of attributes from forms

## Link to relevant ticket

[CRIMAPP-2190](https://dsdmoj.atlassian.net/browse/CRIMAPP-2190)

[CRIMAPP-2190]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test plan to be carried out by Joe in ticket.