### PR TITLE
CRIMAPP-2219: Add CookieOverflow session diagnostics

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require_relative 'boot'
 require_relative '../lib/middleware/business_hours_middleware'
+require_relative '../lib/middleware/session_cookie_overflow_logger'
 
 require 'rails'
 require 'active_record/railtie'
@@ -74,5 +75,8 @@ module LaaApplyForCriminalLegalAid
     config.x.business_hours.end = ENV.fetch('BUSINESS_HOURS_END', "21:30")
 
     config.middleware.use BusinessHoursMiddleware
+
+    # TODO: Remove once CookieOverflow investigation is complete.
+    config.middleware.insert_before(ActionDispatch::Cookies, SessionCookieOverflowLogger)
   end
 end

--- a/lib/middleware/session_cookie_overflow_logger.rb
+++ b/lib/middleware/session_cookie_overflow_logger.rb
@@ -1,0 +1,59 @@
+# app/middleware/session_cookie_overflow_logger.rb
+# frozen_string_literal: true
+
+class SessionCookieOverflowLogger
+  MAX_LOGGED_KEYS = 20
+
+  def initialize(app, logger: Rails.logger)
+    @app = app
+    @logger = logger
+  end
+
+  def call(env) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    @app.call(env)
+  rescue ActionDispatch::Cookies::CookieOverflow => e
+    session = env['rack.session']
+    session_hash = session.respond_to?(:to_hash) ? session.to_hash : {}
+
+    session_values = session_hash.transform_values do |value|
+      {
+        class: value.class.name,
+        estimated_bytes: estimated_bytes(value)
+      }
+    end
+
+    largest_session_keys = session_values
+                           .sort_by { |_key, metadata| -metadata[:estimated_bytes] }
+                           .first(MAX_LOGGED_KEYS)
+                           .to_h
+
+    @logger.error(
+      {
+        event: 'session_cookie_overflow',
+        exception: e.class.name,
+        message: e.message,
+        request_path: env['PATH_INFO'],
+        request_method: env['REQUEST_METHOD'],
+        request_id: env['action_dispatch.request_id'],
+        session_key_count: session_hash.size,
+
+        # Approximate size of the Ruby session payload. This is not the
+        # final cookie size, which includes Rails serialization,
+        # encryption and signing overhead.
+        estimated_session_payload_bytes: session_values.sum { |_key, metadata| metadata[:estimated_bytes] },
+
+        largest_session_keys: largest_session_keys
+      }.to_json
+    )
+
+    raise
+  end
+
+  private
+
+  def estimated_bytes(value)
+    Marshal.dump(value).bytesize
+  rescue StandardError
+    value.to_s.bytesize
+  end
+end

--- a/spec/middleware/session_cookie_overflow_logger_spec.rb
+++ b/spec/middleware/session_cookie_overflow_logger_spec.rb
@@ -1,0 +1,110 @@
+# spec/middleware/session_cookie_overflow_logger_spec.rb
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionCookieOverflowLogger do
+  subject(:middleware) { described_class.new(app, logger:) }
+
+  let(:logger) { instance_spy(Logger) }
+  let(:session) { { 'large_key' => 'x' * 100, 'small_key' => 'abc' } }
+
+  let(:env) do
+    {
+      'rack.session' => session,
+      'PATH_INFO' => '/providers/auth/entra',
+      'REQUEST_METHOD' => 'POST',
+      'action_dispatch.request_id' => 'request-id'
+    }
+  end
+
+  describe '#call' do
+    context 'when the downstream app succeeds' do
+      let(:response) { [200, {}, ['OK']] }
+      let(:app) { ->(_env) { response } }
+
+      it 'returns the downstream response' do
+        expect(middleware.call(env)).to eq(response)
+      end
+
+      it 'does not log anything' do
+        middleware.call(env)
+
+        expect(logger).not_to have_received(:error)
+      end
+    end
+
+    context 'when the downstream app raises CookieOverflow' do
+      let(:app) do
+        lambda do |_env|
+          raise ActionDispatch::Cookies::CookieOverflow,
+                'session cookie overflow'
+        end
+      end
+
+      it 'logs session diagnostics and re-raises the exception' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        expect do
+          middleware.call(env)
+        end.to raise_error(ActionDispatch::Cookies::CookieOverflow)
+
+        expect(logger).to have_received(:error) do |json|
+          payload = JSON.parse(json)
+
+          expect(payload['event']).to eq('session_cookie_overflow')
+          expect(payload['exception']).to eq('ActionDispatch::Cookies::CookieOverflow')
+          expect(payload['request_path']).to eq('/providers/auth/entra')
+          expect(payload['request_method']).to eq('POST')
+          expect(payload['request_id']).to eq('request-id')
+          expect(payload['session_key_count']).to eq(2)
+
+          expect(payload['largest_session_keys']).to include(
+            'large_key',
+            'small_key'
+          )
+
+          expect(
+            payload['largest_session_keys']['large_key']['estimated_bytes']
+          ).to be >
+               payload['largest_session_keys']['small_key']['estimated_bytes']
+
+          expect(
+            payload['largest_session_keys']['large_key']['class']
+          ).to eq('String')
+        end
+      end
+    end
+
+    context 'when estimating the size raises an error' do
+      let(:unmarshallable) do
+        Class.new do
+          def marshal_dump
+            raise TypeError
+          end
+
+          def to_s
+            'fallback'
+          end
+        end.new
+      end
+
+      let(:session) do
+        { 'bad_key' => unmarshallable }
+      end
+
+      let(:app) do
+        lambda do |_env|
+          raise ActionDispatch::Cookies::CookieOverflow,
+                'session cookie overflow'
+        end
+      end
+
+      it 'falls back to using the string representation size' do
+        expect do
+          middleware.call(env)
+        end.to raise_error(ActionDispatch::Cookies::CookieOverflow)
+
+        expect(logger).to have_received(:error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Investigate intermittent ActionDispatch::Cookies::CookieOverflow errors reported in Sentry during the Entra authentication flow.

Introduce temporary Rack middleware that intercepts CookieOverflow exceptions, logs the session keys and an estimated size for each value, then re-raises the original exception.

The diagnostic logging deliberately excludes session values to avoid recording sensitive information, while providing enough metadata to identify which session entries are contributing most to the oversized cookie.

This instrumentation will help determine whether the oversized session is caused by application state, authentication data or another source before deciding on a long-term fix such as reducing session usage or moving away from CookieStore.


## Link to relevant ticket
CRIMAPP-2219
