### PR TITLE
CRIMAPP-2138 Announce conditionally revealed questions to screen readers

### DIFF
--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -30,6 +30,24 @@ module FormBuilderHelper
     super
   end
 
+  # Overrides the GOV.UK form builder's radio button and check box helpers to
+  # inject visually hidden context into the label when the control reveals
+  # conditional content (i.e. is called with a block). Screen readers do not
+  # reliably announce `aria-expanded` on radios and checkboxes, so this text
+  # tells users that selecting the option reveals additional fields. The
+  # `aria-expanded` attribute is intentionally left in place. See CRIMAPP-2138.
+  def govuk_radio_button(attribute_name, value, label: {}, **, &block)
+    label = label_with_conditional_reveal_hint(attribute_name, value, label) if block && label.is_a?(Hash)
+
+    super
+  end
+
+  def govuk_check_box(attribute_name, value, unchecked_value = false, label: {}, **, &block) # rubocop:disable Style/OptionalBooleanParameter
+    label = label_with_conditional_reveal_hint(attribute_name, value, label) if block && label.is_a?(Hash)
+
+    super
+  end
+
   private
 
   def with_inline_error_message(attribute_name, message)
@@ -62,6 +80,29 @@ module FormBuilderHelper
     hidden_span = content_tag(:span, I18n.t('helpers.currency_input_hint'),
                               class: 'govuk-visually-hidden')
     label_opts.merge(text: safe_join([label_text, hidden_span], ' '))
+  end
+
+  # Appends a visually hidden hint to an option's label so screen reader users
+  # are told that selecting it reveals additional fields. Only injects when the
+  # option's label text can be resolved, to avoid overriding the form builder's
+  # own automatic label localisation with incorrect text.
+  def label_with_conditional_reveal_hint(attribute_name, value, label_opts)
+    label_text = label_opts[:text] || localised_option_label(attribute_name, value)
+    return label_opts if label_text.blank?
+
+    hidden_span = content_tag(:span, I18n.t('helpers.conditional_reveal_hint'),
+                              class: 'govuk-visually-hidden')
+    label_opts.merge(text: safe_join([label_text, hidden_span], ' '))
+  end
+
+  # Resolves an option's label the same way the GOV.UK form builder does, i.e.
+  # `helpers.label.<object_name>.<attribute>_options.<value>`, honouring the
+  # builder's nested localisation object-name scanning.
+  def localised_option_label(attribute_name, value)
+    base_object_name = object_name.to_s.scan(/[[:alpha:]][\w\s]*/).join('.')
+    key = "helpers.label.#{base_object_name}.#{attribute_name}_options.#{value}"
+
+    I18n.t(key, default: nil) || I18n.t("#{key}_html", default: nil)&.html_safe
   end
 
   def segment_names

--- a/config/locales/cy/helpers.yml
+++ b/config/locales/cy/helpers.yml
@@ -46,6 +46,7 @@ cy:
     back_to_applications: Yn ôl i'ch ceisiadau
     important: Pwysig
     currency_input_hint: Swm mewn punnoedd
+    conditional_reveal_hint: Os caiff ei ddewis, rhowch fanylion ychwanegol
     submit:
       clear: Clirio
       search: Chwilio

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -46,6 +46,7 @@ en:
     back_to_applications: Back to your applications
     important: Important
     currency_input_hint: Amount in pounds
+    conditional_reveal_hint: If selected, provide additional details
     submit:
       clear: Clear
       search: Search

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -148,4 +148,97 @@ RSpec.describe FormBuilderHelper, type: :helper do
       end
     end
   end
+
+  describe '#govuk_radio_button' do
+    before do
+      allow(form_object).to receive_messages(some_option: nil, errors: ActiveModel::Errors.new(form_object))
+    end
+
+    context 'when the radio button reveals conditional content (block given)' do
+      it 'injects a visually hidden conditional reveal hint into the label' do
+        html = builder.govuk_radio_button(:some_option, 'yes', label: { text: 'Yes' }) { 'revealed content' }
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.text).to include('Yes')
+
+        hidden_span = label.at_css('span.govuk-visually-hidden')
+        expect(hidden_span).to be_present
+        expect(hidden_span.text.strip).to eq('If selected, provide additional details')
+      end
+
+      it 'resolves the real translated option label alongside the hint' do
+        form = Steps::Capital::PremiumBondsForm.new(nil)
+        real_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(
+          :steps_capital_premium_bonds_form, form, self, {}
+        )
+
+        html = real_builder.govuk_radio_button(:has_premium_bonds, YesNoAnswer::YES) { 'revealed content' }
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.text).to include('Yes')
+
+        hidden_span = label.at_css('span.govuk-visually-hidden')
+        expect(hidden_span).to be_present
+        expect(hidden_span.text.strip).to eq('If selected, provide additional details')
+      end
+    end
+
+    context 'when the radio button has no conditional content (no block)' do
+      it 'does not inject a visually hidden span into the label' do
+        html = builder.govuk_radio_button(:some_option, 'yes', label: { text: 'Yes' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.at_css('span.govuk-visually-hidden')).to be_nil
+      end
+    end
+  end
+
+  describe '#govuk_check_box' do
+    before do
+      allow(form_object).to receive_messages(types: [], errors: ActiveModel::Errors.new(form_object))
+    end
+
+    context 'when the check box reveals conditional content (block given)' do
+      it 'injects a visually hidden conditional reveal hint into the label' do
+        html = builder.govuk_check_box(:types, 'income_tax', label: { text: 'Income Tax' }) { 'revealed content' }
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.text).to include('Income Tax')
+
+        hidden_span = label.at_css('span.govuk-visually-hidden')
+        expect(hidden_span).to be_present
+        expect(hidden_span.text.strip).to eq('If selected, provide additional details')
+      end
+
+      it 'resolves the real translated option label alongside the hint' do
+        real_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(
+          :steps_income_client_deductions_form, form_object, self, {}
+        )
+
+        html = real_builder.govuk_check_box(:types, 'income_tax') { 'revealed content' }
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.text).to include('Income Tax')
+
+        hidden_span = label.at_css('span.govuk-visually-hidden')
+        expect(hidden_span).to be_present
+        expect(hidden_span.text.strip).to eq('If selected, provide additional details')
+      end
+    end
+
+    context 'when the check box has no conditional content (no block)' do
+      it 'does not inject a visually hidden span into the label' do
+        html = builder.govuk_check_box(:types, 'income_tax', label: { text: 'Income Tax' })
+        doc = Nokogiri::HTML.fragment(html)
+
+        label = doc.at_css('label')
+        expect(label.at_css('span.govuk-visually-hidden')).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

Conditionally revealed questions (radio/checkbox options that reveal extra input fields when selected) were not announced to screen reader users. `aria-expanded` is present but unreliably supported (NVDA only announces it on checkboxes, JAWS not at all), so many users received no feedback that new fields had appeared.

This adds visually-hidden context to the label of any option that reveals conditional content, telling screen reader users that selecting it provides additional fields. The `aria-expanded` behaviour is intentionally left in place for users on platforms that do announce it.

Rather than editing ~40 view files, this follows the existing `FormBuilderHelper#govuk_number_field` precedent and overrides the GOV.UK form builder's `govuk_radio_button` and `govuk_check_box` helpers to inject the hint automatically — but only when the control is called with a block (i.e. it actually reveals conditional content). This covers every conditional reveal across the journey.

Changes:
- `app/helpers/form_builder_helper.rb` — override `govuk_radio_button`/`govuk_check_box` to append a `govuk-visually-hidden` span to the option label when a reveal block is present. The option label text is resolved exactly as the form builder does (`helpers.label.<object_name>.<attribute>_options.<value>`, honouring nested-localisation object-name scanning); if it can't be resolved, the label is left untouched so we never replace a correct auto-derived label with wrong text.
- `config/locales/en/helpers.yml` / `config/locales/cy/helpers.yml` — add `helpers.conditional_reveal_hint`.

Tests:
- `spec/helpers/form_builder_helper_spec.rb` — hint injected when a block is present (incl. real i18n resolution for both radio and checkbox), and label untouched when no block is given.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2138

## Notes for reviewer

- The Welsh translation of `conditional_reveal_hint` ("Os caiff ei ddewis, rhowch fanylion ychwanegol") should be reviewed by a Welsh translator.
- The screen-reader announcement itself cannot be covered by automated tests; the specs assert the visually-hidden markup is present in the label. Manual verification with NVDA/JAWS/VoiceOver is recommended.
- No change to the `aria-expanded` / `data-aria-controls` wiring (handled by govuk-frontend JS) — it is deliberately retained.
- The override is scoped to controls called with a reveal block, so plain radios/checkboxes are unaffected.

## Screenshots of changes (if applicable)

_No visual change — the added text is visually hidden and only exposed to assistive technology._

### Before changes:

### After changes:

## How to manually test the feature

1. Start the app (`bin/dev`) and begin/resume a means-tested application.
2. Navigate to a page with a conditional reveal, e.g. Income → Deductions (select "Income Tax" / "Other") or any Yes/No question that reveals further fields (e.g. Premium bonds).
3. Inspect a triggering option's `<label>` in the DOM and confirm it contains `<span class="govuk-visually-hidden">If selected, provide additional details</span>` after the visible label text.
4. With a screen reader (NVDA/JAWS/VoiceOver), focus the option and confirm the additional context is announced, while the visible label is unchanged.
5. Confirm plain radios/checkboxes without a reveal do not gain the hidden text.
