### PR TITLE
CRIMAPP-2219: Log oversized OmniAuth locale parameter for investigation

### DIFF
--- a/lib/middleware/session_cookie_overflow_logger.rb
+++ b/lib/middleware/session_cookie_overflow_logger.rb
@@ -70,6 +70,12 @@ class SessionCookieOverflowLogger
       }
     end
 
+    # The locale parameter has been identified as the source of the oversized
+    # session payload. Log its value to determine why it is unexpectedly large.
+    if omniauth_params['locale'].is_a?(String)
+      param_sizes['locale'][:locale_parameter_value] = omniauth_params['locale'].truncate(250)
+    end
+
     param_sizes.sort_by { |_key, metadata| -metadata[:estimated_bytes] }.to_h
   end
 end

--- a/spec/middleware/session_cookie_overflow_logger_spec.rb
+++ b/spec/middleware/session_cookie_overflow_logger_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SessionCookieOverflowLogger do
       'large_key' => 'x' * 100,
       'small_key' => 'abc',
       'omniauth.params' => {
+        'locale' => 'cy',
         'origin' => '/providers',
         'scope' => 'openid email'
       }
@@ -82,6 +83,7 @@ RSpec.describe SessionCookieOverflowLogger do
           ).to eq('String')
 
           expect(payload['omniauth_params']).to include(
+            'locale',
             'origin',
             'scope'
           )
@@ -93,6 +95,18 @@ RSpec.describe SessionCookieOverflowLogger do
           expect(
             payload['omniauth_params']['origin']['estimated_bytes']
           ).to be > 0
+
+          expect(
+            payload['omniauth_params']['locale']['class']
+          ).to eq('String')
+
+          expect(
+            payload['omniauth_params']['locale']['estimated_bytes']
+          ).to be > 0
+
+          expect(
+            payload['omniauth_params']['locale']['locale_parameter_value']
+          ).to eq('cy')
         end
       end
     end


### PR DESCRIPTION
## Description of change
Extend the temporary CookieOverflow diagnostics to capture the value of the `locale` parameter stored in `omniauth.params`.

Previous investigation identified `omniauth.params` as the primary contributor to the oversized session cookie, with the `locale` parameter accounting for approximately 2 KB of the payload.

Log the `locale` parameter value (alongside its estimated size) to determine why an unexpectedly large value is being persisted during the Entra authentication flow. The instrumentation is intentionally limited to the `locale` parameter rather than logging arbitrary OmniAuth request parameters.

## Link to relevant ticket
CRIMAPP-2219
