### PR TITLE
CRIMAPP-2247 Add PDA outage monitoring and Slack alerting

### DIFF
--- a/app/lib/prometheus_metrics/collectors/provider_data_api_requests_collector.rb
+++ b/app/lib/prometheus_metrics/collectors/provider_data_api_requests_collector.rb
@@ -1,0 +1,19 @@
+module PrometheusMetrics
+  module Collectors
+    class ProviderDataApiRequestsCollector < BaseCollector
+      def type
+        'provider_data_api_requests_total'.freeze
+      end
+
+      def description
+        'Total Provider Data API requests by outcome'.freeze
+      end
+
+      def metrics
+        ProviderDataApi::RequestMonitor.snapshot.map do |labels, count|
+          observe_counter(count, labels)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -8,6 +8,7 @@ module PrometheusMetrics
       PrometheusMetrics::Collectors::ApplicationsCountCollector,
       PrometheusMetrics::Collectors::ProvidersCountCollector,
       PrometheusMetrics::Collectors::OfficesCountCollector,
+      PrometheusMetrics::Collectors::ProviderDataApiRequestsCollector,
     ].freeze
 
     # :nocov:

--- a/app/lib/provider_data_api/get_office_schedules.rb
+++ b/app/lib/provider_data_api/get_office_schedules.rb
@@ -10,11 +10,13 @@ module ProviderDataApi
     # otherwise raises ProviderDataApi::RecordNotFound
     def call
       response = http_client.get(schedules_endpoint(office_code))
-      raise RecordNotFound unless response.status == 200
-
-      OfficeSchedules.new(response.body)
+      office_schedules(response)
     rescue Faraday::ResourceNotFound
+      report_not_found
       raise RecordNotFound
+    rescue Faraday::Error => e
+      report_failure(e)
+      raise
     end
 
     class << self
@@ -26,6 +28,10 @@ module ProviderDataApi
     private
 
     attr_reader :office_code, :http_client, :area_of_law
+
+    def operation
+      RequestMonitor::OPERATION_GET_OFFICE_SCHEDULES
+    end
 
     def schedules_endpoint(office_code)
       path = "/provider-offices/#{office_code}/schedules"
@@ -39,6 +45,37 @@ module ProviderDataApi
       URI.encode_www_form(
         'areaOfLaw' => area_of_law
       )
+    end
+
+    def office_schedules(response)
+      return success_response(response) if response.status == 200
+
+      report_not_found(status: response.status)
+      raise RecordNotFound
+    end
+
+    def success_response(response)
+      RequestMonitor.record_success(operation: operation, status: response.status)
+      OfficeSchedules.new(response.body)
+    end
+
+    def report_not_found(status: nil)
+      RequestMonitor.record_not_found(operation:, status:)
+    end
+
+    def report_failure(error)
+      RequestMonitor.record_failure(operation: operation, exception: error)
+      Rails.error.report(error, handled: true, severity: :error, context: failure_context)
+    end
+
+    def failure_context
+      {
+        source: 'provider_data_api',
+        operation: operation,
+        office_code: office_code,
+        area_of_law: area_of_law,
+        endpoint: schedules_endpoint(office_code).to_s,
+      }
     end
   end
 end

--- a/app/lib/provider_data_api/request_monitor.rb
+++ b/app/lib/provider_data_api/request_monitor.rb
@@ -1,0 +1,69 @@
+module ProviderDataApi
+  module RequestMonitor
+    OPERATION_GET_OFFICE_SCHEDULES = 'get_office_schedules'.freeze
+
+    class << self
+      def record_success(operation:, status:)
+        increment(
+          outcome: 'success',
+          operation: operation,
+          http_status: status,
+          error_class: 'none'
+        )
+      end
+
+      def record_not_found(operation:, status: nil)
+        increment(
+          outcome: 'not_found',
+          operation: operation,
+          http_status: status || 404,
+          error_class: 'none'
+        )
+      end
+
+      def record_failure(operation:, exception:, status: nil)
+        increment(
+          outcome: 'failure',
+          operation: operation,
+          http_status: status || extract_status(exception) || 'none',
+          error_class: exception.class.name
+        )
+      end
+
+      def snapshot
+        mutex.synchronize { counters.dup }
+      end
+
+      def reset!
+        mutex.synchronize { @counters = Hash.new(0) }
+      end
+
+      private
+
+      def increment(outcome:, operation:, http_status:, error_class:)
+        labels = {
+          outcome: outcome.to_s,
+          operation: operation.to_s,
+          http_status: http_status.to_s,
+          error_class: error_class.to_s,
+        }.freeze
+
+        mutex.synchronize do
+          counters[labels] += 1
+        end
+      end
+
+      def extract_status(exception)
+        exception.respond_to?(:response) ? exception.response&.dig(:status) : nil
+      end
+
+      def counters
+        @counters ||= Hash.new(0)
+      end
+
+      def mutex
+        @mutex ||= Mutex.new
+      end
+    end
+  end
+end

--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -105,6 +105,23 @@ spec:
             message: Namespace `{{ $labels.exported_namespace }}` is serving 5XX responses.
             dashboard_url: https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log_processed.kubernetes_namespace,log_processed.request_method,log_processed.request_path,log_processed.status,log_processed.upstream_addr,log_processed.upstream_status,log_processed.request_query,log_processed.request_uri),isDirty:!t,sort:!()),metadata:(indexPattern:ef705d70-0d2e-11ef-afac-8f79b1004d33,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ef705d70-0d2e-11ef-afac-8f79b1004d33,key:log_processed.kubernetes_namespace,negate:!f,params:(query:{{ $labels.exported_namespace }}),type:phrase),query:(match_phrase:(log_processed.kubernetes_namespace:{{ $labels.exported_namespace }}))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ef705d70-0d2e-11ef-afac-8f79b1004d33,key:log_processed.status,negate:!f,params:(gte:500,lt:600),type:range),range:(log_processed.status:(gte:500,lt:600)))),query:(language:kuery,query:''))
 
+        - alert: CrimeApply-ProviderDataApiUnavailable
+          expr: >-
+            (
+              sum(rate(ruby_provider_data_api_requests_total{namespace=~"^laa-apply-for-criminal-legal-aid.*", outcome="failure"}[5m]))
+              by (namespace)
+            ) > 0
+            and
+            (
+              sum(rate(ruby_provider_data_api_requests_total{namespace=~"^laa-apply-for-criminal-legal-aid.*", outcome=~"success|not_found"}[5m]))
+              by (namespace)
+            ) == 0
+          for: 3m
+          labels:
+            severity: laa-crime-apply-alerts
+          annotations:
+            message: PDA appears unavailable in `{{ $labels.namespace }}`. Failing requests detected with no successful responses for 3m.
+
         - alert: CrimeApply-PrometheusExporterFailure
           expr: >-
             ruby_collector_working{namespace=~"^laa-apply-for-criminal-legal-aid.*"} != 1

--- a/spec/lib/prometheus_metrics/collectors/provider_data_api_requests_collector_spec.rb
+++ b/spec/lib/prometheus_metrics/collectors/provider_data_api_requests_collector_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe PrometheusMetrics::Collectors::ProviderDataApiRequestsCollector do
+  subject { described_class.new }
+
+  let(:type) { 'provider_data_api_requests_total' }
+  let(:description) { 'Total Provider Data API requests by outcome' }
+  let(:operation) { ProviderDataApi::RequestMonitor::OPERATION_GET_OFFICE_SCHEDULES }
+
+  before do
+    ProviderDataApi::RequestMonitor.reset!
+  end
+
+  describe '#type' do
+    it { expect(subject.type).to eq(type) }
+  end
+
+  describe '#description' do
+    it { expect(subject.description).to eq(description) }
+  end
+
+  describe '#metrics' do
+    let(:success_metric) do
+      {
+        {
+          outcome: 'success',
+          operation: operation,
+          http_status: '200',
+          error_class: 'none',
+        } => 1
+      }
+    end
+    let(:failure_metric) do
+      {
+        {
+          outcome: 'failure',
+          operation: operation,
+          http_status: 'none',
+          error_class: 'Faraday::ConnectionFailed',
+        } => 1
+      }
+    end
+
+    before do
+      ProviderDataApi::RequestMonitor.record_success(
+        operation: operation,
+        status: 200
+      )
+      ProviderDataApi::RequestMonitor.record_failure(
+        operation: operation,
+        exception: Faraday::ConnectionFailed.new('timeout')
+      )
+    end
+
+    it 'returns counters grouped by labels' do
+      expect(
+        subject.metrics.map(&:data)
+      ).to contain_exactly(success_metric, failure_metric)
+    end
+  end
+end

--- a/spec/lib/provider_data_api/get_office_schedules_spec.rb
+++ b/spec/lib/provider_data_api/get_office_schedules_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe ProviderDataApi::GetOfficeSchedules do
+  subject(:service_call) { described_class.new(office_code:, area_of_law:, http_client:).call }
+
+  let(:office_code) { '1A2B3C' }
+  let(:area_of_law) { 'CRIME LOWER' }
+  let(:http_client) { instance_double(Faraday::Connection) }
+
+  before do
+    ProviderDataApi::RequestMonitor.reset!
+  end
+
+  def expect_metric(outcome:, http_status:, error_class: 'none')
+    labels = {
+      outcome: outcome,
+      operation: ProviderDataApi::RequestMonitor::OPERATION_GET_OFFICE_SCHEDULES,
+      http_status: http_status,
+      error_class: error_class,
+    }
+    expect(ProviderDataApi::RequestMonitor.snapshot).to include(labels => 1)
+  end
+
+  describe '#call' do
+    context 'when the request succeeds' do
+      let(:body) { JSON.parse(file_fixture('provider_data_api/public_defender_service.json').read) }
+      let(:response) { instance_double(Faraday::Response, status: 200, body: body) }
+
+      before do
+        allow(http_client).to receive(:get).and_return(response)
+      end
+
+      it 'returns office schedules and records success metrics' do
+        expect(service_call).to be_a(ProviderDataApi::OfficeSchedules)
+        expect_metric(outcome: 'success', http_status: '200')
+      end
+    end
+
+    context 'when the office is not returned by PDA' do
+      let(:response) { instance_double(Faraday::Response, status: 204, body: nil) }
+
+      before do
+        allow(http_client).to receive(:get).and_return(response)
+      end
+
+      it 'raises record not found and records not_found metrics' do
+        expect { service_call }.to raise_error(ProviderDataApi::RecordNotFound)
+        expect_metric(outcome: 'not_found', http_status: '204')
+      end
+    end
+
+    context 'when PDA is unavailable' do
+      let(:connection_error) { Faraday::ConnectionFailed.new('execution expired') }
+
+      before do
+        allow(http_client).to receive(:get).and_raise(connection_error)
+        allow(Rails.error).to receive(:report)
+      end
+
+      it 'reports the error and records failure metrics' do
+        expect { service_call }.to raise_error(Faraday::ConnectionFailed)
+        expect_error_reported
+        expect_metric(outcome: 'failure', http_status: 'none', error_class: 'Faraday::ConnectionFailed')
+      end
+
+      def expect_error_reported
+        expect(Rails.error).to have_received(:report).with(
+          connection_error,
+          hash_including(
+            handled: true,
+            severity: :error,
+            context: hash_including(
+              source: 'provider_data_api',
+              operation: 'get_office_schedules',
+              office_code: '1A2B3C'
+            )
+          )
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Instrument all Provider Data API requests with outcome counters (success, not_found, failure) via a new RequestMonitor module. Expose these as Prometheus metrics through a dedicated collector, and add a PrometheusRule alert that fires when PDA failures are sustained with no successful responses for 3 minutes, routing to the existing #laa-crime-apply-alerts Slack channel.

Report infrastructure failures (Faraday::Error) to Sentry via Rails.error.report with diagnostic context (source, operation, office code, area of law, endpoint).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2247

## How to manually test the feature
