### PR TITLE
CRIMAPP-2219: Extend CookieOverflow diagnostics for omniauth.params

### DIFF
--- a/lib/middleware/session_cookie_overflow_logger.rb
+++ b/lib/middleware/session_cookie_overflow_logger.rb
@@ -9,7 +9,7 @@ class SessionCookieOverflowLogger
     @logger = logger
   end
 
-  def call(env) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+  def call(env) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     @app.call(env)
   rescue ActionDispatch::Cookies::CookieOverflow => e
     session = env['rack.session']
@@ -42,7 +42,9 @@ class SessionCookieOverflowLogger
         # encryption and signing overhead.
         estimated_session_payload_bytes: session_values.sum { |_key, metadata| metadata[:estimated_bytes] },
 
-        largest_session_keys: largest_session_keys
+        largest_session_keys: largest_session_keys,
+
+        omniauth_params: omniauth_param_sizes(session_hash)
       }.to_json
     )
 
@@ -55,5 +57,19 @@ class SessionCookieOverflowLogger
     Marshal.dump(value).bytesize
   rescue StandardError
     value.to_s.bytesize
+  end
+
+  def omniauth_param_sizes(session_hash)
+    omniauth_params = session_hash['omniauth.params']
+    return unless omniauth_params.is_a?(Hash)
+
+    param_sizes = omniauth_params.transform_values do |value|
+      {
+        class: value.class.name,
+        estimated_bytes: estimated_bytes(value)
+      }
+    end
+
+    param_sizes.sort_by { |_key, metadata| -metadata[:estimated_bytes] }.to_h
   end
 end

--- a/spec/middleware/session_cookie_overflow_logger_spec.rb
+++ b/spec/middleware/session_cookie_overflow_logger_spec.rb
@@ -7,7 +7,17 @@ RSpec.describe SessionCookieOverflowLogger do
   subject(:middleware) { described_class.new(app, logger:) }
 
   let(:logger) { instance_spy(Logger) }
-  let(:session) { { 'large_key' => 'x' * 100, 'small_key' => 'abc' } }
+
+  let(:session) do
+    {
+      'large_key' => 'x' * 100,
+      'small_key' => 'abc',
+      'omniauth.params' => {
+        'origin' => '/providers',
+        'scope' => 'openid email'
+      }
+    }
+  end
 
   let(:env) do
     {
@@ -55,7 +65,7 @@ RSpec.describe SessionCookieOverflowLogger do
           expect(payload['request_path']).to eq('/providers/auth/entra')
           expect(payload['request_method']).to eq('POST')
           expect(payload['request_id']).to eq('request-id')
-          expect(payload['session_key_count']).to eq(2)
+          expect(payload['session_key_count']).to eq(3)
 
           expect(payload['largest_session_keys']).to include(
             'large_key',
@@ -70,6 +80,19 @@ RSpec.describe SessionCookieOverflowLogger do
           expect(
             payload['largest_session_keys']['large_key']['class']
           ).to eq('String')
+
+          expect(payload['omniauth_params']).to include(
+            'origin',
+            'scope'
+          )
+
+          expect(
+            payload['omniauth_params']['origin']['class']
+          ).to eq('String')
+
+          expect(
+            payload['omniauth_params']['origin']['estimated_bytes']
+          ).to be > 0
         end
       end
     end


### PR DESCRIPTION
## Description of change
The initial CookieOverflow investigation identified that the session was not being bloated by the OpenID Connect security values (state, nonce or PKCE verifier) as originally suspected.

Instead, the vast majority of the session payload was contained within the `omniauth.params` session entry, which is populated by OmniAuth from the incoming request's query parameters.

Extend the temporary diagnostic middleware to log the structure of `omniauth.params`, including the parameter names, value types and estimated sizes, while continuing to avoid logging the parameter values themselves.

This additional instrumentation will help determine which query parameter(s) are responsible for the oversized session and whether the root cause lies in the application, the OpenID Connect strategy, or the broader authentication flow.

## Link to relevant ticket
CRIMAPP-2219
