### PR TITLE
CRIMAPP-2194 Sanitize evidence filenames to prevent WAF upload blocks

### DIFF
--- a/app/javascript/local/dropzone-cfg.js
+++ b/app/javascript/local/dropzone-cfg.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Dropzone from "dropzone"
+import sanitizeFilename from "./sanitize-filename"
 
 const MIN_FILE_SIZE = 3000 // Bytes = 3KB
 const MAX_FILE_SIZE = 1000000 // Bytes = 10MB
@@ -58,7 +59,10 @@ DropzoneCfg.prototype.init = function () {
   this.$dropzone = new Dropzone(this.$dropzoneContainer, {
     paramName: "document",
     dictDefaultMessage: 'Drag and drop files here or', // TODO: i18n
-    clickable: '#choose_files_button'
+    clickable: '#choose_files_button',
+    // Sanitise the filename sent to the server so the WAF doesn't reject
+    // unsupported characters (e.g. a colon macOS stores in place of a slash).
+    renameFile: (file) => sanitizeFilename(file.name)
   })
 
   this.$dropzoneContainerText = document.querySelector('div.dz-message')

--- a/app/javascript/local/sanitize-filename.js
+++ b/app/javascript/local/sanitize-filename.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Mirrors app/lib/filename_sanitizer.rb.
+//
+// macOS stores a `/` typed in Finder as a `:` on the POSIX filesystem, and the
+// browser uploads that POSIX name. A `:` (and various other characters) in the
+// multipart `filename=` is rejected by the WAF (ModSecurity) before the request
+// reaches Rails, so the upload silently fails. We sanitise the filename before
+// it is sent so the WAF never sees an unsupported character.
+//
+// Keep only letters, numbers, spaces and a small set of safe punctuation
+// (`. _ -`), replacing anything else with a hyphen.
+const FALLBACK = 'file'
+
+export default function sanitizeFilename(filename) {
+  if (!filename) { return FALLBACK }
+
+  const sanitized = filename
+    .normalize('NFC')
+    .replace(/[^\p{L}\p{N}._ -]/gu, '-')
+    .replace(/\s+/g, ' ')
+    .replace(/-+/g, '-')
+    .replace(/^[\s.-]+/, '')
+    .replace(/[\s-]+$/, '')
+
+  return sanitized || FALLBACK
+}

--- a/app/lib/filename_sanitizer.rb
+++ b/app/lib/filename_sanitizer.rb
@@ -1,0 +1,30 @@
+# Sanitises a user-supplied filename so it can be uploaded safely.
+#
+# macOS stores a `/` typed in Finder as a `:` on the POSIX filesystem, and the
+# browser uploads that POSIX name. A `:` (and various other characters) in the
+# multipart `filename=` is rejected by the WAF (ModSecurity) before the request
+# reaches Rails, so the upload silently fails.
+#
+# We keep only letters, numbers, spaces and a small set of safe punctuation
+# (`. _ -`), replacing anything else with a hyphen. The same rules are mirrored
+# client-side (see app/javascript/local/sanitize-filename.js) so the WAF never
+# sees an unsupported character in the first place.
+module FilenameSanitizer
+  ALLOWED = /[^\p{L}\p{N}._ -]/
+  FALLBACK = 'file'.freeze
+
+  module_function
+
+  def call(filename)
+    return FALLBACK if filename.blank?
+
+    sanitized = filename.to_s.unicode_normalize(:nfc)
+                        .gsub(ALLOWED, '-')
+                        .gsub(/\s+/, ' ')
+                        .squeeze('-')
+                        .gsub(/\A[\s.-]+/, '')
+                        .gsub(/[\s-]+\z/, '')
+
+    sanitized.presence || FALLBACK
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -28,7 +28,7 @@ class Document < ApplicationRecord
   def self.create_from_file(file:, crime_application:)
     create(
       crime_application: crime_application,
-      filename: file.original_filename,
+      filename: FilenameSanitizer.call(file.original_filename),
       content_type: Marcel::MimeType.for(file.tempfile),
       file_size: file.tempfile.size,
       tempfile: file.tempfile,

--- a/spec/lib/filename_sanitizer_spec.rb
+++ b/spec/lib/filename_sanitizer_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe FilenameSanitizer do
+  describe '.call' do
+    subject(:sanitized) { described_class.call(filename) }
+
+    context 'with a plain, valid filename' do
+      let(:filename) { 'client-bank-statement.pdf' }
+
+      it { is_expected.to eq('client-bank-statement.pdf') }
+    end
+
+    context 'with a colon (macOS stores a Finder slash as a colon)' do
+      let(:filename) { 'invoice 03:04.pdf' }
+
+      it { is_expected.to eq('invoice 03-04.pdf') }
+    end
+
+    context 'with path separators' do
+      let(:filename) { 'client/statements\\jan.pdf' }
+
+      it { is_expected.to eq('client-statements-jan.pdf') }
+    end
+
+    context 'with assorted unsupported characters' do
+      let(:filename) { 'bank*state?ment<v2>|"final".pdf' }
+
+      it { is_expected.to eq('bank-state-ment-v2-final-.pdf') }
+    end
+
+    context 'with runs of separators and surrounding whitespace' do
+      let(:filename) { '  my :: important   file .pdf  ' }
+
+      it { is_expected.to eq('my - important file .pdf') }
+    end
+
+    context 'with leading dots and hyphens' do
+      let(:filename) { '.-:hidden.pdf' }
+
+      it { is_expected.to eq('hidden.pdf') }
+    end
+
+    context 'with accented (unicode) letters' do
+      let(:filename) { 'café résumé.pdf' }
+
+      it 'preserves the letters' do
+        expect(sanitized).to eq('café résumé.pdf')
+      end
+    end
+
+    context 'when the name has no supported characters' do
+      let(:filename) { '***' }
+
+      it { is_expected.to eq('file') }
+    end
+
+    context 'when blank' do
+      let(:filename) { '' }
+
+      it { is_expected.to eq('file') }
+    end
+
+    context 'when nil' do
+      let(:filename) { nil }
+
+      it { is_expected.to eq('file') }
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Document, type: :model do
 
       described_class.create_from_file(file:, crime_application:)
     end
+
+    context 'when the original filename contains unsupported characters' do
+      before do
+        allow(file).to receive(:original_filename).and_return('invoice 03:04.pdf')
+      end
+
+      it 'stores a sanitised filename' do
+        expect(described_class).to receive(:create).with(
+          hash_including(filename: 'invoice 03-04.pdf')
+        )
+
+        described_class.create_from_file(file:, crime_application:)
+      end
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
## Description of change

Evidence file uploads were being blocked by the WAF (ModSecurity) before the request reached Rails when the filename contained a colon (or other unsupported characters), so providers saw no useful error and could not upload the file.

macOS is the common trigger: a `/` typed in a filename in Finder (e.g. a date like `03/04`) is stored as a `:` on the POSIX filesystem, and the browser uploads that POSIX name — the `:` in the multipart `filename=` is what the WAF rejects.

This PR sanitises filenames using a whitelist (Unicode letters/numbers, spaces and `. _ -`; anything else becomes `-`, with runs collapsed and leading/trailing separators trimmed), applied in two places:

Changes:
- New `FilenameSanitizer.call` (`app/lib/filename_sanitizer.rb`) — canonical sanitisation rules.
- `Document.create_from_file` now stores `FilenameSanitizer.call(file.original_filename)`.
- New JS helper `app/javascript/local/sanitize-filename.js` mirroring the Ruby rules.
- Dropzone `renameFile:` sanitises the filename **before** the request is sent — this is what actually dodges the WAF for the JS upload path.

Tests:
- New `spec/lib/filename_sanitizer_spec.rb` covering colons, path separators, assorted unsupported characters, unicode letters, and blank/nil fallbacks.
- Added a sanitisation case to `spec/models/document_spec.rb`.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2194

## Notes for reviewer

- The **client-side** rename is the part that unblocks the primary (Dropzone) journey, since the WAF rejects the request before Rails runs. Server-side sanitisation is defence-in-depth (keeps the stored filename and download `Content-Disposition` clean, and covers any path where the raw name survives).
- The **non-JS fallback form** cannot be rescued client-side (rare path); a WAF rule change would be needed to cover it and is out of scope here.
- There is no JS unit-test framework in this repo, so `sanitize-filename.js` isn't unit-tested; its logic mirrors the Ruby spec.

## Screenshots of changes (if applicable)

### Before changes:

_No visual change._

### After changes:

_No visual change._

## How to manually test the feature

On macOS, create a file whose name contains a `/` in Finder (e.g. rename a PDF to `invoice 03/04.pdf` — Finder stores it on disk as `invoice 03:04.pdf`). Open an application, go to **Upload supporting evidence**, and upload that file. Confirm it now uploads successfully and appears in the list with an "Uploaded" tag and a working download link, rather than failing with no error.
