### PR TITLE
Bump tar to 7.5.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "esbuild": "^0.28.1"
   },
   "resolutions": {
-    "tar": "7.5.11",
+    "tar": "7.5.19",
     "minimatch": "^10.2.4",
     "glob": "^13.0.3",
     "chokidar": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,16 +1182,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.11":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:7.5.19":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description of change
- Bump `tar` to 7.5.19

This resolves a **critical** vulnerability: https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/security/dependabot/170
And a few related lower level vulnerabilities found in older versions of `tar`.
