### PR TITLE
CRIMAPP-2263: Add missing P45 evidence rule for non-custody job loss

### DIFF
--- a/app/services/evidence/rules/20260715143016_lost_job_not_in_custody.rb
+++ b/app/services/evidence/rules/20260715143016_lost_job_not_in_custody.rb
@@ -1,0 +1,31 @@
+module Evidence
+  module Rules
+    class LostJobNotInCustody < Rule
+      include Evidence::RuleDsl
+
+      key :lost_job_34
+      group :none
+
+      client do |crime_application|
+        required_fields = [
+          crime_application.income,
+          crime_application.income&.employment_status,
+          crime_application.income&.ended_employment_within_three_months,
+          crime_application.income&.lost_job_in_custody,
+        ]
+
+        if required_fields.all?
+          conditions = [
+            crime_application.income.employment_status == [EmploymentStatus::NOT_WORKING.to_s],
+            crime_application.income.ended_employment_within_three_months == 'yes',
+            crime_application.income.lost_job_in_custody == 'no',
+          ]
+
+          conditions.all?(true)
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/app/services/evidence/ruleset/runner.rb
+++ b/app/services/evidence/ruleset/runner.rb
@@ -50,6 +50,7 @@ module Evidence
         # Other
         national_insurance_32
         lost_job_33
+        lost_job_34
         restraint_freezing_order_31
       ].freeze
 

--- a/config/locales/cy/evidence.yml
+++ b/config/locales/cy/evidence.yml
@@ -136,3 +136,5 @@ cy:
         partner: cyfriflen, paslyfr neu dystysgrif buddsoddiadau cyfandaliad eraill, sy'n cynnwys trafodion ar gyfer y 6 mis diwethaf
       LostJob:
         client: eu P45 neu lythyr gan eu cyn gyflogwr
+      LostJobNotInCustody:
+        client: eu P45 neu lythyr gan eu cyn gyflogwr

--- a/config/locales/en/evidence.yml
+++ b/config/locales/en/evidence.yml
@@ -136,3 +136,5 @@ en:
         partner: statement, passbook or certificate of other lump sum investments, covering transactions for the last 6 months
       LostJob:
         client: their P45 or a letter from their former employer
+      LostJobNotInCustody:
+        client: their P45 or a letter from their former employer

--- a/spec/services/evidence/rule_spec.rb
+++ b/spec/services/evidence/rule_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe Evidence::Rule do
         Evidence::Rules::InvestmentBonds,
         Evidence::Rules::OtherLumpSums,
         Evidence::Rules::LostJob,
+        Evidence::Rules::LostJobNotInCustody,
         Evidence::Rules::RestraintOrFreezingOrder,
 
         # Includes test rules in /fixtures

--- a/spec/services/evidence/rules/20260715143016_lost_job_not_in_custody_spec.rb
+++ b/spec/services/evidence/rules/20260715143016_lost_job_not_in_custody_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe Evidence::Rules::LostJobNotInCustody do
+  subject { described_class.new(crime_application) }
+
+  include_context 'serializable application'
+
+  let(:case_type) { CaseType::EITHER_WAY }
+
+  before do
+    income.employment_status = ['not_working']
+    income.lost_job_in_custody = 'no'
+    income.ended_employment_within_three_months = 'yes'
+  end
+
+  it { expect(described_class.key).to eq :lost_job_34 }
+  it { expect(described_class.group).to eq :none }
+  it { expect(described_class.archived).to be false }
+  it { expect(described_class.active?).to be true }
+
+  describe '.client' do
+    subject { described_class.new(crime_application).client_predicate }
+
+    context 'when all conditions are met' do
+      it { expect(subject).to be true }
+    end
+
+    context 'when income is nil' do
+      before do
+        crime_application.income = nil
+      end
+
+      it { expect(subject).to be false }
+    end
+
+    context 'when employment_status is not not_working' do
+      before do
+        income.employment_status = ['employed']
+      end
+
+      it { expect(subject).to be false }
+    end
+
+    context 'when ended_employment_within_three_months is no' do
+      before do
+        income.ended_employment_within_three_months = 'no'
+      end
+
+      it { expect(subject).to be false }
+    end
+
+    context 'when lost_job_in_custody is yes' do
+      before do
+        income.lost_job_in_custody = 'yes'
+      end
+
+      it { expect(subject).to be false }
+    end
+
+    context 'when lost_job_in_custody is nil' do
+      before do
+        income.lost_job_in_custody = nil
+      end
+
+      it { expect(subject).to be false }
+    end
+  end
+
+  describe '.partner' do
+    subject { described_class.new(crime_application).partner_predicate }
+
+    it { expect(subject).to be false }
+  end
+
+  describe '.other' do
+    subject { described_class.new(crime_application).other_predicate }
+
+    it { expect(subject).to be false }
+  end
+
+  describe '#to_h' do
+    let(:expected_hash) do
+      {
+        id: 'LostJobNotInCustody',
+        group: :none,
+        ruleset: nil,
+        key: :lost_job_34,
+        run: {
+          client: {
+            result: true,
+            prompt: ['their P45 or a letter from their former employer'],
+          },
+          partner: {
+            result: false,
+            prompt: [],
+          },
+          other: {
+            result: false,
+            prompt: [],
+          },
+        }
+      }
+    end
+
+    it { expect(subject.to_h).to eq expected_hash }
+  end
+end


### PR DESCRIPTION
## Description of change
- add LostJobNotInCustody evidence rule (key: lost_job_34)
- include lost_job_34 in Evidence::Ruleset::Runner KEYS
- add EN/CY evidence prompt translations
- add specs for new rule and verify runner integration



## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2263

## Notes for reviewer

## Screenshots of changes (if applicable)

### After changes:
<img width="670" height="622" alt="Screenshot 2026-07-20 at 12 45 11" src="https://github.com/user-attachments/assets/5524e1c6-9e1f-4660-848b-ae5695596e3f" />
<img width="965" height="623" alt="Screenshot 2026-07-20 at 12 59 22" src="https://github.com/user-attachments/assets/0e5feb66-9fd2-492f-81c3-510e52e29e01" />

## How to manually test the feature

**Manual Testing**

Navigate to the income section and set the client's employment status to **Not working**. Answer **Yes** to "Did your client end their employment within the last 3 months?" and then answer **No** to "Did your client lose their job as a result of being in custody?". Proceed to the evidence upload step and confirm that a prompt appears under the **Other** section reading *"their P45 or a letter from their former employer"*. To verify the existing rule is unaffected, repeat the journey answering **Yes** to losing the job in custody and entering a job loss date within 3 months of today — the same P45 prompt should also appear. The prompt should **not** appear if the client is not working but answered **No** to ending employment within 3 months, or if their employment status is anything other than **Not working**.
