### PR TITLE
CRIMAPP-2333 Hide conditional reveals from assistive technology until revealed

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,12 @@
 import { initAll } from 'govuk-frontend'
 initAll()
 
+// Hide GOV.UK conditional reveals from assistive technology until their
+// controlling radio/checkbox is selected. Runs after initAll so
+// `data-aria-controls` has been promoted to `aria-controls`.
+import ConditionalReveal from "./local/conditional-reveal"
+new ConditionalReveal(document).init()
+
 // Cookie banner -- Script name is obfuscated to avoid browsers blocking it
 // https://design-system.service.gov.uk/components/cookie-banner/
 import Cbc from "./local/cbc"

--- a/app/javascript/local/conditional-reveal.js
+++ b/app/javascript/local/conditional-reveal.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Accessible conditional reveals
+//
+// GOV.UK Frontend reveals content nested inside a radio/checkbox by toggling
+// the `govuk-*__conditional--hidden` class, which only hides the content
+// *visually* (`display: none`). Some browser + screen reader combinations
+// (e.g. Chrome + VoiceOver) still expose the nested controls to assistive
+// technology, so the reveal's fields — including nested radio groups — get
+// announced before the controlling option has been selected.
+//
+// This module keeps the accessibility state of every GOV.UK conditional reveal
+// in sync with its controlling input: when the input is not selected the reveal
+// is removed from the accessibility tree (`hidden` + `aria-hidden`) and made
+// non-focusable (`inert`); when selected it is restored. It complements, rather
+// than replaces, GOV.UK Frontend's own visual toggling and works for any
+// `data-aria-controls` reveal (radios and checkboxes).
+
+const CONDITIONAL_CLASS = '__conditional';
+
+function ConditionalReveal($root) {
+  this.$root = $root || document;
+  this.controls = [];
+}
+
+ConditionalReveal.prototype.init = function () {
+  const selector = [
+    'input[type="radio"][aria-controls]',
+    'input[type="radio"][data-aria-controls]',
+    'input[type="checkbox"][aria-controls]',
+    'input[type="checkbox"][data-aria-controls]'
+  ].join(', ');
+
+  this.$root.querySelectorAll(selector).forEach(($input) => {
+    const targetId =
+      $input.getAttribute('aria-controls') ||
+      $input.getAttribute('data-aria-controls');
+    if (!targetId) { return }
+
+    const $target = document.getElementById(targetId);
+    if (!$target || !$target.className.includes(CONDITIONAL_CLASS)) { return }
+
+    this.controls.push({ $input: $input, $target: $target });
+  });
+
+  if (!this.controls.length) { return this }
+
+  this.sync = this.sync.bind(this);
+  // GOV.UK Frontend promotes `data-aria-controls` to `aria-controls` and
+  // toggles the reveal on `change`, so we listen for the same event and
+  // for `pageshow` to cover back/forward (bfcache) navigation.
+  this.$root.addEventListener('change', this.sync);
+  window.addEventListener('pageshow', this.sync);
+  this.sync();
+
+  return this;
+};
+
+ConditionalReveal.prototype.sync = function () {
+  this.controls.forEach(({ $input, $target }) => {
+    const revealed = $input.checked;
+
+    $target.hidden = !revealed;
+    $target.inert = !revealed;
+
+    if (revealed) {
+      $target.removeAttribute('aria-hidden');
+    } else {
+      $target.setAttribute('aria-hidden', 'true');
+    }
+  });
+};
+
+export default ConditionalReveal;


### PR DESCRIPTION
## Description of change

On the Income Assessment page (`self-assessment-client`), the "Yes" radio uses the GOV.UK conditional reveal pattern, and the revealed block contains a nested radio group (self-assessment tax bill amount + payment frequency). GOV.UK Frontend only hides an unrevealed block *visually* (via `govuk-radios__conditional--hidden` → `display: none`). Some browser + screen reader combinations (e.g. Chrome + VoiceOver) still expose those nested controls to assistive technology, so screen reader users were told there were more radio buttons than are visible — before "Yes" was selected they heard three radios instead of two.

This adds a small, generalised JS module that keeps the *accessibility* state of every GOV.UK conditional reveal in sync with its controlling input: while the input is unselected the reveal is removed from the accessibility tree (`hidden` + `aria-hidden`) and made non-focusable (`inert`); when selected it is restored. It complements — rather than replaces — GOV.UK Frontend's own visual toggling, and applies to any `data-aria-controls` reveal (radios and checkboxes) across the app, not just this page.

Changes:
- Add `app/javascript/local/conditional-reveal.js` — syncs `hidden`/`aria-hidden`/`inert` on GOV.UK conditional reveals from their controlling radio/checkbox, on load, `change`, and `pageshow`.
- Initialise it in `app/javascript/application.js` after `initAll()` (so `data-aria-controls` has been promoted to `aria-controls`).

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2333

## Notes for reviewer

- This is the short-term Option 2 (JS workaround) from the ticket discussion; the longer-term Option 1 is to split the follow-up questions onto their own page ("one thing per page").
- The app has no JS unit-test framework and system specs run under `rack_test` (no JS driver), so this behaviour is not covered by automated tests and needs manual screen-reader verification (see below). No Ruby/ERB changed, so existing specs are unaffected.
- There is no CSS-only fix: CSS can only hide via `display`/`visibility` (already applied and what failed); setting `aria-hidden`/`inert`/`hidden` requires JS.

## Screenshots of changes (if applicable)

### Before changes:

_No visual change._

### After changes:

_No visual change._

## How to manually test the feature

1. Run the app (`bin/dev`) and start an application, navigating to the income step `steps/income/client/self-assessment-client` (the self-assessment tax bill question).
2. Turn on a screen reader — ideally Chrome + VoiceOver on macOS (the combo from the ticket), and/or NVDA on Windows.
3. With neither option selected, navigate the radio group: confirm only two options are announced ("Yes" and "No", e.g. "1 of 2"), with no nested amount/frequency controls announced.
4. Select "Yes": confirm the amount field and payment-frequency radios are revealed and announced.
5. Select "No": confirm the revealed controls are hidden again and no longer announced, and cannot be reached by keyboard (Tab).
