### PR TITLE
CRIMAPP-2128 Reflect search results outcome in page title

### DIFF
--- a/app/views/application_searches/new.html.erb
+++ b/app/views/application_searches/new.html.erb
@@ -1,4 +1,4 @@
-<% title 'Search' %>
+<% title t('search.page_title') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'shared/contingent_liability_notice' %>

--- a/app/views/application_searches/search.html.erb
+++ b/app/views/application_searches/search.html.erb
@@ -1,4 +1,8 @@
-<% title 'Search' %>
+<% if @search.results.empty? %>
+  <% title [t('search.no_results_title'), t('search.page_title')].join(' - ') %>
+<% else %>
+  <% title [t('search.total', count: @search.total), t('search.page_title')].join(' - ') %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'shared/contingent_liability_notice' %>

--- a/config/locales/cy/dashboard.yml
+++ b/config/locales/cy/dashboard.yml
@@ -4,6 +4,8 @@ cy:
     total:
       one: 1 canlyniad chwilio
       other: "%{count} canlyniad chwilio"
+    page_title: Chwilio ceisiadau
+    no_results_title: Dim canlyniadau chwilio
     heading: Chwilio ceisiadau sydd wedi'u cyflwyno
     subheading: Rydych chi'n chwilio drwy geisiadau sydd wedi'u cyflwyno a'u dychwelyd o dan y rhif cyfrif swyddfa %{current_office_code}.
   table_headings:

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -5,6 +5,8 @@ en:
     total:
       one: 1 search result
       other: "%{count} search results"
+    page_title: Search applications
+    no_results_title: No search results
     heading: Search submitted applications
     subheading: You are searching submitted and returned applications under office account number %{current_office_code}.
   table_headings:

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe 'Search', :authorized do
     it 'shows a list of submitted applications' do
       expect(response).to have_http_status(:success)
 
+      assert_select 'title', '2 search results - Search applications - Apply for criminal legal aid - GOV.UK'
       assert_select 'h1', 'Search submitted applications'
       assert_select 'h2', '2 search results'
-
       assert_select 'tbody.govuk-table__body' do
         assert_select 'tr.govuk-table__row', 2 do
           assert_select 'a', count: 1, text: 'Kit Pound'
@@ -77,6 +77,7 @@ RSpec.describe 'Search', :authorized do
       it 'informs the user that there are no applications' do
         expect(response).to have_http_status(:success)
 
+        assert_select 'title', 'No search results - Search applications - Apply for criminal legal aid - GOV.UK'
         assert_select 'h1', 'Search submitted applications'
         assert_select 'h2', 'There are no results that match the criteria'
       end


### PR DESCRIPTION
## Description of change

On the *Search applications* page, submitting a search reloads the page and shows a bold results-count heading (e.g. "7 search results") for sighted users. The document `<title>` did not reflect this outcome. Since screen readers announce the page title first on reload, assistive-technology users received no immediate feedback about whether results were found.

This change prefixes the search outcome to the page title so screen reader users get the same immediate feedback on reload, without any visible interface change.

Changes:
- Page title now leads with the outcome: `2 search results - Search applications - Apply for criminal legal aid - GOV.UK`, or `No search results - Search applications - ...` when nothing matches.
- Standardised the pre-search form title to `Search applications - ...` for consistency.
- Added `search.page_title` / `search.no_results_title` locale keys (EN + CY parity).

Tests:
- Added `assert_select 'title', ...` assertions to `spec/requests/search_spec.rb` for both results and no-results cases.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2128

## Notes for reviewer

Visible content is unchanged — only the document `<title>` is updated. The on-page H1 still reads "Search submitted applications" (`search.heading`); only the title uses the shorter "Search applications" wording. The screen-reader announcement on page reload is not covered by automated tests and should be verified manually with a screen reader.

## Screenshots of changes (if applicable)

_No visual change._

## How to manually test the feature

1. Sign in and select an office account.
2. Go to the Search applications page.
3. Enter a query that returns results and submit. Inspect the browser tab / `<title>` — it should start with the results count, e.g. `2 search results - Search applications - Apply for criminal legal aid - GOV.UK`.
4. Enter a query that returns no results and submit. The `<title>` should start with `No search results - Search applications - ...`.
5. Optionally, using a screen reader, confirm the outcome is announced immediately when the page reloads.
