### PR TITLE
CRIMAPP-2137 Unify multi-part date error messaging and summary links

### DIFF
--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -11,10 +11,34 @@ module FormBuilderHelper
   end
 
   def date_input(attribute_name, opts = {}, &block)
-    govuk_date_field(attribute_name, segments:, segment_names:, **opts, &block)
+    combined_error_message = DateFieldErrors.joined_inline_message(object, attribute_name)
+
+    return govuk_date_field(attribute_name, segments:, segment_names:, **opts, &block) unless combined_error_message
+
+    with_inline_error_message(attribute_name, combined_error_message) do
+      govuk_date_field(attribute_name, segments:, segment_names:, **opts, &block)
+    end
   end
 
   private
+
+  def with_inline_error_message(attribute_name, message)
+    errors = object.errors
+    return yield if errors.where(attribute_name).blank?
+
+    with_restored_errors(errors) do
+      errors.delete(attribute_name)
+      errors.add(attribute_name, message)
+      yield
+    end
+  end
+
+  def with_restored_errors(errors)
+    original_errors = errors.dup
+    yield
+  ensure
+    errors.copy!(original_errors)
+  end
 
   def submit_button(i18n_key, opts = {}, &block)
     govuk_submit I18n.t("helpers.submit.#{i18n_key}"), **opts, &block

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -36,7 +36,8 @@ module StepsHelper
     end
 
     fields_for(form_object, form_object) do |f|
-      f.govuk_error_summary t('errors.error_summary.heading')
+      f.govuk_error_summary t('errors.error_summary.heading'),
+                            presenter: DateFieldErrorSummaryPresenter.new(form_object)
     end
   end
 

--- a/app/presenters/date_field_error_summary_presenter.rb
+++ b/app/presenters/date_field_error_summary_presenter.rb
@@ -1,0 +1,9 @@
+class DateFieldErrorSummaryPresenter
+  def initialize(form_object)
+    @form_object = form_object
+  end
+
+  def formatted_error_messages
+    DateFieldErrors.error_summary_messages(@form_object)
+  end
+end

--- a/app/presenters/date_field_errors.rb
+++ b/app/presenters/date_field_errors.rb
@@ -1,0 +1,52 @@
+module DateFieldErrors
+  ERROR_SEGMENTS = {
+    blank_day: :day,
+    invalid_day: :day,
+    blank_month: :month,
+    invalid_month: :month,
+    blank_year: :year,
+    invalid_year: :year,
+  }.freeze
+  DATE_INPUT_SEGMENTS = { day: '3i', month: '2', year: '1i' }.freeze
+
+  module_function
+
+  def error_summary_messages(form_object)
+    form_object.errors.messages.flat_map do |attribute, messages|
+      summary_messages_for_attribute(form_object, attribute, messages)
+    end
+  end
+
+  def joined_inline_message(form_object, attribute)
+    messages = segment_error_messages(form_object, attribute).map(&:first)
+
+    messages.join('. ') if messages.many?
+  end
+
+  def summary_messages_for_attribute(form_object, attribute, messages)
+    segment_errors = segment_error_messages(form_object, attribute, messages)
+
+    return [[attribute, messages.first]] if segment_errors.empty?
+
+    segment_errors.map do |message, segment|
+      [attribute, message, "##{date_segment_id(form_object, attribute, segment)}"]
+    end
+  end
+
+  def date_segment_id(form_object, attribute, segment)
+    [
+      form_object.model_name.param_key,
+      attribute,
+      DATE_INPUT_SEGMENTS.fetch(segment),
+    ].join('_')
+  end
+
+  def segment_error_messages(form_object, attribute, messages = form_object.errors.messages[attribute])
+    Array(messages).zip(form_object.errors.details[attribute]).filter_map do |message, detail|
+      segment = ERROR_SEGMENTS[detail[:error]]
+
+      [message, segment] if segment
+    end
+  end
+  private_class_method :segment_error_messages
+end

--- a/app/presenters/date_field_errors.rb
+++ b/app/presenters/date_field_errors.rb
@@ -34,11 +34,18 @@ module DateFieldErrors
   end
 
   def date_segment_id(form_object, attribute, segment)
+    # Use the existing anchor id for the day field
+    return field_error_id(form_object, attribute) if segment == :day
+
     [
       form_object.model_name.param_key,
       attribute,
       DATE_INPUT_SEGMENTS.fetch(segment),
     ].join('_')
+  end
+
+  def field_error_id(form_object, attribute)
+    [form_object.model_name.param_key, attribute, 'field-error'].join('-').tr('_', '-')
   end
 
   def segment_error_messages(form_object, attribute, messages = form_object.errors.messages[attribute])

--- a/spec/forms/steps/case/is_client_remanded_form_spec.rb
+++ b/spec/forms/steps/case/is_client_remanded_form_spec.rb
@@ -116,6 +116,20 @@ RSpec.describe Steps::Case::IsClientRemandedForm do
             ).to be(false)
           end
         end
+
+        context 'when multiple date parts are invalid' do
+          let(:is_client_remanded) { YesNoAnswer::YES.to_s }
+          let(:date_client_remanded) { { 3 => 32, 2 => 13, 1 => 20 } }
+
+          it 'includes an error for each invalid date part' do
+            expect(form).not_to be_valid
+            expect(form.errors.details[:date_client_remanded]).to include(
+              { error: :invalid_day },
+              { error: :invalid_month },
+              { error: :invalid_year }
+            )
+          end
+        end
       end
     end
   end

--- a/spec/helpers/steps_helper_spec.rb
+++ b/spec/helpers/steps_helper_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe StepsHelper, type: :helper do
   describe '#step_form' do
+    def error_snapshot(record)
+      record.errors.map { |error| [error.attribute, error.type, error.options] }
+    end
+
     let(:foo_bar_record) do
       Class.new(ApplicationRecord) do
         def self.load_schema! = @columns_hash = {}
@@ -42,6 +46,66 @@ RSpec.describe StepsHelper, type: :helper do
       expect(helper).to receive(:form_for).with(record,
                                                 expected_defaults.merge(html: { class: %w[test edit_foo_bar_record] }))
       helper.step_form(record, html: { class: 'test' })
+    end
+
+    context 'when rendering a date field with multiple invalid segments' do
+      let(:record) do
+        Steps::Case::IsClientRemandedForm.new(
+          crime_application: CrimeApplication.new,
+          is_client_remanded: YesNoAnswer::YES.to_s,
+          date_client_remanded: { 3 => 32, 2 => 13, 1 => 20 }
+        )
+      end
+
+      before do
+        record.valid?
+      end
+
+      it 'renders all segment errors in the inline message' do
+        expect(
+          helper.step_form(record, url: '/test-path') do |f|
+            f.date_input(:date_client_remanded, legend: { text: 'Enter when they were remanded', size: 's' })
+          end
+        ).to include(
+          '<p class="govuk-error-message" id="steps-case-is-client-remanded-form-date-client-remanded-error">' \
+          '<span class="govuk-visually-hidden">Error: </span>' \
+          'Enter a valid day. Enter a valid month. Enter a valid year</p>'
+        )
+      end
+
+      it 'restores the original errors after rendering' do
+        original_errors = error_snapshot(record)
+
+        helper.step_form(record, url: '/test-path') do |f|
+          f.date_input(:date_client_remanded, legend: { text: 'Enter when they were remanded', size: 's' })
+        end
+
+        expect(error_snapshot(record)).to eq(original_errors)
+      end
+    end
+
+    context 'when only one date segment is invalid' do
+      let(:record) do
+        Steps::Case::IsClientRemandedForm.new(
+          crime_application: CrimeApplication.new,
+          is_client_remanded: YesNoAnswer::YES.to_s,
+          date_client_remanded: { 3 => 32, 2 => 12, 1 => 2020 }
+        )
+      end
+
+      before do
+        record.valid?
+      end
+
+      it 'renders the normal inline error' do
+        html = helper.step_form(record, url: '/test-path') do |f|
+          f.date_input(:date_client_remanded)
+        end
+
+        expect(html).to include('Enter a valid day')
+        expect(html).not_to include('Enter a valid month')
+        expect(html).not_to include('Enter a valid year')
+      end
     end
   end
 
@@ -142,6 +206,80 @@ RSpec.describe StepsHelper, type: :helper do
       it 'prepends the page title with an error hint' do
         helper.govuk_error_summary(form_object)
         expect(title).to start_with('Error: A page')
+      end
+    end
+
+    context 'when a date field has multiple invalid segments' do
+      let(:form_object) do
+        Steps::Case::IsClientRemandedForm.new(
+          crime_application: CrimeApplication.new,
+          is_client_remanded: YesNoAnswer::YES.to_s,
+          date_client_remanded: { 3 => 32, 2 => 13, 1 => 20 }
+        )
+      end
+
+      before do
+        helper.title('A page')
+        form_object.valid?
+      end
+
+      it 'lists each invalid date segment in the summary' do
+        expect(helper.govuk_error_summary(form_object)).to include(
+          '<a data-turbo="false" ' \
+          'href="#steps_case_is_client_remanded_form_date_client_remanded_3i">Enter a valid day</a>',
+          '<a data-turbo="false" ' \
+          'href="#steps_case_is_client_remanded_form_date_client_remanded_2">Enter a valid month</a>',
+          '<a data-turbo="false" ' \
+          'href="#steps_case_is_client_remanded_form_date_client_remanded_1i">Enter a valid year</a>'
+        )
+      end
+    end
+
+    context 'when a date field has one invalid segment' do
+      before do
+        helper.title('A page')
+      end
+
+      it 'links invalid day errors to the day input' do
+        form_object = Steps::Case::IsClientRemandedForm.new(
+          crime_application: CrimeApplication.new,
+          is_client_remanded: YesNoAnswer::YES.to_s,
+          date_client_remanded: { 3 => 32, 2 => 12, 1 => 2020 }
+        )
+        form_object.valid?
+
+        expect(helper.govuk_error_summary(form_object)).to include(
+          '<a data-turbo="false" ' \
+          'href="#steps_case_is_client_remanded_form_date_client_remanded_3i">Enter a valid day</a>'
+        )
+      end
+
+      it 'links invalid month errors to the month input' do
+        form_object = Steps::Case::IsClientRemandedForm.new(
+          crime_application: CrimeApplication.new,
+          is_client_remanded: YesNoAnswer::YES.to_s,
+          date_client_remanded: { 3 => 12, 2 => 13, 1 => 2020 }
+        )
+        form_object.valid?
+
+        expect(helper.govuk_error_summary(form_object)).to include(
+          '<a data-turbo="false" ' \
+          'href="#steps_case_is_client_remanded_form_date_client_remanded_2">Enter a valid month</a>'
+        )
+      end
+
+      it 'links invalid year errors to the year input' do
+        form_object = Steps::Case::IsClientRemandedForm.new(
+          crime_application: CrimeApplication.new,
+          is_client_remanded: YesNoAnswer::YES.to_s,
+          date_client_remanded: { 3 => 12, 2 => 12, 1 => 20 }
+        )
+        form_object.valid?
+
+        expect(helper.govuk_error_summary(form_object)).to include(
+          '<a data-turbo="false" ' \
+          'href="#steps_case_is_client_remanded_form_date_client_remanded_1i">Enter a valid year</a>'
+        )
       end
     end
   end

--- a/spec/helpers/steps_helper_spec.rb
+++ b/spec/helpers/steps_helper_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe StepsHelper, type: :helper do
       it 'lists each invalid date segment in the summary' do
         expect(helper.govuk_error_summary(form_object)).to include(
           '<a data-turbo="false" ' \
-          'href="#steps_case_is_client_remanded_form_date_client_remanded_3i">Enter a valid day</a>',
+          'href="#steps-case-is-client-remanded-form-date-client-remanded-field-error">Enter a valid day</a>',
           '<a data-turbo="false" ' \
           'href="#steps_case_is_client_remanded_form_date_client_remanded_2">Enter a valid month</a>',
           '<a data-turbo="false" ' \
@@ -250,7 +250,7 @@ RSpec.describe StepsHelper, type: :helper do
 
         expect(helper.govuk_error_summary(form_object)).to include(
           '<a data-turbo="false" ' \
-          'href="#steps_case_is_client_remanded_form_date_client_remanded_3i">Enter a valid day</a>'
+          'href="#steps-case-is-client-remanded-form-date-client-remanded-field-error">Enter a valid day</a>'
         )
       end
 


### PR DESCRIPTION
## Description of change
Improve how date validation errors are rendered inline and in the GOV.UK error summary so users consistently see segment-specific feedback.

- Add DateFieldErrors presenter module logic to:
  - map recognised date error types to day/month/year segments
  - build joined inline messages when multiple segments are invalid
  - generate segment-targeted summary links for one or more recognised segment errors
  - preserve default summary behaviour when no recognised segment errors exist
- Add DateFieldErrorSummaryPresenter and wire it into StepsHelper#govuk_error_summary
- Update FormBuilderHelper#date_input to inject combined inline error message at the error-collection level (before render), and restore the full original errors collection afterwards via copy! to avoid ordering/type/option drift
- Update MultiparamDateValidator to avoid adding generic :invalid when attribute-specific errors already exist
- Add/extend specs to cover:
  - multiple invalid date segments inline message
  - full error restoration after rendering
  - single invalid segment keeping normal inline behaviour
  - summary links for single day/month/year segment errors
  - summary links for multiple segment errors

Verification:
- COVERAGE=false bundle exec rspec spec/helpers/steps_helper_spec.rb spec/forms/steps/case/is_client_remanded_form_spec.rb


## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2137

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="854" height="626" alt="Screenshot 2026-07-22 at 17 23 50" src="https://github.com/user-attachments/assets/65846c7c-df25-458f-ba60-a1da6abb4d5c" />

## How to manually test the feature
Updated todo list

Manually test by opening a form with a required date field (for example, *Is client remanded?*), selecting the option that makes the date mandatory, and submitting invalid combinations: first make all parts invalid (e.g. day 32, month 13, short year) and confirm the inline error shows combined messages while the error summary shows separate links to day/month/year inputs; then test single-part failures (only day invalid, only month invalid, only year invalid) and confirm the summary link goes directly to the specific input and inline messaging remains normal for single errors; finally test a non-date validation error on the same page to confirm standard summary behavior is unchanged.
