### PR TITLE
CRIMAPP-2134 Announce currency symbol to screen reader users

### DIFF
--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -20,6 +20,16 @@ module FormBuilderHelper
     end
   end
 
+  # Overrides the GOV.UK form builder's govuk_number_field to inject a
+  # visually hidden "Amount in pounds" span into the label when prefix_text
+  # is '£'. This ensures screen reader users receive the same currency context
+  # that sighted users get from the visible pound symbol prefix.
+  def govuk_number_field(attribute_name, prefix_text: nil, label: {}, **, &block)
+    label = label_with_currency_hint(attribute_name, label) if prefix_text == '£' && label.is_a?(Hash)
+
+    super
+  end
+
   private
 
   def with_inline_error_message(attribute_name, message)
@@ -42,6 +52,16 @@ module FormBuilderHelper
 
   def submit_button(i18n_key, opts = {}, &block)
     govuk_submit I18n.t("helpers.submit.#{i18n_key}"), **opts, &block
+  end
+
+  def label_with_currency_hint(attribute_name, label_opts)
+    label_text = label_opts[:text] ||
+                 I18n.t("helpers.label.#{object_name}.#{attribute_name}", default: nil) ||
+                 attribute_name.to_s.humanize
+
+    hidden_span = content_tag(:span, I18n.t('helpers.currency_input_hint'),
+                              class: 'govuk-visually-hidden')
+    label_opts.merge(text: safe_join([label_text, hidden_span], ' '))
   end
 
   def segment_names

--- a/config/locales/cy/helpers.yml
+++ b/config/locales/cy/helpers.yml
@@ -45,6 +45,7 @@ cy:
     back_link: Yn ôl
     back_to_applications: Yn ôl i'ch ceisiadau
     important: Pwysig
+    currency_input_hint: Swm mewn punnoedd
     submit:
       clear: Clirio
       search: Chwilio

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -45,6 +45,7 @@ en:
     back_link: Back
     back_to_applications: Back to your applications
     important: Important
+    currency_input_hint: Amount in pounds
     submit:
       clear: Clear
       search: Search

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -78,4 +78,74 @@ RSpec.describe FormBuilderHelper, type: :helper do
       end
     end
   end
+
+  describe '#govuk_number_field' do
+    before do
+      allow(form_object).to receive_messages(amount: nil, errors: ActiveModel::Errors.new(form_object))
+    end
+
+    context 'when prefix_text is £' do
+      it 'includes a visually hidden "Amount in pounds" span in the label' do
+        html = builder.govuk_number_field(:amount, prefix_text: '£', label: { text: 'Enter amount' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label).to be_present
+        expect(label.text).to include('Enter amount')
+
+        hidden_span = label.at_css('span.govuk-visually-hidden')
+        expect(hidden_span).to be_present
+        expect(hidden_span.text.strip).to eq('Amount in pounds')
+      end
+
+      it 'preserves the real translated label text alongside the currency hint' do
+        # Uses a genuine application form object and its real translation key to
+        # confirm that label text resolution and currency hint injection both work
+        # correctly end-to-end, without relying on mocked I18n lookups.
+        savings_form = Steps::Capital::SavingsForm.new(nil)
+        real_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(
+          :steps_capital_savings_form, savings_form, self, {}
+        )
+
+        html = real_builder.govuk_number_field(:account_balance, prefix_text: '£', label: { tag: 'h2', size: 'm' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.text).to include('What is the account balance?')
+
+        hidden_span = label.at_css('span.govuk-visually-hidden')
+        expect(hidden_span).to be_present
+        expect(hidden_span.text.strip).to eq('Amount in pounds')
+      end
+
+      it 'renders the £ prefix symbol with aria-hidden on the input wrapper' do
+        html = builder.govuk_number_field(:amount, prefix_text: '£', label: { text: 'Enter amount' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        prefix = doc.at_css('span.govuk-input__prefix')
+        expect(prefix).to be_present
+        expect(prefix['aria-hidden']).to eq('true')
+      end
+    end
+
+    context 'when prefix_text is not £' do
+      it 'does not inject a visually hidden span into the label' do
+        html = builder.govuk_number_field(:amount, prefix_text: 'kg', label: { text: 'Enter weight' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.at_css('span.govuk-visually-hidden')).to be_nil
+      end
+    end
+
+    context 'when prefix_text is not set' do
+      it 'does not inject a visually hidden span into the label' do
+        html = builder.govuk_number_field(:amount, label: { text: 'Enter amount' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.at_css('span.govuk-visually-hidden')).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
The pound (£) prefix on monetary input fields was marked aria-hidden="true", so screen reader users heard only the field label with no indication that the value should be entered in pounds.

Override govuk_number_field in FormBuilderHelper to append a visually hidden span containing "Amount in pounds" (Welsh: "Swm mewn punnoedd") to the label whenever prefix_text: '£' is used. The span is injected via label_with_currency_hint, which resolves the label text through the standard I18n lookup before merging the hidden span in. All other label options (tag, size, etc.) are preserved.

The fix is centralised in the form builder helper so all currency fields across the service benefit automatically, without changes to individual views.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2134

## Notes for reviewer

## Screenshots of changes (if applicable)

### After changes:
<img width="415" height="446" alt="Screenshot 2026-07-29 at 15 13 40" src="https://github.com/user-attachments/assets/0d5ce6a6-8932-4582-893d-a6a776cdbafe" />

## How to manually test the feature
Navigate to any page with a monetary input field — for example, the savings account balance page under Capital, or any employment income or outgoings payment page. Enable a screen reader (VoiceOver on macOS, NVDA or JAWS on Windows, or TalkBack on Android) and tab to the currency input. The screen reader should announce the field label followed by "Amount in pounds" before reading the input role and any error. Confirm that the visible £ prefix is still displayed but not read out a second time. 