### PR TITLE
CRIMAPP-2348: Fix nested form breaking Save and continue on evidence …

### DIFF
--- a/app/views/steps/evidence/upload/_uploaded_file.html.erb
+++ b/app/views/steps/evidence/upload/_uploaded_file.html.erb
@@ -18,9 +18,9 @@
     <% end %>
   </dt>
   <dd class="govuk-summary-list__actions">
-    <%= button_to t('.remove_button'), steps_evidence_upload_path, method: :put,
-                                       value: document.id.to_s,
-                                       name: :document_id,
-                                       class: 'app-button--link app-uploaded-file__delete' %>
+    <%= button_tag t('.remove_button'), type: :submit,
+                                        name: :document_id,
+                                        value: document.id.to_s,
+                                        class: 'app-button--link app-uploaded-file__delete' %>
   </dd>
 </div>


### PR DESCRIPTION
…upload page

## Description of change
Replace `button_to` with `button_tag` in the uploaded file partial. `button_to` wraps its button in a `<form>`, which nested inside the outer `step_form`. Previously the file list used a `<table>`, where browsers foster-parent nested forms outside the table, preserving the outer form. The switch to a `<dl>` summary list (CRIMAPP-2125) removed that behaviour, causing the browser to close `step_form` early and leaving the navigation buttons outside any form.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2348

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="654" height="311" alt="Screenshot 2026-08-19 at 10 38 14" src="https://github.com/user-attachments/assets/b0fe2f6f-19be-4649-a904-273d7e1a44cf" />

### After changes:
<img width="726" height="236" alt="Screenshot 2026-08-19 at 10 37 04" src="https://github.com/user-attachments/assets/56a04b32-8189-4c48-b11a-725ab7007d99" />

## How to manually test the feature

Navigate to an in-progress application and go to the evidence upload page (`/applications/:id/steps/evidence/upload`). Upload a valid file — once it shows the green "Uploaded" tag, click "Save and continue". Before the fix, the page would stay put with no response; after the fix it should advance to the next step (More information or the submission review page).