### PR TITLE
CRIMAPP 2130: Bugfix - added appropriate spacing to stop clashing

### DIFF
--- a/app/assets/stylesheets/local/sortable-table.scss
+++ b/app/assets/stylesheets/local/sortable-table.scss
@@ -7,8 +7,11 @@
 [aria-sort] button:hover {
 
   position: relative;
+  display: inline-block;
+  max-width: 100%;
   margin: 0;
-  padding: 0 10px 0 0;
+  padding: 0 16px 0 0;
+  white-space: normal;
   border-width: 0;
   color: #005ea5;
   background-color: transparent;
@@ -44,7 +47,7 @@
   content: " \25bc";
   position: absolute;
   top: 9px;
-  right: -1px;
+  right: 0;
   font-size: 0.5em;
 }
 
@@ -53,7 +56,7 @@
   content: " \25b2";
   position: absolute;
   top: 1px;
-  right: -1px;
+  right: 0;
   font-size: 0.5em;
 }
 
@@ -69,7 +72,7 @@
   content: " \25b2";
   position: absolute;
   top: 2px;
-  right: -5px;
+  right: 0;
   font-size: 0.8em;
 }
 
@@ -78,6 +81,6 @@
   content: " \25bc";
   position: absolute;
   top: 2px;
-  right: -5px;
+  right: 0;
   font-size: 0.8em;
 }


### PR DESCRIPTION
## Description of change

Added space around the arrows in the column headers to prevent issues when narrowing the browser window

Previously narrowing would result in arrow moving to the left and clashing with the text just before the title split across lines.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2130

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="802" height="603" alt="image" src="https://github.com/user-attachments/assets/6b33da7d-9d8a-44a1-bcaf-ea380b81f8b6" />


### After changes:

<img width="915" height="534" alt="image" src="https://github.com/user-attachments/assets/0a16fc0e-3c96-4075-893a-af40268f1dec" />



## How to manually test the feature
