### PR TITLE
CRIMAPP-2131 Announce successful file upload to screen readers

### DIFF
--- a/app/javascript/local/dropzone-cfg.js
+++ b/app/javascript/local/dropzone-cfg.js
@@ -129,6 +129,7 @@ function createUploadedFileRow(file) {
 function createStatusTag(text) {
   let tag = document.createElement("strong")
   tag.classList.add("govuk-tag", "govuk-tag--yellow", "app-uploaded-file__status")
+  tag.setAttribute("aria-live", "polite")
   tag.textContent = text
   return tag
 }

--- a/app/views/steps/evidence/upload/_uploaded_file.html.erb
+++ b/app/views/steps/evidence/upload/_uploaded_file.html.erb
@@ -8,7 +8,7 @@
     </span>
 
     <% if document.s3_object_key %>
-      <%= govuk_tag(text: t('steps.evidence.upload.edit.uploaded'), colour: 'green', classes: 'app-uploaded-file__status') %>
+      <%= govuk_tag(text: t('steps.evidence.upload.edit.uploaded'), colour: 'green', classes: 'app-uploaded-file__status', html_attributes: { 'aria-live': 'polite' }) %>
     <% else %>
       <% document.valid?(:storage) %>
 

--- a/spec/system/applying/with_supporting_evidence_spec.rb
+++ b/spec/system/applying/with_supporting_evidence_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe 'Supporting evidence' do
 
       # A valid file
       upload_evidence_file('test.csv')
+
+      # Successful upload status is announced to screen readers (CRIMAPP-2131)
+      expect(page).to have_css('[aria-live="polite"]', text: 'Uploaded')
+
       save_and_continue
 
       expect(page).not_to have_step_error 'You must provide the required evidence'


### PR DESCRIPTION
## Description of change

On the **Upload supporting evidence** page, a successful upload updates the page to list the file with a green "Uploaded" tag. This visual-only change was not announced to screen reader users, leaving them unsure whether the upload succeeded.

Adds `aria-live="polite"` directly to the evidence upload status tag so the change from "Uploading" to "Uploaded" is announced to assistive technology. Applied in both rendering paths: the server-rendered `_uploaded_file` partial and the Dropzone JS that builds/updates rows client-side.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2131

## Notes for reviewer

- The live region works because the tag element exists from row creation (as "Uploading") and only its text content mutates to "Uploaded" on success — the change happens *within* the live region, so it is announced.
- System specs run under `rack_test` (no JS driver) and there is no JS unit-test framework, so the Dropzone success path cannot be covered automatically. A view assertion checks the server-rendered tag carries `aria-live="polite"`; the client-side announcement needs a manual screen-reader check.

## Screenshots of changes (if applicable)

### Before changes:

_No visual change._

### After changes:

_No visual change (the tag is unchanged visually; only an `aria-live` attribute is added)._

## How to manually test the feature

Open an application, go to **Upload supporting evidence**, and upload a valid file with a screen reader running (VoiceOver/NVDA). Confirm the successful "Uploaded" status is announced when the file finishes uploading.