### PR TITLE
Apply: Update Banner to utilise MOJ header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'stackprof'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
+gem 'moj_components', git: 'https://github.com/ministryofjustice/moj-components.git',
+tag: 'v0.2.1'
+
 gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.3.0',
     require: 'datastore_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,15 @@ GIT
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
+GIT
+  remote: https://github.com/ministryofjustice/moj-components.git
+  revision: acca6219ae56250fd269e4f0b8925206783f13a4
+  tag: v0.2.1
+  specs:
+    moj_components (0.2.1)
+      govuk-components
+      view_component (>= 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -599,6 +608,7 @@ DEPENDENCIES
   lograge
   logstash-event
   marcel
+  moj_components!
   omniauth-rails_csrf_protection
   omniauth_openid_connect (= 0.8.0)
   ostruct

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,6 @@
 // Design systems
-@use "local/govuk";
 @use "local/moj";
+@use "local/govuk";
 
 // Custom components or features
 @use "local/info_card";

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -35,11 +35,6 @@ $colours: (
 .moj-header__link--organisation-name:active {
   color: #ffffff;
 }
-// Keep the organisation name hover state aligned with the other header links.
-.moj-header__link--organisation-name:hover,
-.moj-header__link--organisation-name:active {
-  border-color: govuk-colour("white");
-}
 
 @media (max-width: 40em) { // 641px
   .moj-header__logotype-crest {

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -15,115 +15,30 @@
   background-color: transparent;
 }
 
-// Differentiate the header in non-production envs by
-// overriding the default colour
+// Differentiate the header and phase banner in each environment.
 $colours: (
+        "local": govuk-colour("green"),
         "staging": govuk-colour("orange"),
-        "local": govuk-colour("green")
+        "production": govuk-colour("blue")
 );
 
 @each $key, $colour in $colours {
-  .govuk-phase-banner-#{$key} {
-    border-bottom-color: $colour;
-  }
-
-  .govuk-header-#{$key} {
+  .app-body--#{$key} .moj-header {
     border-bottom-color: $colour;
   }
 }
 
-// Ensure the logo and organisation name remain inline on
-// all screen sizes and all components follow the design pattern of
-// MoJ Design header https://design-patterns.service.justice.gov.uk/components/moj-header/
-.govuk-header__container {
-  border-bottom: none;
-}
-
-.govuk-header__product-name {
-  margin-top: 10px;
-  font-weight: 700;
-}
-
-.govuk-header__logo {
-  margin-bottom: 20px;
-  width: auto;
-}
-
-.govuk-header__content {
-  width: auto;
-  float: right;
-  margin-top: 10px;
-}
-
-.moj-header__logotype-crest {
-  height: 40px;
-  width: 40px;
-}
-
-.govuk-header__link:hover {
-  margin-bottom: 0;
-  border-bottom: none;
-}
-
-.govuk-header__homepage-link {
-  display: inline-block;
-  margin-right: 10px;
-  font-size: 30px;
-}
-
-@media (min-width: 48.0625em) {
-  .govuk-header__homepage-link {
-    display: inline;
-  }
-}
-
-.govuk-header__homepage-link:link,
-.govuk-header__homepage-link:visited {
-  text-decoration: none;
-}
-
-.govuk-header__homepage-link:hover,
-.govuk-header__homepage-link:active {
-  margin-bottom: -3px;
-  border-bottom: 3px solid;
-}
-
-.govuk-header__homepage-link:focus {
-  margin-bottom: 0;
-  border-bottom: 0;
+.moj-header__link--organisation-name,
+.moj-header__link--organisation-name:link,
+.moj-header__link--organisation-name:visited,
+.moj-header__link--organisation-name:hover,
+.moj-header__link--organisation-name:active {
   color: #ffffff;
-  box-shadow: none;
 }
-
-.govuk-header__menu-button:hover {
-  text-decoration: none;
-}
-
-.govuk-service-navigation__toggle {
-  display: none;
-}
-
-.govuk-service-navigation {
-  background-color: #f4f8fb;
-}
-
-@media (max-width: 52.25em) { // 836px
-  .govuk-header__navigation-list {
-    float: none;
-    margin-top: 0;
-  }
-}
-
-@media (max-width: 48em) { // 769px
-  .govuk-header__content {
-    float: none;
-    margin-bottom: 10px;
-  }
-
-  .govuk-header__menu-button {
-    position: inherit;
-    margin-bottom: 10px;
-  }
+// Keep the organisation name hover state aligned with the other header links.
+.moj-header__link--organisation-name:hover,
+.moj-header__link--organisation-name:active {
+  border-color: govuk-colour("white");
 }
 
 @media (max-width: 40em) { // 641px

--- a/app/assets/stylesheets/local/govuk.scss
+++ b/app/assets/stylesheets/local/govuk.scss
@@ -1,9 +1,4 @@
 // GOV.UK Frontend
 //
 
-@forward "govuk-frontend/dist/govuk/index" with(
-  $govuk-global-styles: true,
-  $govuk-assets-path: '/',
-);
-
 @use "govuk-frontend/dist/govuk/index";

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -8,6 +8,10 @@
 // https://design-patterns.service.justice.gov.uk/components/badge/
 @use "@ministryofjustice/frontend/moj/components/badge/badge";
 
+// Header
+// https://design-patterns.service.justice.gov.uk/components/moj-header/
+@use "@ministryofjustice/frontend/moj/components/header/header";
+
 // Task List
 // https://design-patterns.service.justice.gov.uk/patterns/task-list/
 @use "@ministryofjustice/frontend/moj/components/task-list/task-list";

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,21 +1,6 @@
-<%= govuk_header(homepage_url: root_path, classes: "govuk-header-#{HostEnv.env_name}") do |header|
-  header.with_custom_logo do %>
-    <%= render partial: 'layouts/moj_crest' %>
-  <% end %>
-  <% header.with_product_name(name: t('layouts.header.organisation_name')) %>
-
+<%= moj_header(organisation_name: t('layouts.header.organisation_name'), url: '#') do |header| %>
   <% if signed_in? %>
-    <div class="govuk-header__content">
-      <nav class="govuk-header__navigation" aria-label="Menu">
-        <ul class="govuk-header__navigation-list">
-          <li class="govuk-header__navigation-item app-header__auth-user" aria-role="paragraph">
-            <%= current_provider.display_name %>
-          </li>
-          <li class="govuk-header__navigation-item">
-            <%= link_to t('layouts.header.sign_out'), provider_omniauth_logout_path, class: 'govuk-header__link', aria: { role: 'button' } %>
-          </li>
-        </ul>
-      </nav>
-    </div>
+    <%= header.with_navigation_item(text: current_provider.display_name, href: '#', current: true) %>
+    <%= header.with_navigation_item(text: t('layouts.header.sign_out'), href: provider_omniauth_logout_path) %>
   <% end %>
 <% end %>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,6 +1,6 @@
-<%= moj_header(organisation_name: t('layouts.header.organisation_name'), url: '#') do |header| %>
+<%= moj_header(organisation_name: t('layouts.header.organisation_name'), url: root_path) do |header| %>
   <% if signed_in? %>
-    <%= header.with_navigation_item(text: current_provider.display_name, href: '#', current: true) %>
+    <%= header.with_navigation_item(text: current_provider.display_name) %>
     <%= header.with_navigation_item(text: t('layouts.header.sign_out'), href: provider_omniauth_logout_path) %>
   <% end %>
 <% end %>

--- a/app/views/steps/provider_step/_header.html.erb
+++ b/app/views/steps/provider_step/_header.html.erb
@@ -1,18 +1,4 @@
-<%= govuk_header(homepage_url: root_path, classes: "govuk-header-#{HostEnv.env_name}") do |header|
-  header.with_custom_logo do %>
-    <%= render partial: 'layouts/moj_crest' %>
-  <% end %>
-  <% header.with_product_name(name: t('layouts.header.organisation_name')) %>
-  <div class="govuk-header__content">
-    <nav class="govuk-header__navigation" aria-label="Menu">
-      <ul class="govuk-header__navigation-list">
-        <li class="govuk-header__navigation-item app-header__auth-user">
-          <%= current_provider.display_name %>
-        </li>
-        <li class="govuk-header__navigation-item">
-          <%= link_to t('layouts.header.sign_out'), provider_omniauth_logout_path, class: 'govuk-header__link', aria: { role: 'button' } %>
-        </li>
-      </ul>
-    </nav>
-  </div>
+<%= moj_header(organisation_name: t('layouts.header.organisation_name'), url: '#') do |header| %>
+    <%= header.with_navigation_item(text: current_provider.display_name, href: '#', current: true) %>
+    <%= header.with_navigation_item(text: t('layouts.header.sign_out'), href: provider_omniauth_logout_path) %>
 <% end %>

--- a/app/views/steps/provider_step/_header.html.erb
+++ b/app/views/steps/provider_step/_header.html.erb
@@ -1,4 +1,4 @@
-<%= moj_header(organisation_name: t('layouts.header.organisation_name'), url: '#') do |header| %>
-    <%= header.with_navigation_item(text: current_provider.display_name, href: '#', current: true) %>
+<%= moj_header(organisation_name: t('layouts.header.organisation_name'), url: root_path) do |header| %>
+    <%= header.with_navigation_item(text: current_provider.display_name) %>
     <%= header.with_navigation_item(text: t('layouts.header.sign_out'), href: provider_omniauth_logout_path) %>
 <% end %>

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "yarn": ">=4"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^8.0.0",
+    "@ministryofjustice/frontend": "^10.0.1",
     "accessible-autocomplete": "^3.0.1",
     "dropzone": "^6.0.0-beta.2",
-    "govuk-frontend": "^5.14.0",
+    "govuk-frontend": "^6.4.0",
     "moment": "2.30.1",
     "sass": "^1.101.0"
   },

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+HEADER_NAV_SELECTOR = 'nav.moj-header__navigation'.freeze
+
 RSpec.describe 'Sign in user journey' do
   # Do not leave left overs, as this test will persist
   # a mock provider to the database
@@ -107,8 +109,8 @@ RSpec.describe 'Sign in user journey' do
     end
 
     it 'renders the user menu in the header' do
-      expect(page).to have_css('nav.govuk-header__navigation')
-      expect(page).to have_css('.app-header__auth-user', text: 'provider@example.com')
+      expect(page).to have_css(HEADER_NAV_SELECTOR)
+      expect(page).to have_css('nav.moj-header__navigation a', text: 'provider@example.com')
       expect(page).to have_link('Sign out')
     end
 
@@ -119,7 +121,7 @@ RSpec.describe 'Sign in user journey' do
 
       expect(current_url).to match(root_path)
       expect(page).to have_content('You have signed out')
-      expect(page).not_to have_css('nav.govuk-header__navigation')
+      expect(page).not_to have_css(HEADER_NAV_SELECTOR)
     end
 
     context 'when entra logout disabled' do
@@ -129,7 +131,7 @@ RSpec.describe 'Sign in user journey' do
         click_link('Sign out')
         expect(current_url).to match(root_path)
         expect(page).to have_content('You have signed out')
-        expect(page).not_to have_css('nav.govuk-header__navigation')
+        expect(page).not_to have_css(HEADER_NAV_SELECTOR)
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,13 +196,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ministryofjustice/frontend@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "@ministryofjustice/frontend@npm:8.0.1"
+"@ministryofjustice/frontend@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@ministryofjustice/frontend@npm:10.0.1"
   peerDependencies:
-    govuk-frontend: ^5.11.2
+    govuk-frontend: ^6.0.0
     moment: 2.30.1
-  checksum: 10c0/9754d558e3271aa3ef1ff1493d4d165eb6eeadc361f420f15c4b8591ab96c5e50b68ebb16adb66c378c721333aed45b1ade07018d2c71b808f581e92230a4137
+  checksum: 10c0/ec895678d17ca70e966b8313cdf120e1d56cc4cf44f8832d085a0dfc8648ddb92cbe000941453b1d331808a9fc056c3682637d24e6bea7c788264f64466a3db8
   languageName: node
   linkType: hard
 
@@ -700,10 +700,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^5.14.0":
-  version: 5.14.0
-  resolution: "govuk-frontend@npm:5.14.0"
-  checksum: 10c0/dcb1116003bb4a8ff167434bb30a779d6deafecb10687d044d5c560c0a7ff2053b8666000831c18ad3bcf4aa310678bf3c0cc40d734570b2b81c44853ddd388a
+"govuk-frontend@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "govuk-frontend@npm:6.4.0"
+  checksum: 10c0/0bbf3e9960e6759a9fc39a7b03d3730c35ea0fa612d83a335822b9813c725f05cab349e2ca23a3d188c2251db96a8ddb6b5b9499061fcda5cf3f8bb07dcb28b7
   languageName: node
   linkType: hard
 
@@ -831,11 +831,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "laa-apply-for-criminal-legal-aid@workspace:."
   dependencies:
-    "@ministryofjustice/frontend": "npm:^8.0.0"
+    "@ministryofjustice/frontend": "npm:^10.0.1"
     accessible-autocomplete: "npm:^3.0.1"
     dropzone: "npm:^6.0.0-beta.2"
     esbuild: "npm:^0.28.1"
-    govuk-frontend: "npm:^5.14.0"
+    govuk-frontend: "npm:^6.4.0"
     moment: "npm:2.30.1"
     sass: "npm:^1.101.0"
   languageName: unknown


### PR DESCRIPTION
## Description of change

<img width="1231" height="154" alt="image" src="https://github.com/user-attachments/assets/447ba89b-45e4-4ed0-b4fc-45e83ff25582" />


Utilise a gem for the local header to replace than the local written version. 

This allows us to upgrade our gov and moj dependencies.

## Link to relevant ticket

https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?selectedIssue=CRIMAPP-2281

## Notes for reviewer

1. The header should function as the previous version and appear basically the same (there will be minor nuances in sizing etc) and:
2. The organisation name is no longer underlined upon hover (this brings the app inline with others)
3. The bottom border of the header should have a different color depending on environment:
        dev = green
        staging = orange
        live = blue (this was inadvertently removed when the local header was created)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Run it; click on the various options on the header.
