### PR TITLE
CRIMAPP-2135 Use plain English page title for passported IoJ page

### DIFF
--- a/config/locales/cy/steps.yml
+++ b/config/locales/cy/steps.yml
@@ -278,7 +278,8 @@ cy:
           inset: Rhestrir llysoedd yn Saeseneg gan fod Cymru a Lloegr yn rhannu'r yn system gyfreithiol gyda Saesneg fel y prif iaith.
       ioj_passport:
         edit:
-          page_title: Wedi pasbortio ar sail buddiannau cyfiawnder
+          # TODO: draft translation pending official Welsh copy - confirm or replace
+          page_title: Nid oes angen i chi nodi cyfiawnhad pellach ar gyfer cymorth cyfreithiol
           heading: Ar sail y manylion a ddarparwyd gennych, does dim angen i chi nodi Er Budd Cyfiawnder (IOJ) pellach
           info: Efallai y bydd angen i chi ddarparu manylion cyllid eich cleient o hyd i wneud cais am gymorth cyfreithiol.
       ioj:

--- a/config/locales/cy/steps.yml
+++ b/config/locales/cy/steps.yml
@@ -278,8 +278,7 @@ cy:
           inset: Rhestrir llysoedd yn Saeseneg gan fod Cymru a Lloegr yn rhannu'r yn system gyfreithiol gyda Saesneg fel y prif iaith.
       ioj_passport:
         edit:
-          # TODO: draft translation pending official Welsh copy - confirm or replace
-          page_title: Nid oes angen i chi nodi cyfiawnhad pellach ar gyfer cymorth cyfreithiol
+          page_title: Nid oes arnoch angen rhoi cyfiawnhad pellach dros gael cymorth cyfreithiol
           heading: Ar sail y manylion a ddarparwyd gennych, does dim angen i chi nodi Er Budd Cyfiawnder (IOJ) pellach
           info: Efallai y bydd angen i chi ddarparu manylion cyllid eich cleient o hyd i wneud cais am gymorth cyfreithiol.
       ioj:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -275,7 +275,7 @@ en:
           page_title: First court hearing
       ioj_passport:
         edit:
-          page_title: Passported on IOJ
+          page_title: You do not need to enter further justification for legal aid
           heading: Based on the details you provided, you do not need to enter further Interests of Justice (IOJ)
           info: You might still need to provide details of your client’s finances to apply for legal aid.
       ioj:


### PR DESCRIPTION
## Description of change

The **No further justification required (Passported on IoJ)** page previously used an internal-jargon page title, "Passported on IOJ". Because the page title is the first thing announced to screen reader users on page load, this jargon-heavy title (neither "Passported" nor "IOJ" is explained in the visible content) mismatched the page's clear, plain-English heading and could confuse users — particularly those with cognitive impairments or unfamiliar with legal aid terminology.

This change updates the page title to plain English that aligns with the page's primary message.

Changes:
- `config/locales/en/steps.yml`: `page_title` changed from "Passported on IOJ" to "You do not need to enter further justification for legal aid".
- `config/locales/cy/steps.yml`: Welsh `page_title` updated with the official Welsh translation: "Nid oes arnoch angen rhoi cyfiawnhad pellach dros gael cymorth cyfreithiol".

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2135

## Notes for reviewer

- This is a screen-reader / accessibility change: the page title is not visually displayed, so there is no visual change to the page. It is best verified with a screen reader or by inspecting the browser tab / document `<title>`.
- The view (`app/views/steps/case/ioj_passport/edit.html.erb`) already renders `t('.page_title')`, so no template change was required.

## Screenshots of changes (if applicable)

_No visual change — the page title affects the browser tab / document title announced to screen readers, not the visible page content._

### Before changes:

Document title: "Passported on IOJ"

### After changes:

Document title: "You do not need to enter further justification for legal aid"

## How to manually test the feature

1. Start the app (`bin/dev`) and begin/continue an application that reaches the **No further justification required (Passported on IoJ)** page (`steps/case/ioj_passport`).
2. On that page, check the browser tab / document title (or inspect the `<title>` element).
3. Confirm it reads "You do not need to enter further justification for legal aid" instead of "Passported on IOJ".
4. Optionally, using a screen reader, load the page and confirm the announced page title is the plain-English wording that matches the visible heading.
