### PR TITLE
Bump tar from 7.5.19 to 7.5.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "esbuild": "^0.28.2"
   },
   "resolutions": {
-    "tar": "7.5.19",
+    "tar": "7.5.21",
     "minimatch": "^10.2.4",
     "glob": "^13.0.3",
     "chokidar": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,16 +1182,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.19":
-  version: 7.5.19
-  resolution: "tar@npm:7.5.19"
+"tar@npm:7.5.21":
+  version: 7.5.21
+  resolution: "tar@npm:7.5.21"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
+  checksum: 10c0/bce0e51692356078e6f6a909d5c93f5b4c099c097ffea19b1b1bf10385539a429baba26bca59aabbace68c4519d16f2f1c07afe7eaab55876a449a032480fabc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description of change
Bump `tar` to v7.5.21. This resolves https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/security/dependabot/175.