### PR TITLE
CRIMAPP-2141 Associate delete links with application name for screen readers

### DIFF
--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -25,7 +25,7 @@
           <% @applications.present_each(CrimeApplicationPresenter) do |app| %>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
-                <%= govuk_link_to app.applicant_name, edit_crime_application_path(app), no_visited_state: true %>
+                <%= govuk_link_to app.applicant_name, edit_crime_application_path(app), id: "application-name-#{app.reference}", no_visited_state: true %>
               </th>
               <td class="govuk-table__cell">
                 <%= l(app.created_at) %>
@@ -37,7 +37,7 @@
                 <%= t("crime_applications.index.application_type.#{app.application_type}") %>
               </td>
               <td class="govuk-table__cell">
-                <%= govuk_link_to t('.delete_button'), confirm_destroy_crime_application_path(app) %>
+                <%= govuk_link_to t('.delete_button'), confirm_destroy_crime_application_path(app), aria: { describedby: "application-name-#{app.reference}" } %>
               </td>
             </tr>
           <% end %>

--- a/app/views/returned_applications/index.html.erb
+++ b/app/views/returned_applications/index.html.erb
@@ -23,7 +23,7 @@
           <% @search.results.each do |result| %>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
-                <%= govuk_link_to result.applicant_name, completed_crime_application_path(result), no_visited_state: true %>
+                <%= govuk_link_to result.applicant_name, completed_crime_application_path(result), id: "application-name-#{result.reference}", no_visited_state: true %>
               </th>
               <td class="govuk-table__cell">
                 <%= l(result.submitted_at) %>
@@ -35,7 +35,7 @@
                 <%= t("crime_applications.index.application_type.#{result.application_type}") %>
               </td>
               <td class="govuk-table__cell">
-                <%= govuk_link_to t('.delete_button'), confirm_destroy_returned_application_path(result), no_visited_state: true %>
+                <%= govuk_link_to t('.delete_button'), confirm_destroy_returned_application_path(result), aria: { describedby: "application-name-#{result.reference}" }, no_visited_state: true %>
               </td>
             </tr>
           <% end %>

--- a/config/locales/cy/dashboard.yml
+++ b/config/locales/cy/dashboard.yml
@@ -41,7 +41,6 @@ cy:
         change_in_financial_circumstances: Newid mewn sefyllfa ariannol
       page_title: Eich ceisiadau
       delete_button: Dileu
-      delete_button_a11y: Dileu cais %{applicant_name}
       status:
         in_progress: Yn mynd rhagddo
         submitted: Wedi cyflwyno

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -42,7 +42,6 @@ en:
         post_submission_evidence: Post submission evidence
       page_title: Your applications
       delete_button: Delete
-      delete_button_a11y: Delete %{applicant_name}’s application
       status:
         in_progress: In progress
         submitted: Submitted

--- a/spec/requests/dashboard_lists_spec.rb
+++ b/spec/requests/dashboard_lists_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe 'Dashboard', :authorized do
 
         expect(response.body).not_to include('Jane Doe')
       end
+
+      it 'programmatically associates each Delete link with its application name' do
+        assert_select 'tbody.govuk-table__body tr.govuk-table__row' do |rows|
+          rows.each do |row|
+            name_link = row.at_css('th a')
+            delete_link = row.at_css('td.govuk-table__cell:nth-of-type(4) a')
+
+            expect(name_link['id']).to be_present
+            expect(delete_link['aria-describedby']).to eq(name_link['id'])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/system/dashboard/viewing_returned_applications_spec.rb
+++ b/spec/system/dashboard/viewing_returned_applications_spec.rb
@@ -37,5 +37,15 @@ RSpec.describe 'Viewing Returned Criminal Legal Aid applications' do
     expect(current_tab).to have_text 'Returned'
   end
 
+  it 'programmatically associates each Delete link with its application name' do
+    stubbed_search_results.each do |result|
+      name_link = find('a', id: "application-name-#{result.reference}")
+      delete_link = find("a[aria-describedby='application-name-#{result.reference}']")
+
+      expect(name_link).to have_text(result.applicant_name)
+      expect(delete_link).to have_text('Delete')
+    end
+  end
+
   it_behaves_like 'a datastore api results table'
 end


### PR DESCRIPTION
## Description of change

On the "Your applications" page, each **Delete** link in the Action column was announced generically by screen readers, without identifying which application it applied to. Sighted users get this context from the table layout, but assistive-technology users quickly scanning the Delete links could not tell which application each one referred to.

Each Delete link is now programmatically associated with its application name. The application name link is given a unique `id` (`application-name-<reference>`) and the corresponding Delete link references it via `aria-describedby`. This announces the client name as a description while keeping "Delete" as the link's accessible name (so voice-control users can still activate it by saying "Delete").

This affects both the **In progress** tab (`crime_applications/index`) and the **Returned** tab (`returned_applications/index`). This was originally implemented (as an `aria-label`) but the association was lost when the Delete control was converted from a button to a link — so this restores and improves that behaviour.

Changes:
- Add `id="application-name-<reference>"` to the applicant name link and `aria-describedby` to the Delete link in both index views.
- Remove the now-orphaned `delete_button_a11y` locale keys (en + cy), which were dead after the button→link conversion and are superseded by the `aria-describedby` approach.

Tests:
- Request spec asserting each in-progress Delete link's `aria-describedby` matches its name link `id`.
- System spec asserting the same association for returned applications.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2141

## Notes for reviewer

The screen-reader association is exercised by the automated tests at the DOM level, but the actual announcement should be verified manually with a screen reader (e.g. VoiceOver/NVimda). The `aria-describedby` approach (per the ticket's recommendation) keeps the accessible name as "Delete" rather than overriding it with an `aria-label`.

## Screenshots of changes (if applicable)

_No visual change._ The association is exposed only to assistive technology.

### Before changes:

### After changes:

## How to manually test the feature

1. Sign in and create/have at least two in-progress applications with applicant names.
2. Go to the "Your applications" page (In progress tab).
3. Turn on a screen reader (VoiceOver on macOS, NVDA on Windows).
4. Navigate/tab to a **Delete** link in the Action column.
5. Confirm the screen reader announces "Delete" along with the associated applicant's name (e.g. "Delete, Joe Access").
6. Repeat on the **Returned** tab and confirm the same behaviour.
7. Inspect the DOM: the name link has `id="application-name-<reference>"` and the Delete link has a matching `aria-describedby`.
