### PR TITLE
Update to use expect on params--triggered by linting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
   private
 
   def locale_from_param
-    I18n.available_locales.find { |l| l == params[:locale]&.to_sym }
+    I18n.available_locales.find { |l| l == params.expect(:locale)&.to_sym }
   end
 
   def initialize_crime_application(attributes = {}, &block)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,9 @@ class ApplicationController < ActionController::Base
   private
 
   def locale_from_param
-    I18n.available_locales.find { |l| l == params.expect(:locale)&.to_sym }
+    I18n.available_locales.find { |l| l == params.expect(:locale).to_sym }
+  rescue ActionController::ParameterMissing
+    nil
   end
 
   def initialize_crime_application(attributes = {}, &block)

--- a/app/controllers/concerns/steps/business_resource.rb
+++ b/app/controllers/concerns/steps/business_resource.rb
@@ -13,7 +13,7 @@ module Steps
     end
 
     def set_business
-      @business ||= businesses.find(params[:business_id])
+      @business ||= businesses.find(params.expect(:business_id))
     rescue ActiveRecord::RecordNotFound
       raise Errors::BusinessNotFound
     end

--- a/app/controllers/concerns/steps/capital/property_update_step.rb
+++ b/app/controllers/concerns/steps/capital/property_update_step.rb
@@ -33,7 +33,7 @@ module Steps
       private
 
       def property_record
-        @property_record ||= properties.find(params[:property_id])
+        @property_record ||= properties.find(params.expect(:property_id))
       rescue ActiveRecord::RecordNotFound
         raise Errors::PropertyNotFound
       end

--- a/app/controllers/concerns/steps/income/employment_update_step.rb
+++ b/app/controllers/concerns/steps/income/employment_update_step.rb
@@ -18,7 +18,7 @@ module Steps
       private
 
       def employment_record
-        @employment_record ||= employments.find(params[:employment_id])
+        @employment_record ||= employments.find(params.expect(:employment_id))
       rescue ActiveRecord::RecordNotFound
         raise Errors::EmploymentNotFound
       end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -45,7 +45,7 @@ class DocumentsController < ApplicationController
   private
 
   def set_document
-    @document = current_crime_application.documents.find(params[:document_id])
+    @document = current_crime_application.documents.find(params.expect(:document_id))
   rescue ActiveRecord::RecordNotFound
     raise Errors::DocumentUnavailable, 'CrimeApplication/Document mismatch'
   end

--- a/app/controllers/steps/address_step_controller.rb
+++ b/app/controllers/steps/address_step_controller.rb
@@ -7,7 +7,7 @@ module Steps
     end
 
     def address_record
-      @address_record ||= current_crime_application.addresses.find(params[:address_id])
+      @address_record ||= current_crime_application.addresses.find(params.expect(:address_id))
     end
   end
 end

--- a/app/controllers/steps/capital/investments_controller.rb
+++ b/app/controllers/steps/capital/investments_controller.rb
@@ -31,7 +31,7 @@ module Steps
       private
 
       def investment_record
-        @investment_record ||= investments.find(params[:investment_id])
+        @investment_record ||= investments.find(params.expect(:investment_id))
       rescue ActiveRecord::RecordNotFound
         raise Errors::InvestmentNotFound
       end

--- a/app/controllers/steps/capital/national_savings_certificates_controller.rb
+++ b/app/controllers/steps/capital/national_savings_certificates_controller.rb
@@ -36,7 +36,7 @@ module Steps
 
       def national_savings_certificate_record
         @national_savings_certificate_record ||= national_savings_certificates.find(
-          params[:national_savings_certificate_id]
+          params.expect(:national_savings_certificate_id)
         )
       rescue ActiveRecord::RecordNotFound
         raise Errors::NationalSavingsCertificateNotFound

--- a/app/controllers/steps/capital/savings_controller.rb
+++ b/app/controllers/steps/capital/savings_controller.rb
@@ -31,7 +31,7 @@ module Steps
       private
 
       def saving_record
-        @saving_record ||= savings.find(params[:saving_id])
+        @saving_record ||= savings.find(params.expect(:saving_id))
       rescue ActiveRecord::RecordNotFound
         raise Errors::SavingNotFound
       end

--- a/app/controllers/steps/case/charges_controller.rb
+++ b/app/controllers/steps/case/charges_controller.rb
@@ -37,7 +37,7 @@ module Steps
       private
 
       def charge_record
-        @charge_record ||= case_charges.find(params[:charge_id])
+        @charge_record ||= case_charges.find(params.expect(:charge_id))
       end
 
       def case_charges

--- a/app/controllers/steps/case/charges_dates_controller.rb
+++ b/app/controllers/steps/case/charges_dates_controller.rb
@@ -20,7 +20,7 @@ module Steps
       end
 
       def charge_record
-        @charge_record ||= case_charges.find(params[:charge_id])
+        @charge_record ||= case_charges.find(params.expect(:charge_id))
       end
 
       def case_charges

--- a/app/controllers/steps/evidence/upload_controller.rb
+++ b/app/controllers/steps/evidence/upload_controller.rb
@@ -16,7 +16,7 @@ module Steps
       def step_name
         return :upload_finished unless params.key?('document_id')
 
-        document = current_crime_application.documents.find(params['document_id'])
+        document = current_crime_application.documents.find(params.expect('document_id'))
 
         if deleted?(document)
           @flash = { success: t('steps.evidence.upload.edit.delete.success', file_name: document.filename) }

--- a/app/controllers/steps/income/businesses_controller.rb
+++ b/app/controllers/steps/income/businesses_controller.rb
@@ -33,7 +33,7 @@ module Steps
       private
 
       def business_record
-        @business_record ||= businesses.find(params[:business_id])
+        @business_record ||= businesses.find(params.expect(:business_id))
       rescue ActiveRecord::RecordNotFound
         raise Errors::BusinessNotFound
       end


### PR DESCRIPTION
Fix historical linting failures merged due to a branch protection regression
(https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/commit/cfb29f5fd9df763c14e1ec107b6c34eba4b89b62).

Branch protection issue has now been resolved as follows:

<img width="987" height="269" alt="Screenshot 2026-05-26 at 12 12 37" src="https://github.com/user-attachments/assets/8f295d67-0b23-4fb7-b0cb-cf4cdb159942" />



