### PR TITLE
CRIMAPP-2306 Remove invalid aria-roledescription attribute from search results table

### DIFF
--- a/app/views/application_searches/search.html.erb
+++ b/app/views/application_searches/search.html.erb
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full app-table-container">
-      <table class="govuk-table app-table" aria-roledescription="." aria-label="<%= t('search.table_label') %> <%= t('search.total', count: @search.total) %>">
+      <table class="govuk-table app-table" aria-label="<%= t('search.table_label') %> <%= t('search.total', count: @search.total) %>">
         <%= render DataTable::HeadComponent.new(sorting: @search.sorting, filter: @search.filter) do |head|
               head.with_row do |row|
                 row.with_cell(colname: 'applicant_name')


### PR DESCRIPTION
## Description of change

The application search results `<table>` had an invalid `aria-roledescription="."` attribute. `aria-roledescription` replaces the announced role name of a widget with a custom human-readable name; applying it to a native `<table>` with a value of `.` causes some screen readers to announce the table as "dot" or "period" instead of "table", overriding the correct semantic role and failing WCAG 4.1.2 (Name, Role, Value).

This change removes the attribute entirely. The existing `aria-label` still provides the table's accessible name (label and result count), and the `<table>` retains its correct native role.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2306

## Notes for reviewer

The ticket referenced `app/views/casework/application_searches/search.html.erb`, but the actual affected view is `app/views/application_searches/search.html.erb`. No specs referenced the removed attribute. Screen-reader announcement cannot be covered by automated tests, so please verify manually.

## Screenshots of changes (if applicable)

### Before changes:

_No visual change._

### After changes:

_No visual change._

## How to manually test the feature

- Navigate to the application search results page.
- Inspect the `<table>` element in browser DevTools — `aria-roledescription` must not be present.
- Using VoiceOver or NVDA, navigate to the table — it should be announced as "table" (or equivalent), not as "dot" or any other string.
- Confirm the `aria-label` with the table name and result count is still announced correctly.
