### PR TITLE
Added information banner to main page, apologising for benefit checker

### DIFF
--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -7,6 +7,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
 
+    <%= govuk_notification_banner(title_text: t('helpers.important')) do %>
+      <%= t '.dwp_unavailable_sorry' %>
+    <% end %>
+
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <%= link_to t('.start_button'), new_crime_application_path, class: 'govuk-button',

--- a/config/locales/cy/dashboard.yml
+++ b/config/locales/cy/dashboard.yml
@@ -149,6 +149,7 @@ cy:
       questions: Os oes gennych unrhyw gwestiynau, cysylltwch â’ch rheolwr contract.
     dashboard_header:
       heading: Eich ceisiadau
+      dwp_unavailable_sorry: Mae'r Gwirio Budd-dal DWP ar gael nawr - ymddiheuriadau am unrhyw anghyfleustra
       start_button: Cychwyn cais
       create_button: Gwneud cais newydd
     subnavigation:

--- a/config/locales/en/dashboard.yml
+++ b/config/locales/en/dashboard.yml
@@ -147,6 +147,7 @@ en:
       questions: If you have any questions, contact your contract manager.
     dashboard_header:
       heading: Your applications
+      dwp_unavailable_sorry: DWP Benefit checker is now available - apologies for any inconvenience
       start_button: Start an application
       create_button: Make a new application
     subnavigation:

--- a/spec/system/dashboard/contingent_liability_spec.rb
+++ b/spec/system/dashboard/contingent_liability_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Viewing dashboard with Contingent Liability Criminal Legal Aid a
     it 'redirects to show page when trying to edit an application' do
       click_on('Jo Bloggs')
 
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content([
           'You cannot use this account to start, change or submit applications.',
           'The crime contract linked to office account number 2A555X is currently under Contingent Liability.',
@@ -59,22 +59,22 @@ RSpec.describe 'Viewing dashboard with Contingent Liability Criminal Legal Aid a
     end
 
     it 'shows Contingent Liability notice when viewing all tabs' do
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
 
       click_on('Submitted')
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
 
       click_on('Decided')
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
 
       click_on('Returned')
-      within('.govuk-notification-banner') do |notice|
+      within('.govuk-notification-banner', match: :first) do |notice|
         expect(notice).to have_content('You cannot use this account to start, change or submit applications.')
       end
     end


### PR DESCRIPTION
## Description of change

Added informational banner to show remorse for the past few days.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2334

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="2316" height="1294" alt="image" src="https://github.com/user-attachments/assets/fc93ebe8-6178-45ba-a8be-f543e4cae487" />


### After changes:

<img width="1198" height="688" alt="image" src="https://github.com/user-attachments/assets/5064ba44-ebd5-4b6f-874a-0ac1a4855064" />


## How to manually test the feature
