### PR TITLE
Fix asset and styling bugs

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -1,8 +1,11 @@
 @use "govuk-frontend/dist/govuk" as *;
+@use "govuk-frontend/dist/govuk/core/global-styles.mixin" as global-styles;
 
 // App-specific custom styles and overrides
 // Please use BEM convention: http://getbem.com/naming/
 //
+
+@include global-styles.govuk-global-styles;
 
 @mixin app-button-reset {
   padding: 0;
@@ -215,7 +218,7 @@ $app-blue-button-colour: govuk-colour("blue");
 form.search {
   padding-top: 2em;
   padding-left: 2em;
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   .input-group {
     display: flex;
     .govuk-form-group {

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -4,6 +4,10 @@
 // NOTE: using hand-picked components instead of importing
 // the whole library, as we only need a few ones.
 
+@use "@ministryofjustice/frontend/moj/settings/all" with (
+  $moj-assets-path: "/"
+);
+
 // Badge
 // https://design-patterns.service.justice.gov.uk/components/badge/
 @use "@ministryofjustice/frontend/moj/components/badge/badge";

--- a/app/assets/stylesheets/local/suggestions.scss
+++ b/app/assets/stylesheets/local/suggestions.scss
@@ -7,7 +7,7 @@
   border-width: $govuk-border-width-form-element $govuk-border-width-form-element 0 $govuk-border-width-form-element;
   border-style: solid;
   border-color: currentColor;
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 }
 
 .govuk-input__suggestions-list {


### PR DESCRIPTION
## Description of change
This change fixes a couple of UI bugs and removes deprecated styling.

The bugs:
1. GOV.UK styling was no longer being applied globally, causing some `<p>` and `<a>` elements to be unstyled (see screenshots below).
2. Asset loading was not configured properly, preventing certain assets from appearing on the page -- most notably, the crest in the footer (see screenshots below).

Deprecated code:
1. Use `govuk-colour("black", $variant: "tint-95")` instead of `govuk-colour("light-grey")` .

## Screenshots of changes (if applicable)

### Before changes:
<img width="1320" height="1064" alt="Screenshot 2026-08-07 at 11-03-19 Does your client have a partner - Apply for criminal legal aid - GOV UK" src="https://github.com/user-attachments/assets/e3037321-e6d7-4448-b442-0ed3e632873d" />
<img width="1920" height="82" alt="Screenshot 2026-08-07 at 11-46-53 Does your client have a partner - Apply for criminal legal aid - GOV UK" src="https://github.com/user-attachments/assets/4363ea88-ef15-4d1c-9812-1ee72382c76f" />
<img width="2028" height="454" alt="Screenshot 2026-08-07 at 11-47-15 Does your client get one of these passporting benefits - Apply for criminal legal aid - GOV UK" src="https://github.com/user-attachments/assets/f7efd1b6-6d4f-47d0-9d47-806ac5a7c6d7" />

### After changes:
<img width="1306" height="1112" alt="Screenshot 2026-08-07 at 14-49-06 Does your client have a partner - Apply for criminal legal aid - GOV UK" src="https://github.com/user-attachments/assets/17c6a6c2-ca51-47d6-ae9a-d9034f20bba7" />
<img width="1920" height="82" alt="Screenshot 2026-08-07 at 14-48-26 We signed you out - Apply for criminal legal aid - GOV UK" src="https://github.com/user-attachments/assets/164fadf3-4ad0-472e-a339-46289c428631" />
<img width="2020" height="574" alt="Screenshot 2026-08-07 at 14-48-17 We signed you out - Apply for criminal legal aid - GOV UK" src="https://github.com/user-attachments/assets/455b5452-31c4-40d6-8f57-75ee126de1c7" />


## How to manually test the feature
Once merged, verify that the styling is as expected on staging.