### PR TITLE
CRIMAPP-2125 - Replace evidence upload table with GOV.UK summary list

### DIFF
--- a/app/javascript/local/dropzone-cfg.js
+++ b/app/javascript/local/dropzone-cfg.js
@@ -49,9 +49,9 @@ DropzoneCfg.prototype.init = function () {
   })
 
   // Display of files table (uploaded files only) is conditional on whether JS is enabled
-  let uploadTableJS = document.getElementById('upload-table-dropzone')
+  let uploadTableJS = document.getElementById('uploaded-files-dropzone')
   uploadTableJS.classList.remove("app-evidence-upload-hidden")
-  let uploadTableNonJS = document.getElementById('upload-table-fallback')
+  let uploadTableNonJS = document.getElementById('uploaded-files-fallback')
   uploadTableNonJS.classList.add("app-evidence-upload-hidden")
 
   const self = this
@@ -70,31 +70,31 @@ DropzoneCfg.prototype.init = function () {
     notificationBanner?.remove()
     removeErrorMessages()
 
-    let row = createTableRow(file);
-    self.$feedbackContainer.querySelector('.govuk-table__body').append(row);
+    let row = createUploadedFileRow(file);
+    document.querySelector('#uploaded-files-dropzone .app-uploaded-files').append(row);
   });
 
   this.$dropzone.on('success', (file, response) => {
     // Upload table is default hidden from view if there are no uploaded docs,
     // it needs to be made visible if a doc is successfully uploaded
-    let uploadTable = document.getElementById('upload-table')
+    let uploadTable = document.getElementById('uploaded-files')
     uploadTable.classList.remove("app-evidence-upload-hidden")
 
     createDownloadLink(file, response)
 
-    this.$statusTag = document.getElementById(file.upload.uuid).querySelector(".govuk-tag")
+    this.$statusTag = document.getElementById(file.upload.uuid).querySelector(".app-uploaded-file__status")
     this.$statusTag.classList.remove("govuk-tag--yellow")
     this.$statusTag.classList.add("govuk-tag--green")
     this.$statusTag.innerHTML = "Uploaded"
 
-    amendErrorLink(file, response)
+    setDeleteDocumentValue(file, response)
   });
 
   this.$dropzone.on('error', (file, response) => {
     let errorMsg = generateErrorMessage(file, response)
 
-    this.$tableCell = document.getElementById(file.upload.uuid)
-    this.$tableCell.remove();
+    this.$row = document.getElementById(file.upload.uuid)
+    this.$row.remove();
 
     let errorSummary = createErrorSummary(errorMsg)
     displayErrorMessage(errorSummary, errorMsg)
@@ -105,41 +105,42 @@ DropzoneCfg.prototype.init = function () {
   })
 }
 
-function createTableRow(file) {
-  let row = document.createElement("tr")
-  let cell = document.createElement("td")
+function createUploadedFileRow(file) {
+  let row = document.createElement("div")
+  let value = document.createElement("dt")
   let span = document.createElement("span")
   let statusTag = createStatusTag("Uploading")
-  let errorLink = createDeleteLink()
+  let actions = createDeleteAction()
 
   row.setAttribute("id", file.upload.uuid)
 
-  row.classList.add("govuk-table__row")
-  cell.classList.add("govuk-table__cell")
-  span.classList.add("_uploaded_file__filename")
+  row.classList.add("govuk-summary-list__row", "app-uploaded-file")
+  value.classList.add("govuk-summary-list__value")
+  span.classList.add("app-uploaded-file__filename")
 
   span.append(file.name)
-  cell.append(span)
-  cell.append(statusTag)
-  row.append(cell)
-  row.append(errorLink)
+  value.append(span)
+  value.append(statusTag)
+  row.append(value)
+  row.append(actions)
   return row
 }
 
 function createStatusTag(text) {
   let tag = document.createElement("strong")
-  tag.classList.add("govuk-tag", "govuk-tag--yellow")
+  tag.classList.add("govuk-tag", "govuk-tag--yellow", "app-uploaded-file__status")
   tag.textContent = text
   return tag
 }
 
 function createDownloadLink(file, response) {
-  const fileEntry = document.getElementById(file.upload.uuid).querySelector("._uploaded_file__filename");
+  const fileEntry = document.getElementById(file.upload.uuid).querySelector(".app-uploaded-file__filename");
 
   if (!fileEntry) { return; }
 
   fileEntry.innerText = "";
   const anchor = document.createElement("a");
+  anchor.classList.add("govuk-link");
   anchor.href = response.url;
   anchor.textContent = file.name;
   fileEntry.append(anchor);
@@ -167,28 +168,22 @@ function createErrorSummary (msg) {
   return errorSummary
 }
 
-function createDeleteLink () {
-  const deleteEl = document.createElement("td")
-  deleteEl.classList.add("govuk-table__cell", "govuk-!-text-align-right")
-
-  const input = document.createElement("input")
-  input.setAttribute("type", "hidden")
-  input.setAttribute("value", "put")
-  input.setAttribute("autocomplete", "off")
+function createDeleteAction () {
+  const actions = document.createElement("dd")
+  actions.classList.add("govuk-summary-list__actions")
 
   const deleteButton = document.createElement("button")
-  deleteButton.classList.add("app-button--link")
+  deleteButton.classList.add("app-button--link", "app-uploaded-file__delete")
   deleteButton.setAttribute("type", "submit")
   deleteButton.setAttribute("name", "document_id")
   deleteButton.innerText = "Delete"
 
-  deleteEl.append(input)
-  deleteEl.append(deleteButton)
-  return deleteEl
+  actions.append(deleteButton)
+  return actions
 }
 
-function amendErrorLink (file, response) {
-  let deleteButton = document.getElementById(file.upload.uuid).querySelector(".app-button--link")
+function setDeleteDocumentValue (file, response) {
+  let deleteButton = document.getElementById(file.upload.uuid).querySelector(".app-uploaded-file__delete")
   deleteButton.setAttribute("value", response.id)
 }
 
@@ -200,7 +195,7 @@ function removeErrorMessages () {
   })
   errorSummary.classList.add('app-evidence-upload-hidden')
 
-  document.getElementById('upload-form').classList.remove('govuk-form-group--error')
+  document.getElementById('upload-form-group').classList.remove('govuk-form-group--error')
   document.getElementById('dropzone-error-message').classList.add('app-evidence-upload-hidden')
   document.getElementById('dropzone-error-message').innerHTML = ""
 }
@@ -211,7 +206,7 @@ function displayErrorMessage(errorSummary, errorMsg) {
   pageDiv.prepend(errorSummary)
 
   // Display error above dropzone component
-  const uploadFilesElem = document.getElementById('upload-form')
+  const uploadFilesElem = document.getElementById('upload-form-group')
   uploadFilesElem.classList.add('govuk-form-group--error')
   const errorMessage = document.getElementById('dropzone-error-message')
 

--- a/app/javascript/local/dropzone-cfg.js
+++ b/app/javascript/local/dropzone-cfg.js
@@ -48,11 +48,11 @@ DropzoneCfg.prototype.init = function () {
     e.preventDefault() // prevent submitting form by default
   })
 
-  // Display of files table (uploaded files only) is conditional on whether JS is enabled
-  let uploadTableJS = document.getElementById('uploaded-files-dropzone')
-  uploadTableJS.classList.remove("app-evidence-upload-hidden")
-  let uploadTableNonJS = document.getElementById('uploaded-files-fallback')
-  uploadTableNonJS.classList.add("app-evidence-upload-hidden")
+  // Display of the uploaded files list is conditional on whether JS is enabled
+  let uploadedFilesDropzone = document.getElementById('uploaded-files-dropzone')
+  uploadedFilesDropzone.classList.remove("app-evidence-upload-hidden")
+  let uploadedFilesFallback = document.getElementById('uploaded-files-fallback')
+  uploadedFilesFallback.classList.add("app-evidence-upload-hidden")
 
   const self = this
   this.$dropzone = new Dropzone(this.$dropzoneContainer, {
@@ -75,10 +75,10 @@ DropzoneCfg.prototype.init = function () {
   });
 
   this.$dropzone.on('success', (file, response) => {
-    // Upload table is default hidden from view if there are no uploaded docs,
+    // The uploaded files list is default hidden from view if there are no uploaded docs,
     // it needs to be made visible if a doc is successfully uploaded
-    let uploadTable = document.getElementById('uploaded-files')
-    uploadTable.classList.remove("app-evidence-upload-hidden")
+    let uploadedFilesList = document.getElementById('uploaded-files')
+    uploadedFilesList.classList.remove("app-evidence-upload-hidden")
 
     createDownloadLink(file, response)
 

--- a/app/views/steps/evidence/upload/_upload_form.html.erb
+++ b/app/views/steps/evidence/upload/_upload_form.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-form-group" id="upload-form">
+<div class="govuk-form-group" id="upload-form-group">
   <h2 class="govuk-heading-m">
     <%= t("#{i18n_scope}.upload_files_heading") %>
     <p class="govuk-body govuk-!-padding-top-2"> <%= t("#{i18n_scope}.rename_files") %> </p>

--- a/app/views/steps/evidence/upload/_uploaded_file.html.erb
+++ b/app/views/steps/evidence/upload/_uploaded_file.html.erb
@@ -1,6 +1,6 @@
-<tr class="govuk-table__row" class="_uploaded_file">
-  <td id="<%=document.id%>" class="govuk-table__cell">
-    <span class="_uploaded_file__filename">
+<div class="govuk-summary-list__row app-uploaded-file" id="<%= document.id %>">
+  <dt class="govuk-summary-list__value">
+    <span class="app-uploaded-file__filename">
       <%= govuk_link_to(
             document.filename,
             download_crime_application_document_path(document.crime_application, document),
@@ -8,7 +8,7 @@
     </span>
 
     <% if document.s3_object_key %>
-      <strong class="govuk-tag govuk-tag--green"><%= t('steps.evidence.upload.edit.uploaded') %></strong>
+      <%= govuk_tag(text: t('steps.evidence.upload.edit.uploaded'), colour: 'green', classes: 'app-uploaded-file__status') %>
     <% else %>
       <% document.valid?(:storage) %>
 
@@ -16,11 +16,11 @@
         <span class="govuk-visually-hidden">Error:</span> <%= document.errors.first.full_message %>
       </p>
     <% end %>
-  </td>
-  <td class="govuk-table__cell govuk-!-text-align-right">
+  </dt>
+  <dd class="govuk-summary-list__actions">
     <%= button_to t('.remove_button'), steps_evidence_upload_path, method: :put,
                                        value: document.id.to_s,
                                        name: :document_id,
-                                       class: 'app-button--link' %>
-  </td>
-</tr>
+                                       class: 'app-button--link app-uploaded-file__delete' %>
+  </dd>
+</div>

--- a/app/views/steps/evidence/upload/_uploaded_files.html.erb
+++ b/app/views/steps/evidence/upload/_uploaded_files.html.erb
@@ -1,16 +1,10 @@
-<div id="upload-table" class="<%= documents.present? ? '' : 'app-evidence-upload-hidden' %>">
+<div id="uploaded-files" class="<%= documents.present? ? '' : 'app-evidence-upload-hidden' %>">
   <h2 class="govuk-heading-m"> <%= t('steps.evidence.upload.edit.uploaded_files_heading') %></h2>
   <p class="govuk-body"><%= t('steps.evidence.upload.edit.uploaded_files_info') %></p>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header"><%= t('steps.evidence.upload.edit.file_name') %></th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Delete file</span></th>
-    </tr>
-    </thead>
-    <tbody class="govuk-table__body">
+
+  <h3 class="govuk-heading-s"> <%= t('steps.evidence.upload.edit.file_name') %></h3>
+  <dl class="govuk-summary-list app-uploaded-files">
     <%= render partial: 'steps/evidence/upload/uploaded_file',
                collection: documents, as: :document %>
-    </tbody>
-  </table>
+  </dl>
 </div>

--- a/app/views/steps/evidence/upload/_uploaded_files_list.html.erb
+++ b/app/views/steps/evidence/upload/_uploaded_files_list.html.erb
@@ -1,10 +1,10 @@
 <div class="app-multi-file__uploaded-files">
   <%= step_form form_object do |f| %>
-    <div id="upload-table-dropzone" class="app-evidence-upload-hidden">
+    <div id="uploaded-files-dropzone" class="app-evidence-upload-hidden">
       <%= render partial: 'steps/evidence/upload/uploaded_files', locals: { documents: form_object.documents.stored } %>
     </div>
 
-    <div id="upload-table-fallback">
+    <div id="uploaded-files-fallback">
       <% if form_object.documents.present? %>
         <%= render partial: 'steps/evidence/upload/uploaded_files', locals: { documents: form_object.documents } %>
       <% end %>

--- a/app/views/steps/evidence/upload/edit.en.html.erb
+++ b/app/views/steps/evidence/upload/edit.en.html.erb
@@ -22,6 +22,6 @@
     <%= render partial: 'steps/evidence/upload/upload_form', locals: { i18n_scope: 'steps.evidence.upload.edit',
                                                                        form_object: @form_object } %>
 
-    <%= render partial: 'steps/evidence/upload/uploaded_files_table', locals: { form_object: @form_object } %>
+    <%= render partial: 'steps/evidence/upload/uploaded_files_list', locals: { form_object: @form_object } %>
   </div>
 </div>

--- a/spec/requests/evidence_upload_spec.rb
+++ b/spec/requests/evidence_upload_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe 'Evidence upload page', :authorized do
 
       assert_select 'h1', 'Upload supporting evidence'
 
-      assert_select 'tbody.govuk-table__body' do
-        assert_select 'tr.govuk-table__row:nth-of-type(1)' do
-          assert_select 'span._uploaded_file__filename', 'test.pdf'
+      assert_select 'dl.govuk-summary-list' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(1)' do
+          assert_select 'span.app-uploaded-file__filename', 'test.pdf'
           assert_select 'strong.govuk-tag:nth-of-type(1)', 'Uploaded'
         end
       end
@@ -70,14 +70,14 @@ RSpec.describe 'Evidence upload page', :authorized do
 
     context 'when there are errors with upload' do
       it 'lists file size error messages' do
-        assert_select 'tbody.govuk-table__body' do
-          assert_select 'tr.govuk-table__row:nth-of-type(2)' do
+        assert_select 'dl.govuk-summary-list' do
+          assert_select 'div.govuk-summary-list__row:nth-of-type(2)' do
             assert_select 'span:nth-of-type(1)', 'too_big.pdf'
             assert_select 'p:nth-of-type(1)',
                           "Error: #{I18n.t('activerecord.errors.models.document.attributes.file_size.too_big',
                                            max_size: FileUploadValidator::MAX_FILE_SIZE)}"
           end
-          assert_select 'tr.govuk-table__row:nth-of-type(3)' do
+          assert_select 'div.govuk-summary-list__row:nth-of-type(3)' do
             assert_select 'span:nth-of-type(1)', 'too_small.pdf'
             assert_select 'p:nth-of-type(1)',
                           "Error: #{I18n.t('activerecord.errors.models.document.attributes.file_size.too_small',
@@ -87,7 +87,7 @@ RSpec.describe 'Evidence upload page', :authorized do
       end
 
       it 'lists content type error message' do
-        assert_select 'tr.govuk-table__row:nth-of-type(4)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(4)' do
           assert_select 'span:nth-of-type(1)', 'invalid_content_type.pdf'
           assert_select 'p:nth-of-type(1)',
                         "Error: #{I18n.t('activerecord.errors.models.document.attributes.content_type.invalid')}"
@@ -95,7 +95,7 @@ RSpec.describe 'Evidence upload page', :authorized do
       end
 
       it 'lists generic error message' do
-        assert_select 'tr.govuk-table__row:nth-of-type(5)' do
+        assert_select 'div.govuk-summary-list__row:nth-of-type(5)' do
           assert_select 'span:nth-of-type(1)', 'error.pdf'
           assert_select 'p:nth-of-type(1)',
                         "Error: #{I18n.t('activerecord.errors.models.document.attributes.s3_object_key.blank')}"

--- a/spec/support/matchers/error_message.rb
+++ b/spec/support/matchers/error_message.rb
@@ -35,8 +35,8 @@ end
 
 RSpec::Matchers.define :have_file_error do |filename, error|
   match do |page|
-    document_row = page.find('span._uploaded_file__filename', text: filename)
-                       .ancestor('.govuk-table__cell', match: :first)
+    document_row = page.find('span.app-uploaded-file__filename', text: filename)
+                       .ancestor('.govuk-summary-list__value', match: :first)
 
     @actual_text = document_row.find('.govuk-error-message').text(:all)
 


### PR DESCRIPTION
## Description of change

Replaces the HTML `<table>` used to list uploaded evidence files with the GOV.UK [Summary list](https://design-system.service.gov.uk/components/summary-list/) component. Also renames the markup ids/classes to accurate, `app-`-prefixed hooks, updates the Dropzone JS to build and target the new markup, and decouples the JS element lookups from GOV.UK design-system selectors so it no longer depends on the specific UI classes.

While doing this, fixed a broken `have_file_error` test matcher that still referenced the old `.govuk-table__cell` ancestor.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2125

## Notes for reviewer

- Behaviour is unchanged: upload, delete, and error-summary flows work as before (verified via request and system specs).
- The non-JS fallback list still renders failed uploads (nil `s3_object_key`) with an inline error message.

## Screenshots of changes (if applicable)

### Before changes:

<img width="768" height="867" alt="Screenshot 2026-07-24 at 12 35 29" src="https://github.com/user-attachments/assets/0b6938d7-48ee-4f37-bac0-fb387c5d4f89" />


### After changes:

<img width="700" height="880" alt="Screenshot 2026-07-24 at 12 35 39" src="https://github.com/user-attachments/assets/aa6613bf-8c27-493a-bd41-91e7ca5f8727" />


## How to manually test the feature

Open an application, go to **Upload supporting evidence**, and upload one or more files. Confirm each file appears in the list with an "Uploaded" tag and a working download link and delete button.
