### PR TITLE
CRIMAPP-2219 Guard Devise stored location to prevent session cookie o…

### DIFF
--- a/app/lib/devise/custom_failure_app.rb
+++ b/app/lib/devise/custom_failure_app.rb
@@ -1,8 +1,10 @@
 module Devise
   class CustomFailureApp < Devise::FailureApp
+    MAX_STORED_LOCATION_BYTES = 2048
+
     # rubocop:disable Metrics/MethodLength
     def redirect
-      store_location!
+      store_location_if_safe!
 
       message = warden_message || :unauthenticated
 
@@ -24,5 +26,19 @@ module Devise
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def store_location_if_safe!
+      path = attempted_path.to_s
+      if path.bytesize > MAX_STORED_LOCATION_BYTES
+        Rails.logger.warn(
+          "Skipping store_location! for oversized attempted path (#{path.bytesize} bytes)"
+        )
+        return
+      end
+
+      store_location!
+    end
   end
 end

--- a/spec/lib/devise/custom_failure_app_spec.rb
+++ b/spec/lib/devise/custom_failure_app_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Devise::CustomFailureApp do
+  describe '#redirect' do
+    subject(:redirect_request) { failure_app.redirect }
+
+    let(:failure_app) { described_class.new }
+    let(:attempted_path) { '/applications' }
+
+    before do
+      allow(failure_app).to receive_messages(
+        warden_message: :unauthenticated,
+        attempted_path: attempted_path,
+        unauthenticated_errors_path: '/errors/unauthenticated'
+      )
+      allow(failure_app).to receive(:redirect_to)
+      allow(Rails.logger).to receive(:debug)
+    end
+
+    it 'stores location when path size is within limits' do
+      expect(failure_app).to receive(:store_location!)
+      redirect_request
+    end
+
+    context 'when attempted path exceeds the session-safe size' do
+      let(:attempted_path) { "/test?#{'a' * 3000}" }
+
+      it 'skips storing location and still redirects' do
+        expect(failure_app).not_to receive(:store_location!)
+        expect(Rails.logger).to receive(:warn).with(
+          /Skipping store_location! for oversized attempted path/
+        )
+        expect(failure_app).to receive(:redirect_to).with('/errors/unauthenticated')
+
+        redirect_request
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
The app is using cookie-backed sessions, and Devise::CustomFailureApp always calls store_location! on authentication failures. Very long attempted URLs (e.g., large query strings) can bloat the session payload and trigger:

ActionDispatch::Cookies::CookieOverflow

This change adds a defensive size check before storing attempted_path in session during failure redirects.

- Add MAX_STORED_LOCATION_BYTES = 2048 in Devise::CustomFailureApp
- Replace unconditional store_location! with store_location_if_safe!
- Skip storing when attempted_path exceeds the threshold and log a warning
- Preserve existing redirect behavior for unauthenticated/reauthenticate/etc.

Also adds focused specs for CustomFailureApp redirect behavior:

- stores location when attempted_path is within limits
- skips store_location! and still redirects when attempted_path is oversized

This prevents oversized return URLs from causing session cookie overflows while keeping standard post-auth redirect flow intact.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2219

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
