### PR TITLE
CRIMAPP-2219: Discard invalid locale before OmniAuth persists request…

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,8 +1,37 @@
+# frozen_string_literal: true
+
 require 'omniauth'
+
+# OmniAuth persists request query parameters into the session before redirecting
+# to the identity provider.
+#
+# Production diagnostics identified malformed `locale` parameters exceeding 2 KB,
+# causing the cookie-backed session to exceed the browser's 4 KB cookie limit.
+#
+# The application only supports the configured I18n locales, so discard any
+# invalid locale before OmniAuth writes the request parameters into the session.
+strip_invalid_omniauth_locale = lambda do |env|
+  session = env['rack.session']
+  next unless session.respond_to?(:[])
+
+  omniauth_params = session['omniauth.params']
+  next unless omniauth_params.is_a?(Hash)
+
+  locale = omniauth_params['locale']
+  next unless locale.is_a?(String)
+
+  allowed_locales = I18n.available_locales.map(&:to_s)
+  next if allowed_locales.include?(locale)
+
+  omniauth_params.delete('locale')
+end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   configure do |config|
     config.add_mock(:entra, Silas::OidcStrategy.mock_auth)
-    config.test_mode = Rails.env.test? || ENV.fetch('OMNIAUTH_TEST_MODE', 'false').inquiry.true?
+    config.test_mode = Rails.env.test? ||
+                       ENV.fetch('OMNIAUTH_TEST_MODE', 'false').inquiry.true?
+
+    config.before_request_phase = strip_invalid_omniauth_locale
   end
 end

--- a/spec/lib/silas/oidc_strategy_spec.rb
+++ b/spec/lib/silas/oidc_strategy_spec.rb
@@ -97,4 +97,54 @@ RSpec.describe Silas::OidcStrategy do
       expect(strategy.client_options).to include(expected_options)
     end
   end
+
+  describe 'OmniAuth before_request_phase' do
+    subject(:before_request_phase) { OmniAuth.config.before_request_phase }
+
+    let(:session) { { 'omniauth.params' => omniauth_params } }
+    let(:env) { { 'rack.session' => session } }
+
+    before { before_request_phase.call(env) }
+
+    context 'when locale is valid' do
+      let(:omniauth_params) { { 'locale' => 'cy', 'extra' => 'ignored' } }
+
+      it 'preserves the valid locale' do
+        expect(session['omniauth.params']).to include('locale' => 'cy')
+      end
+    end
+
+    context 'when locale is invalid' do
+      let(:omniauth_params) { { 'locale' => 'cyg', 'extra' => 'ignored' } }
+
+      it 'removes the locale parameter' do
+        expect(session['omniauth.params']).not_to have_key('locale')
+        expect(session['omniauth.params']).to include('extra' => 'ignored')
+      end
+    end
+
+    context 'when locale is oversized' do
+      let(:omniauth_params) { { 'locale' => ('a' * 2_112) } }
+
+      it 'removes the locale parameter' do
+        expect(session['omniauth.params']).not_to have_key('locale')
+      end
+    end
+
+    context 'when omniauth.params is missing' do
+      let(:session) { {} }
+
+      it 'does nothing' do
+        expect { before_request_phase.call(env) }.not_to raise_error
+      end
+    end
+
+    context 'when omniauth.params is not a hash' do
+      let(:session) { { 'omniauth.params' => 'invalid' } }
+
+      it 'does nothing' do
+        expect { before_request_phase.call(env) }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
… params

## Description of change
Investigation into CookieOverflow identified that the majority of the cookie-backed session payload was contained within `omniauth.params`, with a malformed `locale` parameter accounting for approximately 2 KB of the session.

OmniAuth persists request query parameters into the session before redirecting to the identity provider. Since the application only supports configured I18n locales (`en` and `cy`), any other locale value is invalid and serves no purpose.

Configure an OmniAuth `before_request_phase` callback to remove invalid locale values before they are written to the session. This prevents malformed external input from causing CookieOverflow during the Entra authentication flow while preserving existing behaviour for supported locales.

Add specs covering valid locales, invalid and oversized locale values, and defensive behaviour when `omniauth.params` is absent or malformed.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2219

## Link to error log
https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log),isDirty:!t,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-criminal-legal-aid-staging),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-apply-for-criminal-legal-aid-staging)))),query:(language:kuery,query:session_cookie_overflow))
