### PR TITLE
CRIMAPP-2133 Announce age unit to screen readers on dependants page

### DIFF
--- a/app/views/steps/income/dependants/edit.html.erb
+++ b/app/views/steps/income/dependants/edit.html.erb
@@ -23,6 +23,11 @@
         <% index = c.index + 1 %>
 
         <%= c.govuk_fieldset legend: { hidden: true }, id: "dependant_#{index}", class: 'govuk-!-margin-top-4'  do %>
+          <%# The form builder renders suffix_text with aria-hidden="true", so sighted users see
+              "years old" but screen readers do not. We link a visually-hidden duplicate to the
+              input via aria-describedby so assistive technologies announce the unit. The
+              aria: { describedby: } hash is deep-merged by the form builder, preserving any
+              automatically generated hint/error IDs. %>
           <%= c.govuk_number_field :age,
                                    autocomplete: 'off',
                                    class: 'govuk-input--width-2',
@@ -31,7 +36,9 @@
                                    width: 2,
                                    inputmode: 'numeric',
                                    maxlength: 3,
-                                   extra_letter_spacing: true %>
+                                   extra_letter_spacing: true,
+                                   aria: { describedby: "dependant-age-unit-#{index}" },
+                                   after_input: content_tag(:span, t('.age_hint'), class: 'govuk-visually-hidden', id: "dependant-age-unit-#{index}") %>
 
           <%= c.button t('.remove_button', ordinal: index.ordinalize_fully), type: :submit, value: '1', name: c.field_name(:_destroy, index: nil),
                        class: %w[govuk-button govuk-button--warning],

--- a/spec/views/steps/income/dependants/edit.html.erb_spec.rb
+++ b/spec/views/steps/income/dependants/edit.html.erb_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/income/dependants/edit', type: :view do
+  subject(:render_view) { render }
+
+  let(:crime_application) { CrimeApplication.new(case: Case.new, income: Income.new) }
+  let(:dependants_attributes) do
+    {
+      '0' => { 'age' => 5 },
+      '1' => { 'age' => 10 },
+    }
+  end
+
+  let(:form_object) do
+    Steps::Income::DependantsForm.new(
+      crime_application:,
+      dependants_attributes:
+    )
+  end
+
+  before do
+    view.class.include StepsHelper
+    assign(:form_object, form_object)
+    allow(view).to receive_messages(
+      current_crime_application: nil,
+      current_form_object: nil
+    )
+    allow(controller).to receive(:controller_path).and_return('steps/income/dependants')
+    stub_template 'layouts/_step_header.html.erb' => ''
+
+    # step_form builds a URL from the current route, which requires a real request ID.
+    # Stub it to call form_for with a fixed URL so form fields render without routing.
+    without_partial_double_verification do
+      allow(view).to receive(:step_form) do |record, opts = {}, &block|
+        view.form_for(record, { url: '/stub', method: :put }.merge(opts || {}), &block)
+      end
+    end
+  end
+
+  describe 'age unit accessibility' do
+    it 'links the first age input to its unit span via aria-describedby' do
+      render_view
+
+      expect(rendered).to have_css('input[aria-describedby~="dependant-age-unit-1"]')
+    end
+
+    it 'renders a visually-hidden unit span for the first dependant' do
+      render_view
+
+      expect(rendered).to have_css(
+        '#dependant-age-unit-1.govuk-visually-hidden',
+        text: 'years old'
+      )
+    end
+
+    it 'links each age input to its own unique unit span' do
+      render_view
+
+      expect(rendered).to have_css('input[aria-describedby~="dependant-age-unit-1"]')
+      expect(rendered).to have_css('input[aria-describedby~="dependant-age-unit-2"]')
+    end
+
+    it 'renders unique unit span IDs for each dependant' do
+      render_view
+
+      unit_ids = Capybara.string(rendered)
+                         .all('[id^="dependant-age-unit-"]')
+                         .pluck(:id)
+
+      expect(unit_ids).to eq(unit_ids.uniq)
+    end
+
+    context 'when a dependant has a validation error' do
+      let(:dependants_attributes) { { '0' => { 'age' => 999 } } }
+
+      before { form_object.valid? }
+
+      it 'preserves the error description alongside the unit description' do
+        render_view
+
+        document = Capybara.string(rendered)
+        input = document.find('input[aria-describedby~="dependant-age-unit-1"]')
+        error = document.find('.govuk-error-message')
+        described_by_ids = input['aria-describedby'].split
+
+        expect(described_by_ids).to include(
+          'dependant-age-unit-1', error[:id]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add a visually-hidden span with the 'years old' unit text and link it to each age input via aria-describedby. The existing suffix_text remains for visual display (it is aria-hidden by the form builder), while screen reader users now receive the unit information programmatically.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2133

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="533" height="317" alt="Screenshot 2026-07-27 at 17 21 01" src="https://github.com/user-attachments/assets/cb043a2d-d149-40f7-8e05-dfd53f599266" />

## How to manually test the feature
Updated todo list

To manually test this fix, navigate to the Dependants' ages page in the application (via the income section of a legal aid application). Using a screen reader — VoiceOver on macOS (activate with Cmd+F5) or NVDA/JAWS on Windows — tab to one of the age input fields. When the field receives focus, the screen reader should announce something like "How old is the first dependant? years old, spin button" (the exact phrasing varies by screen reader), confirming that "years old" is now read aloud as part of the field description. If multiple dependants are present, verify each age input independently announces the unit, since each uses a unique `aria-describedby` id (`dependant-age-unit-1`, `dependant-age-unit-2`, etc.). Also confirm that any validation error messages on those fields still read out correctly when an invalid value is submitted, as the `aria-describedby` is deep-merged with the form builder's existing hint/error ids rather than replacing them.