### PR TITLE
CRIMAPP-2126: Allow decimal input in money/percentage fields and add focused regressions

### DIFF
--- a/app/views/steps/capital/commercial_property/edit.html.erb
+++ b/app/views/steps/capital/commercial_property/edit.html.erb
@@ -15,10 +15,10 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :usage, autocomplete: 'off', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :value, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } if f.object.include_partner_in_means_assessment? %>
+      <%= f.govuk_number_field :value, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :outstanding_mortgage, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :percentage_applicant_owned, suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :percentage_partner_owned, suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } if f.object.include_partner_in_means_assessment? %>
       <% if f.object.person_has_home_address? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { tag: 'h2', size: 'm' } %>
       <% end %>

--- a/app/views/steps/capital/investments/edit.html.erb
+++ b/app/views/steps/capital/investments/edit.html.erb
@@ -15,7 +15,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_area :description, label: { tag: 'h2', size: 'm' }, autocomplete: 'off', hint: { text: hint_t(:description) }  %>
-      <%= f.govuk_number_field :value, label: { tag: 'h2', size: 'm' }, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+      <%= f.govuk_number_field :value, label: { tag: 'h2', size: 'm' }, prefix_text: '£', width: 'one-third' %>
 
       <%= render partial: 'steps/shared/ownership_form_fields', locals: { f: f, values: OwnershipType.values } %>
 

--- a/app/views/steps/capital/land/edit.html.erb
+++ b/app/views/steps/capital/land/edit.html.erb
@@ -16,10 +16,10 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_number_field :size_in_acres, inputmode: 'numeric', suffix_text: 'acres', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_text_field :usage, autocomplete: 'off', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :value, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } if f.object.include_partner_in_means_assessment? %>
+      <%= f.govuk_number_field :value, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :outstanding_mortgage, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :percentage_applicant_owned, suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :percentage_partner_owned, suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } if f.object.include_partner_in_means_assessment? %>
       <% if f.object.person_has_home_address? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { tag: 'h2', size: 'm' } %>
       <% end %>

--- a/app/views/steps/capital/national_savings_certificates/edit.html.erb
+++ b/app/views/steps/capital/national_savings_certificates/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :holder_number, autocomplete: 'off', label: { tag: 'h2', size: 'm' }, inputmode: 'numeric', extra_letter_spacing: true, width: 'one-half' %>
       <%= f.govuk_text_field :certificate_number, autocomplete: 'off', label: { tag: 'h2', size: 'm' }, inputmode: 'numeric', extra_letter_spacing: true, width: 'one-half' %>
-      <%= f.govuk_number_field :value, label: { tag: 'h2', size: 'm' }, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+      <%= f.govuk_number_field :value, label: { tag: 'h2', size: 'm' }, prefix_text: '£', width: 'one-third' %>
 
       <%= render partial: 'steps/shared/ownership_form_fields', locals: { f: f, values: OwnershipType.exclusive } %>
 

--- a/app/views/steps/capital/partner_premium_bonds/edit.html.erb
+++ b/app/views/steps/capital/partner_premium_bonds/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_radio_buttons_fieldset(:partner_has_premium_bonds, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
         <%= f.govuk_radio_button :partner_has_premium_bonds, YesNoAnswer::YES do %>
           <%= f.govuk_text_field :partner_premium_bonds_holder_number, autocomplete: 'off', extra_letter_spacing: true, width: 'one-third' %>
-          <%= f.govuk_number_field :partner_premium_bonds_total_value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :partner_premium_bonds_total_value, prefix_text: '£', width: 'one-third' %>
         <% end %>
 
         <%= f.govuk_radio_button :partner_has_premium_bonds, YesNoAnswer::NO %>

--- a/app/views/steps/capital/partner_trust_fund/edit.html.erb
+++ b/app/views/steps/capital/partner_trust_fund/edit.html.erb
@@ -10,8 +10,8 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset(:partner_will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }, hint: { text: t('.hint') }) do %>
         <%= f.govuk_radio_button :partner_will_benefit_from_trust_fund, YesNoAnswer::YES do %>
-          <%= f.govuk_number_field :partner_trust_fund_amount_held, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
-          <%= f.govuk_number_field :partner_trust_fund_yearly_dividend, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :partner_trust_fund_amount_held, prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :partner_trust_fund_yearly_dividend, prefix_text: '£', width: 'one-third' %>
         <% end %>
 
         <%= f.govuk_radio_button :partner_will_benefit_from_trust_fund, YesNoAnswer::NO %>

--- a/app/views/steps/capital/premium_bonds/edit.html.erb
+++ b/app/views/steps/capital/premium_bonds/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_radio_buttons_fieldset(:has_premium_bonds, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }) do %>
         <%= f.govuk_radio_button :has_premium_bonds, YesNoAnswer::YES do %>
           <%= f.govuk_text_field :premium_bonds_holder_number, autocomplete: 'off', extra_letter_spacing: true, width: 'one-third' %>
-          <%= f.govuk_number_field :premium_bonds_total_value, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :premium_bonds_total_value, prefix_text: '£', width: 'one-third' %>
         <% end %>
 
         <%= f.govuk_radio_button :has_premium_bonds, YesNoAnswer::NO %>

--- a/app/views/steps/capital/property_owners/edit.html.erb
+++ b/app/views/steps/capital/property_owners/edit.html.erb
@@ -28,7 +28,7 @@
               <%= po_field.govuk_text_field :other_relationship, autocomplete: 'off', width: 'one-third' %>
             <%end%>
           <% end %>
-          <%= po_field.govuk_number_field :percentage_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-quarter',
+          <%= po_field.govuk_number_field :percentage_owned, suffix_text: '%', width: 'one-quarter',
                                           label: { text: label_t("percentage_owned_#{@form_object.record.property_type}"), tag: 'h3', size: 'm' } %>
 
           <%= po_field.button t('.remove_button', index:), type: :submit, value: '1', name: po_field.field_name(:_destroy, index: po_field.id),

--- a/app/views/steps/capital/residential_property/edit.html.erb
+++ b/app/views/steps/capital/residential_property/edit.html.erb
@@ -25,10 +25,10 @@
       <% end %>
 
       <%= f.govuk_number_field :bedrooms, inputmode: 'numeric', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :value, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :outstanding_mortgage, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :percentage_applicant_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :percentage_partner_owned, inputmode: 'numeric', suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } if f.object.include_partner_in_means_assessment? %>
+      <%= f.govuk_number_field :value, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :outstanding_mortgage, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :percentage_applicant_owned, suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :percentage_partner_owned, suffix_text: '%', width: 'one-third', label: { tag: 'h2', size: 'm' } if f.object.include_partner_in_means_assessment? %>
       <% if f.object.person_has_home_address? %>
         <%= f.govuk_collection_radio_buttons :is_home_address, YesNoAnswer.values, :value, inline: true, legend: { tag: 'h2', size: 'm' } %>
       <% end %>

--- a/app/views/steps/capital/savings/edit.html.erb
+++ b/app/views/steps/capital/savings/edit.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_text_field :provider_name, autocomplete: 'off', label: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_text_field :sort_code, autocomplete: 'off', inputmode: 'numeric', extra_letter_spacing: true, width: 'one-half', label: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_text_field :account_number, autocomplete: 'off', inputmode: 'numeric', extra_letter_spacing: true, width: 'one-half', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :account_balance, inputmode: 'numeric', prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :account_balance, prefix_text: '£', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_collection_radio_buttons :is_overdrawn, YesNoAnswer.values, :value, inline: true, legend: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_collection_radio_buttons :are_wages_paid_into_account, YesNoAnswer.values, :value, inline: true, legend: { tag: 'h2', size: 'm' } %>
 

--- a/app/views/steps/capital/trust_fund/edit.html.erb
+++ b/app/views/steps/capital/trust_fund/edit.html.erb
@@ -10,8 +10,8 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset(:will_benefit_from_trust_fund, legend: { text: t('.heading'), tag: 'h1', size: 'xl' }, hint: { text: t('.hint') }) do %>
         <%= f.govuk_radio_button :will_benefit_from_trust_fund, YesNoAnswer::YES do %>
-          <%= f.govuk_number_field :trust_fund_amount_held, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
-          <%= f.govuk_number_field :trust_fund_yearly_dividend, inputmode: 'numeric', prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :trust_fund_amount_held, prefix_text: '£', width: 'one-third' %>
+          <%= f.govuk_number_field :trust_fund_yearly_dividend, prefix_text: '£', width: 'one-third' %>
         <% end %>
 
         <%= f.govuk_radio_button :will_benefit_from_trust_fund, YesNoAnswer::NO %>

--- a/app/views/steps/income/business_financials/edit.html.erb
+++ b/app/views/steps/income/business_financials/edit.html.erb
@@ -14,7 +14,6 @@
           <%= f.govuk_number_field :"#{attribute}_amount",
                                    autocomplete: 'off',
                                    label: { tag: 'h2', size: 'm' },
-                                   inputmode: 'numeric',
                                    width: 'one-third',
                                    prefix_text: '£' %>
 

--- a/app/views/steps/income/business_percentage_profit_share/edit.html.erb
+++ b/app/views/steps/income/business_percentage_profit_share/edit.html.erb
@@ -8,7 +8,6 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_number_field(:percentage_profit_share,
-                               inputmode: 'numeric',
                                suffix_text: '%',
                                width: 'one-half',
                                label: { text: legend_t(:percentage_profit_share), size: 'xl' }) %>

--- a/app/views/steps/income/client/deductions/edit.html.erb
+++ b/app/views/steps/income/client/deductions/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "deduction_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/app/views/steps/income/client/employment_details/edit.html.erb
+++ b/app/views/steps/income/client/employment_details/edit.html.erb
@@ -10,7 +10,7 @@
     <% @form_object.before_or_after_tax = @form_object.record.before_or_after_tax['value'] if @form_object.record.before_or_after_tax %>
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :job_title, autocomplete: 'off', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :amount, autocomplete: 'off', inputmode: 'numeric', width: 'one-third', prefix_text: '£', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :amount, autocomplete: 'off', width: 'one-third', prefix_text: '£', label: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_collection_radio_buttons(:before_or_after_tax, @form_object.before_or_after_tax_options, :value, legend: { tag: 'h3', size: 's', class: 'govuk-!-font-weight-regular' }) %>
       <%= f.govuk_collection_radio_buttons :frequency, PaymentFrequencyType.values, :value, legend: { tag: 'h3', size: 's', class: 'govuk-!-font-weight-regular' } %>
       <%= f.continue_button %>

--- a/app/views/steps/income/income_benefits/edit.html.erb
+++ b/app/views/steps/income/income_benefits/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "income_benefit_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/app/views/steps/income/income_benefits_partner/edit.html.erb
+++ b/app/views/steps/income/income_benefits_partner/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "income_benefit_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/app/views/steps/income/income_payments/edit.html.erb
+++ b/app/views/steps/income/income_payments/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "income_payment_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/app/views/steps/income/income_payments_partner/edit.html.erb
+++ b/app/views/steps/income/income_payments_partner/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "income_payment_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/app/views/steps/income/partner/deductions/edit.html.erb
+++ b/app/views/steps/income/partner/deductions/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "deduction_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/app/views/steps/income/partner/employment_details/edit.html.erb
+++ b/app/views/steps/income/partner/employment_details/edit.html.erb
@@ -10,7 +10,7 @@
     <% @form_object.before_or_after_tax = @form_object.record.before_or_after_tax['value'] if @form_object.record.before_or_after_tax %>
     <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :job_title, autocomplete: 'off', width: 'one-third', label: { tag: 'h2', size: 'm' } %>
-      <%= f.govuk_number_field :amount, autocomplete: 'off', inputmode: 'numeric', width: 'one-third', prefix_text: '£', label: { tag: 'h2', size: 'm' } %>
+      <%= f.govuk_number_field :amount, autocomplete: 'off', width: 'one-third', prefix_text: '£', label: { tag: 'h2', size: 'm' } %>
       <%= f.govuk_collection_radio_buttons(:before_or_after_tax, @form_object.before_or_after_tax_options, :value, legend: { tag: 'h3', size: 's', class: 'govuk-!-font-weight-regular' }) %>
       <%= f.govuk_collection_radio_buttons :frequency, PaymentFrequencyType.values, :value, legend: { tag: 'h3', size: 's', class: 'govuk-!-font-weight-regular' } %>
       <%= f.continue_button %>

--- a/app/views/steps/outgoings/outgoings_payments/edit.html.erb
+++ b/app/views/steps/outgoings/outgoings_payments/edit.html.erb
@@ -15,7 +15,6 @@
               <%= g.govuk_fieldset legend: nil, id: "outgoing_payment_#{type}" do %>
                 <%= g.govuk_number_field :amount,
                                          autocomplete: 'off',
-                                         inputmode: 'numeric',
                                          width: 'one-third',
                                          prefix_text: '£' %>
                 <%= g.govuk_collection_radio_buttons :frequency,

--- a/spec/system/applying/full_means_assessment/employed_with_partner_spec.rb
+++ b/spec/system/applying/full_means_assessment/employed_with_partner_spec.rb
@@ -1,6 +1,76 @@
 require 'rails_helper'
 
 RSpec.describe 'Apply for Criminal Legal Aid when Means Tested' do
+  describe 'Decimal values on client deductions page' do
+    include_context 'means tested with partner'
+
+    before do
+      # steps/income/what_is_clients_employment_status
+      choose_answers("What is your client's employment status?", ['Employed'])
+      save_and_continue
+
+      # steps/income/client/armed_forces
+      choose_answer('Is your client in the armed forces?', 'No')
+      save_and_continue
+
+      # steps/income/current_income_before_tax
+      choose_answer(
+        "Is your client and their partner's joint annual income more than £12,475 a year before tax?",
+        'Yes'
+      )
+      save_and_continue
+
+      # steps/income/client/employer_details/:job_id
+      fill_in("Employer's name", with: 'Ministry of Justice')
+      fill_in('Address line 1', with: 'Test address line 1')
+      fill_in('Address line 2', with: 'Test address line 2')
+      fill_in('Town or city', with: 'Test town')
+      fill_in('Country', with: 'Test Country')
+      fill_in('Postcode', with: 'Test postcode')
+      save_and_continue
+
+      # steps/income/client/employment_details/:job_id
+      fill_in('What is your client’s job title?', with: 'Software Developer')
+      fill_in('What is their salary or wage?', with: 35_000)
+      choose_answer('Is this before or after tax?', 'Before tax')
+      choose_answer('How often do they get this payment?', 'Monthly')
+      save_and_continue
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'persists a decimal National Insurance deduction without a numeric inputmode' do
+      choose_answers('Deductions', ['National Insurance'])
+
+      deductions_page_path = current_path
+      crime_application_id = deductions_page_path[%r{/applications/([^/]+)/}, 1]
+      employment_id = deductions_page_path.split('/').last
+
+      within('#deduction_national_insurance') do
+        national_insurance_input = find("input[name='steps_income_client_deductions_form[national_insurance][amount]']")
+        expect(national_insurance_input[:type]).to eq('number')
+        expect(national_insurance_input[:inputmode]).to be_nil
+
+        fill_in(national_insurance_input[:id], with: '123.83')
+        choose('Monthly')
+      end
+      save_and_continue
+
+      expect(page).to have_content('Do you want to add another job?')
+
+      crime_application = CrimeApplication.find(crime_application_id)
+      employment = crime_application.employments.find(employment_id)
+      deduction = employment.deductions.find_by!(deduction_type: 'national_insurance')
+      expect(deduction.amount).to eq(12_383)
+
+      visit deductions_page_path
+      within('#deduction_national_insurance') do
+        input = find("input[name='steps_income_client_deductions_form[national_insurance][amount]']")
+        expect(input.value).to eq('123.83')
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
   describe 'Submitting a means tested application with an employed client and partner' do
     include_context 'means tested with partner'
 

--- a/spec/system/applying/property_ownership_validation_spec.rb
+++ b/spec/system/applying/property_ownership_validation_spec.rb
@@ -214,6 +214,17 @@ RSpec.describe 'Apply for Criminal Legal Aid with cross-question property owners
       choose_answer('What do you want to do next?', 'Provide the details of this property')
       save_and_continue
 
+      [
+        'How much is the property worth?',
+        'How much is left to pay on the mortgage?',
+        'What percentage of the property does your client own?'
+      ].each do |label|
+        input = find_field(label)
+
+        expect(input[:type]).to eq('number')
+        expect(input[:inputmode]).to be_nil
+      end
+
       # steps/capital/residential-property/{property_id}
       choose_answer('Which type of property is it?', 'Terraced')
       fill_in('How many bedrooms are there?', with: '2')


### PR DESCRIPTION
## Description of change
CRIMAPP-2126: Allow decimal input in money/percentage fields and add focused regressions

- Remove `inputmode: 'numeric'` from decimal-capable monetary fields across income, capital, and outgoings forms
- Remove `inputmode: 'numeric'` from decimal-capable percentage fields (property ownership and business percentage share)
- Keep `inputmode: 'numeric'` on integer-style inputs (for example age, bedrooms, account/reference numbers)

- Add focused system regression for client deductions:
  - assert National Insurance amount input is `type="number"` and has no `inputmode="numeric"`
  - submit `123.83`, assert successful navigation
  - verify persistence as `12_383` pence
  - revisit page and verify value redisplays as `123.83`

- Add focused rendered-attribute assertions in existing residential property journey:
  - property value has no `inputmode="numeric"`
  - outstanding mortgage has no `inputmode="numeric"`
  - percentage owned has no `inputmode="numeric"`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2126

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
On an iPhone or iOS Simulator, visit each affected financial page—at minimum **Deductions** and **Residential property owned by your client**—tap every currency field and confirm the keyboard includes a decimal point; enter an amount such as `123.83`, submit the page, then return to it and confirm the value was accepted and saved correctly. Repeat a quick check on representative income, outgoings and capital fields, confirm whole-pound amounts still work, validation behaves correctly for invalid input, and digits-only fields such as number of bedrooms still show a numeric keyboard.

