### PR TITLE
Remove ModSec rule 921120

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -153,6 +153,7 @@ metadata:
       SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=921120,\
         ctl:ruleRemoveById=920120,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -153,7 +153,7 @@ metadata:
       SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
-        ctl:ruleRemoveById=921120,\
+        ctl:ruleRemoveTargetById=921120;ARGS,\
         ctl:ruleRemoveById=920120,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -153,6 +153,7 @@ metadata:
       SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=921120,\
         ctl:ruleRemoveById=920120,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -153,7 +153,7 @@ metadata:
       SecRule REQUEST_URI "@rx /steps/.+$" \
         "id:1000,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
-        ctl:ruleRemoveById=921120,\
+        ctl:ruleRemoveTargetById=921120;ARGS,\
         ctl:ruleRemoveById=920120,\
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\


### PR DESCRIPTION
## Description of change
This change removes ModSec rule 921120 ('HTTP Response Splitting Attack') from the `/steps/*` routes.

This rule has been blocking a provider by falsely identifying regular user input as malicious. In the latest instance, we can see that ModSec is identifying the string `"\r\nlocation: "` as an HTTP response splitting attack.

OpenSearch logs that have caught this false positive:
1. https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/doc/b95d8900-dd15-11ed-87c8-170407f57c9c/live_k8s_modsec_ingress-2026.08.25?id=02C625AE-B346-ED02-F51F-B6B9BC79CED8
2. https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/doc/b95d8900-dd15-11ed-87c8-170407f57c9c/live_k8s_modsec_ingress-2026.08.25?id=A332AA4C-7F30-5194-E83A-EF5E8038245D
3. https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/doc/b95d8900-dd15-11ed-87c8-170407f57c9c/live_k8s_modsec_ingress-2026.08.25?id=687D66E6-9F49-721D-C625-10F3497E3AA7

## How to manually test the feature
On an application in Crime Apply staging:
1. On the "Why should your client get legal aid?" question, check "It is likely that they will lose their liberty if any matter in the proceedings is decided against them" and in the revealed text box enter a string containing `"\r\nlocation: "` (note the carriage return and new line at the start, typical for Windows).
2. You should be allowed to proceed to the next question.