### PR TITLE
Update deprecated simplecov code

### DIFF
--- a/app/controllers/concerns/steps/capital/property_update_step.rb
+++ b/app/controllers/concerns/steps/capital/property_update_step.rb
@@ -42,7 +42,7 @@ module Steps
         @properties ||= current_crime_application.properties
       end
 
-      # :nocov:
+      # simplecov:disable
       def advance_as
         raise NotImplementedError
       end
@@ -54,7 +54,7 @@ module Steps
       def flash_msg
         nil
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/app/controllers/concerns/steps/income/employment_update_step.rb
+++ b/app/controllers/concerns/steps/income/employment_update_step.rb
@@ -23,7 +23,7 @@ module Steps
         raise Errors::EmploymentNotFound
       end
 
-      # :nocov:
+      # simplecov:disable
       def employments
         raise NotImplementedError
       end
@@ -39,7 +39,7 @@ module Steps
       def flash_msg
         nil
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/app/controllers/concerns/steps/no_op_advance_step.rb
+++ b/app/controllers/concerns/steps/no_op_advance_step.rb
@@ -16,10 +16,10 @@ module Steps
 
     private
 
-    # :nocov:
+    # simplecov:disable
     def advance_as
       raise 'implement in controllers using this concern'
     end
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,11 +10,11 @@ class DashboardController < ApplicationController
   private
 
   # Implement in sub-controllers to narrow down allowed columns
-  # :nocov:
+  # simplecov:disable
   def sortable_columns
     []
   end
-  # :nocov:
+  # simplecov:enable
 
   def in_progress_count
     in_progress_scope.count

--- a/app/controllers/developer_tools/crime_applications_controller.rb
+++ b/app/controllers/developer_tools/crime_applications_controller.rb
@@ -1,4 +1,4 @@
-# :nocov:
+# simplecov:disable
 module DeveloperTools
   class CrimeApplicationsController < ApplicationController # rubocop:disable Metrics/ClassLength
     def destroy
@@ -126,4 +126,4 @@ module DeveloperTools
     end
   end
 end
-# :nocov:
+# simplecov:enable

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,4 +1,4 @@
-# :nocov:
+# simplecov:disable
 class DocumentsController < ApplicationController
   before_action :check_crime_application_presence
   before_action :set_document, only: :download
@@ -78,4 +78,4 @@ class DocumentsController < ApplicationController
     end
   end
 end
-# :nocov:
+# simplecov:enable

--- a/app/controllers/steps/base_step_controller.rb
+++ b/app/controllers/steps/base_step_controller.rb
@@ -6,7 +6,7 @@ module Steps
     before_action :update_navigation_stack, only: [:show, :edit]
     before_action :set_security_headers
 
-    # :nocov:
+    # simplecov:disable
     def show
       raise 'implement this action, if needed, in subclasses'
     end
@@ -18,7 +18,7 @@ module Steps
     def update
       raise 'implement this action, if needed, in subclasses'
     end
-    # :nocov:
+    # simplecov:enable
 
     private
 

--- a/app/forms/concerns/steps/usual_property_details.rb
+++ b/app/forms/concerns/steps/usual_property_details.rb
@@ -21,10 +21,10 @@ module Steps
 
     private
 
-    # :nocov:
+    # simplecov:disable
     def persist!
       true
     end
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/app/forms/steps/base_form_object.rb
+++ b/app/forms/steps/base_form_object.rb
@@ -80,11 +80,11 @@ module Steps
 
     private
 
-    # :nocov:
+    # simplecov:disable
     def persist!
       raise 'Subclasses of BaseFormObject need to implement #persist!'
     end
-    # :nocov:
+    # simplecov:enable
 
     # Override in subclass where needed. For example, to reset attributes.
     def before_save; end

--- a/app/forms/steps/evidence/upload_form.rb
+++ b/app/forms/steps/evidence/upload_form.rb
@@ -22,11 +22,11 @@ module Steps
         )
       end
 
-      # :nocov:
+      # simplecov:disable
       def persist!
         true
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/app/forms/steps/income/client/deductions_form.rb
+++ b/app/forms/steps/income/client/deductions_form.rb
@@ -68,7 +68,7 @@ module Steps
           DeductionFieldsetForm
         end
 
-        # :nocov:
+        # simplecov:disable
         # Precedence: submitted values, stored values, empty Deduction
         def find_or_create_deduction(type) # rubocop:disable Metrics/AbcSize
           if types.include?(type.to_s) && @new_deductions&.key?(type.value.to_s)
@@ -81,7 +81,7 @@ module Steps
 
           Deduction.new(employment: employment, deduction_type: type.to_s)
         end
-        # :nocov:
+        # simplecov:enable
 
         # Individual deductions_fieldset_forms are in charge of saving themselves
         def persist!

--- a/app/lib/devise/custom_failure_app.rb
+++ b/app/lib/devise/custom_failure_app.rb
@@ -18,9 +18,9 @@ module Devise
       when :locked
         redirect_to account_locked_errors_path
       else
-        # :nocov:
+        # simplecov:disable
         super
-        # :nocov:
+        # simplecov:enable
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/lib/prometheus_metrics/collectors/base_collector.rb
+++ b/app/lib/prometheus_metrics/collectors/base_collector.rb
@@ -11,11 +11,11 @@ module PrometheusMetrics
         5.minutes
       end
 
-      # :nocov:
+      # simplecov:disable
       def description
         raise 'implement in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
 
       private
 

--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -11,7 +11,7 @@ module PrometheusMetrics
       PrometheusMetrics::Collectors::ProviderDataApiRequestsCollector,
     ].freeze
 
-    # :nocov:
+    # simplecov:disable
     def self.should_configure?
       return false if ENV.key?('SKIP_PROMETHEUS_EXPORTER')
 
@@ -70,6 +70,6 @@ module PrometheusMetrics
       # instrumentation will need to be changed
       PrometheusExporter::Instrumentation::ActiveRecord.start
     end
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/app/lib/refinements/present_collection.rb
+++ b/app/lib/refinements/present_collection.rb
@@ -1,6 +1,6 @@
 module Refinements
   module PresentCollection
-    # :nocov:
+    # simplecov:disable
     def present_each(presenter)
       each do |obj|
         yield presenter.new(obj)
@@ -12,6 +12,6 @@ module Refinements
         presenter.new(obj)
       end
     end
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/app/lib/usn_seq_helper.rb
+++ b/app/lib/usn_seq_helper.rb
@@ -1,4 +1,4 @@
-# :nocov:
+# simplecov:disable
 class UsnSeqHelper
   # More details about USN, the sequence start, etc:
   # https://dsdmoj.atlassian.net/wiki/spaces/CRIMAP/pages/4210524301/USN
@@ -71,4 +71,4 @@ class UsnSeqHelper
     end
   end
 end
-# :nocov:
+# simplecov:enable

--- a/app/models/concerns/routing.rb
+++ b/app/models/concerns/routing.rb
@@ -5,9 +5,9 @@ module Routing
     include Rails.application.routes.url_helpers
   end
 
-  # :nocov:
+  # simplecov:disable
   def default_url_options
     I18n.locale == I18n.default_locale ? {} : { locale: I18n.locale }
   end
-  # :nocov:
+  # simplecov:enable
 end

--- a/app/presenters/summary/components/base_answer.rb
+++ b/app/presenters/summary/components/base_answer.rb
@@ -44,11 +44,11 @@ module Summary
         )
       end
 
-      # :nocov:
+      # simplecov:disable
       def answer_text
         raise 'must be implemented in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
 
       def absence_answer
         I18n.t("summary.questions.#{question}.absence_answer")

--- a/app/presenters/summary/components/base_record.rb
+++ b/app/presenters/summary/components/base_record.rb
@@ -86,7 +86,7 @@ module Summary
         [summary_link]
       end
 
-      # :nocov:
+      # simplecov:disable
       def answers
         raise 'must be implemented in subclasses'
       end
@@ -102,7 +102,7 @@ module Summary
       def remove_path
         raise 'must be implemented in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
 
       def count
         return unless record_iteration

--- a/app/presenters/summary/sections/base_capital_records_section.rb
+++ b/app/presenters/summary/sections/base_capital_records_section.rb
@@ -28,7 +28,7 @@ module Summary
         )
       end
 
-      # :nocov: #
+      # simplecov:disable
       def item_component_class
         raise 'must be implemented in subclasses'
       end
@@ -44,7 +44,7 @@ module Summary
       def has_records_answer
         raise 'must be implemented in subclasses'
       end
-      # :nocov: #
+      # simplecov:enable
     end
   end
 end

--- a/app/presenters/summary/sections/base_section.rb
+++ b/app/presenters/summary/sections/base_section.rb
@@ -80,11 +80,11 @@ module Summary
         SubjectType.new(:applicant)
       end
 
-      # :nocov:
+      # simplecov:disable
       def answers
         raise 'must be implemented in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/app/presenters/summary/sections/payment_details.rb
+++ b/app/presenters/summary/sections/payment_details.rb
@@ -37,11 +37,11 @@ module Summary
 
       private
 
-      # :nocov:
+      # simplecov:disable
       def no_payments?
         raise 'must be implemented in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
 
       def ordered_payments
         payment_types.index_with { |val| payment_of_type(val) }

--- a/app/presenters/tasks/base_task.rb
+++ b/app/presenters/tasks/base_task.rb
@@ -55,7 +55,7 @@ module Tasks
       validator.complete?
     end
 
-    # :nocov:
+    # simplecov:disable
     def can_start?
       raise 'implement in task subclasses'
     end
@@ -69,6 +69,6 @@ module Tasks
     def validator
       raise 'implement in task subclasses'
     end
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/app/serializers/submission_serializer/definitions/base_definition.rb
+++ b/app/serializers/submission_serializer/definitions/base_definition.rb
@@ -15,11 +15,11 @@ module SubmissionSerializer
         end
       end
 
-      # :nocov:
+      # simplecov:disable
       def to_builder
         raise 'must be implemented in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/app/serializers/submission_serializer/sections/base_section.rb
+++ b/app/serializers/submission_serializer/sections/base_section.rb
@@ -26,17 +26,17 @@ module SubmissionSerializer
       end
 
       # TODO: this in theory will come from a DB attribute
-      # :nocov:
+      # simplecov:disable
       def current_version
         1.0
       end
-      # :nocov:
+      # simplecov:enable
 
-      # :nocov:
+      # simplecov:disable
       def to_builder
         raise 'must be implemented in subclasses'
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/app/services/adapters/structs/case_details.rb
+++ b/app/services/adapters/structs/case_details.rb
@@ -1,13 +1,13 @@
 module Adapters
   module Structs
     class CaseDetails < BaseStructAdapter
-      # :nocov:
+      # simplecov:disable
       def case_type
         return super unless super == CaseType::APPEAL_TO_CROWN_COURT_WITH_CHANGES.to_s
 
         CaseType::APPEAL_TO_CROWN_COURT
       end
-      # :nocov:
+      # simplecov:enable
 
       def charges
         offences.map do |struct|

--- a/app/services/datastore/application_rehydration.rb
+++ b/app/services/datastore/application_rehydration.rb
@@ -85,7 +85,7 @@ module Datastore
       fields_from_applicant = %w[has_partner relationship_to_partner relationship_status separation_date]
       from_applicant = parent.applicant.serializable_hash.slice(*fields_from_applicant)
 
-      # :nocov:
+      # simplecov:disable
       if parent.partner
         fields_from_partner = %w[involvement_in_case conflict_of_interest has_same_address_as_client]
         from_partner = parent.partner.serializable_hash.slice(*fields_from_partner)
@@ -93,7 +93,7 @@ module Datastore
       else
         PartnerDetail.new({}.merge(from_applicant))
       end
-      # :nocov:
+      # simplecov:enable
     end
 
     def ioj

--- a/app/services/decisions/base_decision_tree.rb
+++ b/app/services/decisions/base_decision_tree.rb
@@ -19,7 +19,7 @@ module Decisions
       @partner ||= current_crime_application.partner
     end
 
-    # :nocov:
+    # simplecov:disable
     def show(step_controller, params = {})
       url_options(step_controller, :show, params)
     end
@@ -32,6 +32,6 @@ module Decisions
       { controller: controller, action: action, id: current_crime_application }.merge(params)
     end
 
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/app/services/evidence/rule.rb
+++ b/app/services/evidence/rule.rb
@@ -80,9 +80,9 @@ module Evidence
               persona: persona
             )
           else
-            # :nocov:
+            # simplecov:disable
             false
-            # :nocov:
+            # simplecov:enable
           end
         end
       end

--- a/app/services/evidence/ruleset/base.rb
+++ b/app/services/evidence/ruleset/base.rb
@@ -42,9 +42,9 @@ module Evidence
         if block
           Array.wrap(rules).each(&block)
         else
-          # :nocov:
+          # simplecov:disable
           to_enum(:each)
-          # :nocov:
+          # simplecov:enable
         end
       end
 

--- a/app/services/passporting/base_passporter.rb
+++ b/app/services/passporting/base_passporter.rb
@@ -9,7 +9,7 @@ module Passporting
       @crime_application = crime_application
     end
 
-    # :nocov:
+    # simplecov:disable
     def call
       raise 'implement in subclasses'
     end
@@ -21,7 +21,7 @@ module Passporting
     def passport_types_collection
       raise 'implement in subclasses'
     end
-    # :nocov:
+    # simplecov:enable
 
     private
 

--- a/app/validators/base_answer_validator.rb
+++ b/app/validators/base_answer_validator.rb
@@ -8,7 +8,7 @@ class BaseAnswerValidator
 
   delegate :errors, to: :record
 
-  # :nocov:
+  # simplecov:disable
   def applicable?
     raise 'implement in task subclasses'
   end
@@ -20,5 +20,5 @@ class BaseAnswerValidator
   def validate
     raise 'implement in task subclasses'
   end
-  # :nocov:
+  # simplecov:enable
 end

--- a/app/validators/base_fulfilment_validator.rb
+++ b/app/validators/base_fulfilment_validator.rb
@@ -19,11 +19,11 @@ class BaseFulfilmentValidator < ActiveModel::Validator
 
   # More validations can be added here
   # Errors, when more than one, will maintain the order
-  # :nocov:
+  # simplecov:disable
   def perform_validations
     raise 'implement in subclasses'
   end
-  # :nocov:
+  # simplecov:enable
 
   def evidence_present?
     record.documents.stored.any?

--- a/app/validators/base_payments_validator.rb
+++ b/app/validators/base_payments_validator.rb
@@ -16,11 +16,11 @@ class BasePaymentsValidator < ActiveModel::Validator
     record.errors.add(:base, :none_selected) if has_no_payments?
   end
 
-  # :nocov:
+  # simplecov:disable
   def has_no_payments?
     raise 'must be implemented in subclasses'
   end
-  # :nocov:
+  # simplecov:enable
 
   private
 

--- a/app/validators/deductions_validator.rb
+++ b/app/validators/deductions_validator.rb
@@ -28,12 +28,12 @@ class DeductionsValidator < ActiveModel::Validator
         message: error_message(deduction, error)
       )
 
-      # :nocov:
+      # simplecov:disable
       # We define the attribute getter as it doesn't really exist
       record.define_singleton_method(attr_name) do
         deduction.public_send(error.attribute)
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 

--- a/app/validators/employment_details/answers_validator.rb
+++ b/app/validators/employment_details/answers_validator.rb
@@ -36,7 +36,7 @@ module EmploymentDetails
       income.date_job_lost.present?
     end
 
-    # :nocov:
+    # simplecov:disable
     def validate_client_employment
       return unless employed?
 
@@ -44,7 +44,7 @@ module EmploymentDetails
       validate_employment_details
       validate_employment_income
     end
-    # :nocov:
+    # simplecov:enable
 
     def validate_employment_details
       return unless requires_full_means_assessment?

--- a/app/validators/partner_employment_details/answers_validator.rb
+++ b/app/validators/partner_employment_details/answers_validator.rb
@@ -26,7 +26,7 @@ module PartnerEmploymentDetails
       requires_means_assessment? && include_partner_in_means_assessment?
     end
 
-    # :nocov:
+    # simplecov:disable
     def validate_partner_employment
       return unless income.partner_employed?
 
@@ -34,7 +34,7 @@ module PartnerEmploymentDetails
       validate_employment_details
       validate_employment_income
     end
-    # :nocov:
+    # simplecov:enable
 
     def validate_employment_details
       return unless requires_full_means_assessment?

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -29,7 +29,7 @@ class ValueObject
     # i.e. `#coffee?` returns true for value `:coffee`, false for `:tea`
     def inherited(subclass)
       TracePoint.trace(:end) do |trace|
-        # :nocov:
+        # simplecov:disable
         if subclass == trace.self
           subclass.const_set(
             :INQUIRY_METHODS, subclass.values.map { |value| :"#{value}?" }
@@ -39,7 +39,7 @@ class ValueObject
             subclass.define_method(:"#{value}?") { value.eql?(self) }
           end
         end
-        # :nocov:
+        # simplecov:enable
       end
 
       super

--- a/lib/generators/evidence/rule_generator.rb
+++ b/lib/generators/evidence/rule_generator.rb
@@ -1,4 +1,4 @@
-# :nocov:
+# simplecov:disable
 module Evidence
   class RuleGenerator < Rails::Generators::Base
     class_option :key, type: :string, default: :rule_key_from_confluence
@@ -126,4 +126,4 @@ module Evidence
     end
   end
 end
-# :nocov:
+# simplecov:enable

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,15 +6,15 @@ unless ENV['COVERAGE'] == 'false'
   SimpleCov.start 'rails' do
     minimum_coverage 100 unless ENV['CI_NODE_INDEX']
 
-    add_filter 'app/mailers/application_mailer.rb'
-    add_filter 'app/jobs/application_job.rb'
-    add_filter 'config/initializers'
-    add_filter 'config/routes.rb'
-    add_filter 'lib/rubocop/'
-    add_filter 'spec/'
+    skip 'app/mailers/application_mailer.rb'
+    skip 'app/jobs/application_job.rb'
+    skip 'config/initializers'
+    skip 'config/routes.rb'
+    skip 'lib/rubocop/'
+    skip 'spec/'
 
     # Track all application files to ensure consistent coverage across parallel runs
-    track_files '{app,lib}/**/*.rb'
+    cover '{app,lib}/**/*.rb'
 
     # Support for parallel CI runs - each runner saves results with unique ID
     command_name "Job #{ENV['GITHUB_JOB']}-#{ENV['CI_NODE_INDEX']}" if ENV['GITHUB_JOB'] && ENV['CI_NODE_INDEX']


### PR DESCRIPTION
## Description of change
- Update the `simplecov` configuration to use the new API, introduced in version `1.0.0`
- Replace the deprecated `:nocov:` comments with `simplecov:disable` / `simplecov:enable`

Relevant simplecov docs:
https://github.com/simplecov-ruby/simplecov/blob/main/CHANGELOG.md#deprecations
https://github.com/simplecov-ruby/simplecov/blob/main/README.md#migrating-from-the-legacy-configuration-api