### PR TITLE
CRIMAPP-2247: Update PROVIDER_DATA_API_URL to outage test endpoint

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -21,7 +21,7 @@ data:
   OMNIAUTH_ENTRA_TENANT_ID: ff260a8b-cb92-4cfe-8ae9-d48bb0fd9851
   OMNIAUTH_ENTRA_REDIRECT_URI: https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/auth/entra/callback
   OMNIAUTH_ENTRA_POST_LOGOUT_REDIRECT_URI: https://staging.apply-for-criminal-legal-aid.service.justice.gov.uk/providers/logout
-  PROVIDER_DATA_API_URL: https://laa-provider-details-api-prod.apps.live.cloud-platform.service.justice.gov.uk
+  PROVIDER_DATA_API_URL: https://laa-unreachable-api-prod.apps.live.cloud-platform.service.justice.gov.uk
   RETENTION_PERIOD: "2" # 2 years
   SOFT_DELETION_PERIOD: "30" # 30 days
   BANK_HOLIDAYS_API_URL: https://www.gov.uk/bank-holidays.json


### PR DESCRIPTION
## Description of change
Temporarily point PROVIDER_DATA_API_URL to invalid host to validate PDA outage alerting

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2247

## How to manually test the feature
