### PR TITLE
CRIMAPP-2136 Add contextual accessible names to summary action links

### DIFF
--- a/app/presenters/summary/components/base_record.rb
+++ b/app/presenters/summary/components/base_record.rb
@@ -41,7 +41,7 @@ module Summary
         govuk_link_to(
           I18n.t('summary.dictionary.change'),
           change_path,
-          visually_hidden_suffix: name,
+          visually_hidden_suffix: link_accessibility_suffix,
           no_visited_state: true
         )
       end
@@ -50,7 +50,7 @@ module Summary
         govuk_link_to(
           I18n.t('summary.dictionary.edit'),
           summary_path,
-          visually_hidden_suffix: name,
+          visually_hidden_suffix: link_accessibility_suffix,
           no_visited_state: true
         )
       end
@@ -59,7 +59,7 @@ module Summary
         govuk_link_to(
           I18n.t('summary.dictionary.remove'),
           remove_path,
-          visually_hidden_suffix: name,
+          visually_hidden_suffix: link_accessibility_suffix,
           no_visited_state: true
         )
       end
@@ -109,6 +109,16 @@ module Summary
         return unless record_iteration.size > 1
 
         index + 1
+      end
+
+      def link_accessibility_suffix
+        [incomplete_text, name, count].compact.join(' ')
+      end
+
+      def incomplete_text
+        return if record.complete?
+
+        I18n.t('summary.dictionary.incomplete')
       end
 
       def status_tag

--- a/app/views/steps/submission/shared/_section.html.erb
+++ b/app/views/steps/submission/shared/_section.html.erb
@@ -6,7 +6,14 @@
 
 <%= govuk_summary_card heading_level: 3, title: section.title do |card| %>
   <% if section.editable? && section.change_path %>
-      <% card.with_action { govuk_link_to(I18n.t('summary.dictionary.change'), section.change_path, no_visited_state: true) } %>
+    <% card.with_action do %>
+      <%= govuk_link_to(
+            I18n.t('summary.dictionary.change'),
+            section.change_path,
+            visually_hidden_suffix: section.title,
+            no_visited_state: true
+          ) %>
+    <% end %>
   <% end %>
 <%= render partial: 'steps/submission/shared/summary_list', locals: { section: } %>
 <% end %>

--- a/spec/presenters/summary/components/base_record_spec.rb
+++ b/spec/presenters/summary/components/base_record_spec.rb
@@ -100,6 +100,21 @@ RSpec.describe Summary::Components::BaseRecord do
         'Change<span class="govuk-visually-hidden"> Record human name</span></a>'
       )
     end
+
+    context 'when rendered as an incomplete record in a list' do
+      let(:args) { { record_iteration: double(size: 3, index: 1) } }
+
+      before do
+        allow(record).to receive(:complete?).and_return(false)
+      end
+
+      it 'includes status and item number in the visually hidden text' do
+        expect(component.change_link).to eq(
+          '<a class="govuk-link govuk-link--no-visited-state" href="/change/this">' \
+          'Change<span class="govuk-visually-hidden"> Incomplete Record human name 2</span></a>'
+        )
+      end
+    end
   end
 
   describe '#remove_link' do

--- a/spec/presenters/summary/components/employment_spec.rb
+++ b/spec/presenters/summary/components/employment_spec.rb
@@ -81,6 +81,31 @@ RSpec.describe Summary::Components::Employment, type: :component do
             exact_text: 'Remove Job'
           )
         end
+
+        context 'when rendered as one of multiple jobs' do
+          subject(:component) do
+            render_summary_component(
+              described_class.new(
+                record: record,
+                show_record_actions: true,
+                record_iteration: double(size: 2, index: 1)
+              )
+            )
+          end
+
+          it 'includes the job number in the accessible link names' do
+            expect(page).to have_link(
+              'Change',
+              href: '/applications/APP123/steps/income/client/employer-details/EMPLOYMENT123',
+              exact_text: 'Change Job 2'
+            )
+            expect(page).to have_link(
+              'Remove',
+              href: '/applications/APP123/steps/income/client/employments/EMPLOYMENT123/confirm-destroy',
+              exact_text: 'Remove Job 2'
+            )
+          end
+        end
       end
     end
   end

--- a/spec/presenters/summary/components/offence_spec.rb
+++ b/spec/presenters/summary/components/offence_spec.rb
@@ -52,6 +52,31 @@ RSpec.describe Summary::Components::Offence, type: :component do
             exact_text: 'Remove Offence'
           )
         end
+
+        context 'when rendered as one of multiple offences' do
+          subject(:component) do
+            render_summary_component(
+              described_class.new(
+                record: record,
+                show_record_actions: true,
+                record_iteration: double(size: 2, index: 1)
+              )
+            )
+          end
+
+          it 'includes the offence number in the accessible link names' do
+            expect(page).to have_link(
+              'Change',
+              href: '/applications/APP123/steps/case/charges/OFF123',
+              exact_text: 'Change Offence 2'
+            )
+            expect(page).to have_link(
+              'Remove',
+              href: '/applications/APP123/steps/case/charges/OFF123/confirm-destroy',
+              exact_text: 'Remove Offence 2'
+            )
+          end
+        end
       end
     end
   end

--- a/spec/views/steps/submission/shared/_section.html.erb_spec.rb
+++ b/spec/views/steps/submission/shared/_section.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/submission/shared/_section.html.erb', type: :view do
+  subject(:render_partial) { render partial: 'steps/submission/shared/section', locals: { section: } }
+
+  let(:section) do
+    double(
+      heading: nil,
+      title: 'Files',
+      editable?: true,
+      change_path: '/applications/12345/steps/evidence/upload',
+      answers: []
+    )
+  end
+
+  it 'adds the section title to the accessible link name' do
+    render_partial
+
+    link = Capybara.string(rendered).find(
+      'a[href="/applications/12345/steps/evidence/upload"]'
+    )
+
+    expect(link).to have_text('Change Files', exact: true)
+    expect(link.find('.govuk-visually-hidden').text.strip).to eq('Files')
+  end
+end


### PR DESCRIPTION
## Description of change
Fix generic "Change", "Edit" and "Remove" link names in summary cards so screen readers can distinguish the target item/section.

Changes:
- BaseRecord action links now use `link_accessibility_suffix` instead of a generic record name
- Accessible suffix includes:
  - "Incomplete" when the record is incomplete
  - record name (for example Offence/Job)
  - record index when part of a multi-item list (for example "2")
- Section-level summary card "Change" links now include section title as visually hidden suffix (for example "Files", "Passporting benefit check")

Tests:
- Updated BaseRecord spec to cover indexed + incomplete hidden suffix output
- Updated Offence and Employment component specs to assert indexed accessible link names for multi-item cases
- Added view spec for `_section` partial to assert section-context suffix

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2136

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1460" height="507" alt="Screenshot 2026-07-24 at 14 57 17" src="https://github.com/user-attachments/assets/4ceace31-908b-40fb-913a-3b33b5905a16" />

### After changes:
<img width="1465" height="669" alt="Screenshot 2026-07-24 at 14 54 47" src="https://github.com/user-attachments/assets/a1927e31-2f9e-4749-b0df-39b21c8c94c1" />

## How to manually test the feature
Manually test by opening an in-progress application and visiting **`/applications/<APPLICATION_ID>/steps/submission/review`** (Review application) and **`/applications/<APPLICATION_ID>/steps/case/charges-summary`** (Offences summary), with data set up to include multiple offences and multiple jobs. On each page, inspect the action links and confirm screen-reader names are contextual (for example, “Change Offence 1”, “Remove Offence 2”, “Edit Job 1”) and that section-level links include context (for example, “Change Files”, “Change Passporting benefit check”) while visible text still shows only “Change/Edit/Remove”.
