### PR TITLE
CRIMAPP-2139 Move focus to inputs when activating error summary links

### DIFF
--- a/app/validators/deductions_validator.rb
+++ b/app/validators/deductions_validator.rb
@@ -13,7 +13,7 @@ class DeductionsValidator < ActiveModel::Validator
 
     return unless record.types.empty?
 
-    record.errors.add(:base, :none_selected) if record.employment.has_no_deductions.blank?
+    record.errors.add(:types, :none_selected) if record.employment.has_no_deductions.blank?
   end
 
   private

--- a/app/views/steps/dwp/cannot_check_benefit_status/edit.html.erb
+++ b/app/views/steps/dwp/cannot_check_benefit_status/edit.html.erb
@@ -28,8 +28,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= step_form @form_object do |f| %>
     <div class="govuk-!-margin-bottom-7">
-      <% @form_object.choices.each do |option| %>
-        <%= f.govuk_radio_button :will_enter_nino, option %>
+      <% @form_object.choices.each_with_index do |option, index| %>
+        <%= f.govuk_radio_button :will_enter_nino, option, link_errors: index.zero? %>
       <% end %>
     </div>
 

--- a/app/views/steps/income/client/deductions/edit.html.erb
+++ b/app/views/steps/income/client/deductions/edit.html.erb
@@ -9,8 +9,8 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_check_boxes_fieldset :deductions, legend: { tag: 'h1', size: 'xl' } do |x| %>
 
-        <% @form_object.ordered_deductions.each do |type| %>
-          <%= f.govuk_check_box :types, type, link_errors: true do %>
+        <% @form_object.ordered_deductions.each_with_index do |type, index| %>
+          <%= f.govuk_check_box :types, type, link_errors: index.zero? do %>
             <%= f.fields_for type.to_sym, f.object.public_send(type.to_s) do |g| %>
               <%= g.govuk_fieldset legend: nil, id: "deduction_#{type}" do %>
                 <%= g.govuk_number_field :amount,

--- a/app/views/steps/income/partner/deductions/edit.html.erb
+++ b/app/views/steps/income/partner/deductions/edit.html.erb
@@ -9,8 +9,8 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_check_boxes_fieldset :deductions, legend: { tag: 'h1', size: 'xl' } do |x| %>
 
-        <% @form_object.ordered_deductions.each do |type| %>
-          <%= f.govuk_check_box :types, type, link_errors: true do %>
+        <% @form_object.ordered_deductions.each_with_index do |type, index| %>
+          <%= f.govuk_check_box :types, type, link_errors: index.zero? do %>
             <%= f.fields_for type.to_sym, f.object.public_send(type.to_s) do |g| %>
               <%= g.govuk_fieldset legend: nil, id: "deduction_#{type}" do %>
                 <%= g.govuk_number_field :amount,

--- a/app/views/steps/shared/nino/edit.html.erb
+++ b/app/views/steps/shared/nino/edit.html.erb
@@ -7,7 +7,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset(:has_arc_or_nino, legend: { text: legend_t(:has_arc_or_nino), tag: 'h1', size: 'xl' }) do %>
-        <%= f.govuk_radio_button :has_arc_or_nino, YesNoAnswer::YES do %>
+        <%= f.govuk_radio_button :has_arc_or_nino, YesNoAnswer::YES, link_errors: true do %>
           <%= f.govuk_text_field :nino, autocomplete: 'off', width: 'one-third',
                                  extra_letter_spacing: true %>
         <% end %>

--- a/app/views/steps/submission/cannot_submit_without_nino/edit.html.erb
+++ b/app/views/steps/submission/cannot_submit_without_nino/edit.html.erb
@@ -19,8 +19,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= step_form @form_object do |f| %>
     <div class="govuk-!-margin-bottom-7">
-      <% @form_object.choices.each do |option| %>
-        <%= f.govuk_radio_button :will_enter_nino, option %>
+      <% @form_object.choices.each_with_index do |option, index| %>
+        <%= f.govuk_radio_button :will_enter_nino, option, link_errors: index.zero? %>
       <% end %>
     </div>
 

--- a/config/locales/cy/errors.yml
+++ b/config/locales/cy/errors.yml
@@ -1242,11 +1242,11 @@ cy:
               inclusion: Dewiswch pa mor aml maen nhw'n cael y taliad hwn
         steps/income/client/deductions_form:
           attributes:
-            base:
+            types:
               none_selected: Dewiswch a rhowch ddidyniad neu dewiswch nad oes didyniadau'n cael eu tynnu o gyflog eich cleient
         steps/income/partner/deductions_form:
           attributes:
-            base:
+            types:
               none_selected: Dewiswch a rhowch ddidyniad neu dewiswch nad oes didyniadau'n cael eu tynnu o gyflog eich cleient
         steps/income/client/deduction_fieldset_form: &deduction_fieldset_form
           summary:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1242,11 +1242,11 @@ en:
               inclusion: Select how often they get this payment
         steps/income/client/deductions_form:
           attributes:
-            base:
+            types:
               none_selected: Select and enter a deduction or select that your client does not have deductions taken from their pay
         steps/income/partner/deductions_form:
           attributes:
-            base:
+            types:
               none_selected: Select and enter a deduction or select that your client does not have deductions taken from their pay
         steps/income/client/deduction_fieldset_form: &deduction_fieldset_form
           summary:

--- a/spec/forms/steps/income/client/deductions_form_spec.rb
+++ b/spec/forms/steps/income/client/deductions_form_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Steps::Income::Client::DeductionsForm do
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:base, :none_selected)).to be(true)
+        expect(form.errors.of_kind?(:types, :none_selected)).to be(true)
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.describe Steps::Income::Client::DeductionsForm do
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:base, :none_selected)).to be(true)
+        expect(form.errors.of_kind?(:types, :none_selected)).to be(true)
       end
     end
 

--- a/spec/forms/steps/income/partner/deductions_form_spec.rb
+++ b/spec/forms/steps/income/partner/deductions_form_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Steps::Income::Partner::DeductionsForm do
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:base, :none_selected)).to be(true)
+        expect(form.errors.of_kind?(:types, :none_selected)).to be(true)
       end
     end
 
@@ -145,7 +145,7 @@ RSpec.describe Steps::Income::Partner::DeductionsForm do
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:base, :none_selected)).to be(true)
+        expect(form.errors.of_kind?(:types, :none_selected)).to be(true)
       end
     end
 

--- a/spec/views/steps/dwp/cannot_check_benefit_status/edit.html.erb_spec.rb
+++ b/spec/views/steps/dwp/cannot_check_benefit_status/edit.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/dwp/cannot_check_benefit_status/edit', type: :view do
+  subject(:render_view) { render template: 'steps/dwp/cannot_check_benefit_status/edit' }
+
+  let(:crime_application) { CrimeApplication.new }
+
+  let(:form_object) do
+    Steps::DWP::CannotCheckBenefitStatusForm.build(crime_application)
+  end
+
+  before do
+    view.class.include StepsHelper
+    assign(:form_object, form_object)
+    allow(view).to receive_messages(
+      current_crime_application: crime_application,
+      current_form_object: form_object
+    )
+    without_partial_double_verification do
+      allow(controller).to receive_messages(
+        controller_path: 'steps/dwp/cannot_check_benefit_status',
+        current_form_object: form_object
+      )
+    end
+    stub_template 'layouts/_step_header.html.erb' => ''
+
+    without_partial_double_verification do
+      allow(view).to receive(:step_form) do |record, opts = {}, &block|
+        view.form_for(record, { url: '/stub', method: :put }.merge(opts || {}), &block)
+      end
+    end
+
+    form_object.valid?
+  end
+
+  describe 'error summary accessibility' do
+    it 'links the error summary to an input that exists on the page' do
+      render_view
+
+      document = Capybara.string(rendered)
+      hrefs = document.all('.govuk-error-summary__list a').pluck(:href)
+
+      expect(hrefs).not_to be_empty
+      hrefs.each do |href|
+        expect(document).to have_css("##{href.delete_prefix('#')}")
+      end
+    end
+
+    it 'targets the first radio button in the group' do
+      render_view
+
+      document = Capybara.string(rendered)
+      href = document.first('.govuk-error-summary__list a')[:href]
+      target = document.find(href)
+
+      expect(target.tag_name).to eq('input')
+      expect(target[:type]).to eq('radio')
+      expect(target[:value]).to eq('yes')
+    end
+  end
+end

--- a/spec/views/steps/income/client/deductions/edit.html.erb_spec.rb
+++ b/spec/views/steps/income/client/deductions/edit.html.erb_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/income/client/deductions/edit', type: :view do
+  subject(:render_view) { render template: 'steps/income/client/deductions/edit' }
+
+  let(:crime_application) { CrimeApplication.new }
+  let(:employment) { Employment.create!(crime_application:) }
+
+  let(:form_object) do
+    Steps::Income::Client::DeductionsForm.new(crime_application:).tap do |form|
+      form.employment = employment
+    end
+  end
+
+  before do
+    view.class.include StepsHelper
+    assign(:form_object, form_object)
+    allow(view).to receive_messages(
+      current_crime_application: crime_application,
+      current_form_object: form_object
+    )
+    without_partial_double_verification do
+      allow(controller).to receive_messages(
+        controller_path: 'steps/income/client/deductions',
+        current_form_object: form_object
+      )
+    end
+    stub_template 'layouts/_step_header.html.erb' => ''
+
+    without_partial_double_verification do
+      allow(view).to receive(:step_form) do |record, opts = {}, &block|
+        view.form_for(record, { url: '/stub', method: :put }.merge(opts || {}), &block)
+      end
+    end
+
+    form_object.valid?
+  end
+
+  describe 'error summary accessibility when nothing is selected' do
+    it 'links the error summary to an input that exists on the page' do
+      render_view
+
+      document = Capybara.string(rendered)
+      hrefs = document.all('.govuk-error-summary__list a').pluck(:href)
+
+      expect(hrefs).not_to be_empty
+      hrefs.each do |href|
+        expect(document).to have_css("##{href.delete_prefix('#')}")
+      end
+    end
+
+    it 'targets the first deduction checkbox' do
+      render_view
+
+      document = Capybara.string(rendered)
+      href = document.first('.govuk-error-summary__list a')[:href]
+      target = document.find(href)
+
+      expect(target.tag_name).to eq('input')
+      expect(target[:type]).to eq('checkbox')
+      expect(target[:value]).to eq('income_tax')
+    end
+  end
+end

--- a/spec/views/steps/income/partner/deductions/edit.html.erb_spec.rb
+++ b/spec/views/steps/income/partner/deductions/edit.html.erb_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/income/partner/deductions/edit', type: :view do
+  subject(:render_view) { render template: 'steps/income/partner/deductions/edit' }
+
+  let(:crime_application) { CrimeApplication.new }
+  let(:employment) { Employment.create!(crime_application: crime_application, ownership_type: OwnershipType::PARTNER.to_s) }
+
+  let(:form_object) do
+    Steps::Income::Partner::DeductionsForm.new(crime_application:).tap do |form|
+      form.employment = employment
+    end
+  end
+
+  before do
+    view.class.include StepsHelper
+    assign(:form_object, form_object)
+    allow(view).to receive_messages(
+      current_crime_application: crime_application,
+      current_form_object: form_object
+    )
+    without_partial_double_verification do
+      allow(controller).to receive_messages(
+        controller_path: 'steps/income/partner/deductions',
+        current_form_object: form_object
+      )
+    end
+    stub_template 'layouts/_step_header.html.erb' => ''
+
+    without_partial_double_verification do
+      allow(view).to receive(:step_form) do |record, opts = {}, &block|
+        view.form_for(record, { url: '/stub', method: :put }.merge(opts || {}), &block)
+      end
+    end
+
+    form_object.valid?
+  end
+
+  describe 'error summary accessibility when nothing is selected' do
+    it 'links the error summary to an input that exists on the page' do
+      render_view
+
+      document = Capybara.string(rendered)
+      hrefs = document.all('.govuk-error-summary__list a').pluck(:href)
+
+      expect(hrefs).not_to be_empty
+      hrefs.each do |href|
+        expect(document).to have_css("##{href.delete_prefix('#')}")
+      end
+    end
+
+    it 'targets the first deduction checkbox' do
+      render_view
+
+      document = Capybara.string(rendered)
+      href = document.first('.govuk-error-summary__list a')[:href]
+      target = document.find(href)
+
+      expect(target.tag_name).to eq('input')
+      expect(target[:type]).to eq('checkbox')
+      expect(target[:value]).to eq('income_tax')
+    end
+  end
+end

--- a/spec/views/steps/shared/nino/edit.html.erb_spec.rb
+++ b/spec/views/steps/shared/nino/edit.html.erb_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/shared/nino/edit', type: :view do
+  subject(:render_view) { render template: 'steps/shared/nino/edit' }
+
+  let(:crime_application) { CrimeApplication.new }
+  let(:applicant) { Applicant.new(crime_application:) }
+
+  let(:form_object) do
+    Steps::Shared::NinoForm.new(crime_application: crime_application, record: applicant)
+  end
+
+  before do
+    view.class.include StepsHelper
+    assign(:form_object, form_object)
+    allow(view).to receive_messages(
+      current_crime_application: crime_application,
+      current_form_object: form_object
+    )
+    without_partial_double_verification do
+      allow(controller).to receive_messages(
+        controller_path: 'steps/shared/nino',
+        current_form_object: form_object
+      )
+    end
+    stub_template 'layouts/_step_header.html.erb' => ''
+
+    without_partial_double_verification do
+      allow(view).to receive(:step_form) do |record, opts = {}, &block|
+        view.form_for(record, { url: '/stub', method: :put }.merge(opts || {}), &block)
+      end
+    end
+
+    form_object.valid?
+  end
+
+  describe 'error summary accessibility' do
+    it 'links the error summary to an input that exists on the page' do
+      render_view
+
+      document = Capybara.string(rendered)
+      hrefs = document.all('.govuk-error-summary__list a').pluck(:href)
+
+      expect(hrefs).not_to be_empty
+      hrefs.each do |href|
+        expect(document).to have_css("##{href.delete_prefix('#')}")
+      end
+    end
+
+    it 'targets the first radio button in the group' do
+      render_view
+
+      document = Capybara.string(rendered)
+      href = document.first('.govuk-error-summary__list a')[:href]
+      target = document.find(href)
+
+      expect(target.tag_name).to eq('input')
+      expect(target[:type]).to eq('radio')
+      expect(target[:value]).to eq('yes')
+    end
+  end
+end

--- a/spec/views/steps/submission/cannot_submit_without_nino/edit.html.erb_spec.rb
+++ b/spec/views/steps/submission/cannot_submit_without_nino/edit.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/submission/cannot_submit_without_nino/edit', type: :view do
+  subject(:render_view) { render template: 'steps/submission/cannot_submit_without_nino/edit' }
+
+  let(:crime_application) { CrimeApplication.new }
+
+  let(:form_object) do
+    Steps::Submission::CannotSubmitWithoutNinoForm.build(crime_application)
+  end
+
+  before do
+    view.class.include StepsHelper
+    assign(:form_object, form_object)
+    allow(view).to receive_messages(
+      current_crime_application: crime_application,
+      current_form_object: form_object
+    )
+    without_partial_double_verification do
+      allow(controller).to receive_messages(
+        controller_path: 'steps/submission/cannot_submit_without_nino',
+        current_form_object: form_object
+      )
+    end
+    stub_template 'layouts/_step_header.html.erb' => ''
+
+    without_partial_double_verification do
+      allow(view).to receive(:step_form) do |record, opts = {}, &block|
+        view.form_for(record, { url: '/stub', method: :put }.merge(opts || {}), &block)
+      end
+    end
+
+    form_object.valid?
+  end
+
+  describe 'error summary accessibility' do
+    it 'links the error summary to an input that exists on the page' do
+      render_view
+
+      document = Capybara.string(rendered)
+      hrefs = document.all('.govuk-error-summary__list a').pluck(:href)
+
+      expect(hrefs).not_to be_empty
+      hrefs.each do |href|
+        expect(document).to have_css("##{href.delete_prefix('#')}")
+      end
+    end
+
+    it 'targets the first radio button in the group' do
+      render_view
+
+      document = Capybara.string(rendered)
+      href = document.first('.govuk-error-summary__list a')[:href]
+      target = document.find(href)
+
+      expect(target.tag_name).to eq('input')
+      expect(target[:type]).to eq('radio')
+      expect(target[:value]).to eq('yes')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Fixes an accessibility defect where activating a GOV.UK error summary link did not move keyboard/screen-reader focus to the input that needs correcting. The summary link's `href` pointed at a `…-<attribute>-field-error` id that was never rendered on the page, leaving the user at the top of the page.

The GOV.UK formbuilder only renders that anchor id when a radio/checkbox is built with `link_errors: true`. The affected pages either omitted it or attached the error to an attribute (`:base`) with no matching element.

Changes:
- **NINO** (`steps/shared/nino/edit`) — add `link_errors: true` to the first radio in the `has_arc_or_nino` group.
- **Cannot check benefit status** (`steps/dwp/cannot_check_benefit_status/edit`) — add `link_errors: index.zero?` to the first `will_enter_nino` radio.
- **Deductions** (client + partner) — the "nothing selected" validation error was added to `:base`, whose summary link (`#…-base-field-error`) had no target. Moved it to `:types` in `DeductionsValidator` (shared by both forms) and set `link_errors: index.zero?` on the first checkbox so the link resolves to it. Renamed the paired `base:` → `types:` locale keys (en + cy) so the message still resolves. (The nested amount/frequency summary links already resolved correctly.)

Tests:
- New view specs for all four templates asserting every error-summary link target exists on the page (verified they fail without the fix).
- Updated the two deductions form specs (`of_kind?(:base, …)` → `of_kind?(:types, …)`).
- RuboCop, erb_lint, and the affected unit/view/controller specs pass, plus the NINO and employed-with-partner system specs.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2139

## Notes for reviewer

- Focus/screen-reader behaviour is inherently a JS/AT path not exercised by automated tests; the new view specs assert the structural precondition (the summary link's `href` matches a real element id on the page), which is what enables the browser to move focus.
- Out of scope: the same `:base` + `link_errors: true` pattern exists on other checkbox pages (income payments/benefits, outgoings payments) and is a candidate for a follow-up ticket.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

_No visual change — the error summary and inline errors look the same; only the link target/focus behaviour changes._

## How to manually test the feature

1. Start (or resume) an application and go to the **"Does your client have a National Insurance number?"** page.
2. Leave the question unanswered and select **Save and continue**.
3. In the error summary, activate the **"Select whether…"** link (click, or Tab to it and press Enter).
4. Confirm the page scrolls to and focus moves to the first radio button in the group.
5. Repeat for the **"We cannot check your client's benefits status"** page (leave the yes/no question blank).
6. Repeat for the **Deductions** page (client and partner): submit with nothing selected and confirm the summary link moves focus to the first deduction checkbox.
