### PR TITLE
CRIMAPP-2349: Ensure font is resolved correctly

### DIFF
--- a/app/assets/stylesheets/local/govuk.scss
+++ b/app/assets/stylesheets/local/govuk.scss
@@ -1,4 +1,6 @@
 // GOV.UK Frontend
 //
-
+@use "govuk-frontend/dist/govuk/helpers/font-faces--internal" as govuk-font-faces;
 @use "govuk-frontend/dist/govuk/index";
+
+@include govuk-font-faces.gds-transport;


### PR DESCRIPTION
## Description of change

Problem:
The display doesn't quite look right. Going back to before the header (and UI library updates) change the display looks very similar but comparing 2 screens you can see that the spacing on the font is now greater than it was. This has been rectified and the main body now looks identical to how it did before the header change.

Issue:
app set font-family to GDS Transport, but didn’t reliably provide/resolve the corresponding webfont files at runtime, so browsers fell back to Arial/sans-serif instead of rendering GDS Transport.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2349

## Notes for reviewer

Easiest way is to run this and compare to staging. Flicking between 2 screens you can see the changes in font display which is most noticeable on headings.
## Screenshots of changes (if applicable)

### Before changes:

<img width="966" height="543" alt="image" src="https://github.com/user-attachments/assets/bc66a702-f736-4a1c-9f4f-f29cb086f6af" />


### After changes:

<img width="961" height="538" alt="image" src="https://github.com/user-attachments/assets/f1b835f8-3a94-4ad6-946b-f66435e0df96" />

### Before changes:

<img width="961" height="639" alt="image" src="https://github.com/user-attachments/assets/f7125a4d-e616-4bda-bb78-e2e0fcd6ee21" />

### After changes:

<img width="969" height="644" alt="image" src="https://github.com/user-attachments/assets/bc699603-480f-4ad9-9bbc-3b3f35e5f573" />

## How to manually test the feature

Easiest way is to run this and compare to staging. Flicking between 2 screens you can see the changes in font display which is most noticeable on headings.
