### PR TITLE
CRIMAPP-2330: Emergency fix, Improve information about Benefit Checker unavailability

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Once all the above is done, you should be able to run the application as follows
 a) `bin/dev` - will run foreman, spawning a rails server, `yarn build --watch`, and `yarn build:css --watch` to process javascript and SCSS files and watch for any changes.
 b) `rails server` - will only run the rails server, usually fine if you are not making changes to the CSS.
 
+To simulate the DWP checker being unavailable in local development, start the app with:
+
+- `BC_USE_DEV_MOCK=true DWP_MOCK_UNAVAILABLE=true bin/dev`
+
+`BC_USE_DEV_MOCK=true` enables the mock checker, and `DWP_MOCK_UNAVAILABLE=true` makes the mock behave as if the service is down.
+
 In development, Rails is configured to bypass asset caching. This means that when you modify assets (e.g., CSS, JavaScript),
 Rails will serve the most up-to-date version directly from the file system. If you have run `rails assets:precompile` locally
 you will need to remove the compiled assets from public/assets for this to work.

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -20,9 +20,6 @@
 // https://design-patterns.service.justice.gov.uk/patterns/task-list/
 @use "@ministryofjustice/frontend/moj/components/task-list/task-list";
 
-// Banner
-// https://design-patterns.service.justice.gov.uk/components/banner/
-@use "@ministryofjustice/frontend/moj/components/banner/banner";
 
 // Sub navigation
 @use "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -20,6 +20,9 @@
 // https://design-patterns.service.justice.gov.uk/patterns/task-list/
 @use "@ministryofjustice/frontend/moj/components/task-list/task-list";
 
+// Banner
+// https://design-patterns.service.justice.gov.uk/components/banner/
+@use "@ministryofjustice/frontend/moj/components/banner/banner";
 
 // Sub navigation
 @use "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/services/dwp/mock_benefit_check_service.rb
+++ b/app/services/dwp/mock_benefit_check_service.rb
@@ -26,6 +26,8 @@ module DWP
     end
 
     def call
+      return nil if unavailable?
+
       {
         confirmation_ref: "mocked:#{self.class}",
         benefit_checker_status: result,
@@ -41,6 +43,10 @@ module DWP
     end
 
     private
+
+    def unavailable?
+      ENV.fetch('DWP_MOCK_UNAVAILABLE', 'false').casecmp('true').zero?
+    end
 
     def known_confirmed?
       CONFIRMED.fetch(last_name.to_s.upcase, nil) == applicant_data

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -9,6 +9,18 @@
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
+    <div class="moj-banner moj-banner--information" role="region" aria-label="information">
+      <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+        <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+      C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
+      </svg>
+      <div class="moj-banner__message">
+        <h2 class="govuk-heading-m">   
+            <%= t('.dwp_unavailable') %>
+         </h2>
+      </div>
+    </div>
+
     <%= link_to t('.start_button'), new_crime_application_path, class: 'govuk-button',
                   data: { module: 'govuk-button' }, role: 'button', draggable: false %>
   </div>

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
 
     <%= govuk_notification_banner(title_text: t('helpers.important')) do %>
-      <p><%= t '.dwp_unavailable' %></p>
+      <%= t '.dwp_unavailable' %>
     <% end %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -7,17 +7,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
 
-    <div class="moj-banner moj-banner--information" role="region" aria-label="information">
-      <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-        <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
-      C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
-      </svg>
-      <div class="moj-banner__message">
-        <h2 class="govuk-heading-m">
-            <%= t('.dwp_unavailable') %>
-         </h2>
-      </div>
-    </div>
+    <%= govuk_notification_banner(title_text: t('helpers.important')) do %>
+      <p><%= t '.dwp_unavailable' %></p>
+    <% end %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -13,7 +13,7 @@
       C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
       </svg>
       <div class="moj-banner__message">
-        <h2 class="govuk-heading-m">   
+        <h2 class="govuk-heading-m">
             <%= t('.dwp_unavailable') %>
          </h2>
       </div>

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -7,8 +7,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
     <div class="moj-banner moj-banner--information" role="region" aria-label="information">
       <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
         <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
@@ -20,6 +18,8 @@
          </h2>
       </div>
     </div>
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= link_to t('.start_button'), new_crime_application_path, class: 'govuk-button',
                   data: { module: 'govuk-button' }, role: 'button', draggable: false %>

--- a/app/views/steps/dwp/cannot_check_dwp_status/edit.html.erb
+++ b/app/views/steps/dwp/cannot_check_dwp_status/edit.html.erb
@@ -12,14 +12,10 @@
 
       <%= step_form @form_object do %>
         <p class="govuk-body">
-          <%= t('helpers.hint.steps_dwp_cannot_check_dwp_status_form.next_steps_label_html') %>
+          <%= t('helpers.hint.steps_dwp_cannot_check_dwp_status_form.continue_to_submit') %>
         </p>
-      <% end %>
+    <% end %>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <li><%= t('helpers.hint.steps_dwp_cannot_check_dwp_status_form.next_steps_evidence') %></li>
-          <li><%= t("helpers.hint.steps_dwp_cannot_check_dwp_status_form.next_steps_#{subject}_check") %></li>
-        </ul>
     </div>
 
     <div class="govuk-button-group">

--- a/config/locales/cy/dashboard.yml
+++ b/config/locales/cy/dashboard.yml
@@ -150,7 +150,7 @@ cy:
       questions: Os oes gennych unrhyw gwestiynau, cysylltwch â’ch rheolwr contract.
     dashboard_header:
       heading: Eich ceisiadau
-      dwp_unavailable: Mae gwasanaeth DWP ar hyn o bryd ar gau. Gallwch dal gychwyn cais newydd, ond ni fyddwch yn gallu ei gyflwyno nes bod y gwasanaeth ar gael eto.
+      dwp_unavailable: Mae gwasanaeth DWP ar hyn o bryd ar gau. Tra bod ni’n gweithio i ddatrys hyn, cyflwynwch geisiadau sydd wedi’u pasio gyda’r enw budd-dal, y swm a’r amlder talu.
       start_button: Cychwyn cais
       create_button: Gwneud cais newydd
     subnavigation:

--- a/config/locales/cy/dashboard.yml
+++ b/config/locales/cy/dashboard.yml
@@ -150,6 +150,7 @@ cy:
       questions: Os oes gennych unrhyw gwestiynau, cysylltwch â’ch rheolwr contract.
     dashboard_header:
       heading: Eich ceisiadau
+      dwp_unavailable: Mae gwasanaeth DWP ar hyn o bryd ar gau. Gallwch dal gychwyn cais newydd, ond ni fyddwch yn gallu ei gyflwyno nes bod y gwasanaeth ar gael eto.
       start_button: Cychwyn cais
       create_button: Gwneud cais newydd
     subnavigation:

--- a/config/locales/cy/helpers.yml
+++ b/config/locales/cy/helpers.yml
@@ -459,6 +459,7 @@ cy:
           "no": Os nad oes gennych chi dystiolaeth, bydd angen i chi roi gwybod i ni am incwm %{subject}.
       steps_dwp_has_benefit_evidence_partner_form: *HAS_BENEFIT_EVIDENCE_HINT
       steps_dwp_cannot_check_dwp_status_form:
+        continue_to_submit: Bydd angen i chi roi gwybod i ni am incwm %{subject} a/neu lanlwytho tystiolaeth ar ddiwedd y cais hwn.
         next_steps_label_html: |
           Gallwch chi <button type="submit" class="app-button--link">ceisiwch eto nawr</button>, neu barhau â’r cais hwn a naill ai:
         next_steps_evidence: rhoi tystiolaeth o fudd-dal pasbortio os oes ar gael

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -148,7 +148,7 @@ en:
       questions: If you have any questions, contact your contract manager.
     dashboard_header:
       heading: Your applications
-      dwp_unavailable: The DWP service is currently unavailable. You can still start a new application, but you will not be able to submit it until the service is available again.
+      dwp_unavailable: The DWP service is currently unavailable. Whilst we work to resolve this, please submit passported applications with the benefit name, amount and frequency of payment.
       start_button: Start an application
       create_button: Make a new application
     subnavigation:

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -148,6 +148,7 @@ en:
       questions: If you have any questions, contact your contract manager.
     dashboard_header:
       heading: Your applications
+      dwp_unavailable: The DWP service is currently unavailable. You can still start a new application, but you will not be able to submit it until the service is available again.
       start_button: Start an application
       create_button: Make a new application
     subnavigation:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -456,6 +456,7 @@ en:
           "no": You'll need to tell us about %{subject}’s income if you do not have evidence.
       steps_dwp_has_benefit_evidence_partner_form: *HAS_BENEFIT_EVIDENCE_HINT
       steps_dwp_cannot_check_dwp_status_form:
+        continue_to_submit: Whilst we work to resolve this, please submit passported applications with the benefit name, amount and frequency of payment.
         next_steps_label_html: | 
           You can <button type="submit" class="app-button--link">try again now</button>, or continue with the application and either:
         next_steps_evidence: provide evidence of a passporting benefit if available

--- a/spec/system/dashboard/contingent_liability_spec.rb
+++ b/spec/system/dashboard/contingent_liability_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Viewing dashboard with Contingent Liability Criminal Legal Aid a
     it 'redirects to show page when trying to edit an application' do
       click_on('Jo Bloggs')
 
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content([
           'You cannot use this account to start, change or submit applications.',
           'The crime contract linked to office account number 2A555X is currently under Contingent Liability.',
@@ -59,22 +59,22 @@ RSpec.describe 'Viewing dashboard with Contingent Liability Criminal Legal Aid a
     end
 
     it 'shows Contingent Liability notice when viewing all tabs' do
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
 
       click_on('Submitted')
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
 
       click_on('Decided')
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
 
       click_on('Returned')
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
     end


### PR DESCRIPTION
## Description of change

Whilst DWP Benefit checker continues to be unavailable Case Management have implemented contingencies to process applications to try to remain within target. 

A significant drop in receipts has been identified from data as providers are holding off submitting whilst they wait for BC to come back online. 

- We need to add a banner to the ‘Your Applications’ page to advise providers to keep submitting their applications and advice on what info to provide (as this is outside of usual guidance). 
- We also need to amend the wording in the ‘DWP Unavailable’ interrupt screen further into the user journey. 

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2330

## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="1158" height="647" alt="image" src="https://github.com/user-attachments/assets/307812ea-a056-4bab-80da-1b61f610ee38" />


### After changes:

<img width="1078" height="574" alt="image" src="https://github.com/user-attachments/assets/a5908fcd-de58-43ff-af9d-3daa010efde1" />

### Before changes:
<img width="1344" height="864" alt="image" src="https://github.com/user-attachments/assets/88478fde-31c0-4c1f-b26c-47ff88a9cf55" />

### After changes:

<img width="1896" height="1322" alt="image" src="https://github.com/user-attachments/assets/fd070262-43aa-49c1-9c62-ef4c88780dc4" />


## How to manually test the feature

You can simulate the dwp checker been down but running using (note the 'Your applications' message always appears):
`BC_USE_DEV_MOCK=true DWP_MOCK_UNAVAILABLE=true bin/dev`
