### PR TITLE
Assert Dockerfile Ruby version matches .ruby-version in CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -23,6 +23,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Check Dockerfile Ruby version matches .ruby-version
+        run: |
+          expected="$(tr -d '[:space:]' < .ruby-version)"
+          actual="$(grep -oE '^FROM ruby:[0-9]+\.[0-9]+\.[0-9]+' Dockerfile | head -n1 | sed -E 's/^FROM ruby://')"
+          if [ -z "$actual" ]; then
+            echo "::error file=Dockerfile::Could not find a 'FROM ruby:<version>' line in Dockerfile"
+            exit 1
+          fi
+          if [ "$expected" != "$actual" ]; then
+            echo "::error file=Dockerfile::Ruby version mismatch: .ruby-version is '$expected' but Dockerfile uses '$actual'"
+            exit 1
+          fi
+          echo "Ruby version '$expected' matches between .ruby-version and Dockerfile"
+
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@a30dfa457ad68707b8b910ac3a244714b61c0626 # v1.320.0
         with:


### PR DESCRIPTION
## Description of change

Adds a CI check that fails the build if the Ruby version in the `Dockerfile` (`FROM ruby:<x.y.z>-...`) drifts out of sync with `.ruby-version`.

The Ruby version is currently declared independently in two places — `.ruby-version` (used by `ruby/setup-ruby` and local dev) and the first `FROM` line of the `Dockerfile`. Nothing stops one being bumped without the other. This check enforces that they stay aligned.

Changes:
- Add a "Check Dockerfile Ruby version matches .ruby-version" step to the `lint` job, running immediately after checkout (fast-fail, before Ruby/gem setup).
- Extracts the version from `.ruby-version` and from the Dockerfile `FROM ruby:` line and fails with a GitHub `::error` annotation on mismatch or if no `FROM ruby:` line is found.

## Link to relevant ticket

_No ticket._

## Notes for reviewer

- The check compares only the Ruby version (`x.y.z`), not the Alpine tag suffix (`-alpine3.23`), since `.ruby-version` only encodes the Ruby version.
- Verified locally: passes with the current matching `4.0.6`, and correctly fails on a simulated mismatch.

## Screenshots of changes (if applicable)

_No visual change._

## How to manually test the feature

1. On this branch, confirm `.ruby-version` and the Dockerfile `FROM ruby:` line match — the new CI step passes.
2. Temporarily edit the `Dockerfile` first line to a different version (e.g. `FROM ruby:9.9.9-alpine3.23 AS base`) and push.
3. Observe the `lint` job fails at the "Check Dockerfile Ruby version matches .ruby-version" step with a mismatch error annotation.
4. Revert the Dockerfile change; the step passes again.
